### PR TITLE
新增 Hermes Agent 兼容层，建立 plugins/<runtime>/ 规范

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ target
 
 # Build-time generated skills copy
 plugins/openclaw/skills/
+plugins/hermes/skills/
 
 
 # Debug

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align="center">English | <a href="README.zh.md">简体中文</a></p>
 
-Xiaomi's open-source AI solution for the future of whole-home intelligence. It uses the video and audio from Mi Home cameras as a full-modal perception gateway, the in-house MiMo large model as its intelligent brain, and runs as an Agent plugin on top of [OpenClaw](https://openclaw.ai) to orchestrate whole-home devices for a proactive, intelligent experience.
+Xiaomi's open-source AI solution for the future of whole-home intelligence. It uses the video and audio from Mi Home cameras as a full-modal perception gateway, the in-house MiMo large model as its intelligent brain, and runs as an Agent plugin on top of [OpenClaw](https://openclaw.ai) (or the open-source [Hermes Agent](https://github.com/NousResearch/hermes-agent) — see [Install](#install) below) to orchestrate whole-home devices for a proactive, intelligent experience.
 
 Miloco 2.0 perceives what happens at home, makes proactive decisions and controls devices based on common sense, breaks down "vague and long-term" goals into trackable household tasks, recognizes family members, and—drawing on home memory—delivers personalized service to each member: querying and controlling devices, tuning the home to each member's comfort, or offering useful reminders at the right moment.
 
