### PR TITLE
Prevent duration overcount across synchronized camera exits

### DIFF
--- a/backend/miloco/src/miloco/perception/client.py
+++ b/backend/miloco/src/miloco/perception/client.py
@@ -685,6 +685,21 @@ class PerceptionEngineProxy:
         # 去重粒度从 rule_id 改为 (rule_id, did):同 rule 在 cam_A early 命中后,cam_B
         # 终态又命中应当照常打 True(不同桶),不能被 early 误吃。
         svc = get_manager().rule_service
+        cycle_source_states_by_rule: dict[str, dict[str, bool]] = {}
+        for did, rule_ids in result.device_rule_map.items():
+            for rule_id in rule_ids:
+                cycle_source_states_by_rule.setdefault(rule_id, {})[did] = False
+        for matched_rule in result.matched_rules:
+            did = (
+                matched_rule.source_device_ids[0]
+                if matched_rule.source_device_ids
+                else "perception"
+            )
+            cycle_source_states_by_rule.setdefault(matched_rule.rule_id, {})[did] = True
+        if early_sent_rule_ids:
+            for rule_id, did in early_sent_rule_ids:
+                cycle_source_states_by_rule.setdefault(rule_id, {})[did] = True
+
         for matched_rule in result.matched_rules:
             did = matched_rule.source_device_ids[0] if matched_rule.source_device_ids else "perception"
             if early_sent_rule_ids and (matched_rule.rule_id, did) in early_sent_rule_ids:
@@ -698,6 +713,9 @@ class PerceptionEngineProxy:
                 trigger_dids=matched_rule.source_device_ids,
                 caption=caption_for_dids(result.caption, matched_rule.source_device_ids),
                 device_name=matched_rule.device_name,
+                cycle_source_states=cycle_source_states_by_rule.get(
+                    matched_rule.rule_id
+                ),
             )
 
         # 对本 batch 实际下发过、但未命中的 (rule_id, did) 喂 update_state(False)。
@@ -723,7 +741,12 @@ class PerceptionEngineProxy:
                 # 防 race:下发后 rule 在 cycle 内被 disable
                 if rule_id not in enabled_set:
                     continue
-                await svc.update_state(rule_id, did, False)
+                await svc.update_state(
+                    rule_id,
+                    did,
+                    False,
+                    cycle_source_states=cycle_source_states_by_rule.get(rule_id),
+                )
 
         # result.suggestions 含本窗全部「新链」（dump/上下文已完整）。per-omni 下这些新链
         # 已在 _on_early_suggestions 逐相机早送过（id 记入 early_sent_sugg_ids）——此处据此

--- a/backend/miloco/src/miloco/rule/runner.py
+++ b/backend/miloco/src/miloco/rule/runner.py
@@ -31,7 +31,7 @@ import logging
 import time
 import uuid
 from collections import deque
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, Mapping
 
 if TYPE_CHECKING:
     from miloco.task_record.service import TaskRecordService
@@ -282,6 +282,7 @@ class RuleRunner:
         trigger_dids: list[str] | None = None,
         caption: str = "",
         device_name: str = "",
