### PR TITLE
fix: show 'Standby' instead of 'Watching' when home has no cameras

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -412,10 +412,11 @@ function MainApp() {
             status={status.data}
             allCamerasOff={
               // 未就绪时兜底 false（宁可短暂显"在看家"，不误报"待机中"）
+              // 注意：不要加 data.length > 0 守卫——[].every() 本就返回 true（空集全称量化），
+              // 无摄像头家庭（scopeCameras.data === []）应正确显示"待机中"而非"在看家"。
               !scopeCameras.loading &&
               !scopeCameras.error &&
               !!scopeCameras.data &&
-              scopeCameras.data.length > 0 &&
               scopeCameras.data.every((c) => !c.inUse)
             }
             onConnectMiot={() => setMiotBindOpen(true)}


### PR DESCRIPTION
## Bug

Homes without any cameras incorrectly show **"在看家" (Watching)** on the dashboard instead of **"待机中" (Standby)**.

## Root Cause

In `web/src/App.tsx`, the `allCamerasOff` prop is computed as:

```tsx
allCamerasOff={
  !scopeCameras.loading &&
  !scopeCameras.error &&
  !!scopeCameras.data &&
  scopeCameras.data.length > 0 &&   // ← this guard
  scopeCameras.data.every((c) => !c.inUse)
}
```

When a home has no cameras, `scopeCameras.data` is `[]` (empty array). The `length > 0` check short-circuits to `false`, so `allCamerasOff` becomes `false`, and the UI shows "Watching" — even though there are no cameras to watch with.

## Fix

Remove the redundant `length > 0` guard. `[].every(predicate)` returns `true` by definition (vacuous truth), which correctly evaluates `allCamerasOff` to `true` for camera-less homes.

```diff
- scopeCameras.data.length > 0 &&
  scopeCameras.data.every((c) => !c.inUse)
```

The `!scopeCameras.loading` check already prevents false positives during the loading state, so the `length > 0` guard was unnecessary.

## Behavior Matrix

| Scenario | Before | After |
|---|---|---|
| Loading | Watching (correct) | Watching (correct) |
| Cameras exist, all off | Standby (correct) | Standby (correct) |
| Cameras exist, some on | Watching (correct) | Watching (correct) |
| **No cameras at all** | **Watching (bug)** | **Standby (fixed)** |
