### PR TITLE
fix: handle empty MiOT scenes gracefully

### DIFF
--- a/miloco_server/service/miot_service.py
+++ b/miloco_server/service/miot_service.py
@@ -89,7 +89,8 @@ class MiotService:
         """
         try:
             result = await self._miot_proxy.refresh_scenes()
-            if not result:
+            # None means call failed; an empty dict just means no scenes available and should not be treated as an error
+            if result is None:
                 raise MiotServiceException("Failed to refresh MiOT scenes")
             return True
         except Exception as e:


### PR DESCRIPTION
调整后仅在刷新场景返回 None 时才报错，空字典视为无可用场景不会触发异常