### PR TITLE
Feat: Add same-action deduplication to prevent repeated firing    

### DIFF
--- a/config/prompt_config.yaml
+++ b/config/prompt_config.yaml
@@ -263,15 +263,15 @@ prompts:
       
   trigger_rule_condition_prefixes:
     chinese:
-      current_frames_prefix: "current_frames - 当前图像序列如下, 一共有{vision_use_img_count}张从监控摄像头中截取的帧, 按照{frame_interval}秒间隔截取了.："
+      current_frames_prefix: "current_frames - 当前图像序列如下, 一共有{vision_use_img_count}张从监控摄像头中截取的帧, 按照{frame_interval}毫秒间隔截取.："
       current_time_prefix: "current_time: {time}"
-      last_happened_frames_prefix: "last_happened_frames - 上次满足条件时的图像序列如下, 一共有{vision_use_img_count}张从监控摄像头中截取的帧, 按照{frame_interval}秒间隔截取了.："
+      last_happened_frames_prefix: "last_happened_frames - 上次满足条件时的图像序列如下, 一共有{vision_use_img_count}张从监控摄像头中截取的帧, 按照{frame_interval}毫秒间隔截取.："
       last_happened_time_prefix: "last_happened_time: {time}"
       condition_question_template: "condition_question: 图片是否满足以下条件：{condition}。/no_think"
     english:
-      current_frames_prefix: "current_frames - Now image sequence is as follows, a total of {vision_use_img_count} frames captured from the monitoring camera, with an interval of {frame_interval} seconds between frames.:"
+      current_frames_prefix: "current_frames - Now image sequence is as follows, a total of {vision_use_img_count} frames captured from the monitoring camera, with an interval of {frame_interval} milliseconds between frames.:"
       current_time_prefix: "current_time: {time}"
-      last_happened_frames_prefix: "last_happened_frames - Image sequence from last satisfied event, a total of {vision_use_img_count} frames captured from the monitoring camera, with an interval of {frame_interval} seconds between frames.:"
+      last_happened_frames_prefix: "last_happened_frames - Image sequence from last satisfied event, a total of {vision_use_img_count} frames captured from the monitoring camera, with an interval of {frame_interval} milliseconds between frames.:"
       last_happened_time_prefix: "last_happened_time: {time}"
       condition_question_template: "condition_question: Do the images meet the following condition: {condition}./no_think"
 

--- a/config/prompt_config.yaml
+++ b/config/prompt_config.yaml
@@ -105,9 +105,9 @@ prompts:
 
       ## 输入
       - condition_question：主人设定的检测规则
-      - current_frames：当前图像序列, 一共有6张从监控摄像头中截取的帧, 按照0.5秒间隔截取了三秒.
+      - current_frames：当前图像序列
       - current_time: 当前时间戳，格式为 "YYYY-MM-DD HH:MM:SS"
-      - last_happened_frames：上次is_happened为ture时的图像序列（可能为空）， 一共有6张从监控摄像头中截取的帧, 按照0.5秒间隔截取了三秒. 
+      - last_happened_frames：上次is_happened为ture时的图像序列（可能为空）
       - last_happened_time: 上次is_happened为ture时的时间戳，格式为 "YYYY-MM-DD HH:MM:SS"
 
       ## 任务
@@ -260,18 +260,18 @@ prompts:
       camera_prefix: "Camera: "
       channel_prefix: ", Channel: "
       sequence_prefix: ", Image sequence: "
-
+      
   trigger_rule_condition_prefixes:
     chinese:
-      current_frames_prefix: "current_frames - 当前图像序列如下："
+      current_frames_prefix: "current_frames - 当前图像序列如下, 一共有{{vision_use_img_count}}张从监控摄像头中截取的帧, 按照{{frame_interval}}秒间隔截取了.："
       current_time_prefix: "current_time: {time}"
-      last_happened_frames_prefix: "last_happened_frames - 上次满足条件时的图像序列如下："
+      last_happened_frames_prefix: "last_happened_frames - 上次满足条件时的图像序列如下, 一共有{{vision_use_img_count}}张从监控摄像头中截取的帧, 按照{{frame_interval}}秒间隔截取了.："
       last_happened_time_prefix: "last_happened_time: {time}"
       condition_question_template: "condition_question: 图片是否满足以下条件：{condition}。/no_think"
     english:
-      current_frames_prefix: "current_frames - Now image sequence is as follows:"
+      current_frames_prefix: "current_frames - Now image sequence is as follows, a total of {{vision_use_img_count}} frames captured from the monitoring camera, with an interval of {{frame_interval}} seconds between frames.:"
       current_time_prefix: "current_time: {time}"
-      last_happened_frames_prefix: "last_happened_frames - Image sequence from last satisfied event:"
+      last_happened_frames_prefix: "last_happened_frames - Image sequence from last satisfied event, a total of {{vision_use_img_count}} frames captured from the monitoring camera, with an interval of {{frame_interval}} seconds between frames.:"
       last_happened_time_prefix: "last_happened_time: {time}"
       condition_question_template: "condition_question: Do the images meet the following condition: {condition}./no_think"
 

--- a/config/prompt_config.yaml
+++ b/config/prompt_config.yaml
@@ -263,15 +263,15 @@ prompts:
       
   trigger_rule_condition_prefixes:
     chinese:
-      current_frames_prefix: "current_frames - 当前图像序列如下, 一共有{{vision_use_img_count}}张从监控摄像头中截取的帧, 按照{{frame_interval}}秒间隔截取了.："
+      current_frames_prefix: "current_frames - 当前图像序列如下, 一共有{vision_use_img_count}张从监控摄像头中截取的帧, 按照{frame_interval}秒间隔截取了.："
       current_time_prefix: "current_time: {time}"
-      last_happened_frames_prefix: "last_happened_frames - 上次满足条件时的图像序列如下, 一共有{{vision_use_img_count}}张从监控摄像头中截取的帧, 按照{{frame_interval}}秒间隔截取了.："
+      last_happened_frames_prefix: "last_happened_frames - 上次满足条件时的图像序列如下, 一共有{vision_use_img_count}张从监控摄像头中截取的帧, 按照{frame_interval}秒间隔截取了.："
       last_happened_time_prefix: "last_happened_time: {time}"
       condition_question_template: "condition_question: 图片是否满足以下条件：{condition}。/no_think"
     english:
