### PR TITLE
feat(settings): add server.url / host+port consistency validator

### DIFF
--- a/backend/miloco/src/miloco/config/settings.py
+++ b/backend/miloco/src/miloco/config/settings.py
@@ -582,6 +582,55 @@ class MilocoSettings(BaseSettings):
             self.perception = self.perception.model_copy(update={"engine": new_engine})
         return self
 
+    # ── server.url 与 server.host/port 一致性校验 ────────────────────────
+
+    @model_validator(mode="after")
+    def _validate_server_url_host_port(self) -> "MilocoSettings":
+        """检查 server.url 与 server.host/port 的一致性。
+
+        当 server.host 为 '0.0.0.0' 时，仅检查 port 是否一致；
+        否则同时检查 host 和 port。
+        """
+        from urllib.parse import urlparse
+
+        url = self.server.url
+        try:
+            parsed = urlparse(url)
+        except Exception:
+            # urlparse 基本不会失败，但以防万一
+            logger.warning("无法解析 server.url: %s，跳过一致性校验", url)
+            return self
+
+        url_host = parsed.hostname or "localhost"
+        url_port = parsed.port
+        if url_port is None:
+            # 根据协议推断默认端口
+            if parsed.scheme == "http":
+                url_port = 80
+            elif parsed.scheme == "https":
+                url_port = 443
+            # 对于其他协议，保持 None，后续跳过端口检查
+
+        # 将 localhost 映射为 127.0.0.1
+        if url_host == "localhost":
+            url_host = "127.0.0.1"
+
+        host = self.server.host
+        if host == "localhost":
+            host = "127.0.0.1"
+        # host 为 0.0.0.0 时，后端监听所有接口，url 可以为任意 host，仅检查 port
+        if (url_port is not None and url_port != self.server.port) or (
+            host != "0.0.0.0" and url_host != host ):
+            logger.warning(
+                "server.url (%s) 与 server.host (%s) / server.port (%d) 配置不一致，"
+                "CLI 使用 server.url 访问后端，后端监听 server.host:server.port，"
+                "不一致将导致健康检查失败。",
+                url,
+                self.server.host,
+                self.server.port,
+            )
+        return self
+
     # ── 配置源编排 ──────────────────────────────────────────────────────
 
     @classmethod

--- a/backend/miloco/src/miloco/config/settings.py
+++ b/backend/miloco/src/miloco/config/settings.py
@@ -619,8 +619,9 @@ class MilocoSettings(BaseSettings):
         if host == "localhost":
             host = "127.0.0.1"
         # host 为 0.0.0.0 时，后端监听所有接口，url 可以为任意 host，仅检查 port
-        if (url_port is not None and url_port != self.server.port) or (
-            host != "0.0.0.0" and url_host != host ):
+        port_mismatch = url_port is not None and url_port != self.server.port
+        host_mismatch = host != "0.0.0.0" and url_host != host
+        if port_mismatch or host_mismatch:
             logger.warning(
                 "server.url (%s) 与 server.host (%s) / server.port (%d) 配置不一致，"
                 "CLI 使用 server.url 访问后端，后端监听 server.host:server.port，"

--- a/backend/miloco/src/miloco/config/settings.py
+++ b/backend/miloco/src/miloco/config/settings.py
@@ -596,13 +596,12 @@ class MilocoSettings(BaseSettings):
         url = self.server.url
         try:
             parsed = urlparse(url)
-        except Exception:
-            # urlparse 基本不会失败，但以防万一
+            url_host = parsed.hostname or "localhost"
+            url_port = parsed.port
+        except ValueError:
             logger.warning("无法解析 server.url: %s，跳过一致性校验", url)
             return self
 
-        url_host = parsed.hostname or "localhost"
-        url_port = parsed.port
         if url_port is None:
             # 根据协议推断默认端口
             if parsed.scheme == "http":

--- a/backend/miloco/tests/test_settings.py
+++ b/backend/miloco/tests/test_settings.py
@@ -142,3 +142,72 @@ def test_model_defaults_align_with_schema() -> None:
 # SSL 已废弃：backend 永远 HTTP，跨网加密走反代。原 ssl_enabled / ssl_certfile /
 # ssl_keyfile computed_field 已删除，对应 5 个测试一并移除。tls_certfile / tls_keyfile
 # 字段保留仅用于触发 utils/uvicorn.py 的 deprecation warning。
+
+
+class TestServerUrlHostPortValidator:
+    """server.url 与 server.host/port 一致性校验。"""
+
+    def _make(self, **overrides) -> MilocoSettings:
+        """构造 MilocoSettings 并触发 model_validator。"""
+        base = {
+            "server": {"url": "http://127.0.0.1:1810", "host": "127.0.0.1", "port": 1810},
+        }
+        for k, v in overrides.items():
+            base["server"][k] = v
+        return MilocoSettings(**base)
+
+    def test_matching_config_no_warning(self, caplog):
+        """默认配置完全一致，不触发 warning。"""
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            self._make()
+        assert not any("配置不一致" in r.message for r in caplog.records)
+
+    def test_port_mismatch_warns(self, caplog):
+        """url 端口与 server.port 不一致时触发 warning。"""
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            self._make(port=1811)
+        assert any("配置不一致" in r.message for r in caplog.records)
+
+    def test_host_mismatch_warns(self, caplog):
+        """url host 与 server.host 不一致时触发 warning。"""
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            self._make(host="192.168.1.100")
+        assert any("配置不一致" in r.message for r in caplog.records)
+
+    def test_bind_all_only_checks_port(self, caplog):
+        """host=0.0.0.0 时，url host 不同不告警，仅检查 port。"""
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            self._make(host="0.0.0.0", url="http://192.168.1.50:1810")
+        assert not any("配置不一致" in r.message for r in caplog.records)
+
+    def test_bind_all_port_mismatch_warns(self, caplog):
+        """host=0.0.0.0 但端口不一致时仍触发 warning。"""
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            self._make(host="0.0.0.0", port=9999)
+        assert any("配置不一致" in r.message for r in caplog.records)
+
+    def test_localhost_normalized_no_warning(self, caplog):
+        """localhost 与 127.0.0.1 视为等价，不触发 warning。"""
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            self._make(url="http://localhost:1810", host="127.0.0.1")
+        assert not any("配置不一致" in r.message for r in caplog.records)
+
+    def test_default_port_http_no_warning(self, caplog):
+        """http://host 不带端口时推断 80，与 port=80 匹配。"""
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            self._make(url="http://127.0.0.1", port=80)
+        assert not any("配置不一致" in r.message for r in caplog.records)


### PR DESCRIPTION
## 概述

在 `MilocoSettings` 中新增 `@model_validator(mode="after")` ，在配置加载时校验 `server.url` 与 `server.host` / `server.port` 的一致性，避免因手动改错配置导致 CLI 连接后端失败。

## 背景

`server.url` 是 CLI 和插件访问后端的 HTTP Base URL，`server.host` / `server.port` 是后端进程实际监听的地址。两者不一致时（比如 url 写了 `http://127.0.0.1:1810` 但 port 改成了 `1811`），CLI 健康检查会失败。

## 校验逻辑

- `server.host` 为 `0.0.0.0` 时：仅检查 port（后端监听所有接口，url host 可以是任意地址）
- 其他情况：同时检查 host 和 port
- `localhost` 自动映射为 `127.0.0.1` 避免语义等价误报
- 不一致时 `logger.warning` 提示，不阻断启动（与现有 validator 风格一致）

## 测试

本地验证：修改 `settings.yaml` 中 `server.port` 为不同值，启动后端确认 warning 日志输出；恢复一致后无告警。