+        cycle_source_states: Mapping[str, bool] | None = None,
     ) -> None:
         """Per-frame, per-source state report from the perception engine.
 
@@ -307,15 +308,19 @@ class RuleRunner:
             prev = self._last_source_state.get(key, False)
 
             # duration 窗口必须每 sample 都参与（每帧采样累加），不能被下方帧级抗抖
-            # 丢帧。先按本帧 current_bool 临时替换本 source 旧值算 OR 聚合，传给
-            # _evaluate_duration——既反映本帧真实读数，又不污染状态机（不更新
-            # _last_source_state）。
+            # 丢帧。感知 client 会在同一 cycle 内传入已观测 source 的快照，避免
+            # 多 source 同步翻 False 时先来的 source 仍读到后来的 source 上一帧 True。
+            # 未在本 cycle 观测到的 source 继续沿用 _last_source_state。
             if rule.duration_seconds:
-                effective_state = current_bool or any(
+                observed_states = dict(cycle_source_states or {})
+                observed_states.setdefault(source_did, current_bool)
+                effective_state = any(observed_states.values()) or any(
                     v for k, v in self._last_source_state.items()
-                    if k[0] == rule_id and k != key
+                    if k[0] == rule_id and k[1] not in observed_states
                 )
-                self._evaluate_duration(rule, effective_state, source_did, context, caption, device_name)
+                self._evaluate_duration(
+                    rule, effective_state, source_did, context, caption, device_name
+                )
 
             # 帧级抗抖：source 上次 True 时，单帧 False 不立即翻转 — 视为 LLM 漏识，
             # 留一帧观察窗。下一帧仍 False 才确认 EXIT；翻回 True 则吸收为抖动。

--- a/backend/miloco/src/miloco/rule/service.py
+++ b/backend/miloco/src/miloco/rule/service.py
@@ -491,6 +491,7 @@ class RuleService:
         trigger_dids: list[str] | None = None,
         caption: str = "",
         device_name: str = "",
+        cycle_source_states: dict[str, bool] | None = None,
     ) -> None:
         """Per-frame, per-source state report from the perception engine.
 
@@ -499,6 +500,7 @@ class RuleService:
         await self._runner.update_state(
             rule_id, source_did, current_bool, context, trigger_room, trigger_dids,
             caption=caption, device_name=device_name,
+            cycle_source_states=cycle_source_states,
         )
 
     # ---- Logs ----

--- a/backend/miloco/tests/test_perception_client.py
+++ b/backend/miloco/tests/test_perception_client.py
@@ -150,7 +150,15 @@ async def test_final_matched_rules_meta_passed_to_update_state(proxy):
     with patch("miloco.manager.get_manager", return_value=fake_mgr):
         await proxy.handle_realtime_perception_result(result)
 
-    assert seen == [{"trigger_room": "卧室", "trigger_dids": ["cam-002"], "caption": "", "device_name": ""}]
+    assert seen == [
+        {
+            "trigger_room": "卧室",
+            "trigger_dids": ["cam-002"],
+            "caption": "",
+            "device_name": "",
+            "cycle_source_states": {"cam-002": True},
+        }
+    ]
 
 
 async def test_spawn_in_callback_survives_temp_loop_close(proxy):

--- a/backend/miloco/tests/test_perception_client_rule_dispatch.py
+++ b/backend/miloco/tests/test_perception_client_rule_dispatch.py
@@ -116,6 +116,44 @@ async def test_exited_skips_matched_pair(proxy):
     assert len(calls) == 2
 
 
+async def test_cycle_source_states_include_matched_and_false_pairs(proxy):
+    """同一 cycle 内 True / False 调用都携带完整 source 快照。
+
+    duration_seconds 依赖这个快照避免先处理的 source 读到后处理 source 的上一帧状态。
+    """
+    result = RealtimePerceptionResult(
+        skipped=False,
+        matched_rules=[
+            MatchedRule(
+                rule_id="rule_X",
+                confidence=1.0,
+                reason="A 命中",
+                source_device_ids=["cam_A"],
+            )
+        ],
+        device_rule_map={"cam_A": ["rule_X"], "cam_B": ["rule_X"]},
+    )
+    calls: list[tuple[str, str, bool, dict[str, bool] | None]] = []
+
+    async def capture(rule_id, source_did, current_bool, context="", **kwargs):
+        calls.append(
+            (
+                rule_id,
+                source_did,
+                current_bool,
+                kwargs.get("cycle_source_states"),
+            )
+        )
+
+    with patch("miloco.manager.get_manager", return_value=_fake_mgr(["rule_X"], capture)):
+        await proxy.handle_realtime_perception_result(result, clips_by_device=None)
+
+    assert calls == [
+        ("rule_X", "cam_A", True, {"cam_A": True, "cam_B": False}),
+        ("rule_X", "cam_B", False, {"cam_A": True, "cam_B": False}),
+    ]
+
+
 async def test_early_sent_dedup_per_rule_did_pair(proxy):
     """early 阶段 cam_A 已上报 → set 含 ("rule_X","cam_A");终态 result 也含
     rule_X@cam_A + rule_X@cam_B → A 不重打 True,B 照常打。"""