-      current_frames_prefix: "current_frames - Now image sequence is as follows, a total of {{vision_use_img_count}} frames captured from the monitoring camera, with an interval of {{frame_interval}} seconds between frames.:"
+      current_frames_prefix: "current_frames - Now image sequence is as follows, a total of {vision_use_img_count} frames captured from the monitoring camera, with an interval of {frame_interval} seconds between frames.:"
       current_time_prefix: "current_time: {time}"
-      last_happened_frames_prefix: "last_happened_frames - Image sequence from last satisfied event, a total of {{vision_use_img_count}} frames captured from the monitoring camera, with an interval of {{frame_interval}} seconds between frames.:"
+      last_happened_frames_prefix: "last_happened_frames - Image sequence from last satisfied event, a total of {vision_use_img_count} frames captured from the monitoring camera, with an interval of {frame_interval} seconds between frames.:"
       last_happened_time_prefix: "last_happened_time: {time}"
       condition_question_template: "condition_question: Do the images meet the following condition: {condition}./no_think"
 

--- a/config/prompt_config.yaml
+++ b/config/prompt_config.yaml
@@ -263,13 +263,13 @@ prompts:
 
   trigger_rule_condition_prefixes:
     chinese:
-      current_frames_prefix: "current_frames - 图像序列如下："
+      current_frames_prefix: "current_frames - 当前图像序列如下："
       current_time_prefix: "current_time: {time}"
       last_happened_frames_prefix: "last_happened_frames - 上次满足条件时的图像序列如下："
       last_happened_time_prefix: "last_happened_time: {time}"
       condition_question_template: "condition_question: 图片是否满足以下条件：{condition}。/no_think"
     english:
-      current_frames_prefix: "current_frames - Image sequence is as follows:"
+      current_frames_prefix: "current_frames - Now image sequence is as follows:"
       current_time_prefix: "current_time: {time}"
       last_happened_frames_prefix: "last_happened_frames - Image sequence from last satisfied event:"
       last_happened_time_prefix: "last_happened_time: {time}"

--- a/config/prompt_config.yaml
+++ b/config/prompt_config.yaml
@@ -101,25 +101,129 @@ prompts:
 
   trigger_rule_condition:
     chinese: |
-      你是一个智能摄像头助手，专注于分析家庭环境下的视频内容。你可以识别人物、物体、动作变化以及事件发生顺序，并基于连续的图像序列判断所发生的事件。
-      请你基于我提供的画面内容，准确判断每个场景中发生了什么，并据此判断用户 query 中的条件或状态是否发生。你的回答应基于图像事实，避免臆测。
-      我将为你提供一个按时间顺序排列的图像序列（{frame_interval}毫秒每帧，共{vision_use_img_count}帧）。
-      回复的内容要求以json string格式返回，key值及对应内容如下：
-      1. result: 判断用户设置的条件是否发生，确保推理清晰、结论明确，只可以输出 "yes"、"no"； 
-      不要返回其他内容。
-      # 返回示例
-      {{"result": "yes"}}
-      {{"result": "no"}}
+      你是一个专业的家庭管家, 你的职责是查看监控摄像头提供的内容, 基于主人设定的检测规则, 输出主人要求的信息. 
+
+      ## 输入
+      - condition_question：主人设定的检测规则
+      - current_frames：当前图像序列, 一共有6张从监控摄像头中截取的帧, 按照0.5秒间隔截取了三秒.
+      - current_time: 当前时间戳，格式为 "YYYY-MM-DD HH:MM:SS"
+      - last_happened_frames：上次is_happened为ture时的图像序列（可能为空）， 一共有6张从监控摄像头中截取的帧, 按照0.5秒间隔截取了三秒. 
+      - last_happened_time: 上次is_happened为ture时的时间戳，格式为 "YYYY-MM-DD HH:MM:SS"
+
+      ## 任务
+      根据主人设定的规则和提供的图像序列，完成以下两个判断：
+
+      ### 1. is_happened（条件是否满足）
+      这一步, 你只需要查看，current_frames：当前的画面. 如果当前画面是否满足主人规则中描述的条件, 你就需要输出 is_happened = true, 否则输出 is_happened = false.
+      
+      *核心原则：只关注规则条件本身描述的事件，忽略其他无关行为**
+
+      #### 判断 is_happened 的流程：
+      1. **理解规则内容**：仔细阅读 user_rule_content, 明确规则的具体要求和条件。
+      2. **分析当前画面**：逐帧查看 current_frames，识别画面中的主体、动作和状态。
+      3. **匹配规则条件**：将 current_frames 中的内容与 user_rule_content 进行对比，判断是否满足规则的条件。
+      4. **输出结果**：根据判断结果，输出 is_happened 的值.
+
+
+      ### 2. is_same_action（是否与上次是同一件事）
+      这一步, 你需要对比current_frames当前正在发生的画面, 和 last_happened_frames 上一次触发的画面. 同时, current_time和last_happened_time也可以作为辅助参考.
+      你需要判断, 当前正在发生的画面, 和上一次的画面, 是否属于同一个主体做的同一个事件
+      比如, 上一次记录中的画面是事件刚开始发生, 而当前的画面是事件正在进行时, 那你应该给到 is_same_action = true
+      比如, 
+
+      **核心原则：只关注规则条件本身描述的事件，忽略其他无关行为**
+      
+      #### 判断 is_same_action 的流程：
+
+      1. **如果 is_happened 为 false, 你应该输出 is_same_action = false**
+        - 如果 is_happened = false, 该事件在目前场景中都没有出现, 因此不可能跟记录中属于同一个事件, 所以你需要输出is_same_action = false
+
+      2. **cached_frames 为空, 你应该输出 is_same_action = false** 
+        - 这说明这件事情之前就没发生过, 现在肯定是一个新事件, 所以你需要输出is_same_action = false
+      
+      3. **主体发生变化, 你应该输出 is_same_action = false**
+        - 你现在看到的画面和上一次触发的画面是不同的人, 动物或者物体 → 这说明他不可能是一件事情, 所以你就需要输出 is_same_action = false
+      
+      4. **比较当前画面与上一次画面的时间差, 如果超过基于事件一般持续的时间, 你应该输出 is_same_action = false **
+          - 时间差过长（超过事件一般持续的时间）→ 这说明当前事件和上一次触发的事件, 很可能是两个不同的事件, 你就需要输出 is_same_action = false
+            比如: 如果规则是“有人坐在椅子上”, 一般这个状态会持续较长时间, 如果时间差距在几分钟到几小时内, 他们应该是一个事件, 那么你就需要输出 is_same_action = true, 但是如果时间差距在半天以上, 那么他们很可能是两个不同的事件, 你就需要输出 is_same_action = false.
+                如果规则是“比耶”, 一般这个动作会持续较短时间, 如果时间差距在几秒到几十秒内, 他们应该是一个事件, 那么你就需要输出 is_same_action = true, 但是如果时间差距在几分钟以上, 那么他们很可能是两个不同的事件, 你就需要输出 is_same_action = false.
+      
+      5. **上一次画面包含事件的结束过程**
+          - 如果你看到上一次画面中, 事件已经进入了结束阶段（比如有人正在离开椅子, 或者做手势这类的短暂动作动作已经完成）, 这说明上一次的画面中的事件已经结束, 跟当前不是一个事件, 那么你应该输出 is_same_action = false
+    
+      6. **当前画面包含事件的开始过程**
+          - 如果你看到当前画面中, 事件已经进入了开始阶段（比如有人正在坐下椅子, 或者做手势这类的短暂动作动作刚刚开始）, 这说明当前的事件刚刚开始, 那肯定跟上一次的事件不是同一个事件, 那么你应该输出 is_same_action = false
+    
+      7. **其他你认为现在的画面和记录的画面, 不是同一次事件的情况**
+      
+
+      ## 输出（一个数字, 必须是下面情况中的任意一种, 不要有任何其他内容）
+      // 0: 代表"is_happened": false, "is_same_action": false
+      // 1: 代表"is_happened": true, "is_same_action": false
+      // 2: 代表"is_happened": true, "is_same_action": true
+      0
+
     english: |