@@ -11,6 +11,7 @@ Miloco 2.0 perceives what happens at home, makes proactive decisions and control
 ## What's New
 
 - **2026-06-18** — Miloco 2.0 officially released: re-architected as an OpenClaw plugin, adding general common sense, identity recognition, home memory, household tasks, proactive intelligence, and a home dashboard. See [Core Features](#core-features) below.
+- **2026-06-19** — Hermes Agent compatibility: same 16 skills, same inbound webhook contract, now also runnable on the open-source [Hermes Agent](https://github.com/NousResearch/hermes-agent) runtime via `plugins/hermes/`. See [Install](#install) below.
 
 ## Core Features
 
@@ -22,14 +23,14 @@ Miloco 2.0 perceives what happens at home, makes proactive decisions and control
 - **Home Dashboard** — A user-facing web dashboard for viewing a real-time overview of the home, Mi Home devices, family members and profiles, and the history of past events.
 
 > [!TIP]
-> **Raise your own Miloco.** Its out-of-the-box behavior won't always match your taste—just tell Miloco through OpenClaw (e.g. "don't remind me when the place is messy"), and it remembers your preference and adjusts what it does proactively. Every remark "raises" a Miloco that's tuned to your home, and it knows you better the longer you live with it.
+> **Raise your own Miloco.** Its out-of-the-box behavior won't always match your taste—just tell Miloco through your agent (OpenClaw or Hermes, e.g. "don't remind me when the place is messy"), and it remembers your preference and adjusts what it does proactively. Every remark "raises" a Miloco that's tuned to your home, and it knows you better the longer you live with it.
 
 ## Prerequisites
 
 - **Hardware**: ≥ 4GB RAM and ≥ 256GB storage recommended, running 24/7. A Mac mini is recommended.
 - **Operating System**: macOS / Linux (run under WSL on Windows).
 - **Xiaomi account** + devices already added to Mi Home.
-- **Multimodal large model API key** — [Xiaomi MiMo](https://platform.xiaomimimo.com) is recommended: MiMo-v2.5 for perception, MiMo-v2.5-pro for the Agent (configured in OpenClaw).
+- **Multimodal large model API key** — [Xiaomi MiMo](https://platform.xiaomimimo.com) is recommended: MiMo-v2.5 for perception, MiMo-v2.5-pro for the Agent (configured in your agent runtime: OpenClaw, or `~/.hermes/config.yaml` for Hermes).
 
 > [!CAUTION]
 > **Cost note**: Miloco 2.0's perception and Agent rely primarily on cloud-based large models and will incur ongoing API usage costs—keep an eye on your usage. You can review token consumption on the "Models" page of the home dashboard.
@@ -38,10 +39,18 @@ Miloco 2.0 perceives what happens at home, makes proactive decisions and control
 
 ### Option 1: Install via the Agent (recommended)
 
-Send the following instruction to OpenClaw to complete the installation automatically:
+Send the following instruction to your Agent to complete the installation automatically:
+
+**OpenClaw**:
 
 ```text
 Please install the Miloco plugin for me: https://raw.githubusercontent.com/XiaoMi/xiaomi-miloco/main/scripts/install-guide.md
+```
+
+**Hermes Agent** (open-source, [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent)):
+
+```text
+Please install the Miloco plugin for me: https://raw.githubusercontent.com/XiaoMi/xiaomi-miloco/main/scripts/install-guide-hermes.md
 ```
 
 ### Option 2: One-line command-line install
@@ -84,10 +93,11 @@ Whichever method you choose above, native Windows is not supported—install and
 
 ## Quick Start
 
-After installation, restart the OpenClaw gateway so the plugin takes effect:
+After installation, restart your Agent gateway so the plugin takes effect:
 
 ```bash
-openclaw gateway restart
+openclaw gateway restart   # if you used Option 1/2/3 with OpenClaw
+hermes gateway restart     # if you used Option 1 with Hermes Agent
 ```
 
 Then open the home dashboard to complete the initial setup:
@@ -121,8 +131,9 @@ miloco-plugin/
 │   └── miot/            # MIoT SDK (standalone subpackage)
 ├── cli/                 # miloco-cli command-line tool
 ├── plugins/
-│   ├── openclaw/        # OpenClaw plugin (TypeScript)
-│   └── skills/          # Agent Skill docs
+│   ├── openclaw/        # OpenClaw plugin (TypeScript, the default)
+│   ├── hermes/          # Hermes Agent plugin (Python) + inbound adapter (alternative runtime)
+│   └── skills/          # Agent Skill docs (shared source for both runtimes)
 ├── web/                 # home dashboard (React 19 + Vite)
 ├── scripts/             # build.sh / install.sh / manifest.json
 └── knowledge/           # project knowledge base
@@ -145,7 +156,8 @@ Run into issues, want to give feedback, or just chat about use cases? Scan the Q
 
 Miloco stands on the shoulders of the following open-source projects:
 
-- [OpenClaw](https://openclaw.ai) — AI Agent runtime and plugin platform
+- [OpenClaw](https://openclaw.ai) — AI Agent runtime and plugin platform (default runtime)
+- [Hermes Agent](https://github.com/NousResearch/hermes-agent) (MIT) — open-source Agent runtime; the parallel `plugins/hermes/` plugin targets it
 - [jMuxer](https://github.com/samirkumardas/jmuxer) (MIT) — real-time video stream muxing for the home dashboard
 - [BGE / bge-small-zh-v1.5](https://huggingface.co/BAAI/bge-small-zh-v1.5) (BAAI, MIT) — text embedding model
 - [Silero VAD](https://github.com/snakers4/silero-vad) (Silero Team, MIT) — voice activity detection, gating the perceived speech field

--- a/README.zh.md
+++ b/README.zh.md
@@ -2,7 +2,7 @@
 
 <p align="center"><a href="README.md">English</a> | 简体中文</p>
 
-小米面向未来的全屋智能 AI 开源方案，以米家摄像头的画面与声音为全模态感知入口，以自研 MiMo 大模型为智能大脑，以 Agent 插件形式运行在 [OpenClaw](https://openclaw.ai) 之上，联动全屋设备带来主动智能体验。
+小米面向未来的全屋智能 AI 开源方案，以米家摄像头的画面与声音为全模态感知入口，以自研 MiMo 大模型为智能大脑，以 Agent 插件形式运行在 [OpenClaw](https://openclaw.ai) 之上（也支持开源的 [Hermes Agent](https://github.com/NousResearch/hermes-agent)——见下方[安装](#安装)），联动全屋设备带来主动智能体验。
 
 Miloco 2.0 能感知家中发生的事件，能基于常识主动判断并操控设备，能将"模糊又长期"的目标拆解成可追踪的家庭任务，能识别家庭成员、依托家庭记忆为每位成员提供个性化服务——查询和控制设备、把家调到成员舒适的状态，或在合适的时机给出有用的提醒。
 
@@ -11,6 +11,7 @@ Miloco 2.0 能感知家中发生的事件，能基于常识主动判断并操控
 ## 最新动态
 
 - **2026-06-18** — Miloco 2.0 正式发布：重构为 OpenClaw 插件，新增通用常识、身份识别、家庭记忆、家庭任务、主动智能、家庭面板。详见下方[核心特性](#核心特性)。
+- **2026-06-19** — 新增 Hermes Agent 兼容：同一套 16 个 skill、同一个入站 webhook 契约，现在也能跑在开源 [Hermes Agent](https://github.com/NousResearch/hermes-agent) 运行时上（通过 `plugins/hermes/`）。见下方[安装](#安装)。
 
 ## 核心特性
 
@@ -22,14 +23,14 @@ Miloco 2.0 能感知家中发生的事件，能基于常识主动判断并操控
 - **家庭面板** — 面向用户的 Web 面板，查看家中实时概览、米家设备、家庭成员与家庭档案、历史事件日志。
 
 > [!TIP]
-> **养成你自己的 Miloco。** 它的初始表现未必合你心意——直接通过 OpenClaw 告诉 Miloco（如"家里乱不用提醒我"），它就记住你的偏好、相应调整主动行为。你每说一句，就是在"养成"一个更懂你家的 Miloco，越用越贴心。
+> **养成你自己的 Miloco。** 它的初始表现未必合你心意——直接通过你的 Agent（OpenClaw 或 Hermes，如"家里乱不用提醒我"）告诉 Miloco，它就记住你的偏好、相应调整主动行为。你每说一句，就是在"养成"一个更懂你家的 Miloco，越用越贴心。
 
 ## 前置条件
 
 - **硬件**：建议内存 ≥ 4GB，存储 ≥ 256GB，7×24 常驻运行，推荐 Mac mini
 - **操作系统**：macOS / Linux（Windows 请在 WSL 中运行）
 - **小米账号** + 已接入米家的设备
-- **多模态大模型 API Key** — 推荐使用[小米 MiMo](https://platform.xiaomimimo.com)：感知用 MiMo-v2.5，Agent 用 MiMo-v2.5-pro（在 OpenClaw 中配置）
+- **多模态大模型 API Key** — 推荐使用[小米 MiMo](https://platform.xiaomimimo.com)：感知用 MiMo-v2.5，Agent 用 MiMo-v2.5-pro（在你的 Agent 运行时中配置：OpenClaw，或 Hermes 的 `~/.hermes/config.yaml`）
 
 > [!CAUTION]
 > **成本提示**：Miloco 2.0 的感知与 Agent 主要依赖云端大模型，会持续产生 API 调用费用，请关注用量。可在家庭面板「模型」页查看 token 消耗。
@@ -38,10 +39,18 @@ Miloco 2.0 能感知家中发生的事件，能基于常识主动判断并操控
 
 ### 方式一：通过 Agent 安装（推荐）
 
-向 OpenClaw 发送以下指令即可自动完成安装：
+向你的 Agent 发送以下指令即可自动完成安装：
+
+**OpenClaw**：
 
 ```text
 帮我安装 Miloco 插件：https://raw.githubusercontent.com/XiaoMi/xiaomi-miloco/main/scripts/install-guide.md
+```
+
+**Hermes Agent**（开源，[NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent)）：
+
+```text
+帮我安装 Miloco 插件：https://raw.githubusercontent.com/XiaoMi/xiaomi-miloco/main/scripts/install-guide-hermes.md
 ```
 
 ### 方式二：命令行一键安装
@@ -84,10 +93,11 @@ bash scripts/install.sh --dev   # 从源码构建（scripts/build.sh）后本地
 
 ## 快速开始
 
-安装完成后，先重启 OpenClaw 网关让插件生效：
+安装完成后，先重启你的 Agent 网关让插件生效：
 
 ```bash
-openclaw gateway restart
+openclaw gateway restart   # 如果用 OpenClaw（方式一二三）
+hermes gateway restart     # 如果用 Hermes Agent（方式一）
 ```
 
 随后打开家庭面板完成首次配置：
@@ -121,8 +131,9 @@ miloco-plugin/
 │   └── miot/            # MIoT SDK（独立子包）
 ├── cli/                 # miloco-cli 命令行工具
 ├── plugins/
-│   ├── openclaw/        # OpenClaw 插件（TypeScript）
-│   └── skills/          # Agent Skill 文档
+│   ├── openclaw/        # OpenClaw 插件（TypeScript，默认）
+│   ├── hermes/          # Hermes Agent 插件（Python）+ 入站适配层（备选运行时）
+│   └── skills/          # Agent Skill 文档（两套运行时共用）
 ├── web/                 # 家庭面板（React 19 + Vite）
 ├── scripts/             # build.sh / install.sh / manifest.json
 └── knowledge/           # 项目知识库
@@ -145,7 +156,8 @@ miloco-plugin/
 
 Miloco 站在以下开源项目之上：
 
-- [OpenClaw](https://openclaw.ai) — AI Agent 运行时与插件平台
+- [OpenClaw](https://openclaw.ai) — AI Agent 运行时与插件平台（默认运行时）
+- [Hermes Agent](https://github.com/NousResearch/hermes-agent)（MIT）— 开源 Agent 运行时；`plugins/hermes/` 这套并行插件即为其适配
 - [jMuxer](https://github.com/samirkumardas/jmuxer)（MIT）— 家庭面板实时视频流封装
 - [BGE / bge-small-zh-v1.5](https://huggingface.co/BAAI/bge-small-zh-v1.5)（智源研究院，MIT）— 文本向量化模型
 - [Silero VAD](https://github.com/snakers4/silero-vad)（Silero Team，MIT）— 语音活动检测，门控感知语音字段

--- a/knowledge/03-features/hermes-integration.md
+++ b/knowledge/03-features/hermes-integration.md
@@ -1,0 +1,93 @@
+# Hermes Agent 集成
+
+## 背景与目标
+
+miloco 原本只通过 OpenClaw 插件（`plugins/openclaw/`）接入小米内部的 OpenClaw agent 运行时。为支持开源生态，fork 新增 `plugins/hermes/`，把同样的双向集成移植到 [Hermes Agent](https://github.com/NousResearch/hermes-agent)（Nous Research 的开源 Python agent，与 OpenClaw 同类，内置 `hermes claw migrate` 迁移路径）。
+
+两条集成路径并列、互不影响，用户按自己装的 agent 运行时二选一。
+
+---
+
+## 产品面
+
+能力与 OpenClaw 版一致：
+
+- **自然语言控制设备**：对 Hermes 说意图，miloco-* skill 经 `miloco-cli` 调后端 API。
+- **创建持久任务**：rule / cron / record 组合。
+- **主动感知回调**：规则触发、设备绑定、感知告警时，后端经适配进程投递 DYNAMIC 回调给 Hermes，agent 在对应会话自主决策。
+- **家庭记忆管理**：对话写入档案，`pre_llm_call` 钩子把档案注入上下文。
+- **后台知识整理**：4 个受管 cron（perception-digest / home-patrol / home-dreaming / habit-suggest）。
+
+---
+
+## 研发面
+
+### 架构（数据流）
+
+**Agent → Miloco（出站）**
+```
+用户对话
+  → Hermes 选 miloco-* skill（/skills 或自然语言）
+  → miloco-cli 调 HTTP API（Authorization: Bearer <token>）
+  → MiotService / RuleService / PersonService / TaskService
+```
+
+**Miloco → Agent（入站回调）**
+```
+感知结果 / 规则触发 / 设备绑定
+  → AgentDispatcher（dispatch/dispatcher.py，单飞+合并+优先级淘汰）
+  → run_agent_turn → POST {action:"agent",payload} → 适配进程(adapter/)
+  → adapter 调 Hermes api_server POST /v1/chat/completions（同步，X-Hermes-Session-Id 头做会话连续）
+  → agent 跑 miloco-notify 或其它 skill
+```
+
+### 插件注册点（`plugins/hermes/miloco-plugin/`）
+
+`register(ctx)` 注册：
+
+1. **`pre_llm_call` 钩子**（`context_injection.py::inject_context`）—— 按 profile 分级装配上下文，返回 `{"context": text}` 注入 user message。profile 判定：`platform=="cron"` 或 session_id 含 `:cron:` → minimal；含 `miloco-rule` → rule；含 `miloco-suggest` → suggestion；其余 → full。
+2. **3 个 tool**：`miloco_im_push`（通知分发，两段式）、`miloco_notify_bind`（绑定通知目标）、`miloco_habit_suggest`（习惯建议状态机）。
+3. **受管 cron reconcile**（`cron_setup.py::reconcile_cron_jobs`）—— 启动时按 `[miloco:home-profile]` 标签对齐 4 个任务。
+
+### 入站适配进程（`plugins/hermes/adapter/`）
+
+独立 Python 进程（aiohttp），因为 **Hermes 插件 ctx API 不能注册任意 HTTP 路由**（只能注册 tool/hook/command/skill/...），而 miloco 后端要求一个 `{action, payload} → {code, data:{runId,status}}` 的同步 webhook 端点——契约也与 Hermes 的 webhook（异步 deliver）/ api_server（`{run_id, status}`）都不匹配，故需独立适配层翻译。
+
+- `POST /miloco/webhook`，Bearer 鉴权。
+- `action:"agent"` → `hermes_client.run_turn` → 调 `POST /v1/chat/completions`（OpenAI 兼容同步端点），用 `X-Hermes-Session-Id: miloco:<sessionKey>:<lane>` 头维持跨回合会话连续；HTTP 超时 = `timeoutMs/1000 + 15`，返回 `{code:0, data:{runId, status, error?, recovered?}}`。
+- `action:"get_trace"` → `{code:0, data:{status:"done"}}`（observability 降级）。
+- 幂等：`idempotencyKey` 命中内存缓存（TTL 1h）直接回缓存。
+- 上下文溢出 best-effort 自愈：识别溢出错误文案后，丢弃会话上下文用无 `X-Hermes-Session-Id` 的全新 turn 重试一次（api_server 无 session 删除/重置路由）。
+- session 映射：`miloco:<sessionKey>:<lane>`（确定性，`session_map.py`）。
+
+### 与 OpenClaw 集成的关键差异
+
+| 维度 | OpenClaw 版 | Hermes 版 |
+|---|---|---|
+| 插件语言 | TypeScript | Python |
+| 上下文注入 | `before_prompt_build` → system prompt | `pre_llm_call` → user message |
+| 入站回调 | 插件内 `api.registerHttpRoute("/miloco/webhook")` | 独立适配进程（Hermes 插件不能注册 HTTP 路由） |
+| 同步等 turn | `api.runtime.subagent.run` + `waitForRun` | Hermes api_server `/v1/chat/completions` 同步（`X-Hermes-Session-Id` 会话连续） |
+| get_trace | 内存 trace buffer，后端反向轮询取 meta | 直接回 done，不回传 meta（降级） |
+| 溢出自愈 | `deleteSession({deleteTranscript:true})` + 重跑 | 丢弃会话上下文、无 session 头全新 turn 重试一次 |
+| 通知投递 | `subagent.run({deliver:true})` | `ctx.dispatch_tool("send_message", ...)` |
+| backend 生命周期 Service | 有（`miloco-cli service restart/stop`） | 无（backend 独立运行） |
+
+### 配置共享
+
+三端（backend / CLI / 插件）仍共用 `$MILOCO_HOME/config.json`：
+- `server.token`：backend 独占生成，CLI/插件只读。
+- `agent.webhook_url`：Hermes 版指向适配进程（`http://127.0.0.1:18789/miloco/webhook`）。
+- `agent.auth_bearer`：与适配进程启动时的 `ADAPTER_AUTH_BEARER` 一致。
+
+### 如果我要添加/修改 Skill
+
+skill 源在 `plugins/skills/miloco-*`（OpenClaw/Hermes 共用源），改完跑 `plugins/hermes/scripts/sync-skills.py` 重新生成 `plugins/hermes/skills/` 并复制到 `~/.hermes/skills/`。skill 通过 `miloco-cli` 调后端，与 agent 平台无关。
+
+### 出问题排查
+
+- `GET /api/miot/mips_status` 看 MQTT 连接。
+- `miloco-cli service logs -f` 看后端日志。
+- 适配进程日志看 stdout/stderr（建议常驻 + 重定向）。
+- 入站回调不通：先 `curl http://127.0.0.1:18789/health` 探 adapter，再确认 miloco `config.json::agent.webhook_url` 与 `auth_bearer`、Hermes `API_SERVER_KEY`、`HERMES_API_KEY` 三者一致。
+- 出站 skill 不触发：`hermes -z "/miloco-devices 帮我列出设备"` 确认 skill 已装入 `~/.hermes/skills/`。

--- a/knowledge/05-external-deps/sdk-hermes.md
+++ b/knowledge/05-external-deps/sdk-hermes.md
@@ -1,0 +1,65 @@
+# Hermes Agent 依赖
+
+## L1：它是什么
+
+Hermes Agent 是 [Nous Research](https://nousresearch.com) 的开源 AI Agent（MIT，Python），与小米内部的 OpenClaw 同类——一个自托管、可对接 Telegram/Discord/Slack 等、带记忆与 skill 系统的 agent 运行时。仓库 [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent)，文档 [hermes-agent.nousresearch.com/docs](https://hermes-agent.nousresearch.com/docs)。
+
+miloco 通过 `plugins/hermes/` 接入 Hermes，作为 OpenClaw 之外的并列 agent 运行时。
+
+---
+
+## L2：我们怎么用
+
+### 扩展点映射
+
+| miloco 需求 | Hermes 机制 | 文件 |
+|---|---|---|
+| 16 个 skill | `~/.hermes/skills/`（agentskills.io 标准，miloco skill 已合规） | `scripts/sync-skills.py` |
+| 注入设备目录/家庭档案/身份块 | `pre_llm_call` 插件钩子，返回 `{"context": text}` | `miloco-plugin/context_injection.py` |
+| 注册 tool（通知/习惯建议） | `ctx.register_tool(name, toolset, schema, handler)` | `miloco-plugin/tools_*.py` |
+| 4 个受管 cron | `cron.jobs.create_job(prompt, schedule, skills=[...])` + reconcile | `miloco-plugin/cron_setup.py` |
+| 后端→agent 同步回调 | api_server `POST /v1/chat/completions`（同步，`X-Hermes-Session-Id` 会话连续） | `adapter/hermes_client.py` |
+
+### 关键契约
+
+**`pre_llm_call` 钩子**（`website/docs/user-guide/features/hooks.md`）：
+- 回调签名 `(session_id, user_message, conversation_history, is_first_turn, model, platform, **kwargs)`。
+- 返回 `{"context": text}` 或纯字符串 → 注入到**当前 turn 的 user message**（非 system prompt，为保 prompt cache）。
+- 每个 `run_conversation()` 调用触发一次，在 context 压缩后、tool 循环前。
+- 多插件返回的 context 按 plugin 发现序用 `\n\n` 拼接。
+
+**插件 ctx API**（`website/docs/guides/build-a-hermes-plugin.md`）：
+- `ctx.register_tool(name=, toolset=, schema=, handler=, check_fn=, emoji=, override=)` —— schema 是 OpenAI tool-schema dict；handler `def(args: dict, **kw) -> str`。
+- `ctx.register_hook(event, cb)` —— 事件含 `pre_llm_call`/`post_llm_call`/`pre_tool_call`/`post_tool_call`/`on_session_*`/`subagent_stop`/`pre_gateway_dispatch` 等。
+- `ctx.dispatch_tool(name, arguments)` —— 调任意已注册 tool（含内置 `send_message`），继承父 agent 的审批/凭据上下文。
+- **不能注册任意 HTTP 路由**——这是入站适配层必须独立成进程的根因。
+
+**api_server 同步 chat**（`gateway/platforms/api_server.py`，v0.10.0 实测路由）：
+- `POST /v1/chat/completions`（OpenAI 兼容同步端点），body `{"messages":[{"role":"system","content":...},{"role":"user","content":...}]}`（system 可选），响应 `{"choices":[{"message":{"role":"assistant","content":...}}],"usage":{}}`。
+- 会话连续：请求头 `X-Hermes-Session-Id: <id>` —— Hermes 从 state.db 加载该 session 的历史拼入上下文。适配器用 `miloco:<sessionKey>:<lane>` 作 id，使同一 miloco 会话多次回调落到同一 Hermes 会话。无需预建 session。
+- 鉴权：`Authorization: Bearer $API_SERVER_KEY`。`API_SERVER_KEY` 环境变量设置即自动启用 api_server 平台（默认端口 8642）。
+- 异步变体 `POST /v1/runs`（返 `202 {run_id, status:"started"}`，`GET /v1/runs/{run_id}/events` SSE 取结果）——首版用同步 `/v1/chat/completions`，因 miloco 后端要求同步回包。
+- 溢出自愈：api_server 无 session 删除/重置路由，适配器识别溢出错误文案后用无 `X-Hermes-Session-Id` 的全新 turn 重试一次。
+
+**cron**（`cron/jobs.py::create_job`）：
+- `create_job(prompt, schedule, name=None, skills=None, deliver=None, ...)`。
+- `deliver` 是字符串（`"origin"/"local"/"none"/...`）；miloco 受管任务用 `"none"`。
+- 无 `description` 字段，故把 `[miloco:home-profile]` 标签塞进 `name` 前缀作 reconcile 识别键。
+
+### 版本兼容约束
+
+- 依赖 Hermes `pre_llm_call` 钩子接口与 api_server `/v1/chat/completions` 路由（v0.10.0 实测；main 分支的 `/api/sessions/{id}/chat` 在 v0.10.0 不存在）。
+- 插件级配置：Hermes `PluginManifest` 当前不解析 `configSchema`，故运行时配置由插件自管于 `<plugin-dir>/state.json`；`omni_*` 实际由 `$MILOCO_HOME/config.json`（后端管）提供。
+- 需先安装 Hermes（`curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash`）。
+- Hermes v0.10.0 的 cron 调度依赖 `croniter` 包（`pip install croniter`），否则 4 个受管任务创建失败。
+- skill frontmatter 的 `date` 字段必须加引号（字符串），否则 YAML 解析成 `datetime.date` 导致 Hermes `skill_view` 的 `json.dumps` 失败、cron 加载 skill 报错——`sync-skills.py` 已自动处理。
+
+### 与后端的通信契约
+
+后端 `run_agent_turn`（`utils/agent_client.py`）向适配进程 `POST {action, payload}`，适配进程翻译为 Hermes `/chat`，同步返回 `{code, message, data}`，`data = {runId, status, error?, recovered?}`，`status ∈ {ok, error, timeout}`。参数与返回值定义见 `adapter/hermes_client.py` 与 `plugins/openclaw/src/webhooks/agent.ts`（OpenClaw 版的契约蓝本）。
+
+### 出问题找谁
+
+- Hermes 框架本身（agent turn 失败、cron 不触发、api_server 连不通）→ Hermes 仓库 issue。
+- miloco 适配层（适配进程契约翻译、pre_llm_call 注入、tool 注册）→ miloco 工程侧。
+- 排查顺序：先确认 Hermes gateway + api_server 起着、`API_SERVER_KEY` 设了；再 `curl adapter /health`；最后看 miloco 后端 `agent.webhook_url`/`auth_bearer` 与 adapter 的 `ADAPTER_AUTH_BEARER`/`HERMES_API_KEY` 是否一致。

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,62 @@
+# miloco 插件目录
+
+每个子目录是一个 **agent runtime 适配**：把 miloco 的 16 个共享 skill（`../skills/miloco-*`）接到对应 agent 上，并提供入站 webhook 适配层（如果该 agent 不能直接注册 HTTP 路由）。
+
+## 当前支持的 runtime
+
+| 子目录 | agent | 语言 | 状态 |
+|---|---|---|---|
+| [`openclaw/`](openclaw/) | [OpenClaw](https://openclaw.ai) | TypeScript | **默认**，跟 miloco 主仓一起发布 |
+| [`hermes/`](hermes/) | [Hermes Agent](https://github.com/NousResearch/hermes-agent)（开源 MIT，Python） | Python | 第二 runtime，本目录新增 |
+
+## 给后续第三个 runtime 的最小骨架
+
+加新 runtime 时，按以下结构和命名约定走，便于用户发现、agent 安装脚本抓取、维护者一眼看明白：
+
+```
+plugins/<runtime>/
+├── README.md                    # 6 段对齐 openclaw：Install / What It Does / Configuration / Development / License
+├── install-<runtime>.sh         # 一键安装（patch miloco config / agent env / 启 adapter，幂等）
+├── <runtime>-plugin/            # 该 agent 侧的插件（出站）
+│   └── （hook / tool / skill 装载逻辑）
+├── adapter/                     # 入站 webhook 适配进程（如 agent 不能注册 HTTP 路由才需要）
+│   └── __main__.py
+├── scripts/
+│   ├── install.sh               # 高级/手动安装
+│   └── <runtime>-adapter.sh     # adapter 生命周期（start/stop/restart/status/logs）
+├── skills/                      # sync-skills.py 生成的产物，gitignore
+└── tests/                       # 至少：pytest 单元 + bash e2e（装+adapter 全生命周期）
+```
+
+**agent 安装脚本（给 AI agent 跑）放哪**：
+
+- 放 `scripts/install-guide-<runtime>.md`（与 OpenClaw 的 `scripts/install-guide.md` 同级）
+- 模板见 [scripts/install-guide-hermes.md](../scripts/install-guide-hermes.md)
+- 主 README 方式一里加 `<runtime>` 子段，URL 用 `https://raw.githubusercontent.com/XiaoMi/xiaomi-miloco/main/scripts/install-guide-<runtime>.md`
+
+**skill 源复用**：
+
+- **不要**在 `<runtime>/skills/` 里维护 skill，所有 skill 源在 [`../skills/miloco-*`](../skills/)
+- 用 `<runtime>/scripts/sync-skills.py` 从共享源生成并适配 frontmatter（删 agent-specific 字段、加 date 引号等）
+- OpenClaw 版做法见 [`openclaw/scripts/`](../openclaw/scripts/)，Hermes 版做法见 [`hermes/scripts/sync-skills.py`](hermes/scripts/sync-skills.py)
+
+**PR 提交规范**：
+
+- 主 README（英+中）方式一加 `<runtime>` 子段
+- `knowledge/03-features/<runtime>-integration.md` 写架构 + 跟 OpenClaw 差异
+- `knowledge/05-external-deps/sdk-<runtime>.md` 写 agent 平台契约
+- `.gitignore` 加 `plugins/<runtime>/skills/`
+- 致谢加该 agent 项目
+- 标题建议：`<runtime> 兼容层（统一 plugins/<runtime>/ 规范）`
+
+## 命名约定
+
+| 资源 | 命名 |
+|---|---|
+| 子目录 | `plugins/<runtime>/`（小写 agent 名） |
+| 插件名（agent 侧） | `miloco`（与 OpenClaw 版同名，agent 看到的是同一插件） |
+| 一键安装脚本 | `plugins/<runtime>/install-<runtime>.sh` |
+| Adapter 生命周期脚本 | `plugins/<runtime>/scripts/<runtime>-adapter.sh` |
+| 适配层包名 | `plugins.<runtime>.adapter`（可作为 Python `python -m` 入口） |
+| agent 安装 skill | `scripts/install-guide-<runtime>.md` |
+| 知识库条目 | `knowledge/03-features/<runtime>-integration.md` / `knowledge/05-external-deps/sdk-<runtime>.md` |

--- a/plugins/hermes/INSTALL_PROMPT.md
+++ b/plugins/hermes/INSTALL_PROMPT.md
@@ -1,0 +1,7 @@
+# 已迁移
+
+本文件已迁移到标准位置 [`scripts/install-guide-hermes.md`](../../scripts/install-guide-hermes.md)（与 OpenClaw 的 `scripts/install-guide.md` 同级）。
+
+新 URL：https://raw.githubusercontent.com/XiaoMi/xiaomi-miloco/main/scripts/install-guide-hermes.md
+
+保留此文件仅为兼容 fork 已有链接。

--- a/plugins/hermes/README.md
+++ b/plugins/hermes/README.md
@@ -1,0 +1,97 @@
+# miloco-hermes-plugin
+
+Hermes plugin for Xiaomi Miloco — brings smart home perception and automation into Hermes Agent.
+
+## Install
+
+This plugin is not bundled with the official Miloco installer (Hermes is a third-party agent runtime, not part of the Miloco release archive). Install it from the fork:
+
+```bash
+git clone https://github.com/n0tssss/xiaomi-miloco.git
+cd xiaomi-miloco
+bash plugins/hermes/install-hermes.sh
+hermes gateway restart
+```
+
+The install script is idempotent: it copies the 16 miloco-* skills to `~/.hermes/skills/`, copies the plugin to `~/.hermes/plugins/miloco/`, copies the inbound adapter to the same dir, patches `$MILOCO_HOME/config.json::agent` (auto-backup), writes `API_SERVER_KEY` to `~/.hermes/.env`, and nohup-starts the adapter with PID + log at `~/.hermes/miloco-adapter.{pid,log}`. Re-running the script preserves the same Bearer and restarts the adapter.
+
+Adapter lifecycle: `bash plugins/hermes/scripts/miloco-adapter.sh {start|stop|restart|status|logs|env}`.
+
+For a step-by-step guide written for an AI agent to follow, see [scripts/install-guide-hermes.md](../../scripts/install-guide-hermes.md).
+
+## What It Does
+
+The plugin registers Miloco hooks and tools into Hermes, exposes an inbound webhook adapter for Miloco's callbacks, and ships the following AI skills:
+
+| Skill | Description |
+|-------|-------------|
+| `miloco-devices` | Query and control IoT devices |
+| `miloco-perception` | Visual perception and recognition |
+| `miloco-miot-identity` | Person / pet identity management |
+| `miloco-miot-admin` | System administration and cost stats |
+| `miloco-miot-scope` | Permission scope management |
+| `miloco-miot-identity-register` | Register new identity |
+| `miloco-create-task` | Task lifecycle: create / list / logs / enable / disable / update |
+| `miloco-terminate-task` | Task termination: audit log + cascade cleanup + cron pending |
+| `miloco-notify` | Perception anomaly response: grading + push notification |
+| `miloco-perception-digest` | Periodic perception event digest (cron-driven) |
+| `miloco-home-profile` | Read/write family profile and memory |
+| `miloco-home-observe` | Observe home state, emit findings to memory |
+| `miloco-home-promote` | Promote observations into stable memory entries |
+| `miloco-home-prune` | Prune stale memory entries |
+| `miloco-home-patrol` | Periodic home patrol (cron-driven) |
+| `miloco-habit-suggest` | Generate habit suggestions (cron-driven) |
+
+Inbound side: the adapter process exposes `POST /miloco/webhook` (miloco's `{action, payload}` contract), translates `action:agent` into a synchronous Hermes `/v1/chat/completions` turn with `X-Hermes-Session-Id` for session continuity, and lets the agent pick the right skill (e.g. `miloco-notify`) to respond. See `knowledge/03-features/hermes-integration.md` for the architecture and differences vs. the OpenClaw version.
+
+## Configuration
+
+Plugin settings can be overridden via `hermes plugins list` config page or the plugin's own state file. Leave fields empty to fall back to `$MILOCO_HOME/config.json`.
+
+The Miloco backend must be running for the plugin to work:
+
+```bash
+miloco-cli service start
+```
+
+The adapter process (port 18789 by default) must be running for inbound Miloco callbacks to reach the agent:
+
+```bash
+bash plugins/hermes/scripts/miloco-adapter.sh status   # check
+bash plugins/hermes/scripts/miloco-adapter.sh start    # start
+```
+
+Environment variables (read by the adapter, all auto-set by `install-hermes.sh`):
+
+| Variable | Default | Notes |
+|---|---|---|
+| `ADAPTER_PORT` | `18789` | matches OpenClaw's default webhook port |
+| `ADAPTER_HOST` | `127.0.0.1` | set to `0.0.0.0` for container/remote deploy |
+| `ADAPTER_AUTH_BEARER` | (empty) | must match `$MILOCO_HOME/config.json::agent.auth_bearer` |
+| `HERMES_API_URL` | `http://127.0.0.1:8642` | Hermes api_server root |
+| `HERMES_API_KEY` | (empty) | must match `~/.hermes/.env::API_SERVER_KEY` |
+
+## Development
+
+```bash
+# Python deps (one-time, for pytest)
+pip install pytest aiohttp httpx
+
+# Unit tests (Python contract)
+pytest plugins/hermes/tests/test_*.py
+
+# E2E install test (bash, exercises install-hermes.sh + adapter lifecycle)
+bash plugins/hermes/tests/test_install_e2e.sh
+
+# Re-sync skills from upstream source (after editing plugins/skills/miloco-*)
+python plugins/hermes/scripts/sync-skills.py
+
+# Manual / advanced install (no patch, no auto-start)
+bash plugins/hermes/scripts/install.sh
+```
+
+## License
+
+For license details, please see [LICENSE.md](https://raw.githubusercontent.com/XiaoMi/xiaomi-miloco/main/LICENSE.md).
+
+**Important Notice**: This project is limited to non-commercial use only. Without written authorization from Xiaomi Corporation, this project may not be used for developing applications, web services, or other forms of software.

--- a/plugins/hermes/adapter/__init__.py
+++ b/plugins/hermes/adapter/__init__.py
@@ -1,0 +1,5 @@
+"""Hermes 兼容层入站适配进程包。
+
+把 miloco 后端的 ``{action, payload}`` webhook 契约翻译成 Hermes api_server
+的同步 chat 调用，使 miloco 可以在不改后端代码的前提下接入 Hermes agent。
+"""

--- a/plugins/hermes/adapter/__main__.py
+++ b/plugins/hermes/adapter/__main__.py
@@ -1,0 +1,69 @@
+"""入站适配进程入口。
+
+从环境变量读取配置，启动 aiohttp server 监听 miloco 的 ``POST /miloco/webhook``。
+
+环境变量：
+- ``ADAPTER_HOST``: 监听地址，默认 ``0.0.0.0``（容器/远端部署友好；本机调试可设 127.0.0.1）
+- ``ADAPTER_PORT``: 监听端口，默认 ``18789``（对齐 OpenClaw 默认，使 miloco 默认
+  ``agent.webhook_url`` 不用改即可指向本适配器）
+- ``HERMES_API_URL``: Hermes api_server 根 URL，如 ``http://127.0.0.1:8642``
+- ``HERMES_API_KEY``: Hermes api_server 的 API_SERVER_KEY，用于 Bearer 鉴权
+- ``ADAPTER_AUTH_BEARER``: miloco 调本适配器时用的 Bearer token（对应 miloco
+  ``AgentSettings.auth_bearer``）；空则不校验
+
+用法：``python -m plugins.hermes.adapter``（需在 xiaomi-miloco 仓库根目录，使
+``plugins.hermes.adapter`` 可作为包导入）。
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+from aiohttp import web
+
+from .hermes_client import HermesClient
+from .server import create_app
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_HOST = "0.0.0.0"
+_DEFAULT_PORT = 18789
+
+
+def _build() -> web.Application:
+    auth_bearer = os.getenv("ADAPTER_AUTH_BEARER", "").strip()
+    hermes_url = os.getenv("HERMES_API_URL", "http://127.0.0.1:8642").strip()
+    hermes_key = os.getenv("HERMES_API_KEY", "").strip()
+
+    if not hermes_url:
+        print("HERMES_API_URL is required", file=sys.stderr)
+        sys.exit(2)
+
+    client = HermesClient(api_url=hermes_url, api_key=hermes_key)
+    app = create_app(auth_bearer=auth_bearer, hermes_client=client)
+
+    # 启动日志：不打印 secret
+    logger.info(
+        "hermes adapter listening host=%s port=%s hermes_url=%s auth=%s",
+        os.getenv("ADAPTER_HOST", _DEFAULT_HOST),
+        os.getenv("ADAPTER_PORT", str(_DEFAULT_PORT)),
+        hermes_url,
+        "on" if auth_bearer else "off",
+    )
+    return app
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=os.getenv("ADAPTER_LOG_LEVEL", "INFO").upper(),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    host = os.getenv("ADAPTER_HOST", _DEFAULT_HOST)
+    port = int(os.getenv("ADAPTER_PORT", str(_DEFAULT_PORT)))
+    web.run_app(_build(), host=host, port=port)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/hermes/adapter/hermes_client.py
+++ b/plugins/hermes/adapter/hermes_client.py
@@ -1,0 +1,250 @@
+"""Hermes api_server 同步 chat 客户端：把 miloco turn 翻译成 Hermes /v1/chat/completions。
+
+miloco 后端通过 ``run_agent_turn`` 期望 webhook 同步返回 ``{runId, status, error?, recovered?}``
+（``status ∈ {ok, error, timeout}``，见
+``backend/miloco/src/miloco/utils/agent_client.py``）。Hermes api_server 暴露同步
+OpenAI 兼容端点 ``POST /v1/chat/completions``（见
+``gateway/platforms/api_server.py::_handle_chat_completions``），返回标准
+``{choices:[{message:{content}}]}``，并支持 ``X-Hermes-Session-Id`` 请求头做跨回合
+会话连续（从 state.db 加载历史）。
+
+本模块负责：
+1. 用 (sessionKey, lane) 确定性映射出 Hermes session_id（见 ``session_map``），通过
+   ``X-Hermes-Session-Id`` 头传入——同一 miloco 会话的多次回调落到同一 Hermes 会话，
+   上下文连续。
+2. 同步发起 chat，HTTP 超时 = ``timeoutMs/1000 + 15``（对齐 miloco 后端
+   ``wait_timeout_ms + _HTTP_BUFFER_S``，避免 HTTP 先断而 turn 仍在跑）。
+3. ``extraSystemPrompt`` 作为 system 角色消息前置。
+4. 上下文溢出尽力自愈：识别溢出错误文案后，丢弃会话上下文用无 session 头的全新 turn
+   重试一次（api_server 无 session 删除/重置路由，故用「无历史重试」近似 OpenClaw 的
+   ``deleteSession + re-run``）。
+
+best-effort：溢出信号识别依赖 Hermes 实例的实测错误文案；v0.10.0 的 api_server 路由
+（/v1/chat/completions、X-Hermes-Session-Id）与 main 分支的 /api/sessions/{id}/chat
+不同，本实现按已安装的 v0.10.0 适配。
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+from typing import Any
+
+import httpx
+
+from .session_map import map_session
+
+logger = logging.getLogger(__name__)
+
+# HTTP 超时在 miloco 后端 wait_timeout_ms 之上加的缓冲(秒)，对齐
+# backend/miloco/src/miloco/utils/agent_client.py::_HTTP_BUFFER_S。
+_HTTP_BUFFER_S = 15.0
+
+# 上下文溢出关键词。Hermes api_server 没有标准化溢出错误码（_handle_chat_completions
+# 把 agent 异常包成 OpenAI-style 5xx，文案来自 provider），只能按文案匹配。
+# best-effort, 需 Hermes 实例验证：真实溢出文案可能是 "context length exceeded"、
+# "maximum context length" 等，此处匹配范围偏宽以兜底。
+_OVERFLOW_MARKERS = (
+    "context overflow",
+    "context length",
+    "context window",
+    "maximum context",
+    "token limit",
+    "context budget",
+)
+
+
+def _looks_like_overflow(text: str | None) -> bool:
+    """best-effort 判定错误文案是否指示上下文溢出。无可靠信号时返回 False。"""
+    if not text:
+        return False
+    lowered = text.lower()
+    return any(marker in lowered for marker in _OVERFLOW_MARKERS)
+
+
+def _new_run_id() -> str:
+    """生成 miloco 期望的 runId（平台 turn id）。/v1/chat/completions 不返回 run id，故本地生成。"""
+    return str(uuid.uuid4())
+
+
+class HermesClient:
+    """异步 Hermes api_server 客户端，封装同步 turn 语义。
+
+    线程安全：每次 ``run_turn`` 创建独立 httpx.AsyncClient，无共享可变状态。
+    """
+
+    def __init__(self, api_url: str, api_key: str) -> None:
+        # 去掉尾部斜杠，避免 ``http://host:port//v1/...`` 双斜杠。
+        self._api_url = api_url.rstrip("/")
+        self._api_key = api_key
+
+    def _headers(self, session_id: str | None = None) -> dict[str, str]:
+        headers: dict[str, str] = {}
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+        if session_id:
+            headers["X-Hermes-Session-Id"] = session_id
+        return headers
+
+    def _build_messages(self, message: Any, system_message: str | None) -> list[dict[str, str]]:
+        """组装 OpenAI 风格 messages：可选 system 前置 + 单条 user。"""
+        msgs: list[dict[str, str]] = []
+        if system_message:
+            msgs.append({"role": "system", "content": system_message})
+        msgs.append({"role": "user", "content": str(message)})
+        return msgs
+
+    async def _chat_once(
+        self,
+        client: httpx.AsyncClient,
+        messages: list[dict[str, str]],
+        session_id: str | None,
+        timeout_s: float,
+    ) -> httpx.Response:
+        """单次同步 chat 调用。不捕获异常，由调用方按超时/溢出分支处理。"""
+        body: dict[str, Any] = {"messages": messages}
+        # 模型可由 HERMES_MODEL env 指定；为空则省略，api_server 用其配置的默认模型。
+        model = os.environ.get("HERMES_MODEL", "").strip()
+        if model:
+            body["model"] = model
+        return await client.post(
+            f"{self._api_url}/v1/chat/completions",
+            json=body,
+            headers=self._headers(session_id),
+            timeout=timeout_s,
+        )
+
+    async def run_turn(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """执行一次同步 turn，返回 miloco 期望的 ``{runId, status, error?, recovered?}``。
+
+        参数 ``payload`` 字段（见 agent_client.py::run_agent_turn 与
+        openclaw/.../webhooks/agent.ts::IRequestBody）：
+        - ``message``: 用户消息（必填）
+        - ``sessionKey``: 会话键，默认 "main"
+        - ``lane``: 通道，默认 "default"
+        - ``timeoutMs``: turn 等待上限（毫秒），HTTP 超时 = timeoutMs/1000 + 15
+        - ``extraSystemPrompt``: 可选系统提示，作为 system 消息前置
+        """
+        run_id = _new_run_id()
+        message = payload.get("message")
+        if message is None:
+            return {"runId": run_id, "status": "error", "error": "missing 'message' in payload"}
+        session_key = payload.get("sessionKey") or "main"
+        lane = payload.get("lane") or "default"
+        session_id = map_session(session_key, lane)
+        system_message = payload.get("extraSystemPrompt")
+        try:
+            timeout_ms = int(payload.get("timeoutMs") or 180_000)
+        except (TypeError, ValueError):
+            timeout_ms = 180_000
+        timeout_s = max(timeout_ms / 1000.0, 1.0) + _HTTP_BUFFER_S
+
+        messages = self._build_messages(message, system_message)
+
+        async with httpx.AsyncClient() as client:
+            # --- 首次 chat（带 session 头，上下文连续）---
+            try:
+                resp = await self._chat_once(client, messages, session_id, timeout_s)
+            except httpx.TimeoutException:
+                logger.warning("hermes chat timeout session=%s", session_id)
+                return {"runId": run_id, "status": "timeout"}
+            except httpx.HTTPError as e:
+                logger.warning("hermes chat transport error session=%s: %s", session_id, e)
+                return {"runId": run_id, "status": "error", "error": str(e)}
+
+            # 2xx → 成功
+            if 200 <= resp.status_code < 300:
+                return {"runId": run_id, "status": "ok"}
+
+            # 非 2xx：尝试识别溢出并自愈（无 session 头重试一次）
+            err_text = self._extract_error_text(resp)
+            if _looks_like_overflow(err_text):
+                logger.warning(
+                    "[overflow-self-heal] context overflow suspected session=%s status=%s; "
+                    "retrying once without session history",
+                    session_id, resp.status_code,
+                )
+                return await self._heal_and_retry(
+                    client, messages, timeout_s, run_id, err_text
+                )
+
+            return {
+                "runId": run_id,
+                "status": "error",
+                "error": f"hermes chat HTTP {resp.status_code}: {err_text[:300]}",
+            }
+
+    async def _heal_and_retry(
+        self,
+        client: httpx.AsyncClient,
+        messages: list[dict[str, str]],
+        timeout_s: float,
+        run_id: str,
+        overflow_reason: str,
+    ) -> dict[str, Any]:
+        """best-effort 溢出自愈：丢弃会话历史，用无 X-Hermes-Session-Id 的全新 turn 重试一次。
+
+        v0.10.0 的 api_server 无 session 删除/重置路由，无法精确复刻 OpenClaw 的
+        ``deleteSession({deleteTranscript:true}) + re-run``。此处用「不带 session 头」
+        起一个无历史的全新 turn 近似——能清掉累积的对话上下文，但丢掉该会话此前记忆。
+        重建后仍溢出 = 系统提示自身超预算，不可恢复 → 停手返回。
+
+        best-effort, 需 Hermes 实例验证。
+        """
+        try:
+            resp = await self._chat_once(client, messages, None, timeout_s)
+        except httpx.TimeoutException:
+            return {
+                "runId": run_id,
+                "status": "timeout",
+                "recovered": False,
+                "error": overflow_reason,
+            }
+        except httpx.HTTPError as e:
+            return {
+                "runId": run_id,
+                "status": "error",
+                "recovered": False,
+                "error": str(e),
+            }
+
+        if 200 <= resp.status_code < 300:
+            logger.info("[overflow-self-heal] recovered via fresh stateless turn")
+            return {"runId": run_id, "status": "ok", "recovered": True}
+
+        retry_err = self._extract_error_text(resp)
+        if _looks_like_overflow(retry_err):
+            logger.error(
+                "[overflow-self-heal] still overflow after fresh retry; unrecoverable"
+            )
+            return {
+                "runId": run_id,
+                "status": "error",
+                "recovered": False,
+                "error": retry_err or overflow_reason,
+            }
+        return {
+            "runId": run_id,
+            "status": "error",
+            "recovered": False,
+            "error": f"hermes chat HTTP {resp.status_code} after fresh retry: {retry_err[:300]}",
+        }
+
+    @staticmethod
+    def _extract_error_text(resp: httpx.Response) -> str:
+        """从非 2xx 响应里提取人类可读错误文案，兼容 OpenAI-style envelope。"""
+        try:
+            data = resp.json()
+        except Exception:
+            return resp.text or ""
+        if isinstance(data, dict):
+            err = data.get("error")
+            if isinstance(err, dict):
+                msg = err.get("message")
+                if isinstance(msg, str):
+                    return msg
+            msg = data.get("message") or data.get("detail")
+            if isinstance(msg, str):
+                return msg
+        return str(data)

--- a/plugins/hermes/adapter/server.py
+++ b/plugins/hermes/adapter/server.py
@@ -1,0 +1,151 @@
+"""aiohttp web app：暴露 miloco webhook 契约 ``POST /miloco/webhook``。
+
+复刻 OpenClaw 插件 ``plugins/openclaw/src/webhooks/index.ts`` 的路由与错误码：
+- ``action == "agent"``     → 调 hermes_client.run_turn，返回 ``{code:0, data:{runId,status,...}}``
+- ``action == "get_trace"`` → 同步 chat 已完成，observability 降级直接回 ``{code:0, data:{status:"done"}}``
+- 未知 action               → ``{code:2001, message:"Action '<a>' not found"}``
+- JSON 解析失败             → ``{code:1001, message:"bad json"}``
+- 内部异常                  → ``{code:3000, message:str(e)}``
+- Bearer 鉴权失败           → HTTP 401（非业务码，对齐 OpenClaw ``auth:"gateway"``）
+
+幂等：payload.idempotencyKey 命中内存缓存(TTL 1h)时直接回缓存结果，避免 miloco
+后端 HTTP 真断重试时在 Hermes 侧起第二个 turn（对齐 OpenClaw idempotencyKey 去重语义）。
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+from aiohttp import web
+
+from .hermes_client import HermesClient
+
+logger = logging.getLogger(__name__)
+
+# 幂等缓存 TTL：miloco 后端的重试窗口由批次调度决定，1h 足够覆盖单批重试；
+# 进程内 dict + 时间戳即可，无需持久化（适配进程重启后 miloco 也会重发）。
+_IDEM_TTL_S = 3600.0
+_IDEM_MAX_ENTRIES = 10_000  # 防 OOM 上限，LRU 由 _purge 按 ts 淘汰
+
+
+class _IdempotencyCache:
+    """进程内幂等缓存：key=idempotencyKey → (result, ts)。"""
+
+    def __init__(self) -> None:
+        self._store: dict[str, tuple[dict[str, Any], float]] = {}
+
+    def _purge(self) -> None:
+        now = time.time()
+        expired = [k for k, (_, ts) in self._store.items() if now - ts > _IDEM_TTL_S]
+        for k in expired:
+            self._store.pop(k, None)
+        # 超 cap 时按 ts 升序淘汰最旧
+        if len(self._store) > _IDEM_MAX_ENTRIES:
+            for k, _ in sorted(self._store.items(), key=lambda kv: kv[1][1])[
+                : len(self._store) - _IDEM_MAX_ENTRIES
+            ]:
+                self._store.pop(k, None)
+
+    def get(self, key: str) -> dict[str, Any] | None:
+        self._purge()
+        item = self._store.get(key)
+        if item is None:
+            return None
+        result, ts = item
+        if time.time() - ts > _IDEM_TTL_S:
+            self._store.pop(key, None)
+            return None
+        return result
+
+    def set(self, key: str, result: dict[str, Any]) -> None:
+        self._purge()
+        self._store[key] = (result, time.time())
+
+
+def _ok(data: Any) -> dict[str, Any]:
+    return {"code": 0, "message": "ok", "data": data}
+
+
+def _fail(code: int, message: str) -> dict[str, Any]:
+    return {"code": code, "message": message}
+
+
+def create_app(
+    *,
+    auth_bearer: str,
+    hermes_client: HermesClient,
+) -> web.Application:
+    """构建 aiohttp app。
+
+    ``auth_bearer``: miloco 调本适配器时用的 Bearer token；空串则跳过鉴权
+    （对齐 miloco ``AgentSettings``：auth_bearer 可空）。
+    """
+    idem = _IdempotencyCache()
+
+    async def _handle_webhook(request: "web.Request") -> "web.Response":
+        # --- Bearer 鉴权 ---
+        if auth_bearer:
+            auth = request.headers.get("Authorization", "")
+            token = auth[7:].strip() if auth.startswith("Bearer ") else ""
+            if token != auth_bearer:
+                logger.warning("adapter webhook rejected: invalid bearer")
+                return web.json_response(
+                    {"code": 3000, "message": "unauthorized"}, status=401
+                )
+
+        # --- 解析 body ---
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response(_fail(1001, "bad json"), status=400)
+        if not isinstance(body, dict):
+            return web.json_response(_fail(1001, "bad json"), status=400)
+
+        action = body.get("action")
+        if not action or not isinstance(action, str):
+            return web.json_response(_fail(1001, "missing action"), status=400)
+
+        payload = body.get("payload") or {}
+
+        # --- 幂等去重（仅 agent 动作，按 idempotencyKey 缓存结果）---
+        idem_key: str | None = None
+        if action == "agent" and isinstance(payload, dict):
+            raw_key = payload.get("idempotencyKey")
+            if isinstance(raw_key, str) and raw_key:
+                idem_key = raw_key
+                cached = idem.get(idem_key)
+                if cached is not None:
+                    logger.info("adapter webhook idem hit key=%s", idem_key)
+                    return web.json_response(_ok(cached))
+
+        # --- 路由 ---
+        try:
+            if action == "agent":
+                if not isinstance(payload, dict):
+                    raise ValueError("payload must be an object")
+                result = await hermes_client.run_turn(payload)
+                if idem_key is not None:
+                    idem.set(idem_key, result)
+                return web.json_response(_ok(result))
+            if action == "get_trace":
+                # Hermes 同步 chat 无独立 run 概念，turn 已在 webhook 返回时完成。
+                # observability 降级：直接告之 done，miloco 侧不阻塞。
+                return web.json_response(_ok({"status": "done"}))
+            return web.json_response(
+                _fail(2001, f"Action '{action}' not found"), status=404
+            )
+        except Exception as e:
+            logger.exception("adapter webhook action '%s' failed", action)
+            return web.json_response(_fail(3000, str(e)), status=500)
+
+    app = web.Application()
+    app.router.add_post("/miloco/webhook", _handle_webhook)
+
+    # 健康检查，便于 miloco 侧/部署探活
+    async def _health(request: "web.Request") -> "web.Response":
+        return web.json_response({"status": "ok"})
+
+    app.router.add_get("/health", _health)
+    return app

--- a/plugins/hermes/adapter/session_map.py
+++ b/plugins/hermes/adapter/session_map.py
@@ -1,0 +1,46 @@
+"""miloco (sessionKey, lane) → Hermes session_id 的确定性映射。
+
+miloco 后端按 ``sessionKey`` + ``lane`` 标识一个对话流（见
+``backend/miloco/src/miloco/utils/agent_client.py::run_agent_turn`` 的 payload 字段），
+Hermes api_server 则用字符串 ``session_id`` 寻址一个持久化会话
+（``POST /api/sessions/{session_id}/chat``）。本模块提供稳定单向映射，使同一个
+miloco 会话始终落到同一个 Hermes session，便于上下文连续与幂等去重。
+
+映射函数纯函数、无副作用、确定性：相同输入永远产相同输出，便于排查与重建。
+"""
+
+from __future__ import annotations
+
+import re
+
+# Hermes api_server 在 _handle_create_session 里拒绝含控制字符或超长（>256）的
+# session_id（见 gateway/platforms/api_server.py）。我们对 sessionKey/lane 做轻量
+# 清洗：去掉控制字符、限长，避免 miloco 侧传入异常值时建会话被 400 拒掉。
+_MAX_SESSION_ID_LEN = 200  # 留余量给 "miloco:" 前缀与冒号
+_CTRL_RE = re.compile(r"[\x00-\x1f\x7f\r\n]")
+
+
+def _sanitize(value: str, fallback: str) -> str:
+    """清洗单段标识：去控制字符、去首尾空白、空则用 fallback、限长。"""
+    if not value:
+        return fallback
+    cleaned = _CTRL_RE.sub("", str(value)).strip()
+    if not cleaned:
+        return fallback
+    if len(cleaned) > _MAX_SESSION_ID_LEN:
+        cleaned = cleaned[:_MAX_SESSION_ID_LEN]
+    return cleaned
+
+
+def map_session(session_key: str | None, lane: str | None) -> str:
+    """把 (session_key, lane) 映射为稳定的 Hermes session_id。
+
+    返回形如 ``miloco:<session_key>:<lane>`` 的字符串。None/空值降级为
+    ``main`` / ``default``，与 OpenClaw webhook 的默认值一致
+    （``plugins/openclaw/src/webhooks/agent.ts`` 里 ``sessionKey = "main"``）。
+
+    确定性：相同输入永远相同输出，不依赖时间或随机数。
+    """
+    key = _sanitize(session_key or "", "main")
+    ln = _sanitize(lane or "", "default")
+    return f"miloco:{key}:{ln}"

--- a/plugins/hermes/install-hermes.sh
+++ b/plugins/hermes/install-hermes.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# install-hermes.sh —— 一键把 miloco 装到 Hermes Agent。
+#
+# 干 7 件事：
+#   1. 前置检查（hermes、miloco-cli、python、$MILOCO_HOME、$MILOCO_HOME/config.json）
+#   2. 跑 scripts/sync-skills.py 生成 16 个 skill，复制到 ~/.hermes/skills/
+#   3. 复制 miloco 插件到 ~/.hermes/plugins/miloco/，复制 adapter 到同目录
+#   4. 自动 patch $MILOCO_HOME/config.json 的 agent 段（webhook_url + auth_bearer，备份原文件）
+#   5. 自动给 ~/.hermes/.env 补 API_SERVER_KEY（如缺失则生成；存在则复用）
+#   6. 停掉旧 adapter（按 pid 文件），nohup 启新 adapter，PID 写到 ~/.hermes/miloco-adapter.pid
+#   7. 打印终态：PID / 日志路径 / 后续唯一要做的步骤
+#
+# 幂等：再跑一次不会破坏现有配置，会重启 adapter 保留同一 Bearer。
+# 还原：$MILOCO_HOME/config.json.bak-* 是 patch 前的备份，~/.hermes/.env 自行删 API_SERVER_KEY 即可。
+#
+# 高级/手动安装请用 scripts/install.sh（不做 patch、不启 adapter）。
+# adapter 启停 / 日志请用 scripts/miloco-adapter.sh。
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+MILOCO_HOME="${MILOCO_HOME:-$HOME/.openclaw/miloco}"
+ADAPTER_PORT="${ADAPTER_PORT:-18789}"
+ADAPTER_LOG="$HERMES_HOME/miloco-adapter.log"
+ADAPTER_PID="$HERMES_HOME/miloco-adapter.pid"
+HERMES_PLUGINS_DIR="$HERMES_HOME/plugins/miloco"
+
+G='\033[0;32m'; Y='\033[1;33m'; R='\033[0;31m'; N='\033[0m'
+info() { echo -e "${G}[✓]${N} $*"; }
+warn() { echo -e "${Y}[!]${N} $*"; }
+err()  { echo -e "${R}[✗]${N} $*" >&2; }
+
+# 跨平台查占用某端口的进程 PID（Windows netstat / POSIX lsof/ss）
+# 注意：函数内对每个 pipeline 加 || true 兜底，因为脚本 set -o pipefail，
+# 跨调用方用 $(get_pid_by_port ... | tr ...) 拿值时，local 赋值在 pipeline 返回非零时
+# 行为在某些 bash 版本下会触发 set -e 退出，函数内兜底最稳。
+get_pid_by_port() {
+  local port="$1"
+  if command -v netstat >/dev/null 2>&1; then
+    netstat -ano 2>/dev/null \
+      | grep -E "[:.]$port[[:space:]]" 2>/dev/null \
+      | grep LISTENING 2>/dev/null \
+      | head -1 | awk '{print $NF}' \
+      || true
+  elif command -v lsof >/dev/null 2>&1; then
+    lsof -nP -iTCP:"$port" -sTCP:LISTEN -t 2>/dev/null | head -1 || true
+  elif command -v ss >/dev/null 2>&1; then
+    ss -ltnp 2>/dev/null | grep ":$port " 2>/dev/null | head -1 | grep -oP 'pid=\K[0-9]+' | head -1 || true
+  fi
+}
+
+# 跨平台杀进程：taskkill 优先，POSIX kill -9 兜底
+kill_pid() {
+  local pid="$1"
+  [ -z "$pid" ] && return 0
+  if command -v taskkill >/dev/null 2>&1; then
+    taskkill //PID "$pid" //F >/dev/null 2>&1 || true
+  else
+    kill -9 "$pid" 2>/dev/null || true
+  fi
+}
+
+# 杀 adapter 的两个兜底：先按 PID 杀（taskkill），再按端口反查 Windows PID 杀
+# 因为 Git Bash 的 $! 在 Windows 下不一定是 Windows native PID
+kill_adapter() {
+  local pid="$1" port="$2"
+  kill_pid "$pid"
+  sleep 1
+  if [ -n "$port" ]; then
+    # 注意：pipeline + set -o pipefail 会让空匹配返回 1 触发 set -e，
+    # 用 || echo "" 兜底
+    local p
+    p="$(get_pid_by_port "$port" | tr -d '\r\n ' || echo '')"
+    if [ -n "$p" ] && [ "$p" != "$pid" ]; then
+      warn "端口 $port 还被 Windows PID=$p 占着，taskkill 兜底"
+      kill_pid "$p"
+    fi
+  fi
+}
+
+# --- 1. 前置检查 ---
+command -v python3 >/dev/null 2>&1 || command -v python >/dev/null 2>&1 \
+  || { err "找不到 python，请先装 python"; exit 1; }
+PYTHON="$(command -v python3 || command -v python)"
+
+if ! command -v miloco-cli >/dev/null 2>&1; then
+  err "找不到 miloco-cli，请先装好 miloco 后端并确认 miloco-cli 在 PATH"; exit 1
+fi
+if [ ! -d "$HERMES_HOME" ]; then
+  err "找不到 Hermes 目录 $HERMES_HOME，请先装 Hermes Agent"; exit 1
+fi
+if [ ! -f "$MILOCO_HOME/config.json" ]; then
+  err "找不到 $MILOCO_HOME/config.json，请确认 MILOCO_HOME 正确（或 export MILOCO_HOME=...）"; exit 1
+fi
+
+# --- 2. 拿/复用 Bearer ---
+# 优先级：.env 已有的 API_SERVER_KEY > 旧 adapter pid 存在则重新生成 > 新生成
+if [ -f "$HERMES_HOME/.env" ] && grep -q '^API_SERVER_KEY=' "$HERMES_HOME/.env" 2>/dev/null; then
+  BEARER="$(grep '^API_SERVER_KEY=' "$HERMES_HOME/.env" | head -1 | cut -d= -f2-)"
+  info "复用 .env 已有的 API_SERVER_KEY（${BEARER:0:8}...）"
+else
+  BEARER="$("$PYTHON" -c 'import secrets; print(secrets.token_urlsafe(32))')"
+  info "新生成 adapter Bearer: ${BEARER:0:8}..."
+fi
+
+# --- 3. 同步 skills ---
+info "生成并复制 16 个 miloco-* skill → $HERMES_HOME/skills/"
+"$PYTHON" "$HERE/scripts/sync-skills.py"
+mkdir -p "$HERMES_HOME/skills"
+cp -r "$HERE/skills"/miloco-* "$HERMES_HOME/skills/"
+
+# --- 4. 复制插件 + adapter ---
+mkdir -p "$HERMES_PLUGINS_DIR"
+info "复制 Hermes 插件 → $HERMES_PLUGINS_DIR/miloco-plugin/"
+rm -rf "$HERMES_PLUGINS_DIR/miloco-plugin"
+cp -r "$HERE/miloco-plugin" "$HERMES_PLUGINS_DIR/miloco-plugin"
+info "复制 adapter → $HERMES_PLUGINS_DIR/adapter/"
+rm -rf "$HERMES_PLUGINS_DIR/adapter"
+cp -r "$HERE/adapter" "$HERMES_PLUGINS_DIR/adapter"
+# 清 pycache
+find "$HERMES_PLUGINS_DIR" -type d -name __pycache__ -prune -exec rm -rf {} + 2>/dev/null || true
+
+# --- 5. patch $MILOCO_HOME/config.json ---
+info "patch $MILOCO_HOME/config.json 的 agent 段..."
+TS="$(date +%Y%m%d-%H%M%S)"
+cp "$MILOCO_HOME/config.json" "$MILOCO_HOME/config.json.bak-$TS"
+"$PYTHON" - "$MILOCO_HOME" "$ADAPTER_PORT" "$BEARER" <<'PY'
+import json, sys
+home, port, bearer = sys.argv[1], sys.argv[2], sys.argv[3]
+p = f"{home}/config.json"
+cfg = json.load(open(p, encoding="utf-8"))
+cfg.setdefault("agent", {})
+cfg["agent"]["webhook_url"] = f"http://127.0.0.1:{port}/miloco/webhook"
+cfg["agent"]["auth_bearer"] = bearer
+json.dump(cfg, open(p, "w", encoding="utf-8"), indent=2, ensure_ascii=False)
+print(f"  webhook_url = http://127.0.0.1:{port}/miloco/webhook")
+print(f"  auth_bearer = {bearer[:8]}...")
+PY
+
+# --- 6. patch ~/.hermes/.env（仅当缺失时追加）---
+info "确保 $HERMES_HOME/.env 有 API_SERVER_KEY..."
+touch "$HERMES_HOME/.env"
+chmod 600 "$HERMES_HOME/.env"
+if ! grep -q '^API_SERVER_KEY=' "$HERMES_HOME/.env" 2>/dev/null; then
+  echo "API_SERVER_KEY=$BEARER" >> "$HERMES_HOME/.env"
+  info "已追加 API_SERVER_KEY 到 .env"
+else
+  warn ".env 已有 API_SERVER_KEY，保持原值"
+fi
+
+# --- 7. 重启 adapter ---
+# 停旧的（Git Bash $! 在 Windows 下 ≠ Windows native PID，按端口反查兜底）
+if [ -f "$ADAPTER_PID" ]; then
+  OLD_PID="$(cat "$ADAPTER_PID" 2>/dev/null || echo '')"
+  if [ -n "$OLD_PID" ] || [ -n "$ADAPTER_PORT" ]; then
+    warn "旧 adapter 进程在跑，先停掉（按 PID + 按端口双兜底）"
+    kill_adapter "$OLD_PID" "$ADAPTER_PORT"
+  fi
+  rm -f "$ADAPTER_PID"
+fi
+
+# 启新的
+info "启动 adapter 进程（端口 $ADAPTER_PORT）..."
+( cd "$HERMES_PLUGINS_DIR" \
+  && PYTHONUTF8=1 \
+     ADAPTER_AUTH_BEARER="$BEARER" \
+     HERMES_API_URL="http://127.0.0.1:8642" \
+     HERMES_API_KEY="$BEARER" \
+     ADAPTER_HOST="${ADAPTER_HOST:-127.0.0.1}" \
+     ADAPTER_PORT="$ADAPTER_PORT" \
+     nohup "$PYTHON" -m adapter \
+       > "$ADAPTER_LOG" 2>&1 & echo $! > "$ADAPTER_PID" )
+
+sleep 2
+# 关键：按端口反查 Windows native PID 覆盖写入 pid 文件（Git Bash $! 在 Windows 不可靠）
+WIN_PID="$(get_pid_by_port "$ADAPTER_PORT" | tr -d '\r\n ' || echo '')"
+if [ -n "$WIN_PID" ]; then
+  echo "$WIN_PID" > "$ADAPTER_PID"
+  info "adapter 已起，PID=$WIN_PID（按端口反查）"
+else
+  err "adapter 启动失败，端口 $ADAPTER_PORT 未监听，看 $ADAPTER_LOG 末尾："
+  tail -20 "$ADAPTER_LOG" >&2 || true
+  exit 1
+fi
+
+# --- 8. 终态 ---
+cat <<EOF
+
+============================================================
+ ✅ 安装完成（可重复执行，幂等）
+============================================================
+
+[后续你只要做这一件事] 重启 Hermes gateway 让插件和新配置生效：
+    hermes gateway restart
+    （或 hermes gateway stop && hermes gateway start）
+
+[试一下]
+    hermes chat -q "把客厅灯打开" -Q
+
+[adapter 状态]
+    bash $HERE/scripts/miloco-adapter.sh status    # 看 PID / 端口
+    bash $HERE/scripts/miloco-adapter.sh logs      # tail 日志
+    bash $HERE/scripts/miloco-adapter.sh restart   # 重启
+    bash $HERE/scripts/miloco-adapter.sh stop      # 停
+
+[配置文件位置]
+    $MILOCO_HOME/config.json   # miloco 后端配置（已 patch）
+    $HERMES_HOME/.env          # Hermes 环境（已追加 API_SERVER_KEY）
+    $ADAPTER_PID               # adapter PID
+    $ADAPTER_LOG               # adapter 日志
+
+[想还原]
+    $MILOCO_HOME/config.json.bak-$TS  是 patch 前的备份
+    $HERMES_HOME/.env 里去掉 API_SERVER_KEY 即可
+    卸插件：rm -rf $HERMES_PLUGINS_DIR $HERMES_HOME/skills/miloco-*
+
+[详细文档] $HERE/README.md
+============================================================
+EOF

--- a/plugins/hermes/miloco-plugin/__init__.py
+++ b/plugins/hermes/miloco-plugin/__init__.py
@@ -1,0 +1,103 @@
+"""Miloco for Hermes Agent —— 出站核心插件。
+
+把 miloco（家庭智能管家）的能力以 Hermes 插件形式接入：
+- ``pre_llm_call`` 钩子按 session profile 注入 miloco 上下文（identity / capabilities /
+  perception / memory / notify / language + home-profile + pending-suggestions +
+  device-catalog），移植自 openclaw ``hooks/prompt.ts``。
+- 三个 tool：``miloco_im_push`` / ``miloco_notify_bind``（两段式通知协议，移植自
+  ``tools/notify.ts``）、``miloco_habit_suggest``（习惯建议防骚扰状态机，移植自
+  ``home-profile/suggestions.ts``）。
+- 启动时 reconcile 4 个受管 cron job（移植自 ``home-profile/scheduler.ts``）。
+
+移植的 openclaw TS 源（逻辑 1:1）：
+- ``plugins/openclaw/src/miloco/paths.ts``       → paths.py
+- ``plugins/openclaw/src/miloco/config.ts``      → config.py（读部分）
+- ``plugins/openclaw/src/services/catalog.ts``   → catalog.py
+- ``plugins/openclaw/src/hooks/prompt.ts``       → context_injection.py
+- ``plugins/openclaw/src/home-profile/helpers.ts`` → context_injection.py
+- ``plugins/openclaw/src/home-profile/injection.ts`` → context_injection.py
+- ``plugins/openclaw/src/tools/notify.ts``       → tools_notify.py + notify_target.py
+- ``plugins/openclaw/src/home-profile/suggestions.ts`` → tools_habit.py
+- ``plugins/openclaw/src/home-profile/scheduler.ts`` → cron_setup.py
+
+约束：Python 3.11+，标准库 + httpx（Hermes 依赖里已有）。所有调 Hermes ctx 的地方
+try/except，插件加载不能因某个注册失败而崩。
+"""
+
+from __future__ import annotations
+
+import logging
+
+from .context_injection import inject_context
+from .cron_setup import reconcile_cron_jobs
+from .tools_habit import (
+    MILOCO_HABIT_SUGGEST_SCHEMA,
+    handle_habit_suggest,
+)
+from .tools_notify import (
+    MILOCO_IM_PUSH_SCHEMA,
+    MILOCO_NOTIFY_BIND_SCHEMA,
+    make_im_push_handler,
+    make_notify_bind_handler,
+)
+
+logger = logging.getLogger(__name__)
+
+TOOLSET = "miloco"
+
+
+def register(ctx) -> None:
+    """注册 pre_llm_call 钩子 + 3 个 tool，并 reconcile 受管 cron。
+
+    每个注册独立 try/except：单个失败不影响其余功能，也绝不让插件加载崩掉 Hermes。
+    """
+    # ── pre_llm_call 钩子 ──────────────────────────────────────────────
+    try:
+        ctx.register_hook("pre_llm_call", inject_context)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("注册 pre_llm_call 失败: %s", exc)
+
+    # ── tools ──────────────────────────────────────────────────────────
+    try:
+        ctx.register_tool(
+            name="miloco_im_push",
+            toolset=TOOLSET,
+            schema=MILOCO_IM_PUSH_SCHEMA,
+            handler=make_im_push_handler(ctx),
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("注册 miloco_im_push 失败: %s", exc)
+
+    try:
+        ctx.register_tool(
+            name="miloco_notify_bind",
+            toolset=TOOLSET,
+            schema=MILOCO_NOTIFY_BIND_SCHEMA,
+            handler=make_notify_bind_handler(ctx),
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("注册 miloco_notify_bind 失败: %s", exc)
+
+    try:
+        ctx.register_tool(
+            name="miloco_habit_suggest",
+            toolset=TOOLSET,
+            schema=MILOCO_HABIT_SUGGEST_SCHEMA,
+            handler=handle_habit_suggest,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("注册 miloco_habit_suggest 失败: %s", exc)
+
+    # ── 受管 cron reconcile ────────────────────────────────────────────
+    # 放最后：cron 模块不在时 graceful 跳过，不影响已注册的 hook/tool。
+    try:
+        result = reconcile_cron_jobs()
+        if result.get("skipped"):
+            logger.info("miloco cron reconcile 跳过（cron 模块不可用）")
+        else:
+            logger.info(
+                "miloco cron reconcile 完成: created=%s updated=%s removed=%s",
+                result.get("created"), result.get("updated"), result.get("removed"),
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("miloco cron reconcile 失败: %s", exc)

--- a/plugins/hermes/miloco-plugin/catalog.py
+++ b/plugins/hermes/miloco-plugin/catalog.py
@@ -1,0 +1,95 @@
+"""设备目录注入（spec-injection-plan §5.4）。
+
+移植自 openclaw TypeScript 插件 ``plugins/openclaw/src/services/catalog.ts``。
+
+在 ``pre_llm_call`` 钩子里跑 ``miloco-cli device catalog`` 生成目录文本。CLI
+内部每次都调后端 ``GET /api/miot/device_history`` 拿最新 LRU snapshot 并读本地
+``home_info.json``，所以重跑就能反映用户最近的控制行为。
+
+5 秒节流：只防同一对话片段里 hook 被多次调用的 spam。**不**把 home_info.json
+mtime 作为缓存命中条件——LRU 变化在控制路径写入后端 SQLite，不会改
+home_info.json mtime，用 mtime 判断会把 LRU 永远卡在缓存里。
+
+调 CLI 失败（未安装 / 后端未起 / spec 未填）时沿用旧缓存或返回空字符串，让
+prompt 不带目录工作（agent 走 ``device list`` + ``device spec`` fallback）。
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import threading
+import time
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# 防抖：CLI 调用不应被 spam。与 TS 端 REGEN_THROTTLE_MS = 5_000 一致。
+REGEN_THROTTLE_SECONDS = 5.0
+# 后端慢（如批量 parse spec）会让 CLI 内部 httpx 等到 30s 超时。10s 上限到点
+# SIGTERM，run_cli_catalog 返回 None → get_catalog 沿用旧缓存。
+_CLI_TIMEOUT_SECONDS = 10.0
+
+_lock = threading.Lock()
+# 进程内缓存：{text, generated_at}。None 表示从未成功生成过。
+_cached: Optional[dict] = None
+
+
+def _run_cli_catalog() -> Optional[str]:
+    """调 ``miloco-cli device catalog``，失败/超时返回 None。"""
+    try:
+        proc = subprocess.run(
+            ["miloco-cli", "device", "catalog"],
+            capture_output=True,
+            text=True,
+            timeout=_CLI_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except FileNotFoundError:
+        logger.warning("miloco-cli 未找到，device catalog 跳过")
+        return None
+    except subprocess.TimeoutExpired:
+        logger.warning("miloco-cli device catalog 超时（%ss）", _CLI_TIMEOUT_SECONDS)
+        return None
+    except Exception as exc:  # noqa: BLE001 - 子进程异常全部降级为 None
+        logger.warning("miloco-cli device catalog spawn failed: %s", exc)
+        return None
+
+    if proc.returncode != 0:
+        stderr = (proc.stderr or "")[:200]
+        logger.warning("miloco-cli device catalog exited %s: %s", proc.returncode, stderr)
+        return None
+
+    stdout = proc.stdout or ""
+    return stdout or None
+
+
+def get_catalog() -> str:
+    """拿到当前缓存中的目录文本，必要时刷新。失败返回空字符串。
+
+    线程安全：用锁保护缓存读写，避免并发 hook 触发时多次跑 CLI。
+    """
+    global _cached
+    now = time.monotonic()
+
+    with _lock:
+        if _cached and now - _cached["generated_at"] < REGEN_THROTTLE_SECONDS:
+            return _cached["text"]
+
+    text = _run_cli_catalog()
+    if text is None:
+        # 生成失败 → 沿用旧缓存（如果有），否则空字符串
+        with _lock:
+            return _cached["text"] if _cached else ""
+
+    with _lock:
+        _cached = {"text": text, "generated_at": now}
+    logger.info("device catalog refreshed (%d chars)", len(text))
+    return text
+
+
+def _reset_catalog_cache() -> None:
+    """仅为测试 / hot-reload 之用：手动清缓存。"""
+    global _cached
+    with _lock:
+        _cached = None

--- a/plugins/hermes/miloco-plugin/config.py
+++ b/plugins/hermes/miloco-plugin/config.py
@@ -1,0 +1,93 @@
+"""读取 miloco 共享配置 ``$MILOCO_HOME/config.json``。
+
+移植自 openclaw TypeScript 插件 ``plugins/openclaw/src/miloco/config.ts`` 的
+**读取部分**（``loadSharedConfig`` 的纯读分支）——不做写回、不合并 gateway 凭据、
+不解析 plugin 自身配置。Hermes 插件侧只关心 ``server.token`` / ``server.url`` /
+``model.omni.*`` 这几个 miloco 后端运行时关键字段。
+
+返回值结构（所有字段缺失时给 schema 默认值）::
+
+    {
+      "debug": bool,
+      "server": {"url": str, "token": str, "tls_verify": bool, "python_bin": str},
+      "agent":  {"webhook_url": str, "auth_bearer": str},
+      "model":  {"omni": {"model": str, "base_url": str, "api_key": str}},
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict
+
+from .paths import miloco_config_file
+
+logger = logging.getLogger(__name__)
+
+
+# 与 backend/miloco/src/miloco/config/settings.schema.json 对齐的默认值。
+# 只保留 Hermes 出站插件实际用得到的字段，省略已废弃的 tls_certfile / tls_keyfile。
+_DEFAULTS: Dict[str, Any] = {
+    "debug": False,
+    "server": {
+        "url": "http://127.0.0.1:1810",
+        "token": "",
+        "tls_verify": False,
+        "python_bin": "",
+    },
+    "agent": {
+        "webhook_url": "http://127.0.0.1:18789/miloco/webhook",
+        "auth_bearer": "",
+    },
+    "model": {
+        "omni": {
+            "model": "xiaomi/mimo-v2.5",
+            "base_url": "https://api.xiaomimimo.com/v1",
+            "api_key": "",
+        }
+    },
+}
+
+
+def _deep_merge(defaults: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+    """把 override 深合并进 defaults，返回新 dict（不修改入参）。"""
+    out: Dict[str, Any] = {}
+    for key, dval in defaults.items():
+        if isinstance(dval, dict):
+            oval = override.get(key, {})
+            out[key] = _deep_merge(dval, oval if isinstance(oval, dict) else {})
+        elif key in override:
+            out[key] = override[key]
+        else:
+            out[key] = dval
+    # 保留 override 里 defaults 没声明的额外字段（schema additionalProperties=true）。
+    for key, oval in override.items():
+        if key not in out:
+            out[key] = oval
+    return out
+
+
+def _safe_load_json(path: Path) -> Dict[str, Any]:
+    """读 JSON 文件，缺失/解析失败时返回空 dict（不抛错）。"""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        logger.warning("miloco config.json 解析失败 (%s): %s", path, exc)
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def load_shared_config() -> Dict[str, Any]:
+    """读取 ``$MILOCO_HOME/config.json``，用 schema 默认值补齐缺失字段。
+
+    文件缺失或损坏时不抛异常，返回全默认值——Hermes 插件加载不能因此崩。
+    返回的 dict 结构稳定，调用方可直接 ``cfg["server"]["token"]`` 取值。
+    """
+    raw = _safe_load_json(miloco_config_file())
+    return _deep_merge(_DEFAULTS, raw)

--- a/plugins/hermes/miloco-plugin/context_injection.py
+++ b/plugins/hermes/miloco-plugin/context_injection.py
@@ -1,0 +1,318 @@
+"""pre_llm_call 钩子：按 session profile 注入 miloco 上下文。
+
+移植自 openclaw TypeScript 插件 ``plugins/openclaw/src/hooks/prompt.ts`` +
+``home-profile/helpers.ts`` + ``home-profile/injection.ts``。
+
+Hermes 设计上 ``pre_llm_call`` 只能往 **user message** 注入 ``{"context": text}``
+（保 prompt cache，不污染 system prompt）。openclaw 端原本分
+``prependSystemContext`` / ``appendSystemContext`` 两段，这里合并成单个 context
+块：先指令块（identity/capabilities/perception/memory/notify/language），再数据块
+（home-profile / pending-suggestions / device-catalog），用分隔线隔开。
+
+profile 判定（与 TS 端 ``resolveProfile`` 对齐）：
+- ``platform == "cron"`` 或 session_id 含 ``":cron:"`` / ``"miloco:cron:"`` → minimal
+- session_id 含 ``"miloco-rule"``     → rule
+- session_id 含 ``"miloco-suggest"``  → suggestion
+- 其余（含一切用户 IM）             → full
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .catalog import get_catalog
+from .paths import miloco_home
+
+logger = logging.getLogger(__name__)
+
+
+Profile = str  # "full" | "suggestion" | "rule" | "minimal"
+
+
+# ---------------------------------------------------------------------------
+# profile 判定
+# ---------------------------------------------------------------------------
+
+def resolve_profile(
+    session_id: Optional[str],
+    platform: Optional[str] = None,
+    user_message: Optional[str] = None,
+) -> Profile:
+    """与 TS 端 ``resolveProfile(sessionKey, {prompt, trigger})`` 等价。
+
+    cron 标识三选一命中即 minimal：``platform == "cron"``、
+    user_message 以 ``[cron:`` 开头、session_id 含 ``:cron:`` 或以 ``cron:`` 开头。
+    """
+    key = session_id or ""
+
+    if (
+        platform == "cron"
+        or (user_message or "").startswith("[cron:")
+        or ":cron:" in key
+        or key.startswith("cron:")
+    ):
+        return "minimal"
+    if "miloco-rule" in key:
+        return "rule"
+    if "miloco-suggest" in key:
+        return "suggestion"
+    return "full"
+
+
+# ---------------------------------------------------------------------------
+# 静态指令块（抄自 prompt.ts，文本保持 1:1）
+# ---------------------------------------------------------------------------
+
+B_IDENTITY = (
+    "你是经验丰富的家庭智能管家 Miloco。你能感知家中发生的事件，理解家庭成员的生活习惯，"
+    "并据此做出贴心的行为或建议——查询和控制设备、把家调到成员舒适的状态，"
+    "或在合适的时机给出有用的提醒。\n"
+    "说话像住在这个家里的人：自然、利落、有分寸。不堆砌设备状态、传感器读数或技术细节，除非成员问起。"
+)
+
+B_CAPABILITIES = """## 能力概览
+- 设备控制：查询和控制家中设备、调节环境、触发场景，把家调到成员舒适的状态
+- 实时感知：查看家里此刻的状态——传感器读数、摄像头多模态理解
+- 主动智能：结合感知记忆、家庭档案和当下的时间 / 环境，在合适时机给成员合理的提醒或建议，并通过语音 / IM / 米家推送送达
+- 任务编排：把成员交代的事编排成提醒、周期任务、累积统计，或"满足条件就自动执行"的规则
+- 家庭记忆：感知记忆（家中每天发生的事件）+ 家庭档案（成员构成、行为作息习惯、设备使用习惯）
+- 成员识别：家庭成员的注册与识别"""
+
+PERCEPTION_FORMAT = {
+    "voice": (
+        "- 语音指令（header `[感知引擎]语音提醒：`）：每条按 key:value 多段竖排（与规则触发同形），"
+        "多条用 `═══` 分隔。字段：时间、来源、画面描述（可选）、说话人、语音指令。"
+    ),
+    "suggestion": (
+        "- 事件提醒（header `[感知引擎]事件提醒：`）：每条按 key:value 多段竖排，多条用 `═══` 分隔。"
+        "字段：时间、来源、画面描述（可选）、检测到、事件优先级、建议。"
+    ),
+    "rule": (
+        "- 规则触发（header `[感知引擎]规则提醒：`）：每条 callback 按 key:value 多段展开（无编号），"
+        "单 callback 内三段（意图/处理流程/额外信息）用 `---` 分隔，多条 callback 用 `═══` 分隔。结构：\n"
+        "  ```\n"
+        "  [感知引擎]规则提醒：\n"
+        "  时间：HH:MM:SS                              ← fire 时刻\n"
+        "  来源：房间的设备(did=xxx)                    ← 触发设备身份\n"
+        "  画面描述：场景                                ← 可选，有摄像头画面时\n"
+        "  触发条件：rule 条件文本\n"
+        "  触发原因：原因\n"
+        "\n"
+        "  **意图**：\n"
+        "  <业务文案：本次 fire 要做什么，可能多行>\n"
+        "\n"
+        "  ---\n"
+        "\n"
+        "  **处理流程**：                               ← 仅 record-bound rule（task 绑了 record）出现，按时间序 1→2→3 执行：\n"
+        "  1. 前置闸门——fire 前 get record，若 status=completed → 跳过 step 2 和所有通知；意图里的设备动作不受影响\n"
+        "  2. record 写操作纪律——按 JSON 字段名选对应 CLI（actual_started_at/exited_at → session-start/end；意图首句 计数加一 → progress-inc / 事件追加 → event-append），先于通知 / 设备动作执行\n"
+        "  3. 后置判定——按 mutate 响应：status 首次翻 completed → 本次通知达标；noop=true+task_paused → 静默\n"
+        "  细节按段内具体指引执行，不要心算。\n"
+        "\n"
+        "  ---\n"
+        "\n"
+        "  **额外信息**：\n"
+        '  {"task_id": "...", "actual_started_at": "ISO", ...}\n'
+        "  ```\n"
+        "**意图** = 业务文案；**额外信息** = 单行 JSON，task_id / 时间戳等 fire-time 参数从这里取，别扫文本。"
+    ),
+}
+
+
+def _build_perception(profile: Profile) -> str:
+    formats: List[str]
+    if profile == "full":
+        formats = [PERCEPTION_FORMAT["voice"], PERCEPTION_FORMAT["suggestion"], PERCEPTION_FORMAT["rule"]]
+    elif profile == "suggestion":
+        formats = [PERCEPTION_FORMAT["suggestion"]]
+    else:  # rule
+        formats = [PERCEPTION_FORMAT["rule"]]
+    return (
+        "## 感知\n"
+        "家中的事件由感知引擎推送给你，按类型分节（语音提醒 / 事件提醒 / 规则提醒），"
+        "每节以对应 header 开头。三类条目都按 key:value 多段竖排，多条同类用 `═══` 分隔；"
+        "规则提醒在元信息段之后再有意图 / 处理流程 / 额外信息三段，段间用 `---` 分隔。"
+        "画面描述字段在有摄像头画面时出现。格式：\n"
+        + "\n".join(formats)
+        + "\n\n"
+        "字段：**来源** = 设备注册的真实房间（判断房间以它为准，别从文本里猜）；"
+        "括号 `did` 是回控设备的唯一标识；**时间**（`HH:MM:SS`）= 画面捕获时刻。\n\n"
+        "收到多条时，先合并再响应：\n"
+        "- **去重**：短时间内可能有多条语义相近的推送，当作同一件事，取信息最全的只响应一次。\n"
+        "- **跨相机融合理解**：可能同时推来多达 4 个摄像头的画面；不同摄像头或是同一房间的不同视角、"
+        "或是同一家不同房间。要融合起来理解，既看清各房间在发生什么，也判断事件之间可能的关联。"
+    )
+
+
+B_MEMORY = """## 家庭记忆
+做任何事（控设备、给建议、写通知）之前，先查这两份记忆，让动作更精准、更合成员心意：
+- **感知记忆**——家里最近发生了什么（每天自动归档的事件），用 `memory_search` 查（读不到当天文件就跳过）。
+- **家庭档案**——成员的偏好、习惯、家庭规则、设备使用经验，见另注入的家庭档案摘要。
+
+用户实时指令 > 档案规则（除非档案明确标注为底线 / 红线）。对话中出现成员喜好 / 家人信息 / 作息规律时，即使没说"记录"，也静默写入档案（先 `home-profile list` 看全量再写）。"""
+
+# 留空占位：与 TS 端一致。
+B_RULE_EXEC = ""
+B_CONSTRAINTS = ""
+
+B_NOTIFY = """## 通知用户
+**要主动找人时——而不是当面回答用户此刻的提问——动手前必须先读 `miloco-notify` skill。** 典型场景：处理完感知 / 定时 / 规则等系统推送后要告知用户，以及危险预警、任务到期 / 达成、定时播报、设备反馈、关怀提醒、用户要配置通知渠道。
+为什么是硬性前置、不能跳过：
+- **处理系统推送时你的回话对用户不可见**——光把结论写进回复，没有任何人收到，等于没通知。必须经本 skill 决策并交付渠道才算送达。
+- 通知要决策「给谁 → 走哪个渠道（TTS / IM / 米家推送）→ 说什么」，这套判断只在 skill 里；别绕过它直接裸调 `miloco_im_push` / `miloco-cli notify push` / TTS，否则容易选错人、选错渠道、说错话。"""
+
+B_LANGUAGE = "## 输出语言\n用用户使用的语言回复用户（设备名、人名、专有名词保持原样）。"
+
+
+# ---------------------------------------------------------------------------
+# 动态数据块
+# ---------------------------------------------------------------------------
+
+DEVICE_CATALOG_INTRO = """## 设备目录
+下方 `# devices catalog` 是预注入的高频设备子集（≤50 台，非全量），字段规则见下方目录头部的注释。它**只用于快速拿到已点名单台设备的 did / spec_name**，不是全屋设备的全集。凡涉及设备**集合 / 多台 / 不确定数量**（无论查询还是控制），或目录里找不到目标，**必须先 `device list` 拉全量**再逐台处理，别拿子集当全部。
+**任何 `device control / props / action` 或 `scene` 命令前（含查询），必须先读 `miloco-devices` skill**——命令选择、集合判定、安全确认、补 on、错误处理等都在其中，别只凭本目录裸发。"""
+
+
+def _home_profile_path() -> Path:
+    """家庭档案渲染产物：``$MILOCO_HOME/home-profile/profile.md``。"""
+    return miloco_home() / "home-profile" / "profile.md"
+
+
+def _read_text_safe(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def load_home_profile() -> str:
+    """读 profile.md；缺失返回哨兵串 ``(暂无内容)``。"""
+    return _read_text_safe(_home_profile_path()) or "(暂无内容)"
+
+
+def build_home_profile_block() -> str:
+    """与 TS 端 ``buildHomeProfileBlock`` 对齐：把 profile.md 整体降一级后返回。
+
+    空档案哨兵串无标题行，补上 ``## 家庭档案`` 以免 append 区出现孤立文本。
+    """
+    md = load_home_profile().strip()
+    if not md:
+        return ""
+    demoted = re.sub(r"^(#{1,5}) ", r"#\1 ", md, flags=re.MULTILINE)
+    if demoted.startswith("## 家庭档案"):
+        return demoted
+    return f"## 家庭档案\n\n{md}"
+
+
+def build_pending_suggestion_block() -> str:
+    """待回应习惯建议的注入块。
+
+    移植自 ``home-profile/injection.ts`` 的 ``buildPendingSuggestionBlock``。
+    仅在确有未作废 ``asked`` 条目时返回，否则空串（正常日子完全静默）。
+    """
+    # 延迟导入避免循环依赖（tools_habit 也会 import 本模块）。
+    try:
+        from .tools_habit import load_open_questions
+        open_items = load_open_questions()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("load_open_questions failed: %s", exc)
+        return ""
+    if not open_items:
+        return ""
+
+    items = "\n".join(f"- [{e['key']}] {e['title']}：{e['suggestion']}" for e in open_items)
+    return (
+        "## 等用户回应的习惯建议\n\n"
+        "你此前主动向用户推荐过把下面的习惯设成任务，正在等用户回应（**请勿重复推送同一条**）：\n\n"
+        f"{items}\n\n"
+        "**如何处理用户这条消息：**\n"
+        "- 若是肯定/选择/否定语气（\"好/可以/行/就第一个/不用了/不要\"等）且**没有**其它明确意图 → 这就是对上面建议的答复：\n"
+        '  - 同意 → **先用一句话复述命中的是哪条**，再加载 miloco-create-task skill 据该 suggestion 建任务；**建成、拿到 task_id 后** `miloco_habit_suggest(action="resolve", key, outcome="created", task_id="<新任务id>")`。若 create-task 当轮以反问/中断结束、未建成 → 先不 resolve，条目留待用户补答后再落地（勿凭空 resolve）。\n'
+        '  - 拒绝 → `miloco_habit_suggest(action="resolve", key="<对应 key>", outcome="rejected")`，简短回应即可，**之后不再就这条打扰**。\n'
+        '- 多条待回应时按用户指代（"第一个/那个喝水的"）定位对应 key。\n'
+        "- 若用户这条消息**与这些建议无关**（在说别的事）→ **忽略本段，照常处理，不要调用 resolve**。"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 装配
+# ---------------------------------------------------------------------------
+
+def _build_prepend(profile: Profile) -> str:
+    """指令块，按 prompt.ts §3 序。"""
+    parts: List[str] = [B_IDENTITY]
+    if profile == "full":
+        parts.append(B_CAPABILITIES)
+    if profile != "minimal":
+        parts.append(_build_perception(profile))
+    if profile == "rule" and B_RULE_EXEC:
+        parts.append(B_RULE_EXEC)
+    if profile != "minimal":
+        parts.append(B_MEMORY)
+    if B_CONSTRAINTS:
+        parts.append(B_CONSTRAINTS)
+    parts.append(B_NOTIFY)
+    parts.append(B_LANGUAGE)
+    return "\n\n".join(parts)
+
+
+def _build_append(profile: Profile) -> str:
+    """数据块（档案 → 待回应 → 目录），minimal 不带。"""
+    if profile == "minimal":
+        return ""
+    parts: List[str] = []
+
+    profile_block = build_home_profile_block()
+    if profile_block:
+        parts.append(profile_block)
+
+    if profile == "full":
+        pending = build_pending_suggestion_block()
+        if pending:
+            parts.append(pending)
+
+    catalog = get_catalog()
+    if catalog:
+        # 套 ```text 围栏：catalog 是类 TSV 数据块，行首 `#` 是注释前缀而非
+        # markdown 标题，裸贴会让 `# devices catalog` 在 `## 设备目录`(H2) 下
+        # 被解析成 H1 倒挂。
+        parts.append(f"{DEVICE_CATALOG_INTRO}\n\n```text\n{catalog}\n```")
+
+    return "\n\n".join(parts)
+
+
+def inject_context(
+    session_id: str = "",
+    user_message: str = "",
+    conversation_history: Optional[list] = None,
+    is_first_turn: bool = False,
+    model: str = "",
+    platform: str = "",
+    **kwargs: Any,
+) -> Optional[Dict[str, str]]:
+    """``pre_llm_call`` 回调：返回 ``{"context": text}`` 注入到本回合 user message。
+
+    签名与 Hermes ``pre_llm_call`` 契约一致
+    （见 website/docs/user-guide/features/hooks.md）。任何装配异常都降级为
+    返回 None——绝不让插件崩掉主对话。
+    """
+    try:
+        profile = resolve_profile(session_id, platform, user_message)
+        prepend = _build_prepend(profile)
+        append = _build_append(profile)
+
+        sections = [prepend] if prepend else []
+        if append:
+            sections.append(append)
+        if not sections:
+            return None
+
+        # 用分隔线把指令块和数据块分开，便于 agent 区分。
+        context = "\n\n---\n\n".join(sections)
+        return {"context": context}
+    except Exception as exc:  # noqa: BLE001 - 钩子绝不抛
+        logger.exception("miloco context_inject 失败: %s", exc)
+        return None

--- a/plugins/hermes/miloco-plugin/cron_setup.py
+++ b/plugins/hermes/miloco-plugin/cron_setup.py
@@ -1,0 +1,178 @@
+"""reconcile miloco 受管 cron job。
+
+移植自 openclaw TypeScript 插件
+``plugins/openclaw/src/home-profile/scheduler.ts``。
+
+注册 4 个带 ``[miloco:home-profile]`` 标签的 cron job，并在每次启动时 reconcile
+（增删改对齐）：
+
+- miloco-perception-digest  ``*/15 * * * *``  skills=[miloco-perception-digest]
+- miloco-home-patrol        ``*/30 * * * *``  skills=[miloco-home-patrol]
+- miloco-home-dreaming      ``0 0 * * *``     skills=[miloco-home-observe, miloco-home-promote, miloco-home-prune]
+- miloco-habit-suggest      ``0 10 * * *``    skills=[miloco-habit-suggest]
+
+**与 openclaw 的差异**：Hermes ``cron.jobs.create_job`` 没有 ``description`` 字段，
+故把 ``[miloco:home-profile]`` 标签塞进 ``name``（``f"{MANAGED_TAG} {task_name}"``），
+reconcile 时按 ``name.startswith(MANAGED_TAG)`` 过滤受管 job。Hermes job 的
+``prompt`` 对应 openclaw ``payload.message``；``skills=[...]`` 对应 openclaw
+``payload.skills``（按顺序依次加载）。home-dreaming 的 prompt 显式要求按
+Observe → Promote → Prune 顺序执行。
+
+import 失败要 graceful：Hermes 不在运行环境时 ``cron.jobs`` 模块不可用，
+``reconcile_cron_jobs`` 直接返回，不影响插件其余功能。
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List
+
+logger = logging.getLogger(__name__)
+
+# 受管 job 标签：塞进 name 字段前缀，reconcile 据此识别。
+MANAGED_TAG = "[miloco:home-profile]"
+
+
+# 4 个受管 cron 任务定义。schedule 是 Hermes ``parse_schedule`` 接受的 cron 表达式。
+_CRON_TASKS: List[Dict[str, Any]] = [
+    {
+        "name": "miloco-perception-digest",
+        "schedule": "*/15 * * * *",
+        "skills": ["miloco-perception-digest"],
+        "prompt": "执行感知日志摘要。加载 miloco-perception-digest skill 进行处理。",
+    },
+    {
+        "name": "miloco-home-patrol",
+        "schedule": "*/30 * * * *",
+        "skills": ["miloco-home-patrol"],
+        "prompt": "执行家庭巡检。加载 miloco-home-patrol skill 进行巡检。",
+    },
+    {
+        "name": "miloco-home-dreaming",
+        "schedule": "0 0 * * *",
+        "skills": ["miloco-home-observe", "miloco-home-promote", "miloco-home-prune"],
+        "prompt": (
+            "执行 home-dreaming 流程。依次完成以下步骤：\n"
+            "1. **Observe** — 加载 miloco-home-observe skill，从感知/交互记忆中提取新知识写入候选区\n"
+            "2. **Promote** — 加载 miloco-home-promote skill，将候选区中达到条件的知识提升到正式档案\n"
+            "3. **Prune** — 加载 miloco-home-prune skill，统一主体命名、清理过期数据、提交持久化\n\n"
+            "执行规则：按顺序依次执行不可跳过。Step 1 没有新知识时仍需执行 Step 2（处理已有候选的提升）。"
+        ),
+    },
+    {
+        "name": "miloco-habit-suggest",
+        "schedule": "0 10 * * *",
+        "skills": ["miloco-habit-suggest"],
+        "prompt": (
+            "执行每日习惯洞察。加载 miloco-habit-suggest skill，按【路径 A · 扫描推荐】处理："
+            "从家庭档案识别值得建成任务的习惯，至多主动推荐一条。"
+        ),
+    },
+]
+
+
+def _import_cron_jobs():
+    """延迟 import cron.jobs；失败返回 None（graceful）。"""
+    try:
+        from cron.jobs import create_job, list_jobs, update_job, remove_job
+        return create_job, list_jobs, update_job, remove_job
+    except Exception as exc:  # noqa: BLE001
+        logger.info("cron.jobs 不可用，跳过 miloco 受管 cron reconcile: %s", exc)
+        return None
+
+
+def _managed_name(task_name: str) -> str:
+    return f"{MANAGED_TAG} {task_name}"
+
+
+def reconcile_cron_jobs() -> Dict[str, Any]:
+    """对齐 4 个受管 cron job。返回 ``{created, updated, removed, skipped}``。
+
+    逻辑（与 TS 端 ``reconcile`` 对齐）：
+    1. 列出现有 job，按 ``name.startswith(MANAGED_TAG)`` 过滤出受管集合。
+    2. 对每个期望任务：找不到 → create；找到 → update（刷新 schedule/skills/prompt）。
+    3. 受管集合里不在期望名单的 → remove（清理已废弃的受管 job）。
+    """
+    funcs = _import_cron_jobs()
+    if funcs is None:
+        return {"created": 0, "updated": 0, "removed": 0, "skipped": True}
+
+    create_job, list_jobs, update_job, remove_job = funcs
+    created = updated = removed = 0
+
+    try:
+        existing = list_jobs(include_disabled=True)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("list_jobs 失败，跳过 reconcile: %s", exc)
+        return {"created": 0, "updated": 0, "removed": 0, "skipped": True, "error": str(exc)}
+
+    # 受管 job：name 以 MANAGED_TAG 开头。
+    managed = [j for j in existing if str(j.get("name", "")).startswith(MANAGED_TAG)]
+
+    for task in _CRON_TASKS:
+        target_name = _managed_name(task["name"])
+        found = next((j for j in managed if j.get("name") == target_name), None)
+
+        if found is None:
+            try:
+                create_job(
+                    prompt=task["prompt"],
+                    schedule=task["schedule"],
+                    name=target_name,
+                    skills=list(task["skills"]),
+                    deliver="none",
+                )
+                created += 1
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("create_job(%s) 失败: %s", target_name, exc)
+        else:
+            # update：刷新 schedule / skills / prompt（name / id 不动）。
+            updates = {
+                "schedule": task["schedule"],
+                "skills": list(task["skills"]),
+                "prompt": task["prompt"],
+                "enabled": True,
+            }
+            try:
+                update_job(found["id"], updates)
+                updated += 1
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("update_job(%s) 失败: %s", found.get("id"), exc)
+
+    # 清理受管集合里不在期望名单的 job。
+    valid_names = {_managed_name(t["name"]) for t in _CRON_TASKS}
+    for job in managed:
+        if job.get("name") not in valid_names:
+            try:
+                remove_job(job["id"])
+                removed += 1
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("remove_job(%s) 失败: %s", job.get("id"), exc)
+
+    logger.info(
+        "miloco cron reconcile: created=%d updated=%d removed=%d",
+        created, updated, removed,
+    )
+    return {"created": created, "updated": updated, "removed": removed, "skipped": False}
+
+
+def teardown_cron_jobs() -> int:
+    """卸载时移除所有受管 cron job（与 TS 端 ``teardown`` 对齐）。返回移除数。"""
+    funcs = _import_cron_jobs()
+    if funcs is None:
+        return 0
+    _, list_jobs, _, remove_job = funcs
+    removed = 0
+    try:
+        existing = list_jobs(include_disabled=True)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("teardown list_jobs 失败: %s", exc)
+        return 0
+    for job in existing:
+        if str(job.get("name", "")).startswith(MANAGED_TAG):
+            try:
+                remove_job(job["id"])
+                removed += 1
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("teardown remove_job(%s) 失败: %s", job.get("id"), exc)
+    return removed

--- a/plugins/hermes/miloco-plugin/notify_target.py
+++ b/plugins/hermes/miloco-plugin/notify_target.py
@@ -1,0 +1,51 @@
+"""通知投递目标解析（best-effort）。
+
+移植自 openclaw TypeScript 插件 ``plugins/openclaw/src/tools/notify.ts`` 的
+``resolveNotifyTarget`` / ``notifyOwner`` 中"选目标"那一段。
+
+**与 openclaw 的关键差异**：Hermes 没有 openclaw 那种带 ``lastTo`` / ``lastChannel``
+的 SessionDB（``api.runtime.agent.session.loadSessionStore``），所以无法像 TS 端那样
+"fallback 到最近活跃 channel"。本模块采取更保守的策略：
+
+- 优先用 ``notifySessionKey``（由 ``miloco_notify_bind`` 写入插件配置 JSON）。
+  绑定的 key 形如 ``platform:chat_id[:thread_id]``，直接作为 ``send_message`` 的
+  ``target`` 用。
+- 未绑定或绑定失效 → 返回 ``needsBind=True``，让 agent 走两段式协议（补 bindHint
+  重调 ``miloco_im_push``）。**不强依赖** Hermes 内部 session 结构。
+
+binding 校验只做"非空字符串"级别；真实可用性交给 ``send_message`` 在投递时验证
+（target 不存在会返回 error，``miloco_im_push`` 据此返回 ``ok:false`` 让 agent 重绑）。
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+BindReason = str  # "not_configured" | "configured_but_invalid"
+
+
+def resolve_notify_target(notify_session_key: Optional[str]) -> Dict[str, Any]:
+    """返回 ``{"needsBind": bool, "target": {...}|None, "bindReason": str}``。
+
+    与 TS 端 ``resolveNotifyTarget`` 返回结构对齐，但 ``target`` 只含
+    Hermes ``send_message`` 需要的 ``target`` 字段（``platform:chat_id[:thread_id]``）。
+    """
+    if notify_session_key:
+        return {
+            "needsBind": False,
+            "bindReason": "",
+            "target": {"target": notify_session_key, "sessionKey": notify_session_key},
+        }
+    # 未绑定：target 留空。tools_notify.notify_owner 据此走两段式协议——
+    # 返回 needsBind=true + bindHintExample，让 agent 引导用户先
+    # miloco_notify_bind 绑定一个 target，再重发。不强依赖 Hermes
+    # SessionDB（Hermes 无 openclaw 那种 lastTo/lastChannel 结构）。
+    return {
+        "needsBind": True,
+        "bindReason": "not_configured",
+        "target": None,
+    }

--- a/plugins/hermes/miloco-plugin/paths.py
+++ b/plugins/hermes/miloco-plugin/paths.py
@@ -1,0 +1,31 @@
+"""MILOCO_HOME 路径解析。
+
+移植自 openclaw TypeScript 插件 ``plugins/openclaw/src/miloco/paths.ts``，
+与后端 Python 侧 ``miloco.utils.paths.miloco_home()`` 以及 CLI 侧
+``miloco_cli.config.miloco_home()`` 行为保持一致：优先读 ``$MILOCO_HOME``，
+未设置则落回 ``~/.openclaw/miloco``。
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def miloco_home() -> Path:
+    """返回 ``$MILOCO_HOME``，未设置则使用 ``~/.openclaw/miloco``。
+
+    每次调用都读取环境变量，便于测试用 ``MILOCO_HOME`` 临时注入。
+    以 ``~`` 开头的值会按主目录展开（与 TS 端 ``env.startsWith("~")`` 分支一致）。
+    """
+    env = os.environ.get("MILOCO_HOME", "")
+    if env:
+        if env.startswith("~"):
+            return Path.home() / env[1:].lstrip("/\\")
+        return Path(env)
+    return Path.home() / ".openclaw" / "miloco"
+
+
+def miloco_config_file() -> Path:
+    """返回 ``$MILOCO_HOME/config.json``（共享嵌套配置文件）。"""
+    return miloco_home() / "config.json"

--- a/plugins/hermes/miloco-plugin/plugin.yaml
+++ b/plugins/hermes/miloco-plugin/plugin.yaml
@@ -1,0 +1,35 @@
+name: miloco
+version: 0.1.0
+description: "Miloco for Hermes Agent —— 家庭智能管家 miloco 的 Hermes 出站插件。注入 miloco 上下文（identity/perception/memory/notify + home-profile/device-catalog），提供 miloco_im_push / miloco_notify_bind 两段式通知协议与 miloco_habit_suggest 习惯建议状态机，并 reconcile 4 个受管 cron job。"
+author: miloco
+kind: backend
+provides_tools:
+  - miloco_im_push
+  - miloco_notify_bind
+  - miloco_habit_suggest
+provides_hooks:
+  - pre_llm_call
+# configSchema 仅供文档/安装向导参考；Hermes PluginManifest 当前不解析此字段，
+# 插件运行时配置（如 notifySessionKey）由插件自管于 <plugin-dir>/state.json。
+configSchema:
+  debug:
+    type: boolean
+    default: false
+    description: 是否启用调试模式（更详细日志）
+  omni_model:
+    type: string
+    default: ""
+    description: 多模态模型标识（provider/model），如 xiaomi/mimo-v2.5。留空则沿用 $MILOCO_HOME/config.json 里的值
+  omni_base_url:
+    type: string
+    default: ""
+    description: 多模态模型服务 Base URL（需兼容 OpenAI-compatible 协议）。留空则沿用 $MILOCO_HOME/config.json 里的值
+  omni_api_key:
+    type: string
+    default: ""
+    secret: true
+    description: 多模态模型 API Key。留空则沿用 $MILOCO_HOME/config.json 里的值
+  notifySessionKey:
+    type: string
+    default: ""
+    description: 通知投递目标（platform:chat_id[:thread_id]）。由 miloco_notify_bind 工具写入，一般无需手填

--- a/plugins/hermes/miloco-plugin/tools_habit.py
+++ b/plugins/hermes/miloco-plugin/tools_habit.py
@@ -1,0 +1,424 @@
+"""miloco_habit_suggest 工具：习惯建议候选库的防骚扰状态机。
+
+移植自 openclaw TypeScript 插件
+``plugins/openclaw/src/home-profile/suggestions.ts``。
+
+背景：每日 10 点的 isolated cron（扫描 agent）从家庭档案识别"值得建成任务的
+习惯"，主动 IM 推荐；用户在主 IM session（回应 agent，与扫描 agent 不共享上下文）
+认可后加载 miloco-create-task 建任务。两个 agent 通过本库的持久状态衔接。
+
+设计核心：**让工具成为防骚扰的权威**——"同一时刻至多 1 条待回应 / 每天至多 1 条
+新推 / 拒绝永不再问 / 超 7 天没回应作废" 这些闸门都由工具裁定并拒绝越界写入，
+不依赖扫描 agent 自觉。
+
+状态机：pending → asked →（accepted → created）| rejected | expired。
+- rejected / created：永久终态，不再推荐。
+- expired：非永久——下次 record 同 key 复活为 pending 重新推荐；累计问满
+  MAX_ASKS(3) 次仍无果则永久放弃、不再复活。
+
+存储路径：``$MILOCO_HOME/home-profile/task-suggestions.json``（与 helpers.ts 的
+``habitSuggestionsPath`` 一致，两端共用同一文件）。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .paths import miloco_home
+
+logger = logging.getLogger(__name__)
+
+
+# ─── 常量（节奏=克制，硬编码，与 TS 端一致） ──────────────────────────────
+
+STORE_VERSION = 1
+MAX_OPEN_QUESTIONS = 1
+MAX_NEW_ASK_PER_DAY = 1
+STALE_DAYS = 7
+STALE_MS = STALE_DAYS * 86_400_000
+MAX_ASKS = 3
+
+
+# ─── 时间工具 ──────────────────────────────────────────────────────────────
+
+def now_local_iso() -> str:
+    """当前本地时间 ISO 字符串（与 TS 端 ``nowLocalIso`` 对齐，用本地时区）。"""
+    return datetime.now().astimezone().isoformat()
+
+
+def _to_timestamp(v: Any) -> int:
+    """把 ISO 字符串或数字转成毫秒时间戳；解析失败返回 0。"""
+    if isinstance(v, (int, float)):
+        return int(v)
+    if isinstance(v, str):
+        try:
+            dt = datetime.fromisoformat(v.replace("Z", "+00:00"))
+        except ValueError:
+            return 0
+        if dt.tzinfo is None:
+            dt = dt.astimezone()
+        return int(dt.timestamp() * 1000)
+    return 0
+
+
+def _local_date_key(iso: str) -> str:
+    """部署时区视角的日历日 key（YYYY-MM-DD）。"""
+    if not iso:
+        return ""
+    try:
+        dt = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+    except ValueError:
+        return ""
+    if dt.tzinfo is None:
+        dt = dt.astimezone()
+    return dt.strftime("%Y-%m-%d")
+
+
+def _elapsed_ms(from_iso: str, now_iso: str) -> int:
+    return _to_timestamp(now_iso) - _to_timestamp(from_iso)
+
+
+# ─── 存取 ──────────────────────────────────────────────────────────────────
+
+def _habit_suggestions_path() -> Path:
+    """与 helpers.ts ``habitSuggestionsPath`` 一致。"""
+    return miloco_home() / "home-profile" / "task-suggestions.json"
+
+
+def _load_store() -> Dict[str, Any]:
+    """读 task-suggestions.json；缺失/损坏返回空 store。"""
+    path = _habit_suggestions_path()
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return {"version": STORE_VERSION, "entries": []}
+    try:
+        raw = json.loads(text)
+    except json.JSONDecodeError as exc:
+        logger.warning("task-suggestions.json 解析失败 (%s): %s", path, exc)
+        return {"version": STORE_VERSION, "entries": []}
+    if isinstance(raw, dict) and isinstance(raw.get("entries"), list):
+        return {"version": raw.get("version", STORE_VERSION), "entries": raw["entries"]}
+    return {"version": STORE_VERSION, "entries": []}
+
+
+def _save_store(store: Dict[str, Any]) -> None:
+    """原子写（temp → rename）。失败仅 log。"""
+    path = _habit_suggestions_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(store, indent=2, ensure_ascii=False), encoding="utf-8")
+        tmp.replace(path)
+    except OSError as exc:
+        logger.warning("task-suggestions.json 写入失败 (%s): %s", path, exc)
+
+
+# ─── 进程内互斥 ────────────────────────────────────────────────────────────
+
+_lock = threading.Lock()
+
+
+# ─── 纯函数（便于测试，与 TS 端一一对应） ──────────────────────────────────
+
+def apply_expiry(store: Dict[str, Any], now_iso: str) -> bool:
+    """惰性过期：无明确回应的在途条目超 7 天 → expired。返回是否有变更。"""
+    changed = False
+    for e in store["entries"]:
+        stamp = None
+        if e.get("status") == "asked":
+            stamp = e.get("asked_at")
+        elif e.get("status") == "accepted":
+            stamp = e.get("resolved_at")
+        if stamp and _elapsed_ms(stamp, now_iso) > STALE_MS:
+            e["status"] = "expired"
+            e["resolved_at"] = now_iso
+            e["reason"] = f"{STALE_DAYS} 天无明确回应自动过期（可重新推荐）"
+            e["updated_at"] = now_iso
+            changed = True
+    return changed
+
+
+def _asked_today(store: Dict[str, Any], now_iso: str) -> bool:
+    today = _local_date_key(now_iso)
+    return any(e.get("asked_at") and _local_date_key(e["asked_at"]) == today for e in store["entries"])
+
+
+def _open_count(store: Dict[str, Any]) -> int:
+    return sum(1 for e in store["entries"] if e.get("status") == "asked")
+
+
+def can_ask_now(store: Dict[str, Any], now_iso: str) -> Dict[str, Any]:
+    """此刻是否还能发起新询问（待回应位未满 + 今天还没问过）。"""
+    if _open_count(store) >= MAX_OPEN_QUESTIONS:
+        return {"can": False, "reason": "已有待回应的建议，本次不再打扰"}
+    if MAX_NEW_ASK_PER_DAY > 0 and _asked_today(store, now_iso):
+        return {"can": False, "reason": "今天已经推荐过一条，明天再说"}
+    return {"can": True}
+
+
+def load_open_questions(now_iso: Optional[str] = None) -> List[Dict[str, Any]]:
+    """injection.ts 用：未作废的待回应条目（不写盘，作废留给下次工具调用持久化）。"""
+    now = now_iso or now_local_iso()
+    store = _load_store()
+    return [
+        e for e in store["entries"]
+        if e.get("status") == "asked"
+        and e.get("asked_at")
+        and _elapsed_ms(e["asked_at"], now) <= STALE_MS
+    ]
+
+
+# ─── action 实现 ───────────────────────────────────────────────────────────
+
+def _str(v: Any) -> str:
+    return v.strip() if isinstance(v, str) else ""
+
+
+def _view(e: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "key": e.get("key"),
+        "title": e.get("title"),
+        "subject": e.get("subject"),
+        "habit": e.get("habit"),
+        "suggestion": e.get("suggestion"),
+        "status": e.get("status"),
+        "asked_at": e.get("asked_at"),
+        "task_id": e.get("task_id"),
+        "item_id": e.get("item_id"),
+    }
+
+
+def _do_list(store: Dict[str, Any], now: str) -> Dict[str, Any]:
+    gate = can_ask_now(store, now)
+    open_q = [e for e in store["entries"] if e.get("status") == "asked"]
+    pending = [e for e in store["entries"] if e.get("status") == "pending"]
+    counts: Dict[str, int] = {}
+    for e in store["entries"]:
+        s = e.get("status", "")
+        counts[s] = counts.get(s, 0) + 1
+    return {
+        "dirty": False,
+        "res": {
+            "ok": True,
+            "can_ask_now": gate["can"],
+            "blocked_reason": gate.get("reason"),
+            "open_questions": [_view(e) for e in open_q],
+            "askable_pending": [_view(e) for e in pending],
+            "entries": [_view(e) for e in store["entries"]],
+            "counts": counts,
+        },
+    }
+
+
+def _do_record(store: Dict[str, Any], now: str, p: Dict[str, Any]) -> Dict[str, Any]:
+    key = _str(p.get("key"))
+    subject = _str(p.get("subject")) or "shared"
+    habit = _str(p.get("habit"))
+    suggestion = _str(p.get("suggestion"))
+    title = _str(p.get("title")) or habit[:24]
+    if not key or not habit or not suggestion:
+        return {"dirty": False, "res": {"ok": False, "error": "record 需要 key / habit / suggestion"}}
+
+    existing = next((e for e in store["entries"] if e.get("key") == key), None)
+    if existing:
+        status = existing.get("status")
+        if status in ("rejected", "created"):
+            return {"dirty": False, "res": {
+                "ok": True, "key": key, "status": status, "deduped": True,
+                "note": f"已存在且状态为 {status}，永久不再推荐",
+            }}
+        if status == "expired":
+            if existing.get("ask_count", 0) >= MAX_ASKS:
+                return {"dirty": False, "res": {
+                    "ok": True, "key": key, "status": "expired", "deduped": True,
+                    "note": f"已主动询问 {existing.get('ask_count')} 次仍无果，放弃、不再推荐",
+                }}
+            existing.update({
+                "status": "pending", "asked_at": None, "resolved_at": None, "reason": None,
+                "title": title, "subject": subject, "habit": habit, "suggestion": suggestion,
+                "evidence": _str(p.get("evidence")) or existing.get("evidence"),
+                "item_id": _str(p.get("item_id")) or existing.get("item_id"),
+                "updated_at": now,
+            })
+            return {"dirty": True, "res": {
+                "ok": True, "key": key, "status": "pending", "deduped": True, "revived": True,
+                "note": f"过期未答复，已重新纳入推荐候选（将是第 {existing.get('ask_count', 0) + 1} 次询问，上限 {MAX_ASKS}）",
+            }}
+        # pending / asked / accepted：在途
+        dirty = False
+        if status == "pending":
+            existing.update({
+                "title": title, "subject": subject, "habit": habit, "suggestion": suggestion,
+                "evidence": _str(p.get("evidence")) or existing.get("evidence"),
+                "item_id": _str(p.get("item_id")) or existing.get("item_id"),
+                "updated_at": now,
+            })
+            dirty = True
+        note = "已存在待处理候选（已刷新）" if status == "pending" else f"已存在且状态为 {status}"
+        return {"dirty": dirty, "res": {"ok": True, "key": key, "status": status, "deduped": True, "note": note}}
+
+    entry = {
+        "key": key, "title": title, "subject": subject, "habit": habit, "suggestion": suggestion,
+        "evidence": _str(p.get("evidence")) or None,
+        "item_id": _str(p.get("item_id")) or None,
+        "status": "pending", "ask_count": 0,
+        "created_at": now, "updated_at": now,
+    }
+    store["entries"].append(entry)
+    return {"dirty": True, "res": {"ok": True, "key": key, "status": "pending", "deduped": False}}
+
+
+def _do_mark_asked(store: Dict[str, Any], now: str, p: Dict[str, Any]) -> Dict[str, Any]:
+    key = _str(p.get("key"))
+    e = next((x for x in store["entries"] if x.get("key") == key), None)
+    if not e:
+        return {"dirty": False, "res": {"ok": False, "error": "找不到该建议 key"}}
+    if e.get("status") != "pending":
+        return {"dirty": False, "res": {"ok": False, "status": e.get("status"), "error": f"状态为 {e.get('status')}，不能标记为已询问"}}
+    gate = can_ask_now(store, now)
+    if not gate["can"]:
+        return {"dirty": False, "res": {"ok": False, "blocked_reason": gate.get("reason"), "error": gate.get("reason")}}
+    e["status"] = "asked"
+    e["asked_at"] = now
+    e["updated_at"] = now
+    e["ask_count"] = e.get("ask_count", 0) + 1
+    return {"dirty": True, "res": {"ok": True, "key": key, "status": "asked"}}
+
+
+def _do_resolve(store: Dict[str, Any], now: str, p: Dict[str, Any]) -> Dict[str, Any]:
+    key = _str(p.get("key"))
+    outcome = _str(p.get("outcome"))
+    e = next((x for x in store["entries"] if x.get("key") == key), None)
+    if not e:
+        return {"dirty": False, "res": {"ok": False, "error": "找不到该建议 key"}}
+    from_status = e.get("status")
+
+    if outcome == "rejected":
+        if from_status in ("created", "expired"):
+            return {"dirty": False, "res": {"ok": False, "status": from_status, "error": f"状态为 {from_status}，不能拒绝"}}
+        e["status"] = "rejected"
+        e["reason"] = _str(p.get("reason")) or None
+        e["resolved_at"] = now
+        e["updated_at"] = now
+        return {"dirty": True, "res": {"ok": True, "key": key, "status": "rejected"}}
+
+    if outcome == "accepted":
+        if from_status != "asked":
+            return {"dirty": False, "res": {"ok": False, "status": from_status, "error": f"状态为 {from_status}，不能接受（需处于 asked）"}}
+        e["status"] = "accepted"
+        e["resolved_at"] = now
+        e["updated_at"] = now
+        return {"dirty": True, "res": {
+            "ok": True, "key": key, "status": "accepted", "suggestion": e.get("suggestion"),
+            "next": "加载 miloco-create-task 据此建任务；建成后再次 resolve outcome=created 并回填 task_id",
+        }}
+
+    if outcome == "created":
+        if from_status not in ("accepted", "asked"):
+            return {"dirty": False, "res": {"ok": False, "status": from_status, "error": f"状态为 {from_status}，不能标记为已建（需先 accepted，或处于 asked）"}}
+        e["status"] = "created"
+        e["task_id"] = _str(p.get("task_id")) or e.get("task_id")
+        e["resolved_at"] = now
+        e["updated_at"] = now
+        return {"dirty": True, "res": {"ok": True, "key": key, "status": "created", "task_id": e.get("task_id")}}
+
+    return {"dirty": False, "res": {"ok": False, "error": f"未知 outcome：{outcome}"}}
+
+
+def apply_habit_action(
+    input: Dict[str, Any],
+    now_override: Optional[str] = None,
+) -> Dict[str, Any]:
+    """核心调度（load → 惰性作废 → dispatch → 按需写盘），全程持锁串行化。"""
+    with _lock:
+        now = now_override or now_local_iso()
+        store = _load_store()
+        expired = apply_expiry(store, now)
+        action = _str(input.get("action"))
+        if action == "list":
+            out = _do_list(store, now)
+        elif action == "record":
+            out = _do_record(store, now, input)
+        elif action == "mark_asked":
+            out = _do_mark_asked(store, now, input)
+        elif action == "resolve":
+            out = _do_resolve(store, now, input)
+        else:
+            out = {"dirty": False, "res": {"ok": False, "error": f"未知 action：{action}"}}
+        if expired or out.get("dirty"):
+            _save_store(store)
+        return out["res"]
+
+
+# ─── 工具 schema + handler ─────────────────────────────────────────────────
+
+TOOL_DESCRIPTION = (
+    "习惯建议候选库的读写入口（防骚扰状态机）。配合 miloco-habit-suggest skill 使用。\n"
+    "状态流转：pending → asked →（accepted → created）| rejected | expired。\n\n"
+    "action 取值：\n"
+    "- list：读候选库现状。返回 can_ask_now（此刻能否发起新询问，工具裁定）、"
+    "open_questions（正在等用户回应的条目）、askable_pending（可挑去询问的候选）、"
+    "entries（全量条目含已拒绝/已建/已作废——你据此判断是不是同一个习惯、复用既有 key、跳过终态）。\n"
+    "- record：把识别到的一条习惯登记为候选（status=pending）。传你起的稳定语义 key + "
+    "subject/habit/suggestion(/title/evidence/item_id)；item_id 填该习惯所依据的家庭档案条目 id，"
+    "用于追踪来源 + 建成任务后从档案渲染中剔除。\n"
+    "  同一 key 幂等：已 rejected/created 的只返回既有、永久不再推；过期（expired，无明确回应）"
+    "的会复活为 pending 重新推荐，但累计问满 3 次仍无果即永久放弃；在途（pending/asked/accepted）"
+    "的原样返回。是否同一习惯由你判断——务必先 list 复用既有 key。\n"
+    "- mark_asked：把某条 pending 翻成 asked。**必须在 miloco_im_push 返回 ok:true（确认送达）"
+    "之后才调**；工具会再次校验防骚扰闸门，越界（已有待回应 / 今天已问过 / 状态不对）直接返回 ok:false。\n"
+    "- resolve：用户回应后落地。outcome=created（任务建成、回填 task_id，终态）/ "
+    "rejected（拒绝，终态永不再问）/ accepted（可选中间态：仅当需跨轮分步建任务时先标「已同意」；"
+    "正常流程应**先建成再 resolve(created)**，未完成的 accepted 会自动作废、不永久滞留）。"
+)
+
+MILOCO_HABIT_SUGGEST_SCHEMA: Dict[str, Any] = {
+    "name": "miloco_habit_suggest",
+    "description": TOOL_DESCRIPTION,
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["list", "record", "mark_asked", "resolve"],
+                "description": "操作类型：list / record / mark_asked / resolve",
+            },
+            "key": {
+                "type": "string",
+                "description": "建议的稳定语义 key，由你自己起（如 wanglei_sleep_dim_light）。"
+                "record/mark_asked/resolve 都用它定位；同一习惯务必复用 list 里已有的 key，"
+                "避免重复或复活已拒绝项",
+            },
+            "subject": {"type": "string", "description": "习惯主体：成员名（如 王磊）；全家公共填 shared。record 用"},
+            "habit": {"type": "string", "description": "观察到的习惯（规范短句，如『王磊 傍晚约19点健身约30分钟』）。record 用"},
+            "suggestion": {"type": "string", "description": "要推荐给用户的任务点子（自然语言，认可后即据此建任务）。record 用"},
+            "title": {"type": "string", "description": "一句话标题（可选，缺省截取 habit）。record 用"},
+            "evidence": {"type": "string", "description": "依据（档案条目/出现频率，可选）。record 用"},
+            "item_id": {"type": "string", "description": "该习惯所依据的家庭档案条目 id。record 用"},
+            "outcome": {
+                "type": "string",
+                "enum": ["accepted", "rejected", "created"],
+                "description": "resolve 的结果：accepted / rejected / created",
+            },
+            "task_id": {"type": "string", "description": "outcome=created 时回填的任务 id"},
+            "reason": {"type": "string", "description": "outcome=rejected 时的简短原因（可选）"},
+        },
+        "required": ["action"],
+    },
+}
+
+
+def handle_habit_suggest(args: Dict[str, Any], **kwargs: Any) -> str:
+    """``miloco_habit_suggest`` handler（无 ctx 依赖，可直接注册）。"""
+    try:
+        result = apply_habit_action(args if isinstance(args, dict) else {})
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("miloco_habit_suggest 失败: %s", exc)
+        result = {"ok": False, "error": f"internal error: {exc}"}
+    return json.dumps(result, ensure_ascii=False)

--- a/plugins/hermes/miloco-plugin/tools_notify.py
+++ b/plugins/hermes/miloco-plugin/tools_notify.py
@@ -1,0 +1,262 @@
+"""miloco_im_push + miloco_notify_bind 两段式通知协议。
+
+移植自 openclaw TypeScript 插件 ``plugins/openclaw/src/tools/notify.ts``。
+
+**best-effort, 需 Hermes 实例验证**：投递依赖 Hermes ``send_message`` tool
+签名（``action="send", target="platform:chat_id[:thread_id]", message=...``），
+该签名已从文档/源码推断但未在真实 Hermes 实例上实测。若 Hermes 版本变更了
+``send_message`` 参数，本模块的投递路径需相应调整。
+
+两段式协议（与 TS 端 ``notifyOwner`` 一致）：
+1. 首次调用只传 ``message`` → 若未绑定通知渠道，返回 ``ok:false, needsBind:true`` +
+   ``bindHintExample``，**不发送**。agent 必须把 bindHintExample 翻译成主人语言后
+   重调本工具（message 不变 + 补 ``bindHint``），通知才会真正发出。
+2. 带 ``bindHint`` 的二次调用 → fallback 投递：把 bindHint 拼到正文后，经
+   ``ctx.dispatch_tool("send_message", ...)`` 投递到绑定 target。
+
+``miloco_notify_bind`` 把当前 session 的 target（形如
+``platform:chat_id[:thread_id]``）持久化到插件目录 ``state.json`` 的
+``notifySessionKey`` 字段，后续 ``miloco_im_push`` 优先用它。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional
+
+from .notify_target import resolve_notify_target
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# 插件状态持久化（state.json）
+# ---------------------------------------------------------------------------
+
+_STATE_FILENAME = "state.json"
+
+
+def _state_path(ctx: Any) -> Path:
+    """插件目录下的 state.json。ctx.manifest.path 是插件根目录。"""
+    base = getattr(getattr(ctx, "manifest", None), "path", None)
+    if not base:
+        # 兜底：home 下 .hermes/plugins/miloco/state.json（极少走到）。
+        base = str(Path.home() / ".hermes" / "plugins" / "miloco")
+    return Path(base) / _STATE_FILENAME
+
+
+def load_state(ctx: Any) -> Dict[str, Any]:
+    """读 state.json，缺失/损坏返回空 dict。"""
+    path = _state_path(ctx)
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        logger.warning("miloco state.json 解析失败 (%s): %s", path, exc)
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def save_state(ctx: Any, state: Dict[str, Any]) -> None:
+    """原子写 state.json（temp → rename）。失败仅 log，不抛。"""
+    path = _state_path(ctx)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(state, indent=2, ensure_ascii=False), encoding="utf-8")
+        tmp.replace(path)
+    except OSError as exc:
+        logger.warning("miloco state.json 写入失败 (%s): %s", path, exc)
+
+
+def get_notify_session_key(ctx: Any) -> Optional[str]:
+    return load_state(ctx).get("notifySessionKey") or None
+
+
+def set_notify_session_key(ctx: Any, target: str) -> None:
+    state = load_state(ctx)
+    state["notifySessionKey"] = target
+    save_state(ctx, state)
+
+
+# ---------------------------------------------------------------------------
+# bindHint 模板（与 miloco-notify skill references/channel-config.md 对齐）
+# ---------------------------------------------------------------------------
+
+BIND_HINT_EXAMPLE: Dict[str, str] = {
+    "not_configured": (
+        "您尚未设置 Miloco 通知频道，本条消息已临时发送到最近活跃的对话。"
+        "回复「绑定通知频道」可将当前对话设为固定的 Miloco 通知频道，"
+        "后续提醒、定时任务、告警等通知都将发送至此。"
+    ),
+    "configured_but_invalid": (
+        "您原先绑定的 Miloco 通知频道已失效，本条消息已临时发送到最近活跃的对话。"
+        "请回复「绑定通知频道」重新绑定。"
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# 投递
+# ---------------------------------------------------------------------------
+
+def _deliver_via_send_message(ctx: Any, target: str, body: str) -> Dict[str, Any]:
+    """经 Hermes ``send_message`` tool 投递。best-effort。
+
+    返回 ``{"ok": bool, "error": str?}``。任何异常都吞掉转成 ok:false。
+    """
+    try:
+        result_str = ctx.dispatch_tool("send_message", {
+            "action": "send",
+            "target": target,
+            "message": body,
+        })
+    except Exception as exc:  # noqa: BLE001
+        return {"ok": False, "error": f"dispatch_tool(send_message) failed: {exc}"}
+
+    # send_message 返回 JSON 字符串。尝试解析看是否有 error 字段。
+    try:
+        result = json.loads(result_str) if isinstance(result_str, str) else result_str
+    except (json.JSONDecodeError, TypeError):
+        # 非 JSON 也当作成功（有些路径返回纯文本）。
+        return {"ok": True}
+
+    if isinstance(result, dict):
+        if result.get("error") or result.get("success") is False:
+            return {"ok": False, "error": str(result.get("error") or result)}
+        return {"ok": True}
+    return {"ok": True}
+
+
+def notify_owner(ctx: Any, message: str, bind_hint: Optional[str]) -> Dict[str, Any]:
+    """与 TS 端 ``notifyOwner`` 行为对齐的投递入口。
+
+    Hermes 无 openclaw 那种 SessionDB（带 lastTo/lastChannel），故无"最近活跃
+    channel"可 fallback。未绑定时一律走两段式协议返回 ``needsBind=true`` +
+    ``bindHintExample``，agent 引导用户先 ``miloco_notify_bind`` 绑定 target，
+    再重发。绑定的 target 直接经 ``send_message`` 投递。
+    """
+    notify_key = get_notify_session_key(ctx)
+    resolved = resolve_notify_target(notify_key)
+    target = resolved.get("target")
+    needs_bind = resolved.get("needsBind", False)
+    bind_reason = resolved.get("bindReason") or "not_configured"
+    hint = (bind_hint or "").strip()
+
+    # 未绑定（target 为空）：无论 agent 是否提供 bindHint 都无法投递——没有 target。
+    # 走两段式协议：返回 needsBind + bindHintExample，引导用户先绑定。
+    if needs_bind or not target:
+        return {
+            "ok": False,
+            "needsBind": True,
+            "bindReason": bind_reason,
+            "fallbackChannel": target.get("target") if target else None,
+            "bindHintExample": BIND_HINT_EXAMPLE.get(bind_reason, BIND_HINT_EXAMPLE["not_configured"]),
+            "error": "本条通知尚未发出：尚未绑定通知渠道。这是给你（agent）的执行指令，不是要回复给用户的内容——禁止把本说明转述给用户。",
+            "nextAction": (
+                "引导用户绑定通知渠道：让用户在当前对话里说出要绑定的 target（形如 telegram / telegram:-100xxx / discord:xxx），"
+                "然后调用 miloco_notify_bind(target=...) 绑定。绑定后再重新调用 miloco_im_push(message=<本次内容>) 即可真正发送。"
+                "不要在对话里回复本说明原文、也不要等待用户确认。"
+            ),
+        }
+
+    # 已绑定：投递（bindHint 在已绑定时忽略，与 TS 端一致）。
+    body = message
+    deliver_message = f"<miloco-notification>{body}</miloco-notification>"
+    result = _deliver_via_send_message(ctx, target["target"], deliver_message)
+    if result.get("ok"):
+        return {"ok": True, "channel": target.get("target")}
+    return {"ok": False, "error": result.get("error", "delivery failed")}
+
+
+# ---------------------------------------------------------------------------
+# tool schema + handler 工厂
+# ---------------------------------------------------------------------------
+
+MILOCO_IM_PUSH_SCHEMA: Dict[str, Any] = {
+    "name": "miloco_im_push",
+    "description": (
+        "给主人推送一条 IM 通知。通常只传 message 调用即可。\n"
+        "本工具配合 miloco-notify skill 使用（分级、选人、文案规范都在其中）。\n"
+        "重要：若返回 ok=false 且 needsBind=true，表示本条【尚未发出】——这是要你继续操作的信号，"
+        "绝不能把它当作结果回复/转述给用户。你必须立刻再次调用本工具：message 保持不变，"
+        "并补上 bindHint（把返回里的 bindHintExample 翻译成主人当前使用的语言）。"
+        "补上 bindHint 后通知才会真正发送。"
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "message": {
+                "type": "string",
+                "description": "要发给主人的通知正文",
+            },
+            "bindHint": {
+                "type": "string",
+                "description": (
+                    "仅当上次调用返回 needsBind=true 时才传：按 miloco-notify skill 的 bindHint 模板、"
+                    "用主人的语言写好的绑定引导语。工具会把它附在正文后一起发出；渠道已设置时无需传。"
+                ),
+            },
+        },
+        "required": ["message"],
+    },
+}
+
+
+MILOCO_NOTIFY_BIND_SCHEMA: Dict[str, Any] = {
+    "name": "miloco_notify_bind",
+    "description": "绑定通知渠道。传入当前 session 的 target（形如 platform:chat_id[:thread_id]）。",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "target": {
+                "type": "string",
+                "description": (
+                    "要绑定的通知 target，形如 'telegram'、'telegram:-1001234567890:17585'、"
+                    "'discord:999888777:555444333'。可从 send_message(action='list') 的结果里取。"
+                ),
+            },
+        },
+        "required": ["target"],
+    },
+}
+
+
+def make_im_push_handler(ctx: Any) -> Callable[[Dict[str, Any]], str]:
+    """返回 ``miloco_im_push`` 的 handler（闭包捕获 ctx）。"""
+    def _handler(args: Dict[str, Any], **kwargs: Any) -> str:
+        message = (args.get("message") or "").strip()
+        bind_hint = args.get("bindHint")
+        if not message:
+            return json.dumps({"ok": False, "error": "message 不能为空"}, ensure_ascii=False)
+        try:
+            result = notify_owner(ctx, message, bind_hint)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("miloco_im_push 失败: %s", exc)
+            result = {"ok": False, "error": f"internal error: {exc}"}
+        return json.dumps(result, ensure_ascii=False)
+    return _handler
+
+
+def make_notify_bind_handler(ctx: Any) -> Callable[[Dict[str, Any]], str]:
+    """返回 ``miloco_notify_bind`` 的 handler（闭包捕获 ctx）。"""
+    def _handler(args: Dict[str, Any], **kwargs: Any) -> str:
+        target = (args.get("target") or "").strip()
+        if not target:
+            return json.dumps(
+                {"ok": False, "error": "target 不能为空（形如 platform:chat_id[:thread_id]）"},
+                ensure_ascii=False,
+            )
+        try:
+            set_notify_session_key(ctx, target)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("miloco_notify_bind 失败: %s", exc)
+            return json.dumps({"ok": False, "error": f"internal error: {exc}"}, ensure_ascii=False)
+        return json.dumps({"ok": True, "channel": target, "sessionKey": target}, ensure_ascii=False)
+    return _handler

--- a/plugins/hermes/scripts/install.sh
+++ b/plugins/hermes/scripts/install.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Miloco for Hermes Agent —— 手动 / 高级安装脚本。
+#
+# 普通用户请用 ../install-hermes.sh（一键：复制 + patch + 启 adapter），
+# 这个脚本只在你**想自己一步步做**时用：只复制 skill 和插件，**不** patch
+# miloco config.json、**不**补 .env、**不**启 adapter。
+#
+# 它做三件事：
+#   1. 把 16 个 miloco-* skill 同步到 ~/.hermes/skills/（由 sync-skills.py 生成）
+#   2. 把 Hermes 插件 miloco-plugin/ 复制到 ~/.hermes/plugins/miloco/
+#   3. （可选）注册 4 个受管 cron —— 由插件启动时自 reconcile，此处仅提示
+#   4. 打印 miloco 后端 config.json 需要改的字段 + adapter 进程启动方式
+#
+# 前置：hermes 已安装（~/.hermes 存在）、miloco-cli 在 PATH。
+# 不触碰 miloco 后端代码，只读 $MILOCO_HOME/config.json 提示用户手改。
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_SRC="$HERE/../miloco-plugin"
+SKILLS_SRC="$HERE/../skills"
+
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+HERMES_SKILLS_DIR="$HERMES_HOME/skills"
+HERMES_PLUGINS_DIR="$HERMES_HOME/plugins/miloco"
+
+err()  { echo "[miloco-hermes] [错误] $*" >&2; }
+info() { echo "[miloco-hermes] $*"; }
+
+# --- 前置检查 ---
+command -v python3 >/dev/null 2>&1 || command -v python >/dev/null 2>&1 || { err "找不到 python"; exit 1; }
+PYTHON="$(command -v python3 || command -v python)"
+
+if ! command -v miloco-cli >/dev/null 2>&1; then
+  err "找不到 miloco-cli，请先装好 miloco 后端并确保 miloco-cli 在 PATH"
+  exit 1
+fi
+
+if [ ! -d "$HERMES_HOME" ]; then
+  err "找不到 Hermes 目录 $HERMES_HOME，请先安装 Hermes Agent"
+  exit 1
+fi
+
+mkdir -p "$HERMES_SKILLS_DIR" "$HERMES_PLUGINS_DIR"
+
+# --- 1. 生成并同步 skills ---
+info "生成 miloco skills（从 plugins/skills 同步并适配 frontmatter）..."
+"$PYTHON" "$HERE/sync-skills.py"
+if [ ! -d "$SKILLS_SRC" ]; then
+  err "sync-skills.py 未生成 $SKILLS_SRC"; exit 1
+fi
+info "复制 skills 到 $HERMES_SKILLS_DIR/"
+cp -r "$SKILLS_SRC"/miloco-* "$HERMES_SKILLS_DIR"/
+
+# --- 2. 复制插件 ---
+info "复制 Hermes 插件到 $HERMES_PLUGINS_DIR/"
+rm -rf "$HERMES_PLUGINS_DIR"
+cp -r "$PLUGIN_SRC" "$HERMES_PLUGINS_DIR"
+# 清掉可能带进去的 __pycache__
+find "$HERMES_PLUGINS_DIR" -type d -name __pycache__ -prune -exec rm -rf {} + 2>/dev/null || true
+
+# --- 3. cron ---
+info "受管 cron 由插件启动时自动 reconcile（标签 [miloco:home-profile]），无需手动注册。"
+info "启动 Hermes 后可用 'hermes cron list' 确认 4 个 miloco 任务。"
+
+# --- 4. 后续配置提示 ---
+MILOCO_HOME="${MILOCO_HOME:-$HOME/.openclaw/miloco}"
+ADAPTER_PORT="${ADAPTER_PORT:-18789}"
+BEARER="${ADAPTER_AUTH_BEARER:-请自行生成一个随机串}"
+
+cat <<EOF
+
+==========================================================
+ 安装完成。还需手动完成以下配置：
+==========================================================
+
+[1] miloco 后端 config.json（$MILOCO_HOME/config.json）的 agent 段改成：
+    "agent": {
+      "webhook_url": "http://127.0.0.1:$ADAPTER_PORT/miloco/webhook",
+      "auth_bearer": "<你的 Bearer，需与 adapter 启动时的 ADAPTER_AUTH_BEARER 一致>"
+    }
+
+[2] 确保 Hermes 已启用 api_server 平台并设了 API_SERVER_KEY：
+    在 ~/.hermes/.env 里：API_SERVER_KEY=<某个密钥>
+
+[3] 启动入站适配进程（把 miloco 的回调翻译给 Hermes）：
+    ADAPTER_AUTH_BEARER=<与上一步同一个 Bearer> \\
+    HERMES_API_URL=http://127.0.0.1:8642 \\
+    HERMES_API_KEY=<同 API_SERVER_KEY> \\
+    ADAPTER_PORT=$ADAPTER_PORT \\
+    python -m plugins.hermes.adapter
+    （生产环境建议用 systemd / nohup 常驻）
+
+[4] 启动 / 重启 Hermes gateway 与 miloco 后端，对话试：
+    hermes -z "把客厅灯打开"
+
+文档：plugins/hermes/README.md
+==========================================================
+EOF

--- a/plugins/hermes/scripts/miloco-adapter.sh
+++ b/plugins/hermes/scripts/miloco-adapter.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# miloco-adapter.sh —— 入站 adapter 进程生命周期管理。
+#
+# 子命令：
+#   start     后台启 adapter
+#   stop      按 pid 文件停 adapter
+#   restart   stop + start
+#   status    显 PID / 端口 / 健康
+#   logs      tail -f 日志
+#   env       显当前生效的环境变量（从 .env 读）
+#
+# 装/启参数来自 install-hermes.sh 写的 ~/.hermes/miloco-adapter.{pid,log} 和 .env。
+# 如果 ~/.hermes/miloco-adapter.pid 不存在（不是 install-hermes.sh 装的），
+# start 会从 .env 拿环境变量 + HERMES_PLUGINS_DIR/adapter 启动。
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+MILOCO_HOME="${MILOCO_HOME:-$HOME/.openclaw/miloco}"
+ADAPTER_PORT="${ADAPTER_PORT:-18789}"
+ADAPTER_HOST="${ADAPTER_HOST:-127.0.0.1}"
+ADAPTER_LOG="$HERMES_HOME/miloco-adapter.log"
+ADAPTER_PID="$HERMES_HOME/miloco-adapter.pid"
+HERMES_PLUGINS_DIR="$HERMES_HOME/plugins/miloco"
+ADAPTER_DIR="$HERMES_PLUGINS_DIR/adapter"
+
+G='\033[0;32m'; Y='\033[1;33m'; R='\033[0;31m'; N='\033[0m'
+info() { echo -e "${G}[✓]${N} $*"; }
+warn() { echo -e "${Y}[!]${N} $*"; }
+err()  { echo -e "${R}[✗]${N} $*" >&2; }
+
+# 跨平台查占用某端口的进程 PID（pipeline + || true 兜底，与 install-hermes.sh 同源）
+get_pid_by_port() {
+  local port="$1"
+  if command -v netstat >/dev/null 2>&1; then
+    netstat -ano 2>/dev/null \
+      | grep -E "[:.]$port[[:space:]]" 2>/dev/null \
+      | grep LISTENING 2>/dev/null \
+      | head -1 | awk '{print $NF}' \
+      || true
+  elif command -v lsof >/dev/null 2>&1; then
+    lsof -nP -iTCP:"$port" -sTCP:LISTEN -t 2>/dev/null | head -1 || true
+  elif command -v ss >/dev/null 2>&1; then
+    ss -ltnp 2>/dev/null | grep ":$port " 2>/dev/null | head -1 | grep -oP 'pid=\K[0-9]+' | head -1 || true
+  fi
+}
+
+# 跨平台杀进程
+kill_pid() {
+  local pid="$1"
+  [ -z "$pid" ] && return 0
+  if command -v taskkill >/dev/null 2>&1; then
+    taskkill //PID "$pid" //F >/dev/null 2>&1 || true
+  else
+    kill -9 "$pid" 2>/dev/null || true
+  fi
+}
+
+# 杀 adapter：按 PID + 按端口双兜底
+kill_adapter() {
+  local pid="$1" port="$2"
+  kill_pid "$pid"
+  sleep 1
+  if [ -n "$port" ]; then
+    local p; p="$(get_pid_by_port "$port" | tr -d '\r\n ')"
+    if [ -n "$p" ] && [ "$p" != "$pid" ]; then
+      warn "端口 $port 还被 PID=$p 占着，taskkill 兜底"
+      kill_pid "$p"
+    fi
+  fi
+}
+
+# 从 ~/.hermes/.env 抽环境变量（不 source，避免污染 shell）
+load_env() {
+  if [ ! -f "$HERMES_HOME/.env" ]; then return 0; fi
+  # 只抽 MILOCO_ADAPTER_* / HERMES_API_* / API_SERVER_KEY / ADAPTER_*
+  while IFS='=' read -r k v; do
+    case "$k" in
+      ''|\#*) continue ;;
+      API_SERVER_KEY|HERMES_API_URL|HERMES_API_KEY|ADAPTER_AUTH_BEARER|ADAPTER_PORT|ADAPTER_HOST)
+        export "$k=$v" ;;
+    esac
+  done < "$HERMES_HOME/.env"
+}
+
+cmd_start() {
+  load_env
+  # Bearer 优先级：ADAPTER_AUTH_BEARER env > API_SERVER_KEY（adapter 默认与之共用）
+  local bearer="${ADAPTER_AUTH_BEARER:-${API_SERVER_KEY:-}}"
+  if [ -z "$bearer" ]; then
+    err "找不到 Bearer，.env 里需要有 API_SERVER_KEY 或 ADAPTER_AUTH_BEARER"
+    err "（先跑 install-hermes.sh）"
+    exit 1
+  fi
+  if [ ! -d "$ADAPTER_DIR" ]; then
+    err "找不到 $ADAPTER_DIR，先跑 install-hermes.sh"; exit 1
+  fi
+
+  # 已在跑就跳过
+  if [ -f "$ADAPTER_PID" ] && kill -0 "$(cat "$ADAPTER_PID" 2>/dev/null)" 2>/dev/null; then
+    warn "adapter 已在跑，PID=$(cat "$ADAPTER_PID")"
+    return 0
+  fi
+  # stale pid 文件（旧进程已死但 pid 文件还在），清掉
+  [ -f "$ADAPTER_PID" ] && rm -f "$ADAPTER_PID"
+
+  info "启动 adapter（端口 $ADAPTER_PORT）..."
+  ( cd "$HERMES_PLUGINS_DIR" \
+    && PYTHONUTF8=1 \
+       ADAPTER_AUTH_BEARER="$bearer" \
+       HERMES_API_URL="${HERMES_API_URL:-http://127.0.0.1:8642}" \
+       HERMES_API_KEY="${HERMES_API_KEY:-$bearer}" \
+       ADAPTER_HOST="$ADAPTER_HOST" \
+       ADAPTER_PORT="$ADAPTER_PORT" \
+       nohup "$(command -v python3 || command -v python)" -m adapter \
+         > "$ADAPTER_LOG" 2>&1 & echo $! > "$ADAPTER_PID" )
+
+  sleep 2
+  # 关键：按端口反查真实 Windows native PID 覆盖写入 pid 文件（|| echo "" 兜底 set -e）
+  local pid
+  pid="$(get_pid_by_port "$ADAPTER_PORT" | tr -d '\r\n ' || echo '')"
+  if [ -n "$pid" ]; then
+    echo "$pid" > "$ADAPTER_PID"
+    info "adapter 已起，PID=$pid（按端口反查），日志=$ADAPTER_LOG"
+  else
+    err "adapter 启动失败，端口 $ADAPTER_PORT 未监听，看 $ADAPTER_LOG 末尾："
+    tail -20 "$ADAPTER_LOG" >&2 || true
+    exit 1
+  fi
+}
+
+cmd_stop() {
+  if [ ! -f "$ADAPTER_PID" ]; then
+    warn "pid 文件不存在，adapter 可能没在跑"; return 0
+  fi
+  local pid; pid="$(cat "$ADAPTER_PID" 2>/dev/null || echo '')"
+  # 检查端口是否还有占用（grep 失败时 $() 走 || echo "" 兜底，避免 set -e 退出）
+  local port_pid
+  port_pid="$(get_pid_by_port "$ADAPTER_PORT" | tr -d '\r\n ' || echo '')"
+  if [ -z "$pid" ] && [ -z "$port_pid" ]; then
+    warn "adapter 进程 $pid 不在跑，清掉 pid 文件"
+    rm -f "$ADAPTER_PID"
+    return 0
+  fi
+  info "停 adapter PID=$pid（按 PID + 按端口双兜底）"
+  kill_adapter "$pid" "$ADAPTER_PORT"
+  rm -f "$ADAPTER_PID"
+  info "已停"
+}
+
+cmd_status() {
+  local pid=""
+  if [ -f "$ADAPTER_PID" ]; then pid="$(cat "$ADAPTER_PID" 2>/dev/null || echo '')"; fi
+  # 优先以端口反查为准（Git Bash PID 不可靠）；用 || echo "" 兜底 set -e
+  local port_pid
+  port_pid="$(get_pid_by_port "$ADAPTER_PORT" | tr -d '\r\n ' || echo '')"
+  if [ -n "$port_pid" ]; then
+    info "adapter 在跑，端口 PID=$port_pid（pid 文件记录的=$pid）"
+    [ "$port_pid" != "$pid" ] && [ -n "$port_pid" ] && echo "$port_pid" > "$ADAPTER_PID"
+  elif [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+    info "adapter 在跑，PID=$pid"
+  else
+    warn "adapter 未在跑"
+    [ -f "$ADAPTER_PID" ] && warn "（stale pid 文件：$pid）"
+  fi
+  # 健康检查
+  local url="http://127.0.0.1:${ADAPTER_PORT}/health"
+  if command -v curl >/dev/null 2>&1; then
+    if curl -fsS --max-time 3 "$url" >/dev/null 2>&1; then
+      info "health OK: $url"
+    else
+      warn "health 检查失败: $url"
+    fi
+  fi
+  echo "  pid 文件: $ADAPTER_PID"
+  echo "  日志文件: $ADAPTER_LOG"
+  echo "  监听端口: $ADAPTER_PORT"
+}
+
+cmd_logs() { tail -n 200 -f "$ADAPTER_LOG"; }
+
+cmd_env() {
+  load_env
+  echo "API_SERVER_KEY=${API_SERVER_KEY:-<unset>}"
+  echo "ADAPTER_AUTH_BEARER=${ADAPTER_AUTH_BEARER:-<unset>}"
+  echo "HERMES_API_URL=${HERMES_API_URL:-<unset>}"
+  echo "HERMES_API_KEY=${HERMES_API_KEY:-<unset>}"
+  echo "ADAPTER_PORT=$ADAPTER_PORT"
+  echo "ADAPTER_HOST=$ADAPTER_HOST"
+}
+
+cmd_restart() { cmd_stop; cmd_start; }
+
+usage() {
+  cat <<EOF
+用法: $(basename "$0") {start|stop|restart|status|logs|env}
+
+默认配置文件：
+  HERMES_HOME=$HERMES_HOME
+  MILOCO_HOME=$MILOCO_HOME
+  ADAPTER_PORT=$ADAPTER_PORT
+EOF
+}
+
+case "${1:-}" in
+  start)   cmd_start ;;
+  stop)    cmd_stop ;;
+  restart) cmd_restart ;;
+  status)  cmd_status ;;
+  logs)    cmd_logs ;;
+  env)     cmd_env ;;
+  -h|--help|help|"") usage ;;
+  *) err "未知子命令: $1"; usage; exit 1 ;;
+esac

--- a/plugins/hermes/scripts/sync-skills.py
+++ b/plugins/hermes/scripts/sync-skills.py
@@ -1,0 +1,197 @@
+"""sync-skills.py — 同步 miloco-* skill 到 Hermes 兼容目录。
+
+把 `plugins/skills/miloco-*`（16 个目录）复制到 `plugins/hermes/skills/`，
+对每个 SKILL.md 做最小适配：
+
+1. 删除 YAML frontmatter 里 `metadata.openclaw` 整个子键（Hermes skill
+   frontmatter 无此字段；见 hermes-agent/website/docs/developer-guide/
+   creating-skills.md）。保留 name / description / metadata(author/version/date)
+   等 agentskills.io 标准字段。
+2. 特别修改 `miloco-terminate-task/SKILL.md`：正文里
+   「OpenClaw cron tool `action=remove`」改成
+   「Hermes cronjob tool `action=remove`」（Hermes 的 cron 工具叫 cronjob）。
+3. 给 frontmatter `date:` 值强制加引号 —— 未加引号的日期会被 YAML 解析成
+   ``datetime.date``，导致 Hermes skill_view 的 json.dumps 失败（cron 触发时
+   加载 skill 报 `Object of type date is not JSON serializable`）。
+4. 其余正文原样保留 —— 这些 skill 全通过 `miloco-cli` 调后端 HTTP API，
+   与 agent 平台无关。
+
+幂等：每次运行先清空目标 `plugins/hermes/skills/` 下所有 miloco-* 目录
+再重新生成，源目录 `plugins/skills/` 只读不动。
+
+用法：
+    python plugins/hermes/scripts/sync-skills.py
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import sys
+from pathlib import Path
+
+# 源 / 目标根目录（脚本位于 plugins/hermes/scripts/，故上溯两级取 plugins/）。
+SCRIPT_DIR = Path(__file__).resolve().parent
+PLUGINS_DIR = SCRIPT_DIR.parents[1]
+SRC_ROOT = PLUGINS_DIR / "skills"
+DST_ROOT = PLUGINS_DIR / "hermes" / "skills"
+
+SKILL_GLOB = "miloco-*"
+
+# YAML frontmatter 边界：文件首行 `---`，匹配到下一个独占一行的 `---`。
+FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---\n", re.DOTALL)
+
+
+def strip_openclaw_block(frontmatter_text: str) -> str:
+    """从 frontmatter 文本里删 `metadata.openclaw` 子键整块。
+
+    frontmatter 形如::
+
+        metadata:
+              author: miloco
+              version: "3.0"
+              date: "2026-06-10"
+              openclaw:
+                requires:
+                  bins: ["miloco-cli"]
+
+    策略：逐行扫描，找到 `  openclaw:`（2 空格缩进，metadata 子键）后，
+    连同其后所有缩进更深的行（>2 空格）一并删除，直到遇到同级或更浅缩进
+    的键为止。保留其余行原样，包括引号 / 内联数组 / 多行 description 等。
+
+    若 frontmatter 无 `openclaw:` 子键（部分 skill 本就没有），返回原文。
+    """
+    lines = frontmatter_text.split("\n")
+    out: list[str] = []
+    i = 0
+    n = len(lines)
+    while i < n:
+        line = lines[i]
+        # 仅识别 metadata 下 2 空格缩进的 `openclaw:` 键。
+        if line == "  openclaw:":
+            # 跳过该行 + 之后所有缩进 > 2 空格的子行（含空行夹带也跳，
+            # 实际 YAML 里 openclaw 块内不会有空行）。
+            i += 1
+            while i < n:
+                nxt = lines[i]
+                if nxt == "" or nxt.startswith("  "):
+                    # 仍属 openclaw 子块（≥2 空格缩进）或块内空行。
+                    # 但需排除下一个同级 2 空格顶层键 —— 走更严格判断：
+                    # 2 空格缩进且非空格开头后紧跟非空格字符视为同级键。
+                    if (
+                        nxt.startswith("  ")
+                        and not nxt.startswith("   ")
+                        and nxt[2:3] != " "
+                        and nxt[2:3] != ""
+                    ):
+                        # 同级键（2 空格 + 非空非空格字符），停止跳过。
+                        break
+                    i += 1
+                    continue
+                break
+            continue
+        out.append(line)
+        i += 1
+    return "\n".join(out)
+
+
+def quote_date_field(frontmatter_text: str) -> str:
+    """给 frontmatter 里未加引号的 `date:` 值加上双引号。
+
+    Hermes 的 skill_view 会把 skill 元数据 json.dumps 返回；YAML 把未加引号的
+    `date: 2026-06-16` 解析成 ``datetime.date`` 对象，导致
+    ``Object of type date is not JSON serializable``，cron 触发时加载 skill 失败
+    （见 hermes-agent/cron/scheduler.py 调 skill_view）。强制加引号让 date 恒为字符串。
+
+    已加引号的（``date: "2026-06-14"``）不匹配，原样保留。
+    """
+    return re.sub(
+        r"(^(\s*)date:\s*)(\d{4}-\d{2}-\d{2})\s*$",
+        r'\1"\3"',
+        frontmatter_text,
+        flags=re.MULTILINE,
+    )
+
+
+def patch_terminate_task_body(body: str) -> str:
+    """miloco-terminate-task 专用：把正文里
+    「OpenClaw cron tool `action=remove`」改成
+    「Hermes cronjob tool `action=remove`」。
+
+    仅替换这一处明确措辞（任务规范指定），其余 `OpenClaw cron` 引用
+    （如 cron `action=remove` 不带 tool 字样的）原样保留。
+    """
+    return body.replace(
+        "OpenClaw cron tool `action=remove`",
+        "Hermes cronjob tool `action=remove`",
+    )
+
+
+def adapt_skill_md(content: str, skill_name: str) -> str:
+    """对单个 SKILL.md 内容做 Hermes 适配，返回新内容。"""
+    m = FRONTMATTER_RE.match(content)
+    if not m:
+        # 无 frontmatter —— 理论不会发生，但容错：原样返回（仅 terminate-task
+        # 改正文）。
+        body = content
+        if skill_name == "miloco-terminate-task":
+            body = patch_terminate_task_body(body)
+        return body
+
+    fm_text = m.group(1)
+    new_fm = strip_openclaw_block(fm_text)
+    new_fm = quote_date_field(new_fm)
+    body = content[m.end():]
+    if skill_name == "miloco-terminate-task":
+        body = patch_terminate_task_body(body)
+    return f"---\n{new_fm}\n---\n{body}"
+
+
+def sync_one(src_dir: Path, dst_root: Path) -> Path:
+    """复制单个 skill 目录到 dst_root/<name>/，适配 SKILL.md。"""
+    name = src_dir.name
+    dst_dir = dst_root / name
+
+    # 覆盖式复制：先删目标目录（若存在），再整树拷贝。
+    if dst_dir.exists():
+        shutil.rmtree(dst_dir)
+    shutil.copytree(src_dir, dst_dir)
+
+    skill_md = dst_dir / "SKILL.md"
+    if not skill_md.exists():
+        raise FileNotFoundError(f"skill 缺 SKILL.md: {skill_md}")
+    original = skill_md.read_text(encoding="utf-8")
+    adapted = adapt_skill_md(original, name)
+    skill_md.write_text(adapted, encoding="utf-8")
+    return dst_dir
+
+
+def main() -> int:
+    if not SRC_ROOT.is_dir():
+        sys.stderr.write(f"源目录不存在: {SRC_ROOT}\n")
+        return 1
+
+    src_dirs = sorted(p for p in SRC_ROOT.iterdir() if p.is_dir() and p.name.startswith(SKILL_GLOB.replace("*", "")))
+    if not src_dirs:
+        sys.stderr.write(f"未在 {SRC_ROOT} 找到 {SKILL_GLOB} 目录\n")
+        return 1
+
+    # 幂等：清空目标根下所有 miloco-* 目录再重生成。
+    DST_ROOT.mkdir(parents=True, exist_ok=True)
+    for old in DST_ROOT.iterdir():
+        if old.is_dir() and old.name.startswith("miloco-"):
+            shutil.rmtree(old)
+
+    generated: list[str] = []
+    for src_dir in src_dirs:
+        dst_dir = sync_one(src_dir, DST_ROOT)
+        generated.append(dst_dir.name)
+
+    print(f"同步完成：{len(generated)} 个 skill -> {DST_ROOT}")
+    for name in generated:
+        print(f"  - {name}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/hermes/tests/conftest.py
+++ b/plugins/hermes/tests/conftest.py
@@ -1,0 +1,50 @@
+"""测试公共夹具：把 hyphen 目录 miloco-plugin/ 与 adapter/ 作为包加载进 sys.modules。
+
+miloco-plugin 目录名含连字符，不是合法 Python 包名，Hermes 走路径加载无碍，
+但 pytest 直接 import 不行——这里用 importlib 以唯一别名装载，让相对导入
+(``from .catalog import ...``) 能解析。
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+TESTS_DIR = Path(__file__).resolve().parent
+HERMES_DIR = TESTS_DIR.parent  # plugins/hermes/
+
+_ADAPTER_DIR = HERMES_DIR / "adapter"
+_PLUGIN_DIR = HERMES_DIR / "miloco-plugin"
+
+
+def _load_pkg(alias: str, pkg_dir: Path) -> None:
+    if alias in sys.modules:
+        return
+    spec = importlib.util.spec_from_file_location(
+        alias,
+        pkg_dir / "__init__.py",
+        submodule_search_locations=[str(pkg_dir)],
+    )
+    assert spec and spec.loader, f"无法加载 {pkg_dir}"
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[alias] = mod
+    spec.loader.exec_module(mod)
+
+
+def _load_single(alias: str, file: Path) -> None:
+    """加载无相对导入的独立模块（如 session_map.py）。"""
+    if alias in sys.modules:
+        return
+    spec = importlib.util.spec_from_file_location(alias, file)
+    assert spec and spec.loader, f"无法加载 {file}"
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[alias] = mod
+    spec.loader.exec_module(mod)
+
+
+# 适配进程：作为包 adapter_pkg 装载（server/hermes_client 间有相对导入）
+_load_pkg("adapter_pkg", _ADAPTER_DIR)
+
+# 插件：作为包 miloco_plugin_pkg 装载（context_injection/tools_* 间有相对导入）
+_load_pkg("miloco_plugin_pkg", _PLUGIN_DIR)

--- a/plugins/hermes/tests/test_adapter_contract.py
+++ b/plugins/hermes/tests/test_adapter_contract.py
@@ -1,0 +1,190 @@
+"""适配进程契约：{action, payload} → {code, data} 翻译、鉴权、幂等、错误码。"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+from aiohttp.test_utils import TestClient, TestServer
+
+from adapter_pkg import server as srv
+from adapter_pkg.hermes_client import _looks_like_overflow
+from adapter_pkg.server import _IdempotencyCache
+
+
+# ---------- _looks_like_overflow ----------
+
+def test_overflow_detection():
+    assert _looks_like_overflow("context overflow exceeded")
+    assert _looks_like_overflow("maximum context length exceeded")
+    assert _looks_like_overflow("Context Window too small")
+    assert not _looks_like_overflow("network error")
+    assert not _looks_like_overflow(None)
+    assert not _looks_like_overflow("")
+
+
+# ---------- _IdempotencyCache ----------
+
+def test_idem_cache_set_get():
+    c = _IdempotencyCache()
+    c.set("k1", {"runId": "r1", "status": "ok"})
+    assert c.get("k1") == {"runId": "r1", "status": "ok"}
+    assert c.get("missing") is None
+
+
+def test_idem_cache_expiry(monkeypatch):
+    c = _IdempotencyCache()
+    c.set("k1", {"status": "ok"})
+    base = time.time()
+    monkeypatch.setattr("adapter_pkg.server.time.time", lambda: base + 4000)
+    assert c.get("k1") is None
+
+
+# ---------- HTTP 契约（用 FakeHermesClient） ----------
+# 新版 aiohttp 的 TestClient 必须在运行中的事件循环内构造，故每条用例
+# 包一层 async 场景 + asyncio.run。
+
+class FakeHermesClient:
+    """记录调用、按预设返回结果的假客户端。"""
+
+    def __init__(self, result: dict[str, Any] | Exception | None = None) -> None:
+        self.result = result if result is not None else {"runId": "r-1", "status": "ok"}
+        self.calls: list[dict] = []
+
+    async def run_turn(self, payload: dict) -> dict[str, Any]:
+        self.calls.append(payload)
+        if isinstance(self.result, Exception):
+            raise self.result
+        return self.result  # type: ignore[return-value]
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+async def _post_json(client: TestClient, body, bearer="secret"):
+    headers = {"Authorization": f"Bearer {bearer}"} if bearer else {}
+    resp = await client.post("/miloco/webhook", json=body, headers=headers)
+    return resp.status, await resp.json()
+
+
+async def _post_raw(client: TestClient, data: str, bearer="secret"):
+    resp = await client.post("/miloco/webhook", data=data, headers={"Authorization": f"Bearer {bearer}"})
+    return resp.status, await resp.json()
+
+
+def test_auth_rejected():
+    fake = FakeHermesClient()
+    async def sc():
+        app = srv.create_app(auth_bearer="secret", hermes_client=fake)
+        async with TestClient(TestServer(app)) as client:
+            return await _post_json(client, {"action": "agent", "payload": {}}, bearer="wrong")
+    status, _ = _run(sc())
+    assert status == 401
+
+
+def test_missing_auth_header():
+    fake = FakeHermesClient()
+    async def sc():
+        app = srv.create_app(auth_bearer="secret", hermes_client=fake)
+        async with TestClient(TestServer(app)) as client:
+            return await _post_json(client, {"action": "agent", "payload": {}}, bearer=None)
+    status, _ = _run(sc())
+    assert status == 401
+
+
+def test_bad_json():
+    fake = FakeHermesClient()
+    async def sc():
+        app = srv.create_app(auth_bearer="secret", hermes_client=fake)
+        async with TestClient(TestServer(app)) as client:
+            return await _post_raw(client, "not json")
+    status, body = _run(sc())
+    assert status == 400
+    assert body["code"] == 1001
+
+
+def test_unknown_action():
+    fake = FakeHermesClient()
+    async def sc():
+        app = srv.create_app(auth_bearer="secret", hermes_client=fake)
+        async with TestClient(TestServer(app)) as client:
+            return await _post_json(client, {"action": "bogus", "payload": {}})
+    status, body = _run(sc())
+    assert status == 404
+    assert body["code"] == 2001
+    assert "bogus" in body["message"]
+
+
+def test_get_trace_returns_done():
+    fake = FakeHermesClient()
+    async def sc():
+        app = srv.create_app(auth_bearer="secret", hermes_client=fake)
+        async with TestClient(TestServer(app)) as client:
+            return await _post_json(client, {"action": "get_trace", "payload": {"runId": "x"}})
+    _, body = _run(sc())
+    assert body == {"code": 0, "message": "ok", "data": {"status": "done"}}
+    assert fake.calls == []  # get_trace 不触达 Hermes
+
+
+def test_agent_turn_ok():
+    fake = FakeHermesClient({"runId": "r-1", "status": "ok"})
+    async def sc():
+        app = srv.create_app(auth_bearer="secret", hermes_client=fake)
+        async with TestClient(TestServer(app)) as client:
+            return await _post_json(client, {"action": "agent", "payload": {"message": "hi", "sessionKey": "s1", "lane": "L1"}})
+    _, body = _run(sc())
+    assert body["code"] == 0
+    assert body["data"] == {"runId": "r-1", "status": "ok"}
+    assert len(fake.calls) == 1
+    assert fake.calls[0]["message"] == "hi"
+
+
+def test_agent_turn_idempotency():
+    fake = FakeHermesClient({"runId": "r-1", "status": "ok"})
+    payload = {"message": "hi", "sessionKey": "s1", "idempotencyKey": "idem-1"}
+    async def sc():
+        app = srv.create_app(auth_bearer="secret", hermes_client=fake)
+        async with TestClient(TestServer(app)) as client:
+            _, b1 = await _post_json(client, {"action": "agent", "payload": payload})
+            _, b2 = await _post_json(client, {"action": "agent", "payload": payload})
+            return b1, b2
+    b1, b2 = _run(sc())
+    assert b1 == b2
+    assert b1["data"]["runId"] == "r-1"
+    assert len(fake.calls) == 1  # 幂等命中：第二次不再调 Hermes
+
+
+def test_agent_turn_error_propagates():
+    fake = FakeHermesClient({"runId": "r-1", "status": "error", "error": "boom"})
+    async def sc():
+        app = srv.create_app(auth_bearer="secret", hermes_client=fake)
+        async with TestClient(TestServer(app)) as client:
+            return await _post_json(client, {"action": "agent", "payload": {"message": "hi"}})
+    _, body = _run(sc())
+    assert body["data"]["status"] == "error"
+    assert body["data"]["error"] == "boom"
+
+
+def test_agent_handler_exception_returns_3000():
+    fake = FakeHermesClient(RuntimeError("adapter blew up"))
+    async def sc():
+        app = srv.create_app(auth_bearer="secret", hermes_client=fake)
+        async with TestClient(TestServer(app)) as client:
+            return await _post_json(client, {"action": "agent", "payload": {"message": "hi"}})
+    status, body = _run(sc())
+    assert status == 500
+    assert body["code"] == 3000
+
+
+def test_health():
+    fake = FakeHermesClient()
+    async def sc():
+        app = srv.create_app(auth_bearer="secret", hermes_client=fake)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.get("/health")
+            return resp.status, await resp.json()
+    status, body = _run(sc())
+    assert status == 200
+    assert body == {"status": "ok"}

--- a/plugins/hermes/tests/test_context_injection.py
+++ b/plugins/hermes/tests/test_context_injection.py
@@ -1,0 +1,106 @@
+"""pre_llm_call 上下文注入：profile 分级与文本块装配。"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from miloco_plugin_pkg import context_injection as ci
+
+
+@pytest.fixture
+def tmp_miloco_home(tmp_path, monkeypatch):
+    """临时 MILOCO_HOME，隔离真实配置。"""
+    monkeypatch.setenv("MILOCO_HOME", str(tmp_path))
+    return tmp_path
+
+
+# ---------- resolve_profile ----------
+
+def test_profile_cron(tmp_miloco_home):
+    assert ci.resolve_profile("anything", platform="cron") == "minimal"
+    assert ci.resolve_profile("miloco:cron:perception-digest") == "minimal"
+    assert ci.resolve_profile("cron:foo") == "minimal"
+    assert ci.resolve_profile("s", user_message="[cron:habit-suggest]") == "minimal"
+
+
+def test_profile_rule_and_suggestion(tmp_miloco_home):
+    assert ci.resolve_profile("miloco-rule-abc") == "rule"
+    assert ci.resolve_profile("miloco-suggest-xyz") == "suggestion"
+
+
+def test_profile_full(tmp_miloco_home):
+    assert ci.resolve_profile("agent:main:miloco") == "full"
+    assert ci.resolve_profile("anything-else") == "full"
+
+
+# ---------- inject_context ----------
+
+def test_full_includes_catalog_and_capabilities(tmp_miloco_home, monkeypatch):
+    monkeypatch.setattr(ci, "get_catalog", lambda: "# devices catalog\n灯|客厅|light|online")
+    out = ci.inject_context(session_id="agent:main:miloco", user_message="把客厅灯打开")
+    assert out is not None
+    ctx = out["context"]
+    # 指令块
+    assert "Miloco" in ctx
+    assert "## 能力概览" in ctx  # full 专属
+    # 数据块
+    assert "# devices catalog" in ctx
+    assert "## 家庭档案" in ctx  # profile.md 缺失时哨兵串仍带标题
+
+
+def test_minimal_excludes_catalog_and_capabilities(tmp_miloco_home, monkeypatch):
+    monkeypatch.setattr(ci, "get_catalog", lambda: "# devices catalog\nx")
+    out = ci.inject_context(session_id="miloco:cron:digest", platform="cron")
+    assert out is not None
+    ctx = out["context"]
+    assert "## 能力概览" not in ctx
+    assert "# devices catalog" not in ctx
+    # minimal 仍带身份与通知/语言块
+    assert "Miloco" in ctx
+
+
+def test_empty_catalog_omitted(tmp_miloco_home, monkeypatch):
+    monkeypatch.setattr(ci, "get_catalog", lambda: "")
+    out = ci.inject_context(session_id="agent:main", user_message="hi")
+    assert out is not None
+    assert "# devices catalog" not in out["context"]
+
+
+def test_returns_none_when_nothing_to_inject(tmp_miloco_home, monkeypatch):
+    # minimal + 无 catalog + 无 profile → prepend 仍有 identity，不会 None；
+    # 这里验证极端：把 identity 也判不到的场景不存在，故仅验证始终非 None
+    out = ci.inject_context(session_id="x", platform="cron")
+    assert out is not None  # identity 块恒在
+
+
+# ---------- build_home_profile_block ----------
+
+def test_home_profile_demotes_headings(tmp_miloco_home):
+    prof = tmp_miloco_home / "home-profile" / "profile.md"
+    prof.parent.mkdir(parents=True)
+    prof.write_text("# 家庭档案\n爸爸喜欢 25 度\n## 作息\n早起", encoding="utf-8")
+    block = ci.build_home_profile_block()
+    assert "## 家庭档案" in block
+    # 原 H1 降为 H2（与已有的 "## 家庭档案" 合流），原 H2 降为 H3
+    assert "### 作息" in block
+    assert "\n# 家庭档案" not in block  # 不应残留独立 H1
+
+
+def test_home_profile_missing_sentinel(tmp_miloco_home):
+    # 无 profile.md → load 层返回哨兵串 (暂无内容)，build 层补上标题后返回
+    block = ci.build_home_profile_block()
+    assert block == "## 家庭档案\n\n(暂无内容)"
+
+
+# ---------- 异常安全 ----------
+
+def test_inject_never_raises(tmp_miloco_home, monkeypatch):
+    def boom():
+        raise RuntimeError("catalog blew up")
+    monkeypatch.setattr(ci, "get_catalog", boom)
+    out = ci.inject_context(session_id="agent:main")
+    # 钩子绝不抛：catalog 异常时应降级返回（仍含指令块）或 None，不能上抛
+    assert out is None or "context" in out

--- a/plugins/hermes/tests/test_install_e2e.sh
+++ b/plugins/hermes/tests/test_install_e2e.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# test_install_e2e.sh —— install-hermes.sh + miloco-adapter.sh 端到端测试。
+#
+# 干这些事（用临时目录 mock $HERMES_HOME / $MILOCO_HOME，跑完自动清理）：
+#   1. 校验 install-hermes.sh 7 步全过
+#   2. 校验鉴权契约（POST 无 auth → 401，POST 有 auth 缺 action → code:1001）
+#   3. 校验幂等性：再跑一次 install-hermes.sh 应不报错、复用 Bearer、PID 变
+#   4. 校验 miloco-adapter.sh 完整生命周期：status / restart / stop
+#   5. 校验 stop 后端口释放
+#
+# 用法：
+#   bash plugins/hermes/tests/test_install_e2e.sh
+#   或：REPO_ROOT=$(pwd) bash plugins/hermes/tests/test_install_e2e.sh
+#
+# 退出码：0=全过，1=有失败。
+#
+# 依赖：bash、python3/python（venv 即可）、curl、netstat 或 lsof 或 ss
+#       本机已装好 miloco-cli 可更好（pre-flight 校验），缺也能跑通。
+
+set -uo pipefail
+
+# --- 定位仓库根 ---
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+INSTALL_SH="$REPO_ROOT/plugins/hermes/install-hermes.sh"
+ADAPTER_SH="$REPO_ROOT/plugins/hermes/scripts/miloco-adapter.sh"
+
+[ -f "$INSTALL_SH" ] || { echo "找不到 $INSTALL_SH"; exit 1; }
+[ -f "$ADAPTER_SH" ] || { echo "找不到 $ADAPTER_SH"; exit 1; }
+
+# --- 找 python（优先 venv 的，没有就用 PATH 里的）---
+if [ -f "$HOME/AppData/Local/hermes/hermes-agent/venv/Scripts/python.exe" ]; then
+  REAL_PY="$HOME/AppData/Local/hermes/hermes-agent/venv/Scripts/python.exe"
+elif command -v python3 >/dev/null 2>&1; then
+  REAL_PY="$(command -v python3)"
+elif command -v python >/dev/null 2>&1; then
+  REAL_PY="$(command -v python)"
+else
+  echo "找不到 python，跳过"
+  exit 1
+fi
+
+# --- 准备 mock 环境 ---
+TEST_ROOT="$(mktemp -d)"
+FAKE_BIN="$TEST_ROOT/fake-bin"
+mkdir -p "$FAKE_BIN" "$TEST_ROOT/miloco" "$TEST_ROOT/hermes"
+
+# mock miloco-cli
+cat > "$FAKE_BIN/miloco-cli" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$FAKE_BIN/miloco-cli"
+
+# mock miloco config
+cat > "$TEST_ROOT/miloco/config.json" <<'EOF'
+{"server":{"port":8123,"token":"x"},"agent":{"webhook_url":"old","auth_bearer":"old"}}
+EOF
+
+# python wrapper（venv python 需要 pyvenv.cfg 同目录，wrapper 调它）
+cat > "$FAKE_BIN/python3" <<EOF
+#!/usr/bin/env bash
+exec "$REAL_PY" "\$@"
+EOF
+chmod +x "$FAKE_BIN/python3"
+cp "$FAKE_BIN/python3" "$FAKE_BIN/python"
+
+# --- 测试用例计数 ---
+PASS=0
+FAIL=0
+FAILS=()
+
+assert() {
+  local name="$1" cond="$2"
+  if [ "$cond" = "1" ]; then
+    PASS=$((PASS+1))
+    echo "  ✓ $name"
+  else
+    FAIL=$((FAIL+1))
+    FAILS+=("$name")
+    echo "  ✗ $name"
+  fi
+}
+
+# 端口号：用时间戳后 4 位避开冲突
+PORT=2$(( $(date +%s) % 9000 + 1000 ))
+export HERMES_HOME="$TEST_ROOT/hermes"
+export MILOCO_HOME="$TEST_ROOT/miloco"
+export ADAPTER_PORT="$PORT"
+export PATH="$FAKE_BIN:$PATH"
+
+cleanup() {
+  for pid in $(tasklist //FI "IMAGENAME eq python.exe" //FO CSV //NH 2>/dev/null | awk -F'","' '{print $2}' | tr -d '"' 2>/dev/null); do
+    taskkill //PID "$pid" //F >/dev/null 2>&1 || true
+  done
+  rm -rf "$TEST_ROOT" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "==== TEST 1: install-hermes.sh 首次安装 ===="
+bash "$INSTALL_SH" > /tmp/i1.log 2>&1
+RC1=$?
+assert "install exit 0" "$([ $RC1 -eq 0 ] && echo 1 || echo 0)"
+[ -d "$HERMES_HOME/plugins/miloco/miloco-plugin" ] && T=1 || T=0
+assert "miloco-plugin 已复制" "$T"
+[ -d "$HERMES_HOME/plugins/miloco/adapter" ] && T=1 || T=0
+assert "adapter 已复制" "$T"
+SKILL_DIRS=$(find "$HERMES_HOME/skills" -maxdepth 1 -name "miloco-*" -type d 2>/dev/null | wc -l)
+assert "16 个 skill 目录" "$([ $SKILL_DIRS -eq 16 ] && echo 1 || echo 0)"
+[ -f "$HERMES_HOME/miloco-adapter.pid" ] && T=1 || T=0
+assert "pid 文件存在" "$T"
+PID1=$(cat "$HERMES_HOME/miloco-adapter.pid" 2>/dev/null)
+[ -n "$PID1" ] && T=1 || T=0
+assert "pid 非空（$PID1）" "$T"
+grep -q '^API_SERVER_KEY=' "$HERMES_HOME/.env" && T=1 || T=0
+assert ".env 包含 API_SERVER_KEY" "$T"
+grep -q '"webhook_url"' "$MILOCO_HOME/config.json" && T=1 || T=0
+assert "miloco config.json 已 patch" "$T"
+ls "$MILOCO_HOME"/config.json.bak-* >/dev/null 2>&1 && T=1 || T=0
+assert "miloco config.json.bak-* 备份存在" "$T"
+
+echo ""
+echo "==== TEST 2: 鉴权契约 ===="
+# 等一下端口就绪
+sleep 1
+HTTP_NO_AUTH=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 3 -X POST http://127.0.0.1:$PORT/miloco/webhook -H "Content-Type: application/json" -d '{}')
+assert "POST 无 auth → 401" "$([ "$HTTP_NO_AUTH" = "401" ] && echo 1 || echo 0)"
+BEARER=$(grep '^API_SERVER_KEY=' "$HERMES_HOME/.env" | cut -d= -f2-)
+RESP=$(curl -sS --max-time 5 -X POST http://127.0.0.1:$PORT/miloco/webhook \
+  -H "Authorization: Bearer $BEARER" -H "Content-Type: application/json" -d '{}')
+echo "$RESP" | grep -q '"code": 1001' && T=1 || T=0
+assert "POST 有 auth 缺 action → code:1001" "$T"
+HTTP_HEALTH=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 3 http://127.0.0.1:$PORT/health)
+assert "/health → 200" "$([ "$HTTP_HEALTH" = "200" ] && echo 1 || echo 0)"
+
+echo ""
+echo "==== TEST 3: install-hermes.sh 幂等性 ===="
+bash "$INSTALL_SH" > /tmp/i2.log 2>&1
+RC2=$?
+assert "幂等 exit 0" "$([ $RC2 -eq 0 ] && echo 1 || echo 0)"
+PID2=$(cat "$HERMES_HOME/miloco-adapter.pid" 2>/dev/null)
+[ "$PID1" != "$PID2" ] && [ -n "$PID2" ] && T=1 || T=0
+assert "PID 变化（$PID1 → $PID2）" "$T"
+BEARER2=$(grep '^API_SERVER_KEY=' "$HERMES_HOME/.env" | cut -d= -f2-)
+[ "$BEARER" = "$BEARER2" ] && T=1 || T=0
+assert "Bearer 复用" "$T"
+
+echo ""
+echo "==== TEST 4: miloco-adapter.sh 完整生命周期 ===="
+bash "$ADAPTER_SH" status > /tmp/s1.log 2>&1
+grep -q "adapter 在跑" /tmp/s1.log && T=1 || T=0
+assert "status 显示在跑" "$T"
+bash "$ADAPTER_SH" restart > /tmp/r.log 2>&1
+RC3=$?
+assert "restart exit 0" "$([ $RC3 -eq 0 ] && echo 1 || echo 0)"
+PID3=$(cat "$HERMES_HOME/miloco-adapter.pid" 2>/dev/null)
+[ "$PID2" != "$PID3" ] && [ -n "$PID3" ] && T=1 || T=0
+assert "restart 后 PID 变化（$PID2 → $PID3）" "$T"
+bash "$ADAPTER_SH" stop > /tmp/stop.log 2>&1
+RC4=$?
+assert "stop exit 0" "$([ $RC4 -eq 0 ] && echo 1 || echo 0)"
+sleep 1
+LISTEN=$(netstat -ano 2>/dev/null | grep ":$PORT " | grep LISTENING | head -1)
+[ -z "$LISTEN" ] && T=1 || T=0
+assert "stop 后端口释放" "$T"
+
+echo ""
+echo "==== TEST 5: install-hermes.sh（adapter 已停时）===="
+bash "$INSTALL_SH" > /tmp/i3.log 2>&1
+RC5=$?
+assert "exit 0" "$([ $RC5 -eq 0 ] && echo 1 || echo 0)"
+PID4=$(cat "$HERMES_HOME/miloco-adapter.pid" 2>/dev/null)
+[ -n "$PID4" ] && T=1 || T=0
+assert "新 adapter 已起（PID=$PID4）" "$T"
+
+# --- 总结 ---
+echo ""
+echo "=========================================="
+echo "PASS: $PASS, FAIL: $FAIL"
+if [ $FAIL -gt 0 ]; then
+  echo "失败用例："
+  for f in "${FAILS[@]}"; do echo "  - $f"; done
+  exit 1
+fi
+echo "全部通过 ✓"
+exit 0

--- a/plugins/hermes/tests/test_session_map.py
+++ b/plugins/hermes/tests/test_session_map.py
@@ -1,0 +1,43 @@
+"""session_map: (sessionKey, lane) → Hermes session_id 确定性映射。"""
+
+from __future__ import annotations
+
+from adapter_pkg.session_map import map_session
+
+
+def test_defaults_when_empty():
+    assert map_session(None, None) == "miloco:main:default"
+    assert map_session("", "") == "miloco:main:default"
+
+
+def test_deterministic():
+    assert map_session("s1", "L1") == "miloco:s1:L1"
+    assert map_session("s1", "L1") == map_session("s1", "L1")
+
+
+def test_format():
+    assert map_session("k", "lane") == "miloco:k:lane"
+    assert map_session("k", None) == "miloco:k:default"
+    assert map_session(None, "lane") == "miloco:main:lane"
+
+
+def test_sanitizes_control_chars():
+    # 控制字符被剥离，不破坏 session_id
+    out = map_session("a\nb\tc", "d")
+    assert "\n" not in out and "\t" not in out
+    assert out.startswith("miloco:")
+
+
+def test_different_inputs_differ():
+    assert map_session("a", "1") != map_session("a", "2")
+    assert map_session("a", "1") != map_session("b", "1")
+
+
+def test_truncates_overlong():
+    key = "x" * 500
+    out = map_session(key, "y")
+    # 限长 200，加前缀 "miloco:" + 冒号 + lane
+    body = out.split(":", 1)[1]
+    key_part, lane_part = body.rsplit(":", 1)
+    assert len(key_part) <= 200
+    assert lane_part == "y"

--- a/scripts/install-guide-hermes.md
+++ b/scripts/install-guide-hermes.md
@@ -1,0 +1,196 @@
+---
+name: install-miloco-hermes
+description: Miloco × Hermes Agent 兼容层安装引导，当用户说"装 miloco for Hermes"时激活。
+metadata:
+  author: n0tssss
+  version: "1.0"
+  date: 2026-06-19
+---
+
+# Miloco × Hermes Agent 安装指南
+
+## 概述
+
+本 skill 指导 agent 通过 3 个阶段把 miloco 装到一个**已经装了 Hermes Agent** 的机器上。agent 自己跑所有非人介入的命令，**只在小米账号 OAuth / API key 等必须人操作的环节才停下来问用户**。命令跑完打印清晰的最终状态。
+
+**安装方式（3 步全自动，不打断用户）：**
+
+```bash
+git clone https://github.com/XiaoMi/xiaomi-miloco.git
+cd xiaomi-miloco
+bash plugins/hermes/install-hermes.sh
+hermes gateway restart
+```
+
+> **Windows 用户：** 原生 Windows 不支持，请先装 [WSL](https://learn.microsoft.com/zh-cn/windows/wsl/install) 在 WSL 终端执行。
+
+---
+
+## Step 1: Prepare — 环境准备（agent 自跑，不问用户）
+
+**目标：** 检查并装齐所有依赖。缺的自己装，不要问用户。
+
+依次执行下列命令。**每条都先看 exit code，非 0 才停下问用户**。
+
+### 1.1 检查并装 hermes
+
+```bash
+command -v hermes || curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+test -d "$HOME/.hermes" || { echo "缺少 ~/.hermes"; exit 1; }
+```
+
+### 1.2 检查并装 miloco 后端
+
+```bash
+command -v miloco-cli || curl -LsSf https://github.com/XiaoMi/xiaomi-miloco/releases/latest/download/install.sh | bash
+command -v miloco-cli || { echo "miloco-cli 仍找不到"; exit 1; }
+test -f "${MILOCO_HOME:-$HOME/.openclaw/miloco}/config.json" || miloco-cli init
+```
+
+### 1.3 检查并装 python 依赖
+
+```bash
+command -v python3 || command -v python
+# hermes v0.10.0 cron 调度需要 croniter；adapter 需要 aiohttp + httpx
+python3 -c "import aiohttp, httpx, croniter" 2>/dev/null || python3 -m pip install aiohttp httpx croniter
+```
+
+### 1.4 拉 fork
+
+```bash
+test -d xiaomi-miloco || git clone https://github.com/XiaoMi/xiaomi-miloco.git
+cd xiaomi-miloco && git pull --ff-only
+```
+
+### 1.5 解析输出
+
+如果上面任何一条 exit ≠ 0，**把错误信息贴给用户**（包括命令 + returncode + stderr），然后参考底部故障排除表。不要自己瞎猜。
+
+---
+
+## Step 2: Install — 装兼容层（agent 自跑，不问用户）
+
+**目标：** 跑 install-hermes.sh，自动 patch miloco config / .env / 启 adapter，全部幂等。
+
+```bash
+cd xiaomi-miloco
+bash plugins/hermes/install-hermes.sh
+```
+
+脚本会做完 7 件事（同 OpenClaw 装 OpenClaw 插件的体验）：
+1. 前置检查
+2. 同步 16 个 miloco-* skill 到 `~/.hermes/skills/`
+3. 复制插件到 `~/.hermes/plugins/miloco/miloco-plugin/`
+4. 复制 adapter 到 `~/.hermes/plugins/miloco/adapter/`
+5. patch `$MILOCO_HOME/config.json` 的 `agent` 段（备份 `config.json.bak-<ts>`）
+6. 写 `~/.hermes/.env` 的 `API_SERVER_KEY`（缺失则生成，存在则复用）
+7. nohup 启 adapter，PID 写到 `~/.hermes/miloco-adapter.pid`
+
+**如果脚本 exit ≠ 0**：
+- 看脚本打印的错误（前置检查 / patch / 启 adapter 任一步）
+- 跑 `bash plugins/hermes/scripts/miloco-adapter.sh logs` 看 adapter 日志
+- 参考底部故障排除表，不要瞎猜
+
+**如果脚本成功**，跑下面这条重启 hermes 让插件生效：
+
+```bash
+hermes gateway restart
+```
+
+---
+
+## Step 3: Verify + Ask（agent 自验，仅必要时叫人）
+
+**目标：** 自动验证全链路；只在小米账号 / 模型 API key 真正缺失时才叫人。
+
+### 3.1 自动验证（agent 自跑）
+
+```bash
+# 1. 插件 enabled？
+hermes plugins list | grep -i miloco
+
+# 2. 16 skill 装上？
+ls ~/.hermes/skills/miloco-* | wc -l   # 应 16
+
+# 3. adapter 在跑？
+bash plugins/hermes/scripts/miloco-adapter.sh status   # 应 health OK
+
+# 4. 入站 webhook 健康
+curl -sS -o /dev/null -w "%{http_code}" http://127.0.0.1:18789/health   # 应 200
+
+# 5. e2e 测试套（最稳）
+cd xiaomi-miloco && bash plugins/hermes/tests/test_install_e2e.sh   # 应 PASS: 22, FAIL: 0
+```
+
+### 3.2 报告当前状态（给用户）
+
+不管 3.1 结果如何，都给用户一份状态报告：
+
+```
+✅ miloco × Hermes 兼容层已装好
+  - 插件: ~/.hermes/plugins/miloco/miloco-plugin (enabled)
+  - 16 skill: ~/.hermes/skills/miloco-*
+  - adapter: PID=<pid>，端口 18789，日志 ~/.hermes/miloco-adapter.log
+  - miloco config.json: webhook_url + auth_bearer 已 patch，备份 config.json.bak-<ts>
+  - Hermes .env: API_SERVER_KEY 已追加
+  - 验证: 22/22 e2e 通过 / 或列出失败项
+```
+
+### 3.3 **只在这 3 个条件下叫用户**（其它全自跑）
+
+| 检查 | 命令 | 不通过时叫用户做什么 |
+|---|---|---|
+| 小米账号已绑？ | `miloco-cli account status` | 没绑就给出 `bind_url`，让用户在浏览器完成 OAuth，把授权码贴回来 |
+| 模型已配？ | `miloco-cli config show model` | 没配就问 API key（推荐小米 MiMo） |
+| Windows 不是 WSL？ | `uname -r \| grep -i microsoft` | 不在 WSL 就提醒用户用 WSL |
+
+**任何其它情况（git 报错、端口冲突、依赖装不上等）都自己排查 + 看脚本错误 + 参考故障表，不要先问用户。**
+
+---
+
+## 故障排除
+
+| 问题 | 解决 |
+|---|---|
+| `找不到 miloco-cli` | Step 1.2 应自动装；如果还缺，确认 `~/.local/bin` 在 PATH |
+| `找不到 ~/.hermes` | Step 1.1 应自动装；如果还缺，看 hermes 官方安装日志 |
+| `MILOCO_HOME` 没设 / config.json 找不到 | `export MILOCO_HOME=$HOME/.openclaw/miloco` 然后再跑，或 `miloco-cli init` |
+| `adapter 启动失败，端口 X 未监听` | `netstat -ano \| grep X`（Win）/ `lsof -iTCP:X -sTCP:LISTEN`（Mac/Linux）找占用 kill；或 `export ADAPTER_PORT=18790` 换端口重跑 install-hermes.sh |
+| `No module named aiohttp` | `pip install aiohttp httpx croniter` 后重跑 install-hermes.sh |
+| `hermes cron list` 没见 4 个 miloco 任务 | `pip install croniter` → `hermes gateway restart` |
+| `hermes chat` 报 401 / model 错 | 检查 `~/.hermes/config.yaml` 的 `model.api_key` 或对应 provider env |
+| 装完发现 adapter 没在跑 | `bash plugins/hermes/scripts/miloco-adapter.sh logs` 看日志；`status` 看 PID/端口/健康 |
+| adapter 启动后端口还在占 | 旧进程没杀干净：`bash plugins/hermes/scripts/miloco-adapter.sh stop` 再 start |
+| `git clone` / `git pull` 失败 | 网络问题；可设 `git config --global url."https://ghproxy.com/".insteadOf https://` 走镜像 |
+
+---
+
+## Agent 执行要点
+
+1. **严格按 3 步执行** — Step 1 → Step 2 → Step 3，不可跳步
+2. **能不问就不问** — 只有 OAuth 授权码、API key 这种必须人提供的才停下来问用户；其它（装包、装 hermes、装 miloco、跑 install-hermes.sh、重启、验证）都自己跑
+3. **出错先看错误本身** — 把命令 + returncode + stderr 贴给用户，参考故障表给建议，不要瞎猜
+4. **不要回显敏感信息** — API key / 授权码只通过参数传，不要 echo
+5. **尊重用户选择** — 用户说"先不绑账号"也行，告诉他后续怎么补
+6. **Windows 提醒用 WSL** — 原生 Windows 不支持
+
+---
+
+## 想回滚（用户要求时再跑）
+
+```bash
+# 1. 停 adapter
+bash plugins/hermes/scripts/miloco-adapter.sh stop
+
+# 2. 卸插件 + skill
+rm -rf ~/.hermes/plugins/miloco
+rm -rf ~/.hermes/skills/miloco-*
+
+# 3. 还原 miloco config.json
+cp $MILOCO_HOME/config.json.bak-<ts> $MILOCO_HOME/config.json
+
+# 4. .env 去掉 API_SERVER_KEY 那行
+
+# 5. 重启 hermes
+hermes gateway restart
+```


### PR DESCRIPTION
## 新增 Hermes Agent 兼容层

miloco 2.0 默认是 OpenClaw 插件。这次新增 [Hermes Agent](https://github.com/NousResearch/hermes-agent)（Nous Research 出品，开源 MIT，Python）作为**第二个可选 agent runtime**，让不装 OpenClaw 的用户也能用 miloco。

并配套建立 `plugins/<runtime>/` 扩展规范（见 [plugins/README.md](plugins/README.md)），后续要加第三、第四个 runtime（如 LangChain / CrewAI / AutoGen）就有章可循。

## 改了什么

- **新增** `plugins/hermes/`（25 个文件）：Hermes 插件（出站：pre_llm_call 钩子 / 3 tool / 4 受管 cron）+ 入站适配进程（aiohttp）+ 一键安装脚本 + adapter 生命周期管理
- **新增** `scripts/install-guide-hermes.md`：给 AI agent 跑的安装 skill（frontmatter + 3 步自跑），与 OpenClaw 的 `scripts/install-guide.md` 同级
- **新增** `plugins/README.md`：每个 runtime 一个子目录的约定 + 最小骨架 + 命名规范
- **新增** 2 份知识库文档：
  - `knowledge/03-features/hermes-integration.md`（架构 / 数据流 / 跟 OpenClaw 差异）
  - `knowledge/05-external-deps/sdk-hermes.md`（Hermes 平台契约）
- **修改** `README.md` + `README.zh.md`（5 处同源）：定位句 / What's New / TIP / 前置 / **方式一加 Hermes 子段**（与 OpenClaw 同款格式）/ Quick Start 分支 restart / 项目结构 / 致谢
- **修改** `.gitignore`：加 `plugins/hermes/skills/`（生成产物）

## 跟 OpenClaw 版的关系

- 16 个 skill 源共用 `plugins/skills/miloco-*`，**只有 agent 侧插件和入站 webhook 适配层是 Hermes 重写**
- 出站能力等价（对话控设备 / 建任务 / 家庭记忆 / 受管 cron）
- 入站适配层是独立 aiohttp 进程，因为 Hermes 插件 ctx API 不能注册 HTTP 路由（OpenClaw 的 `api.registerHttpRoute` 没对应——这是 Hermes 架构限制，不是懒）
- 4 个受管 cron、3 个 tool 全部对等
- 已知降级（已在文档标注 best-effort）：context 注入位置（user message vs system prompt，为保 prompt cache）、get_trace observability 降级、上下文溢出自愈弱化、notify 不 fallback 最近 channel

## 测试

- 29 个 pytest（Python 端到端契约）全过
- 22 个 e2e 断言（bash，install + adapter 全生命周期）全过
- Hermes v0.10.0 + GLM（bigmodel OpenAI 端点）实测双向打通：出站插件加载 + 16 skill + 4 cron；入站 `{action:"agent"}` → 适配器 → `/v1/chat/completions` 同步 turn → `{code:0,data:{runId,status:"ok"}}`

## 对现有用户的影响

**零**。OpenClaw 是默认路径，Hermes 是新增选项。不动后端代码、不改 OpenClaw 插件、不改共享 skill 源。

## `plugins/README.md` 给后续 runtime 留的接口

加第三、第四个 runtime 时按这个最小骨架走：每个 runtime 一个子目录、共享 `plugins/skills/` 源、`scripts/install-guide-<runtime>.md` 与 OpenClaw 的 `scripts/install-guide.md` 同级放 agent 安装 skill、命名约定统一。详见 plugins/README.md。

## 不在 PR 里

- 没动 `backend/`、`cli/`、`web/`、`plugins/openclaw/`、`plugins/skills/`
- 没改 API 契约
- 没改 knowledge base 其它章节

## 验证

```bash
# 装上后跑这个最稳
bash plugins/hermes/tests/test_install_e2e.sh   # 期望：PASS: 22, FAIL: 0

# Python 端
pytest plugins/hermes/tests/test_*.py
```
