### PR TITLE
fix:adjust lan broadcast handling on macos

### DIFF
--- a/miot_kit/miot/lan.py
+++ b/miot_kit/miot/lan.py
@@ -347,6 +347,9 @@ class MIoTLan:
             sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            # Allow binding the same UDP port on multiple interfaces (needed on macOS).
+            if hasattr(socket, "SO_REUSEPORT"):
+                sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
             self.__bind_socket_to_interface(sock=sock, if_name=if_name)
             sock.bind(("", self._local_port or 0))
             self._internal_loop.add_reader(sock.fileno(), self.__socket_read_handler, (if_name, sock))


### PR DESCRIPTION
macOS 下解决如下3个问题：
1、mac没有 SO_BINDTODEVICE，原来直接调用导致套接字创建失败、LAN 线程无法发包。
2、绑定接口后仍用 255.255.255.255 广播，macOS 路由检查会返回 “No route to host”，广播被拒绝。
3、开启虚拟网卡后，多接口绑定同一 UDP 端口没有 SO_REUSEPORT，第二个接口创建时报 “[Errno 48] Address already in use”。

以上在Mac mini m2芯片与 ubuntu 22.04  Intel芯片 验证正常