--- a/backend/miloco/tests/test_perception_rule_e2e.py
+++ b/backend/miloco/tests/test_perception_rule_e2e.py
@@ -302,34 +302,17 @@ async def test_e2e_pending_exit_no_cross_pollution(
     assert dids == ["enter-rule_pex"]
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Known limitation: duration_seconds + 多 source rule 在 cycle 内同步翻 "
-        "True→False 时,update_state 入口处 effective_state 用'本帧 current_bool ⊔ "
-        "其他桶上一帧' OR 聚合;先来的 source 看到其他桶上一帧 True → append 1 + "
-        "round_id 消化,后来的 source 跳过 → deque 虚高 1 格,可能触发误 fire。"
-        "修复需重构 duration fire 时序(从 update_state 入口同步 fire 改为 cycle 末延迟 "
-        "fire),改动 N 个 duration 测试,ROI 不划算。当前 1 摄像头部署不暴露;多摄像头 + "
-        "duration rule + 同步翻转极端场景才暴露,误差 ≤ 1 个 sample。等业务真翻车再做。"
-    ),
-)
 @pytest.mark.asyncio
 async def test_e2e_duration_multi_source_sync_transition_no_overcount(
     proxy_with_runner, mock_miot_proxy, mock_log_repo
 ):
-    """xfail 锁定 bug:duration_seconds 配置 rule,多 source 同步翻 True→False 时
-    deque 虚高 1 格 → 可能触发误 fire。
+    """duration_seconds 配置 rule,多 source 同步翻 True→False 时不应过计数。
 
     场景:rule 绑 [cam_A, cam_B] duration_seconds=1, ratio=1.0, sample_interval=0.5
     (maxlen=2 → 满 ratio 即 fire)。
     - cycle 1 (round=200): A=True, B=True → 累计 [1]
     - cycle 2 (round=201): A=False, B=False → 实际应累计 [1, 0]，不 fire;
-      但当前实现下 false 广播 cam_A 先到时 effective_state 看 cam_B 上一帧=True →
-      append 1 → win=[1, 1] → sum/maxlen=1.0 ≥ ratio → **误 fire**。
-
-    本 case xfail (strict=True),修复后该 case 应自然通过 → strict 让 unexpected
-    pass 也报错,提醒移除 xfail mark。
+      false 广播 cam_A 先到时也不能把 cam_B 的上一帧 True 当成本轮 True。
     """
     from miloco.rule.runner import RuleRunner
     from miloco.rule.schema import (

--- a/backend/miloco/tests/test_perception_rule_e2e.py
+++ b/backend/miloco/tests/test_perception_rule_e2e.py
@@ -375,7 +375,8 @@ async def test_e2e_duration_multi_source_sync_transition_no_overcount(
 
     await runner_dur.drain()
 
-    # 期望(修复后):不触发 fire。当前(bug 存在):"fire-d" 出现在 fire 列表 → xfail。
+    # 两 source 同步退出时，本轮状态应按 cycle 快照聚合为 False，不能沿用任一
+    # source 的上一帧 True 过计入 duration 窗口。
     dids = [
         call[0][0][0].did
         for call in mock_miot_proxy.set_device_properties.call_args_list


### PR DESCRIPTION
Multi-source duration rules sampled each source update independently, so the first false update in a cycle could still see another camera's stale true state and overcount the duration window. The perception client now sends the runner a per-cycle source-state snapshot, and the runner uses that snapshot for observed sources while preserving previous state for unobserved sources.