-      You are an intelligent camera assistant specializing in analyzing video content in home environments. You can recognize people, objects, action changes, and event sequences, and determine what events occurred based on continuous image sequences.
-      Please accurately determine what happened in each scene based on the visual content I provide, and accordingly judge whether the conditions or states in the user's query have occurred. Your answers should be based on image facts, avoiding speculation.
-      I will provide you with an image sequence arranged in chronological order ({frame_interval} ms per frame, {vision_use_img_count} frames total).
-      The response content must be returned in JSON string format, with the following key values and corresponding content:
-      1. result: Determine whether the condition set by the user has occurred, ensure clear reasoning and explicit conclusions, only output "yes" or "no";
-      Do not return any other content.
-      # Response examples
-      {{"result": "yes"}}
-      {{"result": "no"}}
+      You are a professional household butler. Your duty is to review content provided by surveillance cameras and, based on the detection rules set by the master, output the information requested by the master.
+
+      ## Input
+      - condition_question: Detection rules set by the master
+      - current_frames: Current image sequence, consisting of 6 frames captured from the surveillance camera at 0.5-second intervals over three seconds
+      - current_time: Current timestamp, format "YYYY-MM-DD HH:MM:SS"
+      - last_happened_frames: Image sequence from when is_happened was last true (may be empty), consisting of 6 frames captured from the surveillance camera at 0.5-second intervals over three seconds
+      - last_happened_time: Timestamp from when is_happened was last true, format "YYYY-MM-DD HH:MM:SS"
+
+      ## Task
+      Based on the rules set by the master and the provided image sequences, complete the following two judgments:
+
+      ### 1. is_happened (whether the condition is satisfied)
+      In this step, you only need to review current_frames: the current scene. If the current scene satisfies the conditions described in the master's rule, you need to output is_happened = true, otherwise output is_happened = false.
+
+      **Core Principle: Focus only on the event described in the rule condition itself, ignore other irrelevant behaviors**
+
+      #### Process for determining is_happened:
+      1. **Understand the rule content**: Carefully read user_rule_content, clarify the specific requirements and conditions of the rule.
+      2. **Analyze the current scene**: Review current_frames frame by frame, identify the subjects, actions, and states in the scene.
+      3. **Match rule conditions**: Compare the content in current_frames with user_rule_content to determine whether the rule conditions are satisfied.
+      4. **Output result**: Based on the judgment result, output the value of is_happened.
+
+      ### 2. is_same_action (whether it is the same event as last time)
+      In this step, you need to compare current_frames (the scene currently happening) with last_happened_frames (the scene from the last trigger). Additionally, current_time and last_happened_time can also be used as auxiliary references.
+      You need to determine whether the currently occurring scene and the previous scene belong to the same event performed by the same subject.
+      For example, if the previous recorded scene shows the event just beginning, while the current scene shows the event in progress, you should output is_same_action = true.
+
+      **Core Principle: Focus only on the event described in the rule condition itself, ignore other irrelevant behaviors**
+
+      #### Process for determining is_same_action:
+
+      1. **If is_happened is false, you should output is_same_action = false**
+        - If is_happened = false, the event does not appear in the current scene at all, so it cannot belong to the same event as the recorded one, therefore you need to output is_same_action = false
+
+      2. **If cached_frames is empty, you should output is_same_action = false**
+        - This indicates the event has never occurred before, so it must be a new event, therefore you need to output is_same_action = false
+
+      3. **If the subject has changed, you should output is_same_action = false**
+        - The scene you're currently viewing and the last triggered scene involve different people, animals, or objects → This indicates they cannot be the same event, so you need to output is_same_action = false
+
+      4. **Compare the time difference between the current scene and the last scene; if it exceeds the typical duration of the event, you should output is_same_action = false**
+        - Time difference too long (exceeds the typical duration of the event) → This indicates the current event and the last triggered event are likely two different events, you need to output is_same_action = false
+          For example: If the rule is "someone sitting on a chair," this state typically persists for a long time. If the time difference is within a few minutes to a few hours, they should be the same event, so you need to output is_same_action = true. But if the time difference is more than half a day, they are likely two different events, you need to output is_same_action = false.
+          If the rule is "peace sign gesture," this action typically persists for a short time. If the time difference is within a few seconds to tens of seconds, they should be the same event, so you need to output is_same_action = true. But if the time difference is more than a few minutes, they are likely two different events, you need to output is_same_action = false.
+
+      5. **If the last scene contains the ending process of the event**
+        - If you see that in the last scene, the event has entered the ending phase (such as someone leaving the chair, or a brief action like a hand gesture has been completed), this indicates the event in the last scene has ended and is not the same event as the current one, so you should output is_same_action = false
+
+      6. **If the current scene contains the beginning process of the event**
+        - If you see that in the current scene, the event has entered the beginning phase (such as someone sitting down on a chair, or a brief action like a hand gesture just starting), this indicates the current event has just begun, so it definitely is not the same event as the last one, so you should output is_same_action = false
+
+      7. **Other situations where you believe the current scene and the recorded scene are not the same event**
+
+      ## Output (a single number, must be one of the following situations, no other content)
+      // 0: represents "is_happened": false, "is_same_action": false
+      // 1: represents "is_happened": true, "is_same_action": false
+      // 2: represents "is_happened": true, "is_same_action": true
+      0
 
   vision_understanding:
     chinese: |
