### PR TITLE
Fix wrong directory and doc

### DIFF
--- a/docker/docker-compose-lite.yaml
+++ b/docker/docker-compose-lite.yaml
@@ -14,11 +14,11 @@ services:
       - BACKEND_LOG_LEVEL=${BACKEND_LOG_LEVEL:-info}
       - TZ=${TZ:-Asia/Shanghai}
     volumes:
-      - ./data:/app/miloco_server/.temp
-      - ./log/backend:/app/miloco_server/.temp/log
+      - ../data:/app/miloco_server/.temp
+      - ../log/backend:/app/miloco_server/.temp/log
     # NOTICE: Mount configuration files, if you want to use your own configuration files, please mount them here.
-    #  - ./config/server_config.yaml:/app/config/server_config.yaml
-    #  - ./config/prompt_config.yaml:/app/config/prompt_config.yaml
+    #  - ../config/server_config.yaml:/app/config/server_config.yaml
+    #  - ../config/prompt_config.yaml:/app/config/prompt_config.yaml
     restart: unless-stopped
     healthcheck:
       disable: true

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -10,11 +10,11 @@ services:
       - AI_ENGINE_LOG_LEVEL=${AI_ENGINE_LOG_LEVEL:-info}
       - TZ=${TZ:-Asia/Shanghai}
     volumes:
-      - ./models:/models
-      - ./log/ai_engine:/app/.log/ai_engine
+      - ../models:/models
+      - ../log/ai_engine:/app/.log/ai_engine
     # NOTICE: If you want to use your own configuration files or models path, please mount them here.
-    #   - ./config/ai_engine_config.yaml:/app/config/ai_engine_config.yaml
-    #   - ./config/prompt_config.yaml:/app/config/prompt_config.yaml
+    #   - ../config/ai_engine_config.yaml:/app/config/ai_engine_config.yaml
+    #   - ../config/prompt_config.yaml:/app/config/prompt_config.yaml
 
     deploy:
       resources:
@@ -42,11 +42,11 @@ services:
       - BACKEND_LOG_LEVEL=${BACKEND_LOG_LEVEL:-info}
       - TZ=${TZ:-Asia/Shanghai}
     volumes:
-      - ./data:/app/miloco_server/.temp
-      - ./log/backend:/app/miloco_server/.temp/log
+      - ../data:/app/miloco_server/.temp
+      - ../log/backend:/app/miloco_server/.temp/log
     # NOTICE: Mount configuration files, if you want to use your own configuration files, please mount them here.
-    #  - ./config/server_config.yaml:/app/config/server_config.yaml
-    #  - ./config/prompt_config.yaml:/app/config/prompt_config.yaml
+    #  - ../config/server_config.yaml:/app/config/server_config.yaml
+    #  - ../config/prompt_config.yaml:/app/config/prompt_config.yaml
     restart: unless-stopped
     healthcheck:
       disable: true

--- a/docs/environment-setup_zh-Hans.md
+++ b/docs/environment-setup_zh-Hans.md
@@ -55,7 +55,7 @@ macOS 环境配置可参考：[English](./environment-setup-macos.md) | [简体�
 
 ## 下载模型
 
-下述所有操作都在`models`文件下进行。
+下述所有操作都在克隆后的存储库下的`models`文件夹进行。
 
 ### Xiaomi MiMo-VL-Miloco-7B
 
@@ -90,6 +90,8 @@ macOS 环境配置可参考：[English](./environment-setup-macos.md) | [简体�
 - 下载`Qwen3-8B-Q4_K_M.gguf`放到`Qwen3-8B`目录下
 
 ## 运行
+
+##下述所有操作都在克隆后的存储库下的`docker`文件夹进行。##
 
 使用`docker compose`运行程序，复制`.env.example`，命名为`.env`，端口根据实际环境修改。
 

--- a/docs/environment-setup_zh-Hans.md
+++ b/docs/environment-setup_zh-Hans.md
@@ -91,7 +91,7 @@ macOS 环境配置可参考：[English](./environment-setup-macos.md) | [简体�
 
 ## 运行
 
-##下述所有操作都在克隆后的存储库下的`docker`文件夹进行。##
+## 下述所有操作都在克隆后的存储库下的`docker`文件夹进行。##
 
 使用`docker compose`运行程序，复制`.env.example`，命名为`.env`，端口根据实际环境修改。
 


### PR DESCRIPTION
This pull request updates Docker volume mount paths and clarifies documentation to ensure users operate within the correct directories. The main changes include adjusting relative paths in Docker Compose files for both the backend and AI engine services, and updating the Chinese setup documentation to specify the correct working directories for model downloads and Docker operations.

**Docker Compose configuration updates:**

* Changed volume mount paths in `docker/docker-compose.yaml` and `docker/docker-compose-lite.yaml` from `./` (current directory) to `../` (parent directory) for `models`, `data`, and `log` directories to align with the expected directory structure. [[1]](diffhunk://#diff-89fafc265c1fa601cf2364b20be83308031335fda9467fcf3249d5ec1c0c8172L13-R17) [[2]](diffhunk://#diff-89fafc265c1fa601cf2364b20be83308031335fda9467fcf3249d5ec1c0c8172L45-R49) [[3]](diffhunk://#diff-daa46ee0fd80c655d450efb027f050c8fcc56ce14cfe964702ff0a3d06d2d46dL17-R21)
* Updated commented-out configuration file mount examples to use the new parent directory path (`../config/...`) in both Docker Compose files. [[1]](diffhunk://#diff-89fafc265c1fa601cf2364b20be83308031335fda9467fcf3249d5ec1c0c8172L13-R17) [[2]](diffhunk://#diff-89fafc265c1fa601cf2364b20be83308031335fda9467fcf3249d5ec1c0c8172L45-R49) [[3]](diffhunk://#diff-daa46ee0fd80c655d450efb027f050c8fcc56ce14cfe964702ff0a3d06d2d46dL17-R21)

**Documentation improvements:**

* Clarified in `docs/environment-setup_zh-Hans.md` that all model-related operations should be performed in the `models` folder within the cloned repository.
* Added a note to the same documentation that all Docker-related operations should be performed in the `docker` folder within the cloned repository.