### PR TITLE
修复加载预制MCP失败问题

### DIFF
--- a/miot_kit/miot/mcp.py
+++ b/miot_kit/miot/mcp.py
@@ -73,9 +73,7 @@ class _BaseMcp(Generic[T]):
         self._mcp = FastMCP(
             name=self.translate(key="name", default=self._name_default),
             instructions=self.translate(key="instructions", default=self._instructions_default),
-            on_duplicate_tools="replace",     # Configure behavior for duplicate tool names
-            on_duplicate_prompts="replace",
-            on_duplicate_resources="replace",
+            on_duplicate="replace",     # Configure behavior for duplicate tool names
             mask_error_details=True,          # only error messages from ToolError will include details
         )
 


### PR DESCRIPTION
新版本fastmcp不再使用on_duplicate_tools、on_duplicate_resources 和 on_duplicate_prompts 三个独立的参数，被统一为一个 on_duplicate 参数