### PR TITLE
修复fastmcp初始化失败问题

### DIFF
--- a/miloco_server/mcp/local_mcp_servers.py
+++ b/miloco_server/mcp/local_mcp_servers.py
@@ -40,9 +40,7 @@ class LocalMCPBase:
         self.mcp = FastMCP(
             name=self.name,
             instructions=self.instructions,
-            on_duplicate_tools="error",
-            on_duplicate_prompts="error",
-            on_duplicate_resources="error",
+            on_duplicate="error",
             mask_error_details=True,
         )
 


### PR DESCRIPTION
新版本fastmcp不再使用on_duplicate_tools、on_duplicate_resources 和 on_duplicate_prompts 三个独立的参数，被统一为一个 on_duplicate 参数