### PR TITLE
fix: avoid RuntimeError when iterating and modifying device_buffer

### DIFF
--- a/miot_kit/miot/client.py
+++ b/miot_kit/miot/client.py
@@ -321,7 +321,7 @@ class MIoTClient:
 
         # Update lan information.
         lan_devices = await self._lan_client.get_devices_async()
-        for did in self._device_buffer.keys():
+        for did in list(self._device_buffer.keys()):
             if did not in devices:
                 self._device_buffer.pop(did, None)
                 continue


### PR DESCRIPTION
## Problem

When devices are removed from the cloud list, `get_devices_async()` in `client.py` throws:

```
RuntimeError: dictionary changed size during iteration
```

## Root Cause

At line 324, iterating over `self._device_buffer.keys()` returns a live view. Inside the loop, `.pop()` removes stale entries from the same dictionary.

## Fix

One-line change: `list(self._device_buffer.keys())` creates a static copy before iterating.

## Reproduce

Call `list_devices(refresh=true)` after removing a device from Mi Home app.