### PR TITLE
fix(openclaw): 恢复 register 中 loadSharedConfig 调用

### DIFF
--- a/plugins/openclaw/src/index.ts
+++ b/plugins/openclaw/src/index.ts
@@ -7,6 +7,7 @@ import {
 } from "./config.js";
 import { registerHomeProfile } from "./home-profile/index.js";
 import { registerHooks } from "./hooks/index.js";
+import { loadSharedConfig } from "./miloco/config.js";
 import { registerServices } from "./services/index.js";
 import { registerNotifyTool } from "./tools/notify.js";
 import { logger } from "./utils/logger.js";
@@ -19,6 +20,12 @@ export default {
   configSchema: MilocoPluginConfigSchema,
   register(api: OpenClawPluginApi) {
     logger.init(api);
+
+    // 必须在 registerServices 之前：loadSharedConfig 的副作用是把 gateway 当前
+    // token 解析并写入 ~/.openclaw/miloco/config.json::agent.auth_bearer。否则
+    // 紧随其后的 backend 拉起读到空 bearer，调回 /miloco/webhook 会 401。
+    // 看似不用返回值，实际依赖这个写盘副作用——别再删了。
+    loadSharedConfig(api);
 
     // 注册相关服务和扩展
     registerServices(api);


### PR DESCRIPTION
loadSharedConfig 的副作用是把 gateway 当前 token 解析并写入
~/.openclaw/miloco/config.json::agent.auth_bearer。之前误判为无用调用 被删除后，backend 启动读到空 bearer，回调 /miloco/webhook 401，
dispatcher 三次重试后 skip batch。

恢复调用并加注释钉死其真正职责，避免再被误删。