### PR TITLE
fix(decoder): add G711A/G711U audio decoder support

### DIFF
--- a/backend/miot/src/miot/camera.py
+++ b/backend/miot/src/miot/camera.py
@@ -641,6 +641,7 @@ class MIoTCameraInstance:
                 )
         elif codec_id in [
             MIoTCameraCodec.AUDIO_OPUS,
+            MIoTCameraCodec.AUDIO_PCM,
             MIoTCameraCodec.AUDIO_G711A,
             MIoTCameraCodec.AUDIO_G711U,
         ]:

--- a/backend/miot/src/miot/camera.py
+++ b/backend/miot/src/miot/camera.py
@@ -641,7 +641,6 @@ class MIoTCameraInstance:
                 )
         elif codec_id in [
             MIoTCameraCodec.AUDIO_OPUS,
-            MIoTCameraCodec.AUDIO_PCM,
             MIoTCameraCodec.AUDIO_G711A,
             MIoTCameraCodec.AUDIO_G711U,
         ]:

--- a/backend/miot/src/miot/decoder.py
+++ b/backend/miot/src/miot/decoder.py
@@ -336,10 +336,6 @@ class MIoTMediaDecoder(threading.Thread):
             # Create audio decoder
             if frame_data.codec_id == MIoTCameraCodec.AUDIO_OPUS:
                 self._audio_decoder = AudioCodecContext.create("opus", "r")
-            elif frame_data.codec_id == MIoTCameraCodec.AUDIO_PCM:
-                self._audio_decoder = AudioCodecContext.create("pcm_s16le", "r")
-                self._audio_decoder.sample_rate = 8000
-                self._audio_decoder.layout = "mono"
             elif frame_data.codec_id == MIoTCameraCodec.AUDIO_G711A:
                 self._audio_decoder = AudioCodecContext.create("pcm_alaw", "r")
                 self._audio_decoder.sample_rate = 8000

--- a/backend/miot/src/miot/decoder.py
+++ b/backend/miot/src/miot/decoder.py
@@ -279,6 +279,9 @@ class MIoTMediaDecoder(threading.Thread):
                 self._video_decoder = VideoCodecContext.create("h264", "r")
             elif frame_data.codec_id == MIoTCameraCodec.VIDEO_H265:
                 self._video_decoder = VideoCodecContext.create("hevc", "r")
+            else:
+                _LOGGER.error("unsupported video codec: %s, skipping frame", frame_data.codec_id)
+                return
             _LOGGER.info("video decoder created, %s", frame_data.codec_id)
         pkt = Packet(frame_data.data)
         frames: List[VideoFrame] = self._video_decoder.decode(pkt)  # type: ignore
@@ -333,6 +336,21 @@ class MIoTMediaDecoder(threading.Thread):
             # Create audio decoder
             if frame_data.codec_id == MIoTCameraCodec.AUDIO_OPUS:
                 self._audio_decoder = AudioCodecContext.create("opus", "r")
+            elif frame_data.codec_id == MIoTCameraCodec.AUDIO_PCM:
+                self._audio_decoder = AudioCodecContext.create("pcm_s16le", "r")
+                self._audio_decoder.sample_rate = 8000
+                self._audio_decoder.layout = "mono"
+            elif frame_data.codec_id == MIoTCameraCodec.AUDIO_G711A:
+                self._audio_decoder = AudioCodecContext.create("pcm_alaw", "r")
+                self._audio_decoder.sample_rate = 8000
+                self._audio_decoder.layout = "mono"
+            elif frame_data.codec_id == MIoTCameraCodec.AUDIO_G711U:
+                self._audio_decoder = AudioCodecContext.create("pcm_mulaw", "r")
+                self._audio_decoder.sample_rate = 8000
+                self._audio_decoder.layout = "mono"
+            else:
+                _LOGGER.error("unsupported audio codec: %s, skipping frame", frame_data.codec_id)
+                return
             self._resampler = AudioResampler(format="s16", layout="mono", rate=16000)
             _LOGGER.info("audio decoder created, %s", frame_data.codec_id)
         pkt = Packet(frame_data.data)


### PR DESCRIPTION
## 概述

摄像头音频编码为 G711A/G711U/PCM 时，`_on_audio_callback` 未创建对应解码器但仍调用 `decode()`，导致 `'NoneType' object has no attribute 'decode'` 错误持续刷屏。本 PR 补齐三种音频解码器支持、在 `camera.py` 中注册 PCM codec，并在 video/audio 两侧添加 unsupported codec 的 early return 防崩溃。

## 修改内容

### `backend/miot/src/miot/decoder.py`

**`_on_audio_callback`**：
- 新增 `AUDIO_PCM` → `pcm_s16le`（sample_rate=8000, mono）
- 新增 `AUDIO_G711A` → `pcm_alaw`（sample_rate=8000, mono）
- 新增 `AUDIO_G711U` → `pcm_mulaw`（sample_rate=8000, mono）
- 新增 unsupported codec → error log + early return

**`_on_video_callback`**（防御性）：
- 新增 unsupported codec → error log + early return，与 audio 侧保持一致

### `backend/miot/src/miot/camera.py`

- 在音频 codec 注册列表中补充 `AUDIO_PCM`，与 decoder.py 侧新增的 PCM 支持对齐