### PR TITLE
fix(cli): 客户端连接时将 0.0.0.0 归一化为 127.0.0.1

### DIFF
--- a/cli/src/miloco_cli/client.py
+++ b/cli/src/miloco_cli/client.py
@@ -8,10 +8,22 @@
 import json
 import sys
 from typing import NoReturn
+from urllib.parse import urlparse, urlunparse
 
 import httpx
 
 from miloco_cli.config import load_config
+
+
+def _normalize_server_url(url: str) -> str:        
+    """0.0.0.0 是服务端 bind 地址，客户端连接时应替换为 127.0.0.1。"""
+    parsed = urlparse(url)
+    if parsed.hostname == "0.0.0.0":
+        replaced = parsed._replace(
+            netloc=parsed.netloc.replace("0.0.0.0", "127.0.0.1", 1)
+        )
+        return urlunparse(replaced)
+    return url
 
 
 def _get_client(cfg: dict) -> httpx.Client:
@@ -22,7 +34,7 @@ def _get_client(cfg: dict) -> httpx.Client:
     tls = server.get("tls_verify", False)
     verify = tls if isinstance(tls, bool) else str(tls).lower() == "true"
     return httpx.Client(
-        base_url=server["url"],
+        base_url=_normalize_server_url(server["url"]),
         headers=headers,
         verify=verify,
         timeout=30,

--- a/cli/src/miloco_cli/commands/service.py
+++ b/cli/src/miloco_cli/commands/service.py
@@ -57,6 +57,8 @@ def _is_running(pid: int) -> bool:
 def _is_port_in_use(base_url: str) -> bool:
     parsed = urlparse(base_url)
     host = parsed.hostname or "localhost"
+    if host == "0.0.0.0":
+        host = "127.0.0.1"
     port = parsed.port
     if port is None:
         return False
@@ -322,9 +324,10 @@ def _resolve_backend_pid(cfg: dict, timeout: float = 8.0) -> int | None:
 
 def _wait_for_health(cfg: dict, pretty: bool) -> None:
     """轮询 /health，超时 30 秒。检测 FATAL 状态提前退出。"""
+    from miloco_cli.client import _normalize_server_url
     import httpx
 
-    health_url = cfg["server"]["url"].rstrip("/") + "/health"
+    health_url = _normalize_server_url(cfg["server"]["url"]).rstrip("/") + "/health"
     deadline = time.time() + 30
     while time.time() < deadline:
         status = _supervisorctl("status", _PROGRAM_NAME).stdout


### PR DESCRIPTION
## 问题

`config.json` 的 `server.url` 允许被设为 `http://0.0.0.0:1810`，同时CLI 直接拿这个 URL 做 HTTP 连接，但 `0.0.0.0` 是**服务端 bind 地址**（"监听所有网卡"），不是合法的客户端连接目标。

实际表现在不同OS下会有差异：
- 在`linux`下，请求会自动路由到`127.0.0.1`，可正常访问
- 在`macos`和`windows` 下，请求会失败。

## 修复

在 `client.py` 新增 `_normalize_server_url()`，将 URL 中的 `0.0.0.0` 替换为 `127.0.0.1`。覆盖所有客户端 HTTP 连接点：

| 文件 | 函数 | 影响范围 |
|------|------|----------|
| `client.py` | `_get_client()` | 所有 CLI API 调用（base_url） |
| `service.py` | `_wait_for_health()` | service restart 健康检查轮询 |
| `service.py` | `_is_port_in_use()` | 端口占用检测的 socket connect |

配置文件本身不修改——`0.0.0.0` 作为服务端 bind 地址仍然有效，仅修正客户端连接行为。