### PR TITLE
fix: build llama-mico on Windows by MSVC

### DIFF
--- a/miloco_ai_engine/core/CMakeLists.txt
+++ b/miloco_ai_engine/core/CMakeLists.txt
@@ -8,6 +8,11 @@ add_library(llama-mico SHARED ${LIB_SOURCE_FILES})
 set(THIRD_PARTY_PATH ${PROJECT_SOURCE_DIR}/../../third_party)
 set(LLAMA_THIRD_PARTY_PATH ${THIRD_PARTY_PATH}/llama.cpp)
 
+if(MSVC)
+    target_compile_features(llama-mico PRIVATE cxx_std_17)
+    target_compile_definitions(llama-mico PRIVATE LLAMA_MICO_EXPORTS)
+endif()
+
 include_directories(${PROJECT_SOURCE_DIR}
                     ${PROJECT_SOURCE_DIR}/utils
                     ${PROJECT_SOURCE_DIR}/cache_manager

--- a/miloco_ai_engine/core/llama-mico.h
+++ b/miloco_ai_engine/core/llama-mico.h
@@ -8,7 +8,15 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef _WIN32
+#ifdef LLAMA_MICO_EXPORTS
+#define LLAMA_MICO_API __declspec(dllexport)
+#else
+#define LLAMA_MICO_API __declspec(dllimport)
+#endif
+#else
 #define LLAMA_MICO_API
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -33,14 +41,14 @@ extern "C" {
  *   "cache_seq_num": 8,
  * }
  */
-int32_t llama_mico_init(const char *config_json, void **handle);
+LLAMA_MICO_API int32_t llama_mico_init(const char *config_json, void **handle);
 
 /**
  * @brief Free Llama Mico context
  * @param handle Context handle
  * @return 0 on success, -1 on failure
  */
-int32_t llama_mico_free(void *handle);
+LLAMA_MICO_API int32_t llama_mico_free(void *handle);
 
 /**
  * @brief Process initial prompt request (OpenAI compatible format)
@@ -50,8 +58,8 @@ int32_t llama_mico_free(void *handle);
  * @param content Output parameter, returns generated content (error message if return is -1, otherwise normal text)
  * @return 0 on success, -1 on failure
  */
-int32_t llama_mico_request_prompt(void *handle, const char *request_json_str, int32_t *is_finished,
-                                  const char **content);
+LLAMA_MICO_API int32_t llama_mico_request_prompt(void *handle, const char *request_json_str, int32_t *is_finished,
+                                                 const char **content);
 
 /**
  * @brief Generate next token (OpenAI compatible format)
@@ -61,8 +69,8 @@ int32_t llama_mico_request_prompt(void *handle, const char *request_json_str, in
  * @param content Output parameter, returns generated content (error message if return is -1, otherwise normal text)
  * @return 0 on success, -1 on failure
  */
-int32_t llama_mico_request_generate(void *handle, const char *request_json_str, int32_t *is_finished,
-                                    const char **content);
+LLAMA_MICO_API int32_t llama_mico_request_generate(void *handle, const char *request_json_str, int32_t *is_finished,
+                                                   const char **content);
 
 #ifdef __cplusplus
 }

--- a/miloco_ai_engine/core_python/lib_manager.py
+++ b/miloco_ai_engine/core_python/lib_manager.py
@@ -47,12 +47,27 @@ class LibraryManager:
             raise InvalidArgException(f"Library directory not found: {lib_dir}")
         return lib_dir
 
+    def _add_search_path(self):
+        """Add necessary search paths to load llama-mico dependencies.
+
+        On Windows, the CUDA_PATH would not search by default, we need to add it
+        explicitly.
+        """
+        if os.name != "nt":
+            return
+        cuda_path = os.environ.get("CUDA_PATH")
+        if not cuda_path or not os.path.exists(cuda_path):
+            return
+        os.add_dll_directory(os.path.join(cuda_path, "bin/x64"))
+        os.add_dll_directory(os.path.join(cuda_path, "bin"))
+
     def _load_library(self) -> Optional[ctypes.CDLL]:
         """Load library"""
         if self._library is not None:
             return self._library
 
         # Get library path
+        self._add_search_path()
         lib_dir = self._get_library_path()
         # Library name list
         library_names = [

--- a/third_party/llama.cpp/common/CMakeLists.txt
+++ b/third_party/llama.cpp/common/CMakeLists.txt
@@ -13,7 +13,10 @@ add_library(${TARGET} OBJECT ${OUTPUT_FILE})
 # if (BUILD_SHARED_LIBS)
     # set_target_properties(${TARGET} PROPERTIES POSITION_INDEPENDENT_CODE ON)
 # endif()
-set(LLAMA_COMMON_EXTRA_LIBS build_info)
+if (NOT MSVC)
+    # link an object library in MSVC is not feasible
+    set(LLAMA_COMMON_EXTRA_LIBS build_info)
+endif()
 
 # set(TARGET common)
 set(TARGET llama)
@@ -45,7 +48,9 @@ target_sources(${TARGET} PUBLIC
     speculative.cpp
     speculative.h
     )
-
+if (MSVC)
+    target_sources(${TARGET} PUBLIC ${OUTPUT_FILE})
+endif()
 # if (BUILD_SHARED_LIBS)
     # set_target_properties(${TARGET} PROPERTIES POSITION_INDEPENDENT_CODE ON)
 # endif()


### PR DESCRIPTION
This pull request introduces several improvements to the build system and cross-platform compatibility, particularly for Windows (MSVC). The most significant changes include adding proper DLL export/import macros for the `llama-mico` API, updating CMake configurations for MSVC compatibility, and ensuring the Python library loader correctly handles CUDA DLL search paths on Windows.

**Windows/MSVC compatibility and build improvements:**

* Added DLL export/import macros (`LLAMA_MICO_API`) to all public API functions in `llama-mico.h`, ensuring correct symbol visibility when building or consuming the shared library on Windows. [[1]](diffhunk://#diff-97446b69e125f884362d7a2ad75fd6b17508f449e54cf1deea0e466992009929R11-R19) [[2]](diffhunk://#diff-97446b69e125f884362d7a2ad75fd6b17508f449e54cf1deea0e466992009929L36-R51) [[3]](diffhunk://#diff-97446b69e125f884362d7a2ad75fd6b17508f449e54cf1deea0e466992009929L53-R61) [[4]](diffhunk://#diff-97446b69e125f884362d7a2ad75fd6b17508f449e54cf1deea0e466992009929L64-R72)
* Updated `miloco_ai_engine/core/CMakeLists.txt` to set C++17 standard and define `LLAMA_MICO_EXPORTS` when building with MSVC, improving build reliability on Windows.
* Modified `third_party/llama.cpp/common/CMakeLists.txt` to handle object library linking and source file inclusion differently for MSVC, addressing platform-specific build issues. [[1]](diffhunk://#diff-5b1e74a486de5a443a3b17da8631c43dc6a27161aef27b788ac83b9dff823943R16-R19) [[2]](diffhunk://#diff-5b1e74a486de5a443a3b17da8631c43dc6a27161aef27b788ac83b9dff823943L48-R53)

**Python integration improvements:**

* Enhanced the Python library loader (`lib_manager.py`) to add CUDA DLL directories to the search path on Windows, ensuring dependencies are found during runtime.