### PR TITLE
Fix file linking issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-English | [简体中文](CONTRIBUTING_zh_Hans.md)
+English | [简体中文](CONTRIBUTING.zh_Hans.md)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <div align="center">
 
-English | [简体中文](README_zh_Hans.md)
+English | [简体中文](README.zh_Hans.md)
 
 </div>
 

--- a/README.zh_Hans.md
+++ b/README.zh_Hans.md
@@ -69,7 +69,7 @@ bash scripts/install.sh
 
 ## 贡献指南
 
-请参考 [贡献指南](CONTRIBUTING_zh_Hans.md)。
+请参考 [贡献指南](CONTRIBUTING.zh_Hans.md)。
 
 ## 许可证
 


### PR DESCRIPTION
The README.md file links to CONTRIBUTING_zh_Hans.md and README_zh_Hans.md, but these two files are named as CONTRIBUTING.zh_Hans.md and README.zh_Hans.md in the repository.