### PR TITLE
feat: remove llama.cpp GPU generation limit

### DIFF
--- a/scripts/ai_engine_cuda_build.sh
+++ b/scripts/ai_engine_cuda_build.sh
@@ -7,12 +7,8 @@ PROJECT_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
 # BUILD_TYPE: Release, Debug
 BUILD_TYPE=Release
 
-# Build CUDA architectures. Please modify it according to your own needs if necessary. 
-# For reference https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/#gpu-feature-list
-CUDA_ARCS="86;89;90" # default 30xx/40xx/50xx
-
-# Build support native cpu architecture (ON)/ all cpu architectures (OFF)
-NATIVE_ARCS=OFF
+# Build supports native GPU architecture (ON)/ all GPU architectures (OFF)
+NATIVE_ARCH=OFF
 
 AI_ENGINE_DIR="${PROJECT_ROOT}/miloco_ai_engine/core"
 BUILD_DIR="${PROJECT_ROOT}/build/ai_engine"
@@ -23,9 +19,8 @@ mkdir -p "${BUILD_DIR}" "${OUTPUT_DIR}"
 
 cmake -S "${AI_ENGINE_DIR}" -B "${BUILD_DIR}" \
     -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
-    -DCMAKE_CUDA_ARCHITECTURES=${CUDA_ARCS} \
     -DGGML_CUDA=ON \
-    -DGGML_NATIVE=${NATIVE_ARCS}
+    -DGGML_NATIVE=${NATIVE_ARCH}
 
 cmake --build "${BUILD_DIR}" --target llama-mico -j"$(nproc)"
 cmake --install "${BUILD_DIR}" --prefix "${OUTPUT_DIR}"


### PR DESCRIPTION
Remove the arbitrary CUDA version limit. This should enable all llama.cpp supported NVIDIA GPUs.

Tested on Tesla P4

**Note**
Please help test this change on more hardware.