@@ -159,11 +263,17 @@ prompts:
 
   trigger_rule_condition_prefixes:
     chinese:
-      image_sequence_prefix: "图像序列如下："
-      condition_question_template: "图片是否满足以下条件：{condition}。/no_think"
+      current_frames_prefix: "current_frames - 图像序列如下："
+      current_time_prefix: "current_time: {time}"
+      last_happened_frames_prefix: "last_happened_frames - 上次满足条件时的图像序列如下："
+      last_happened_time_prefix: "last_happened_time: {time}"
+      condition_question_template: "condition_question: 图片是否满足以下条件：{condition}。/no_think"
     english:
-      image_sequence_prefix: "Image sequence is as follows:"
-      condition_question_template: "Do the images meet the following condition: {condition}./no_think"
+      current_frames_prefix: "current_frames - Image sequence is as follows:"
+      current_time_prefix: "current_time: {time}"
+      last_happened_frames_prefix: "last_happened_frames - Image sequence from last satisfied event:"
+      last_happened_time_prefix: "last_happened_time: {time}"
+      condition_question_template: "condition_question: Do the images meet the following condition: {condition}./no_think"
 
   action_description_dynamic_execute:
     chinese: "请依次执行下述动作：{action_descriptions}"

--- a/config/server_config.yaml
+++ b/config/server_config.yaml
@@ -53,6 +53,7 @@ trigger_rule_runner:
   interval_seconds: 2
   vision_use_img_count: 3
   trigger_rule_log_ttl: 30 #days
+  timeout_seconds: 30
 
 # Camera configuration
 camera:

--- a/config/server_config.yaml
+++ b/config/server_config.yaml
@@ -20,7 +20,7 @@ database:
 server:
   host: "0.0.0.0"
   port: 8000
-  log_level: "error"
+  log_level: "info"
   enable_console_logging: true
   enable_file_logging: true
 

--- a/config/server_config.yaml
+++ b/config/server_config.yaml
@@ -20,7 +20,7 @@ database:
 server:
   host: "0.0.0.0"
   port: 8000
-  log_level: "warning"
+  log_level: "info"
   enable_console_logging: true
   enable_file_logging: true
 

--- a/config/server_config.yaml
+++ b/config/server_config.yaml
@@ -51,12 +51,12 @@ chat:
 # Trigger rule runner configuration
 trigger_rule_runner:
   interval_seconds: 2
-  vision_use_img_count: 6
+  vision_use_img_count: 3
   trigger_rule_log_ttl: 30 #days
 
 # Camera configuration
 camera:
-  frame_interval: 500 # Unit: Millisecond (ms)
+  frame_interval: 1000 # Unit: Millisecond (ms)
 
 
 # MIoT configuration, default to 'cn', use your MiHome cloud server

--- a/config/server_config.yaml
+++ b/config/server_config.yaml
@@ -20,7 +20,7 @@ database:
 server:
   host: "0.0.0.0"
   port: 8000
-  log_level: "info"
+  log_level: "warning"
   enable_console_logging: true
   enable_file_logging: true
 

--- a/config/server_config.yaml
+++ b/config/server_config.yaml
@@ -20,7 +20,7 @@ database:
 server:
   host: "0.0.0.0"
   port: 8000
-  log_level: "info"
+  log_level: "error"
   enable_console_logging: true
   enable_file_logging: true
 

--- a/config/server_config.yaml
+++ b/config/server_config.yaml
@@ -53,7 +53,9 @@ trigger_rule_runner:
   interval_seconds: 2
   vision_use_img_count: 3
   trigger_rule_log_ttl: 30 #days
-  timeout_seconds: 30
+  # Deside the model request timeout seconds in trigger rule decition making
+  # If it always ERROR as timeout, please change your model API provider to a faster one
+  request_timeout_seconds: 30 
 
 # Camera configuration
 camera:

--- a/miloco_server/config/normal_config.py
+++ b/miloco_server/config/normal_config.py
@@ -95,7 +95,7 @@ TRIGGER_RULE_RUNNER_CONFIG = {
     "interval_seconds": _config["trigger_rule_runner"]["interval_seconds"],
     "vision_use_img_count": _config["trigger_rule_runner"]["vision_use_img_count"],
     "trigger_rule_log_ttl": _config["trigger_rule_runner"]["trigger_rule_log_ttl"],
-    "timeout_seconds": _config["trigger_rule_runner"]["timeout_seconds"],
+    "request_timeout_seconds": _config["trigger_rule_runner"]["request_timeout_seconds"],
 }
 
 # Camera configuration

--- a/miloco_server/config/normal_config.py
+++ b/miloco_server/config/normal_config.py
@@ -95,6 +95,7 @@ TRIGGER_RULE_RUNNER_CONFIG = {
     "interval_seconds": _config["trigger_rule_runner"]["interval_seconds"],
     "vision_use_img_count": _config["trigger_rule_runner"]["vision_use_img_count"],
     "trigger_rule_log_ttl": _config["trigger_rule_runner"]["trigger_rule_log_ttl"],
+    "timeout_seconds": _config["trigger_rule_runner"]["timeout_seconds"],
 }
 
 # Camera configuration

--- a/miloco_server/schema/trigger_schema.py
+++ b/miloco_server/schema/trigger_schema.py
@@ -117,4 +117,7 @@ class TriggerRuleDetail(TriggerRule):
         return TriggerRule(
             **instance_data, cameras=camera_dids, execute_info=execute_info)
 
-
+class SendingState(BaseModel):
+    """Sending state data model"""
+    flag: bool = Field(False, description="Sending flag")
+    time: float = Field(0.0, description="Last sending flag time")

--- a/miloco_server/service/trigger_rule_runner.py
+++ b/miloco_server/service/trigger_rule_runner.py
@@ -154,13 +154,13 @@ class TriggerRuleRunner:
         start_time = int(time.time() * 1000)
         """Specific execution logic for scheduled tasks"""
         if self._sending_flag:
