### PR TITLE
fix: stop current query before switching history sessions

### DIFF
--- a/web_ui/src/pages/Instant/index.jsx
+++ b/web_ui/src/pages/Instant/index.jsx
@@ -8,6 +8,7 @@ import { useTranslation } from 'react-i18next';
 import { Popconfirm } from 'antd';
 import { CloseOutlined } from '@ant-design/icons';
 import { useChatStore } from '@/stores/chatStore';
+import { useGlobalSocket } from '@/hooks/useGlobalSocket';
 import { Icon } from '@/components';
 import DeviceList from './components/DeviceList'
 import ChatDialog from './components/ChatDialog'
@@ -30,6 +31,7 @@ const Instant = () => {
     cameraList,
     historyList,
     historyLoading,
+    isAnswering,
     fetchCameraList,
     fetchMcpServices,
     refreshMiotInfo,
@@ -37,6 +39,8 @@ const Instant = () => {
     handleHistoryClick,
     deleteHistoryRecord
   } = useChatStore();
+
+  const { globalCloseMessage } = useGlobalSocket();
 
   useEffect(() => {
     fetchCameraList()
@@ -59,6 +63,10 @@ const Instant = () => {
   }
 
   const handleClickHistory = async (id) => {
+    // Stop current query if there is one in progress
+    if (isAnswering) {
+      globalCloseMessage();
+    }
     await handleHistoryClick(id);
     setRightDrawerVisible(false);
   }


### PR DESCRIPTION
避免在AI回答时，切换会话，出现原会话的内容出现在切换的会话上，在切换历史会话前停止当前进行的回答；如图
<img width="1755" height="862" alt="屏幕截图 2025-12-02 105447" src="https://github.com/user-attachments/assets/752bd0bb-a596-4267-97e9-8df473dec3ca" />
