### PR TITLE
fix: correct log level in .env.example

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -12,7 +12,7 @@ BACKEND_HOST=0.0.0.0
 # Backend port.
 BACKEND_PORT=8000
 # Log level: debug, info, warning, error, critical.
-BACKEND_LOG_LEVER=info
+BACKEND_LOG_LEVEL=info
 
 ################################################
 # AI engine configuration.
@@ -22,4 +22,4 @@ AI_ENGINE_HOST=0.0.0.0
 # AI engine port.
 AI_ENGINE_PORT=8001
 # Log level: debug, info, warning, error, critical.
-AI_ENGINE_LOG_LEVER=info
+AI_ENGINE_LOG_LEVEL=info


### PR DESCRIPTION
### Fixed
- Correct log level in .env.example