### PR TITLE
fix: update FastMCP constructor to use unified `on_duplicate` parameter

### DIFF
--- a/miloco_server/mcp/local_mcp_servers.py
+++ b/miloco_server/mcp/local_mcp_servers.py
@@ -40,9 +40,7 @@ class LocalMCPBase:
         self.mcp = FastMCP(
             name=self.name,
             instructions=self.instructions,
-            on_duplicate_tools="error",
-            on_duplicate_prompts="error",
-            on_duplicate_resources="error",
+            on_duplicate="error",
             mask_error_details=True,
         )
 

--- a/miot_kit/miot/mcp.py
+++ b/miot_kit/miot/mcp.py
@@ -73,9 +73,7 @@ class _BaseMcp(Generic[T]):
         self._mcp = FastMCP(
             name=self.translate(key="name", default=self._name_default),
             instructions=self.translate(key="instructions", default=self._instructions_default),
-            on_duplicate_tools="replace",     # Configure behavior for duplicate tool names
-            on_duplicate_prompts="replace",
-            on_duplicate_resources="replace",
+            on_duplicate="replace",           # Configure behavior for duplicate tool/resource/prompt names
             mask_error_details=True,          # only error messages from ToolError will include details
         )
 


### PR DESCRIPTION
## 问题

FastMCP 库更新后，移除了独立的 `on_duplicate_tools` / `on_duplicate_prompts` / `on_duplicate_resources` 参数，统一为 `on_duplicate` 参数。

当前代码仍使用旧参数，导致所有 MCP server/client 初始化直接报错：

```
TypeError: FastMCP() no longer accepts `on_duplicate_tools`. Use `on_duplicate=` instead.
```

结果：米家/HA 授权完成后，MCP 服务列表为空。

Fixes #260

## 修改内容

- `miloco_server/mcp/local_mcp_servers.py`: `on_duplicate="error"`
- `miot_kit/miot/mcp.py`: `on_duplicate="replace"`

## 验证

修改后重新构建 Docker 镜像，MCP 服务应能正常初始化。