-            logger.warning("Previous trigger check still running, now: %s", start_time)
+            logger.info("Previous trigger check still running, now: %s", start_time)
             return
         self._sending_flag = True
         
         llm_proxy = self._get_vision_understaning_llm_proxy()
         if not llm_proxy:
-            logger.warning(
+            logger.info(
                 "Vision understaning LLM proxy not available, skipping rules trigger")
             self._sending_flag = False
             return
@@ -172,7 +172,7 @@ class TriggerRuleRunner:
                         if trigger_filter.pre_filter(rule)]
 
         if not enabled_rules:
-            logger.warning("No enabled trigger rules to check")
+            logger.info("No enabled trigger rules to check")
             self._sending_flag = False
             return
 
@@ -182,7 +182,7 @@ class TriggerRuleRunner:
                 timeout=TIMEOUT_SECONDS
             )
             if condition_results is None:
-                logger.warning("Check scheduled task failed, Jump to next scheduled task")
+                logger.info("Check scheduled task failed, Jump to next scheduled task")
                 return
         except asyncio.TimeoutError:
             logger.error("Check scheduled task timeout")
@@ -398,7 +398,7 @@ class TriggerRuleRunner:
 
             content = response["content"]
             
-            logger.error(
+            logger.info(
                 "Condition result, rule name: %s, rule condition: %s, camera_id: %s, channel: %s, content: %s",
                 rule.name, rule.condition, camera_id, channel, content
             )

--- a/miloco_server/service/trigger_rule_runner.py
+++ b/miloco_server/service/trigger_rule_runner.py
@@ -148,13 +148,14 @@ class TriggerRuleRunner:
             logger.info(
                 "Preparing to check trigger rule: %s %s", rule_id, rule.name)
             task = self._check_trigger_condition(rule, llm_proxy,
-                                                camera_motion_dict,
-                                                camera_info_dict)
+                                                 camera_motion_dict,
+                                                 camera_info_dict)
             tasks.append(task)
             rule_info_list.append((rule_id, rule))
 
         # Concurrently execute all trigger rule checks
-        condition_results = await asyncio.gather(*tasks, return_exceptions=True)
+        condition_results = await asyncio.gather(*tasks, 
+                                                 return_exceptions=True)
 
         return rule_info_list, condition_results, camera_motion_dict
 
@@ -179,14 +180,11 @@ class TriggerRuleRunner:
             return
 
         rule_info_list, condition_results, camera_motion_dict = await self._check_scheduled_task(llm_proxy, enabled_rules)
-        if condition_results is None:
-            logger.info("Check scheduled task empty, Jump to next scheduled task")
-            return
 
         # Process results
         for (rule_id,
-            rule), condition_result_list in zip(rule_info_list,
-                                                condition_results):
+             rule), condition_result_list in zip(rule_info_list,
+                                                 condition_results):
             # Check for exceptions
             if isinstance(condition_result_list, Exception):
                 logger.error(
@@ -218,13 +216,13 @@ class TriggerRuleRunner:
                 execute_result = await self._execute_trigger_action(
                     execute_id, rule, camera_motion_dict)
                 await self._log_rule_execution(execute_id, start_time, rule,
-                                                camera_motion_dict,
-                                                condition_result_list,
-                                                execute_result)
+                                               camera_motion_dict,
+                                               condition_result_list,
+                                               execute_result)
 
