### PR TITLE
fix(release): 给 github-release job 的 gh 命令加 --repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,10 +146,10 @@ jobs:
           else
             rel_flag="--latest"
           fi
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            gh release upload "$TAG" assets/* --clobber
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release upload "$TAG" assets/* --clobber --repo "$GITHUB_REPOSITORY"
           else
-            gh release create "$TAG" $rel_flag --title "$TAG" --generate-notes assets/*
+            gh release create "$TAG" $rel_flag --title "$TAG" --generate-notes --repo "$GITHUB_REPOSITORY" assets/*
           fi
 
   # ── dry-run 专用：组装资产预览 + 汇总将发布什么（不碰 release）─────────────────


### PR DESCRIPTION
github-release job 只 download-artifact 不 checkout，gh CLI 无法 从 git remote 推断仓库导致 release 失败。与 preflight job 写法对齐， 统一传 --repo "$GITHUB_REPOSITORY"。