### PR TITLE
fix: skip unselected mcp actions

### DIFF
--- a/miloco_server/tools/rule_create_tool.py
+++ b/miloco_server/tools/rule_create_tool.py
@@ -111,8 +111,8 @@ class RuleCreateTool(Actor):
             if not chosen_camera_infos:
                 chosen_camera_infos = all_camera_infos
 
-            miot_scene_actions = await self._default_preset_action_manager.get_miot_scene_actions()
-            ha_automation_actions = await self._default_preset_action_manager.get_ha_automation_actions()
+            miot_scene_actions = await self._default_preset_action_manager.get_miot_scene_actions(self._mcp_ids)
+            ha_automation_actions = await self._default_preset_action_manager.get_ha_automation_actions(self._mcp_ids)
 
             no_matched_action_descriptions, matched_actions = (
                 await self._action_descriptions_to_preset_actions(
@@ -313,4 +313,3 @@ class RuleCreateTool(Actor):
         except Exception as e:  # pylint: disable=broad-exception-caught
             logger.error("[%s] Error in action mapping: %s", self._request_id, str(e))
             return generated_action
-


### PR DESCRIPTION
1、背景条件
a.Home Assistant 服务已关掉。
b.在 Miloco 的 MCP 选择里未勾选 HA（ha_automations）。

2、问题现象
尝试创建“无人时发送通知”规则时，系统仍调用 ha_automations/get_automations，连接 127.0.0.1:8123 被拒绝，提示 “Error calling tool 'get_automations'”，规则创建失败。
<img width="1360" height="766" alt="image" src="https://github.com/user-attachments/assets/3726ec4a-9057-494e-958c-3c36c38d362a" />


3、问题原因
预设动作获取逻辑未过滤用户选的 MCP，默认去拉取 HA/MIoT 动作；HA 关机导致连接错误，导致规则创建终止。

4、解决方案
a.miloco_server/utils/default_action.py：按 mcp_ids 过滤，未选 ha_automations/miot_manual_scenes 时跳过；调用异常捕获后返回空动作。
b.miloco_server/tools/rule_create_tool.py：将会话的 mcp_ids 传入预设动作获取，确保只访问用户勾选的 MCP。