-                logger.info(
-                    "Scheduled task completed, checked %d trigger rules", len(enabled_rules)
-                )
+        logger.info(
+            "Scheduled task completed, checked %d trigger rules", len(enabled_rules)
+        )
 
     async def _log_rule_execution(
             self,
@@ -341,9 +339,9 @@ class TriggerRuleRunner:
 
         sending_state = self._sending_states.get(rule.id)
         if sending_state and sending_state.flag and start_time - sending_state.time < TRIGGER_RULE_RUNNER_CONFIG["timeout_seconds"]:
-            logger.warning("%s %s Rule %s is sending, skip", start_time, rule.name, rule.id)
+            logger.info("%s %s Rule %s is sending, skip", start_time, rule.name, rule.id)
             return []
-        logger.warning("%s %s Rule %s start check", start_time, rule.name, rule.id)
+        logger.info("%s %s Rule %s start check", start_time, rule.name, rule.id)
         self._sending_states[rule.id] = SendingState(flag=True, time=start_time)
 
 
@@ -374,7 +372,7 @@ class TriggerRuleRunner:
         for ((camera_id, channel),
              camera_img_seq), response in zip(cameras_video.items(),
                                               responses):
-            logger.warning("Rule %s %s Camera %s channel %s LLM response: %s", rule.id, rule.name, camera_id, channel, response)
+            logger.info("Rule %s %s Camera %s channel %s LLM response: %s", rule.id, rule.name, camera_id, channel, response)
 
             if isinstance(response, TimeoutError):
                 logger.error(

--- a/miloco_server/service/trigger_rule_runner.py
+++ b/miloco_server/service/trigger_rule_runner.py
@@ -177,10 +177,15 @@ class TriggerRuleRunner:
             return
 
         try:
+            logger.error("run async check scheduled task")
             rule_info_list, condition_results, camera_motion_dict = await asyncio.wait_for(
                 self._check_scheduled_task(llm_proxy, enabled_rules),
                 timeout=TIMEOUT_SECONDS
             )
+            if condition_results is None:
+                logger.error("Check scheduled task failed")
+                self._sending_flag = False
+                return
         except asyncio.TimeoutError:
             logger.error("Check scheduled task timeout")
             condition_results = None
@@ -192,6 +197,7 @@ class TriggerRuleRunner:
             self._sending_flag = False
             return
         finally:
+            logger.error("remove flag")
             self._sending_flag = False
 
         # Process results

--- a/miloco_server/service/trigger_rule_runner.py
+++ b/miloco_server/service/trigger_rule_runner.py
@@ -367,7 +367,7 @@ class TriggerRuleRunner:
                 continue
 
             content = response["content"]
-            logger.info("LLM Response: %s", content)
+            
             logger.info(
                 "Condition result, rule name: %s, rule condition: %s, camera_id: %s, channel: %s, content: %s",
                 rule.name, rule.condition, camera_id, channel, content

--- a/miloco_server/service/trigger_rule_runner.py
+++ b/miloco_server/service/trigger_rule_runner.py
@@ -204,7 +204,6 @@ class TriggerRuleRunner:
             execable = any([
                 trigger_filter.post_filter(
                     rule_id,
-                    f"{condition_result.camera_info.did},{condition_result.channel}",
                     condition_result.result)
                 for condition_result in condition_result_list
             ])
@@ -358,13 +357,7 @@ class TriggerRuleRunner:
                           camera_img_seq) in channel_motion_dict.items():
                 # check sending state flag:
                 if not if_motion or not camera_img_seq:
-                    condition_result_list.append(
-                        TriggerConditionResult(camera_info=camera_info,
-                                               channel=channel,
-                                               result=False,
-                                               images=None))
                     continue
-
                 cameras_video[camera_id, channel] = camera_img_seq
 
         # Concurrently execute LLM calls for all cameras  
@@ -430,10 +423,6 @@ class TriggerRuleRunner:
                 logger.info(
                     "Rule %s camera %s channel %s: no action detected (output 0)",
                     rule.name, camera_id, channel)
-                condition_result_list.append(TriggerConditionResult(camera_info=camera_info,
-                                               channel=channel,
-                                               result=False,
-                                               images=None))
                 continue
 
             # Output 1: action triggered, and is a new action(execution needed)
@@ -454,10 +443,6 @@ class TriggerRuleRunner:
                     "Rule %s camera %s channel %s: action triggered, but is not a new action (No execution needed) (output 2), only update cache",
                     rule.name, camera_id, channel)
                 self._last_happened_cache[(rule.id, camera_id, channel)] = camera_img_seq
-                condition_result_list.append(TriggerConditionResult(camera_info=camera_info,
-                                               channel=channel,
-                                               result=False,
-                                               images=None))
                 continue
         
         self._sending_states[rule.id] = SendingState(flag=False, time=start_time)

--- a/miloco_server/service/trigger_rule_runner.py
+++ b/miloco_server/service/trigger_rule_runner.py
@@ -164,7 +164,7 @@ class TriggerRuleRunner:
         
         llm_proxy = self._get_vision_understaning_llm_proxy()
         if not llm_proxy:
-            logger.info(
+            logger.warning(
                 "Vision understaning LLM proxy not available, skipping rules trigger")
             return
 
@@ -219,13 +219,13 @@ class TriggerRuleRunner:
                 execute_result = await self._execute_trigger_action(
                     execute_id, rule, camera_motion_dict)
                 await self._log_rule_execution(execute_id, start_time, rule,
-                                            camera_motion_dict,
-                                            condition_result_list,
-                                            execute_result)
+                                                camera_motion_dict,
+                                                condition_result_list,
+                                                execute_result)
 
-            logger.info(
-                "Scheduled task completed, checked %d trigger rules", len(enabled_rules)
-            )
+                logger.info(
+                    "Scheduled task completed, checked %d trigger rules", len(enabled_rules)
+                )
 
     async def _log_rule_execution(
             self,
@@ -376,6 +376,10 @@ class TriggerRuleRunner:
         # Concurrently execute all tasks
         responses = await asyncio.gather(*tasks, return_exceptions=True)
 
+        # if over timeout, return None
+        if time.time() - start_time > TRIGGER_RULE_RUNNER_CONFIG["timeout_seconds"]:
+            return []
+        
         # Process results
         for ((camera_id, channel),
              camera_img_seq), response in zip(cameras_video.items(),

--- a/miloco_server/service/trigger_rule_runner.py
+++ b/miloco_server/service/trigger_rule_runner.py
@@ -64,7 +64,7 @@ class TriggerRuleRunner:
         self._vision_use_img_count = TRIGGER_RULE_RUNNER_CONFIG["vision_use_img_count"]
         # Per-camera last happened cache: key=(rule_id, camera_did, channel), value=CameraImgSeq
         self._last_happened_cache: Dict[tuple, CameraImgSeq] = {}
-        self._sending_states: Dict[tuple, SendingState] = {}
+        self._sending_states: Dict[str, SendingState] = {}
         logger.info(
             "TriggerRuleRunner init success, trigger_rules: %s", self.trigger_rules
         )
@@ -81,13 +81,11 @@ class TriggerRuleRunner:
         """Remove trigger rule"""
         if rule_id in self.trigger_rules:
             del self.trigger_rules[rule_id]
+            del self._sending_states[key]
         # Clean up cache entries for this rule
         keys_to_remove = [k for k in self._last_happened_cache if k[0] == rule_id]
         for key in keys_to_remove:
             del self._last_happened_cache[key]
-        keys_to_remove = [k for k in self._sending_states if k[0] == rule_id]
-        for key in keys_to_remove:
-            del self._sending_states[key]
 
     async def _periodic_task(self):
         """Scheduled task execution method, runs at configured interval"""

--- a/miloco_server/service/trigger_rule_runner.py
+++ b/miloco_server/service/trigger_rule_runner.py
@@ -341,9 +341,9 @@ class TriggerRuleRunner:
 
         sending_state = self._sending_states.get(rule.id)
         if sending_state and sending_state.flag and start_time - sending_state.time < TRIGGER_RULE_RUNNER_CONFIG["timeout_seconds"]:
-            logger.warning("%s Rule %s is sending, skip", start_time, rule.id)
+            logger.warning("%s %s Rule %s is sending, skip", start_time, rule.name, rule.id)
             return []
-        logger.warning("%s Rule %s start check", start_time, rule.id)
+        logger.warning("%s %s Rule %s start check", start_time, rule.name, rule.id)
         self._sending_states[rule.id] = SendingState(flag=True, time=start_time)
 
 
@@ -374,7 +374,7 @@ class TriggerRuleRunner:
         for ((camera_id, channel),
              camera_img_seq), response in zip(cameras_video.items(),
                                               responses):
-            logger.warning("Camera %s channel %s LLM response: %s", camera_id, channel, response)
+            logger.warning("Rule %s %s Camera %s channel %s LLM response: %s", rule.id, rule.name, camera_id, channel, response)
 
             if isinstance(response, TimeoutError):
                 logger.error(

--- a/miloco_server/utils/prompt_helper.py
+++ b/miloco_server/utils/prompt_helper.py
@@ -95,8 +95,6 @@ class TriggerRuleConditionPromptBuilder:
             "text": prefixes["condition_question_template"].format(condition=condition)
         })
 
-        logger.debug("User Content: %s", user_content)
-
         chat_history_messages.add_content("user", user_content)
 
         return chat_history_messages

--- a/miloco_server/utils/prompt_helper.py
+++ b/miloco_server/utils/prompt_helper.py
@@ -89,12 +89,13 @@ class TriggerRuleConditionPromptBuilder:
             logger.info("Current Time: %s", current_time_str)
             logger.info("Last Trigger Time: %s", last_time_str)
 
-
         # user_rule_content
         user_content.append({
             "type": "text",
             "text": prefixes["condition_question_template"].format(condition=condition)
         })
+
+        logger.debug("User Content: %s", user_content)
 
         chat_history_messages.add_content("user", user_content)
 

--- a/miloco_server/utils/prompt_helper.py
+++ b/miloco_server/utils/prompt_helper.py
@@ -6,19 +6,29 @@ Prompt helper utilities for building chat messages and prompts.
 Provides builders for trigger rule conditions and vision understanding prompts.
 """
 
+from datetime import datetime
+from typing import Optional
+import logging
 from miloco_server.config.prompt_config import PromptConfig, PromptType, UserLanguage
 from miloco_server.schema.chat_history_schema import ChatHistoryMessages
 from miloco_server.schema.miot_schema import CameraImgSeq
 
+logger = logging.getLogger(name=__name__)
 
 class TriggerRuleConditionPromptBuilder:
     """Trigger rule prompt builder"""
 
     @staticmethod
+    def _s_to_time_str(timestamp: int) -> str:
+        """Convert millisecond timestamp to YYYY-MM-DD HH:MM:SS format"""
+        return datetime.fromtimestamp(timestamp).strftime("%Y-%m-%d %H:%M:%S")
+
+    @staticmethod
     def build_trigger_rule_prompt(
         img_seq: CameraImgSeq,
         condition: str,
-        language: UserLanguage = UserLanguage.CHINESE
+        language: UserLanguage = UserLanguage.CHINESE,
+        last_happened_img_seq: Optional[CameraImgSeq] = None,
     ) -> ChatHistoryMessages:
         chat_history_messages = ChatHistoryMessages()
 
@@ -33,11 +43,19 @@ class TriggerRuleConditionPromptBuilder:
 
         user_content = []
 
+        # current_time
+        current_time_str = TriggerRuleConditionPromptBuilder._s_to_time_str(
+            img_seq.img_list[0].timestamp)
         user_content.append({
             "type": "text",
-            "text": prefixes["image_sequence_prefix"]
+            "text": prefixes["current_time_prefix"].format(time=current_time_str)
         })
 
+        # current_frames
+        user_content.append({
+            "type": "text",
+            "text": prefixes["current_frames_prefix"]
+        })
         for image_data in img_seq_base64.img_list:
             user_content.append({
                 "type": "image_url",
@@ -45,6 +63,34 @@ class TriggerRuleConditionPromptBuilder:
                     "url": image_data.data
                 }
             })
+
+        # last_happened_frames and last_happened_time
+        if last_happened_img_seq is not None and last_happened_img_seq.img_list:
+            logger.info("Last Image Detected")
+            last_happened_base64 = last_happened_img_seq.to_base64()
+            last_time_str = TriggerRuleConditionPromptBuilder._s_to_time_str(
+                last_happened_img_seq.img_list[0].timestamp)
+            user_content.append({
+                "type": "text",
+                "text": prefixes["last_happened_time_prefix"].format(time=last_time_str)
+            })
+            user_content.append({
+                "type": "text",
+                "text": prefixes["last_happened_frames_prefix"]
+            })
+            for image_data in last_happened_base64.img_list:
+                user_content.append({
+                    "type": "image_url",
+                    "image_url": {
+                        "url": image_data.data
+                    }
+                })
+            
+            logger.info("Current Time: %s", current_time_str)
+            logger.info("Last Trigger Time: %s", last_time_str)
+
+
+        # user_rule_content
         user_content.append({
             "type": "text",
             "text": prefixes["condition_question_template"].format(condition=condition)

--- a/miloco_server/utils/prompt_helper.py
+++ b/miloco_server/utils/prompt_helper.py
@@ -9,7 +9,7 @@ Provides builders for trigger rule conditions and vision understanding prompts.
 from datetime import datetime
 from typing import Optional
 import logging
-from miloco_server.config.prompt_config import PromptConfig, PromptType, UserLanguage
+from miloco_server.config.prompt_config import PromptConfig, PromptType, UserLanguage, CAMERA_IMG_FRAME_INTERVAL
 from miloco_server.config.normal_config import TRIGGER_RULE_RUNNER_CONFIG
 from miloco_server.schema.chat_history_schema import ChatHistoryMessages
 from miloco_server.schema.miot_schema import CameraImgSeq
@@ -57,7 +57,7 @@ class TriggerRuleConditionPromptBuilder:
             "type": "text",
             "text": prefixes["current_frames_prefix"].format(
                 vision_use_img_count=TRIGGER_RULE_RUNNER_CONFIG["vision_use_img_count"],
-                frame_interval=TRIGGER_RULE_RUNNER_CONFIG["frame_interval"]
+                frame_interval=CAMERA_IMG_FRAME_INTERVAL
             )
         })
         for image_data in img_seq_base64.img_list:
@@ -82,7 +82,7 @@ class TriggerRuleConditionPromptBuilder:
                 "type": "text",
                 "text": prefixes["last_happened_frames_prefix"].format(
                     vision_use_img_count=TRIGGER_RULE_RUNNER_CONFIG["vision_use_img_count"],
-                    frame_interval=TRIGGER_RULE_RUNNER_CONFIG["frame_interval"]
+                    frame_interval=CAMERA_IMG_FRAME_INTERVAL
                 )
             })
             for image_data in last_happened_base64.img_list:
@@ -105,7 +105,7 @@ class TriggerRuleConditionPromptBuilder:
         for item in user_content:
             if item["type"] == "text":
                 temp_log_output.append(item["text"])
-        logger.info(f"TriggerRuleConditionPromptBuilder: {temp_log_output}")
+        logger.error(f"TriggerRuleConditionPromptBuilder: {temp_log_output}")
 
         return chat_history_messages
 

--- a/miloco_server/utils/prompt_helper.py
+++ b/miloco_server/utils/prompt_helper.py
@@ -105,7 +105,7 @@ class TriggerRuleConditionPromptBuilder:
         for item in user_content:
             if item["type"] == "text":
                 temp_log_output.append(item["text"])
-        logger.error(f"TriggerRuleConditionPromptBuilder: {temp_log_output}")
+        logger.warning(f"TriggerRuleConditionPromptBuilder: {temp_log_output}")
 
         return chat_history_messages
 

--- a/miloco_server/utils/prompt_helper.py
+++ b/miloco_server/utils/prompt_helper.py
@@ -85,9 +85,6 @@ class TriggerRuleConditionPromptBuilder:
                         "url": image_data.data
                     }
                 })
-            
-            logger.info("Current Time: %s", current_time_str)
-            logger.info("Last Trigger Time: %s", last_time_str)
 
         # user_rule_content
         user_content.append({

--- a/miloco_server/utils/prompt_helper.py
+++ b/miloco_server/utils/prompt_helper.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from typing import Optional
 import logging
 from miloco_server.config.prompt_config import PromptConfig, PromptType, UserLanguage
+from miloco_server.config.normal_config import TRIGGER_RULE_RUNNER_CONFIG
 from miloco_server.schema.chat_history_schema import ChatHistoryMessages
 from miloco_server.schema.miot_schema import CameraImgSeq
 
@@ -54,7 +55,10 @@ class TriggerRuleConditionPromptBuilder:
         # current_frames
         user_content.append({
             "type": "text",
-            "text": prefixes["current_frames_prefix"]
+            "text": prefixes["current_frames_prefix"].format(
+                vision_use_img_count=TRIGGER_RULE_RUNNER_CONFIG["vision_use_img_count"],
+                frame_interval=TRIGGER_RULE_RUNNER_CONFIG["frame_interval"]
+            )
         })
         for image_data in img_seq_base64.img_list:
             user_content.append({
@@ -76,7 +80,10 @@ class TriggerRuleConditionPromptBuilder:
             })
             user_content.append({
                 "type": "text",
-                "text": prefixes["last_happened_frames_prefix"]
+                "text": prefixes["last_happened_frames_prefix"].format(
+                    vision_use_img_count=TRIGGER_RULE_RUNNER_CONFIG["vision_use_img_count"],
+                    frame_interval=TRIGGER_RULE_RUNNER_CONFIG["frame_interval"]
+                )
             })
             for image_data in last_happened_base64.img_list:
                 user_content.append({
@@ -93,6 +100,12 @@ class TriggerRuleConditionPromptBuilder:
         })
 
         chat_history_messages.add_content("user", user_content)
+
+        temp_log_output = []
+        for item in user_content:
+            if item["type"] == "text":
+                temp_log_output.append(item["text"])
+        logger.info(f"TriggerRuleConditionPromptBuilder: {temp_log_output}")
 
         return chat_history_messages
 

--- a/miloco_server/utils/prompt_helper.py
+++ b/miloco_server/utils/prompt_helper.py
@@ -105,7 +105,7 @@ class TriggerRuleConditionPromptBuilder:
         for item in user_content:
             if item["type"] == "text":
                 temp_log_output.append(item["text"])
-        logger.warning(f"TriggerRuleConditionPromptBuilder: {temp_log_output}")
+        logger.debug(f"TriggerRuleConditionPromptBuilder: {temp_log_output}")
 
         return chat_history_messages
 


### PR DESCRIPTION
问题

状态判断僵化：用户反馈：例如"如果我坐着/如果我睡醒了，就...”出现重复触发

目标

能够区别状态和动作持续状态中只触发一次。
”小孩在读书的时候，给我发通知-->在看书的期间只发一次通知”每动作一次就触发一次。
“我比个耶就给我发送一次通知-->每比一次耶就发送一次通知”

解决方法

  - 重构触发规则条件判断逻辑，新增 is_same_action 判断，解决同一事件被重复触发的问题
  - 引入 _last_happened_cache 内存缓存，保存每个摄像头/通道上次触发时的图像序列，用于与当前画面对比
  - 重写 LLM prompt，从简单的 yes/no JSON 输出改为数字编码（0/1/2），分别表示：未发生、新事件、同一事件
  - 更新 prompt_helper.py，构建 prompt 时附带上次触发的图像帧和时间戳，供 LLM 进行对比判断

修改内容

  - config/prompt_config.yaml: 重写 trigger_rule_condition prompt（中英文），增加 is_same_action 判断流程和输出格式；新增
  current_time_prefix、last_happened_frames_prefix、last_happened_time_prefix 等前缀配置
  - miloco_server/service/trigger_rule_runner.py:
    - 新增 _last_happened_cache 字典缓存上次触发的图像序列
    - 新增 _load_last_happened_img_seq() 和 _parse_llm_output() 方法
    - 重构 _check_trigger_condition() 中的 LLM 响应解析逻辑，从 JSON 解析改为数字解析（0/1/2）
    - 删除规则时自动清理对应缓存
  - miloco_server/utils/prompt_helper.py: build_trigger_rule_prompt() 新增 last_happened_img_seq 参数，构建包含历史帧和时间戳的完整 prompt
  
 

    The trigger rule system monitors camera feeds and executes actions when conditions are met. The current implementation has a deduplication issue: rules fire repeatedly while conditions remain satisfied, causing the same action to execute multiple times for a single continuous event.
  
  Summary                                                                                                                                        
                                                                                                                                                 
  - Add is_same_action detection to prevent the same ongoing event from repeatedly triggering rule execution
  - Introduce _last_happened_cache to store the last triggered image sequence per camera/channel for comparison with current frames
  - Rewrite LLM prompt from simple yes/no JSON output to numeric encoding (0/1/2): not happened, new event, same event
  - Update prompt builder to include last triggered frames and timestamps for LLM comparison

  Changes

  - config/prompt_config.yaml: Rewrite trigger_rule_condition prompt (Chinese & English) with is_same_action judgment flow and numeric output
  format; add current_time_prefix, last_happened_frames_prefix, last_happened_time_prefix prefix configs
  - miloco_server/service/trigger_rule_runner.py:
    - Add _last_happened_cache dict to cache last triggered image sequences
    - Add _load_last_happened_img_seq() and _parse_llm_output() methods
    - Refactor LLM response parsing in _check_trigger_condition() from JSON to numeric (0/1/2)
    - Auto-clean cache entries when a rule is removed
  - miloco_server/utils/prompt_helper.py: Add last_happened_img_seq parameter to build_trigger_rule_prompt(), building complete prompts with
  historical frames and timestamps
  
