### PR TITLE
fix: mac handle missing dynamic libraries and service call failures by returning None and logging warnings

### DIFF
--- a/miloco_server/utils/local_models.py
+++ b/miloco_server/utils/local_models.py
@@ -62,9 +62,13 @@ class LocalModels:
 
     async def local_cuda_info(self):
         """Get local CUDA info."""
-        url = self._get_service_url(LocalModelApi.CUDA_INFO)
-        json_resp = await self._forward_local_models_services(url, method_get=True)
-        return json_resp
+        try:
+            url = self._get_service_url(LocalModelApi.CUDA_INFO)
+            json_resp = await self._forward_local_models_services(url, method_get=True)
+            return json_resp
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            logger.warning("Get local cuda info failed: %s", e)
+            return None
 
     async def get_local_models(self) -> List[LLMModelInfo]:
         """Get cached local model list."""


### PR DESCRIPTION
修复mac下两个bug，一是启动时缺少 camera 动态库不会 block，二是模型管理 ai_engine 未启动时不会直接进 500  
<img width="1051" height="790" alt="image" src="https://github.com/user-attachments/assets/7e9f911b-b764-46bc-b13c-570b75381685" />
