### PR TITLE
feat(camera): add Xiaomi 智能家庭屏 Pro 8 to wifispeaker allowlist

### DIFF
--- a/backend/miot/src/miot/configs/camera_extra_info.yaml
+++ b/backend/miot/src/miot/configs/camera_extra_info.yaml
@@ -51,6 +51,9 @@ allowlist:
       name: Xiaomi 智能家庭屏 8 云台版
       vendor: 小米
       year: 2025
+    xiaomi.wifispeaker.x8f:
+      name: Xiaomi 智能家庭屏 Pro 8
+      vendor: 小米
   controller:
     xiaomi.controller.oh10p:
       name: 小米智能中控屏 Max


### PR DESCRIPTION
## 概述

Xiaomi 智能家庭屏 Pro 8（model: `xiaomi.wifispeaker.x8f`）内置摄像头，但未在 `camera_extra_info.yaml` 的 `wifispeaker` allowlist 中注册，导致 miloco 感知引擎无法识别该设备的摄像头能力。

## 修改内容

在 `backend/miot/src/miot/configs/camera_extra_info.yaml` 的 `allowlist.wifispeaker` 中添加：

```yaml
xiaomi.wifispeaker.x8f:
  name: Xiaomi 智能家庭屏 Pro 8
  vendor: 小米
```

## 测试

本地验证：添加后 miloco 成功识别设备摄像头，`CameraImgManager init success`，视频流和音频流正常启动。