### PR TITLE
fix(watchdog): check camera power status on first-frame timeout

### DIFF
--- a/backend/miloco/src/miloco/miot/client.py
+++ b/backend/miloco/src/miloco/miot/client.py
@@ -1095,8 +1095,8 @@ class MiotProxy:
             if iid.startswith("prop.") and entry.get("readable", False)
         ]
 
-    async def get_device_spec(self, did: str) -> dict:
-        """Return a device's spec by DID, including camera-only entries."""
+    async def get_raw_spec(self, did: str) -> dict:
+        """Return raw MIoT spec by DID, including camera-only entries."""
         device = self._device_info_dict.get(did) or self._camera_info_dict.get(did)
         if not device:
             return {}

--- a/backend/miloco/src/miloco/miot/client.py
+++ b/backend/miloco/src/miloco/miot/client.py
@@ -1095,6 +1095,13 @@ class MiotProxy:
             if iid.startswith("prop.") and entry.get("readable", False)
         ]
 
+    async def get_device_spec(self, did: str) -> dict:
+        """Return a device's spec by DID, including camera-only entries."""
+        device = self._device_info_dict.get(did) or self._camera_info_dict.get(did)
+        if not device:
+            return {}
+        return await self._fetch_device_spec(device.urn)
+
     async def call_device_action(self, param: MIoTActionParam) -> dict:
         """Call device action via MIoT cloud API."""
         try:

--- a/backend/miloco/src/miloco/miot/router.py
+++ b/backend/miloco/src/miloco/miot/router.py
@@ -75,6 +75,31 @@ def _truncate_ws_reason(reason: str) -> str:
 _FIRST_FRAME_TIMEOUT_S = 12.0
 
 
+async def _check_camera_power(camera_id: str) -> bool | None:
+    """检查摄像头电源状态。
+
+    Returns:
+        True  — 摄像头开启
+        False — 摄像头关闭(可能摄像头关闭或开了物理遮蔽)
+        None  — 查询失败(属性不存在/网络异常)
+    """
+    try:
+        from miot.types import MIoTGetPropertyParam
+
+        miot_service = manager.miot_service
+        props = await miot_service.miot_client.get_device_properties(
+            [MIoTGetPropertyParam(did=camera_id, siid=2, piid=1)]
+        )
+        if props and isinstance(props, list) and len(props) > 0:
+            value = props[0].get("value")
+            if isinstance(value, bool):
+                return value
+        return None
+    except Exception as e:
+        logger.debug("check camera power failed, %s: %s", camera_id, e)
+        return None
+
+
 async def _first_frame_watchdog(
     websocket: WebSocket, camera_id: str, channel: int
 ) -> None:
@@ -88,19 +113,32 @@ async def _first_frame_watchdog(
     await asyncio.sleep(_FIRST_FRAME_TIMEOUT_S)
     if miot_video_stream_manager.has_emitted_frame(camera_id, channel):
         return
-    logger.warning(
-        "First-frame watchdog fired, %s.%d — no frame in %.0fs, camera likely "
-        "unreachable (cross-LAN / offline / PPCS relay not established)",
-        camera_id, channel, _FIRST_FRAME_TIMEOUT_S,
-    )
+
+    # 尝试检查摄像头电源状态,给出更精确的错误提示
+    camera_on = await _check_camera_power(camera_id)
+    if camera_on is False:
+        reason = "camera_power_off"
+        message = "摄像头已关闭或开启物理遮蔽"
+        logger.warning(
+            "First-frame watchdog fired, %s.%d — camera power is off",
+            camera_id, channel,
+        )
+    else:
+        reason = "camera_unreachable"
+        message = "连不上摄像头(可能不在同一局域网,或摄像头离线)"
+        logger.warning(
+            "First-frame watchdog fired, %s.%d — no frame in %.0fs, camera likely "
+            "unreachable (cross-LAN / offline / PPCS relay not established)",
+            camera_id, channel, _FIRST_FRAME_TIMEOUT_S,
+        )
     try:
         # reason 是给将来按机器码分流预留的字段;前端 watch.html 当前只展示 message,
         # 不读 reason。两个都发,前端按需取。
         await websocket.send_text(
             json.dumps({
                 "type": "error",
-                "reason": "camera_unreachable",
-                "message": "连不上摄像头(可能不在同一局域网,或摄像头离线)",
+                "reason": reason,
+                "message": message,
             })
         )
     except Exception as err:

--- a/backend/miloco/src/miloco/miot/router.py
+++ b/backend/miloco/src/miloco/miot/router.py
@@ -78,6 +78,9 @@ _FIRST_FRAME_TIMEOUT_S = 12.0
 async def _check_camera_power(camera_id: str) -> bool | None:
     """检查摄像头电源状态。
 
+    这里用 camera-control/on 区分摄像头关闭/物理遮蔽,适用于该属性语义就是
+    取流/隐私挡片可用状态的机型;若机型把物理遮蔽做成独立属性,本判断只作为弱提示。
+
     Returns:
         True  — 摄像头开启
         False — 摄像头关闭(可能摄像头关闭或开了物理遮蔽)
@@ -87,7 +90,7 @@ async def _check_camera_power(camera_id: str) -> bool | None:
         from miot.types import MIoTGetPropertyParam
 
         miot_proxy = manager.miot_proxy
-        spec = await miot_proxy.get_device_spec(camera_id)
+        spec = await miot_proxy.get_raw_spec(camera_id)
         power_iids = [
             iid
             for iid, entry in spec.items()
@@ -110,6 +113,9 @@ async def _check_camera_power(camera_id: str) -> bool | None:
             value = props[0].get("value")
             if isinstance(value, bool):
                 return value
+            if isinstance(value, (int, str)):
+                return str(value).lower() in ("1", "true", "on")
+            logger.debug("camera power value not interpretable: %r", value)
         return None
     except Exception:
         logger.warning("check camera power failed")

--- a/backend/miloco/src/miloco/miot/router.py
+++ b/backend/miloco/src/miloco/miot/router.py
@@ -86,9 +86,25 @@ async def _check_camera_power(camera_id: str) -> bool | None:
     try:
         from miot.types import MIoTGetPropertyParam
 
-        miot_service = manager.miot_service
-        props = await miot_service._miot_proxy.get_device_properties(
-            [MIoTGetPropertyParam(did=camera_id, siid=2, piid=1)]
+        miot_proxy = manager.miot_proxy
+        spec = await miot_proxy.get_device_spec(camera_id)
+        power_iids = [
+            iid
+            for iid, entry in spec.items()
+            if iid.startswith("prop.")
+            and entry.get("readable", False)
+            and entry.get("service_type_name") == "camera-control"
+            and entry.get("type_name") == "on"
+        ]
+        if not power_iids:
+            return None
+        _, siid, piid = power_iids[0].split(".")
+        props = await miot_proxy.get_device_properties(
+            [
+                MIoTGetPropertyParam(
+                    did=camera_id, siid=int(siid), piid=int(piid)
+                )
+            ]
         )
         if props and isinstance(props, list) and len(props) > 0:
             value = props[0].get("value")
@@ -141,9 +157,7 @@ async def _first_frame_watchdog(
         return
     try:
         # 1011 + 短 reason(已被 _truncate_ws_reason 口径约束在 control frame 上限内)
-        await websocket.close(
-            code=1011, reason=_truncate_ws_reason("camera_unreachable")
-        )
+        await websocket.close(code=1011, reason=_truncate_ws_reason(reason))
     except Exception as err:
         logger.info("watchdog close failed, %s.%d: %s", camera_id, channel, err)
 

--- a/backend/miloco/src/miloco/miot/router.py
+++ b/backend/miloco/src/miloco/miot/router.py
@@ -100,46 +100,59 @@ async def _check_camera_power(camera_id: str) -> bool | None:
         return None
 
 
+async def _try_recover_ppcs(camera_id: str, channel: int) -> bool:
+    """尝试通过 stop+start camera instance 来恢复 PPCS 连接。
+
+    比 destroy+recreate 轻量:保留同一个 instance,只重启 PPCS 会话,
+    不干扰已注册的 perception 解码回调。
+    """
+    proxy = manager.miot_service._miot_proxy
+    handler = proxy._camera_img_managers.get(camera_id)
+    if handler is None:
+        return False
+    try:
+        logger.info("PPCS recovery: stop+start camera instance %s", camera_id)
+        await handler.miot_camera_instance.stop_async()
+        await handler.miot_camera_instance.start_async(enable_reconnect=True, enable_audio=True)
+        return await miot_video_stream_manager.re_subscribe(camera_id, channel)
+    except Exception as e:
+        logger.warning("PPCS recovery failed for %s: %s", camera_id, e)
+        return False
+
+
 async def _first_frame_watchdog(
     websocket: WebSocket, camera_id: str, channel: int
 ) -> None:
-    """等首帧;超时仍无帧 → 发 error 信令 + 主动关闭,让前端能明确告知住户连不上。
+    """等首帧;启动时先尝试 PPCS 恢复,再等帧;仍无帧 → 发 error 信令。
 
     被 ``video_stream_websocket`` 当后台 task 起。正常出帧时这个 task 等满
     ``_FIRST_FRAME_TIMEOUT_S`` 后发现 ``has_emitted_frame`` 为真,啥也不做退出。
     取消安全:住户在超时前主动关页 → 主流程 finally 里 cancel 本 task,
     ``CancelledError`` 直接向上抛,不吞。
     """
+    # ── 立即尝试 PPCS 恢复 ──
+    recovered = await _try_recover_ppcs(camera_id, channel)
     await asyncio.sleep(_FIRST_FRAME_TIMEOUT_S)
     if miot_video_stream_manager.has_emitted_frame(camera_id, channel):
         return
 
-    # 尝试检查摄像头电源状态,给出更精确的错误提示
+    # ── 仍无帧:报错 ──
     camera_on = await _check_camera_power(camera_id)
     if camera_on is False:
         reason = "camera_power_off"
         message = "摄像头已关闭或开启物理遮蔽"
-        logger.warning(
-            "First-frame watchdog fired, %s.%d — camera power is off",
-            camera_id, channel,
-        )
     else:
         reason = "camera_unreachable"
         message = "连不上摄像头(可能不在同一局域网,或摄像头离线)"
-        logger.warning(
-            "First-frame watchdog fired, %s.%d — no frame in %.0fs, camera likely "
-            "unreachable (cross-LAN / offline / PPCS relay not established)",
-            camera_id, channel, _FIRST_FRAME_TIMEOUT_S,
-        )
+    logger.warning(
+        "First-frame watchdog: %s.%d — no frame after reinit=%s",
+        camera_id, channel, "ok" if recovered else "skip/failed",
+    )
     try:
         # reason 是给将来按机器码分流预留的字段;前端 watch.html 当前只展示 message,
         # 不读 reason。两个都发,前端按需取。
         await websocket.send_text(
-            json.dumps({
-                "type": "error",
-                "reason": reason,
-                "message": message,
-            })
+            json.dumps({"type": "error", "reason": reason, "message": message})
         )
     except Exception as err:
         # send 失败基本意味着连接已被对端关掉——再 close 也是白搭,还会再抛一条

--- a/backend/miloco/src/miloco/miot/router.py
+++ b/backend/miloco/src/miloco/miot/router.py
@@ -95,8 +95,8 @@ async def _check_camera_power(camera_id: str) -> bool | None:
             if isinstance(value, bool):
                 return value
         return None
-    except Exception as e:
-        logger.warning("check camera power failed, %s: %s", camera_id, e)
+    except Exception:
+        logger.warning("check camera power failed")
         return None
 
 
@@ -123,8 +123,8 @@ async def _first_frame_watchdog(
         reason = "camera_unreachable"
         message = "连不上摄像头(可能不在同一局域网,或摄像头离线)"
     logger.warning(
-        "First-frame watchdog: %s.%d — no frame, power=%s",
-        camera_id, channel, camera_on,
+        "First-frame watchdog fired — no frame, power=%s",
+        camera_on,
     )
     try:
         # reason 是给将来按机器码分流预留的字段;前端 watch.html 当前只展示 message,

--- a/backend/miloco/src/miloco/miot/router.py
+++ b/backend/miloco/src/miloco/miot/router.py
@@ -87,7 +87,7 @@ async def _check_camera_power(camera_id: str) -> bool | None:
         from miot.types import MIoTGetPropertyParam
 
         miot_service = manager.miot_service
-        props = await miot_service.miot_client.get_device_properties(
+        props = await miot_service._miot_proxy.get_device_properties(
             [MIoTGetPropertyParam(did=camera_id, siid=2, piid=1)]
         )
         if props and isinstance(props, list) and len(props) > 0:
@@ -96,47 +96,25 @@ async def _check_camera_power(camera_id: str) -> bool | None:
                 return value
         return None
     except Exception as e:
-        logger.debug("check camera power failed, %s: %s", camera_id, e)
+        logger.warning("check camera power failed, %s: %s", camera_id, e)
         return None
-
-
-async def _try_recover_ppcs(camera_id: str, channel: int) -> bool:
-    """尝试通过 stop+start camera instance 来恢复 PPCS 连接。
-
-    比 destroy+recreate 轻量:保留同一个 instance,只重启 PPCS 会话,
-    不干扰已注册的 perception 解码回调。
-    """
-    proxy = manager.miot_service._miot_proxy
-    handler = proxy._camera_img_managers.get(camera_id)
-    if handler is None:
-        return False
-    try:
-        logger.info("PPCS recovery: stop+start camera instance %s", camera_id)
-        await handler.miot_camera_instance.stop_async()
-        await handler.miot_camera_instance.start_async(enable_reconnect=True, enable_audio=True)
-        return await miot_video_stream_manager.re_subscribe(camera_id, channel)
-    except Exception as e:
-        logger.warning("PPCS recovery failed for %s: %s", camera_id, e)
-        return False
 
 
 async def _first_frame_watchdog(
     websocket: WebSocket, camera_id: str, channel: int
 ) -> None:
-    """等首帧;启动时先尝试 PPCS 恢复,再等帧;仍无帧 → 发 error 信令。
+    """等首帧;超时仍无帧 → 发 error 信令 + 主动关闭,让前端能明确告知住户连不上。
 
     被 ``video_stream_websocket`` 当后台 task 起。正常出帧时这个 task 等满
     ``_FIRST_FRAME_TIMEOUT_S`` 后发现 ``has_emitted_frame`` 为真,啥也不做退出。
     取消安全:住户在超时前主动关页 → 主流程 finally 里 cancel 本 task,
     ``CancelledError`` 直接向上抛,不吞。
     """
-    # ── 立即尝试 PPCS 恢复 ──
-    recovered = await _try_recover_ppcs(camera_id, channel)
     await asyncio.sleep(_FIRST_FRAME_TIMEOUT_S)
     if miot_video_stream_manager.has_emitted_frame(camera_id, channel):
         return
 
-    # ── 仍无帧:报错 ──
+    # ── 无帧:检查电源状态,区分物理遮蔽和网络不通 ──
     camera_on = await _check_camera_power(camera_id)
     if camera_on is False:
         reason = "camera_power_off"
@@ -145,8 +123,8 @@ async def _first_frame_watchdog(
         reason = "camera_unreachable"
         message = "连不上摄像头(可能不在同一局域网,或摄像头离线)"
     logger.warning(
-        "First-frame watchdog: %s.%d — no frame after reinit=%s",
-        camera_id, channel, "ok" if recovered else "skip/failed",
+        "First-frame watchdog: %s.%d — no frame, power=%s",
+        camera_id, channel, camera_on,
     )
     try:
         # reason 是给将来按机器码分流预留的字段;前端 watch.html 当前只展示 message,

--- a/backend/miloco/src/miloco/miot/ws.py
+++ b/backend/miloco/src/miloco/miot/ws.py
@@ -648,6 +648,24 @@ class MIoTVideoStreamManager:
             )
             await self._broadcast(camera_tag, payload=header + nal_bytes)
 
+    async def re_subscribe(self, camera_id: str, channel: int) -> bool:
+        """重新注册视频流回调（用于 PPCS 恢复后）。"""
+        camera_tag = f"{camera_id}.{channel}"
+        try:
+            reg_id = await manager.miot_service.start_video_stream(
+                camera_id=camera_id,
+                channel=channel,
+                callback=self.__video_stream_callback,
+            )
+            if reg_id >= 0:
+                self._camera_reg_id[camera_tag] = reg_id
+                logger.info("Re-subscribed %s.%d reg_id=%d", camera_id, channel, reg_id)
+                return True
+            return False
+        except Exception as e:
+            logger.warning("Re-subscribe failed %s.%d: %s", camera_id, channel, e)
+            return False
+
 
 miot_video_stream_manager = MIoTVideoStreamManager()
 

--- a/backend/miloco/src/miloco/miot/ws.py
+++ b/backend/miloco/src/miloco/miot/ws.py
@@ -648,24 +648,6 @@ class MIoTVideoStreamManager:
             )
             await self._broadcast(camera_tag, payload=header + nal_bytes)
 
-    async def re_subscribe(self, camera_id: str, channel: int) -> bool:
-        """重新注册视频流回调（用于 PPCS 恢复后）。"""
-        camera_tag = f"{camera_id}.{channel}"
-        try:
-            reg_id = await manager.miot_service.start_video_stream(
-                camera_id=camera_id,
-                channel=channel,
-                callback=self.__video_stream_callback,
-            )
-            if reg_id >= 0:
-                self._camera_reg_id[camera_tag] = reg_id
-                logger.info("Re-subscribed %s.%d reg_id=%d", camera_id, channel, reg_id)
-                return True
-            return False
-        except Exception as e:
-            logger.warning("Re-subscribe failed %s.%d: %s", camera_id, channel, e)
-            return False
-
 
 miot_video_stream_manager = MIoTVideoStreamManager()
 


### PR DESCRIPTION
## 概述

首帧超时时新增摄像头电源状态检查，根据 `on@摄像机控制` 属性给出更精确的错误提示，帮助用户区分"摄像头离线/网络不通"和"摄像头被关闭/物理遮蔽"两种场景。

## 背景

当前 `_first_frame_watchdog` 超时后统一报 `camera_unreachable`，无法区分具体原因。用户在米家开启了物理遮蔽后，前端仍提示"连不上摄像头（可能不在同一局域网，或摄像头离线）"，误导排查方向。

## 修改内容

**`backend/miloco/src/miloco/miot/router.py`**

- 新增 `_check_camera_power(camera_id)` 函数：通过 MIoT API 查询摄像头 `on@摄像机控制` 属性，返回 `True`/`False`/`None`
- 修改 `_first_frame_watchdog`：超时后先检查电源状态
  - `camera_on=False` → reason=`camera_power_off`，提示"摄像头已关闭或开启物理遮蔽"
  - 其他情况 → 保持原有 `camera_unreachable` 提示

**Review 后更新**

- 通过 `manager.miot_proxy` 公开入口访问 MIoT proxy，不再穿透 service 私有属性
- 根据每台摄像头的 MIoT spec 动态定位 `camera-control/on` 属性，不再硬编码 `prop.2.1`
- WebSocket 关闭帧复用实际分支的 `reason`，确保与前置 error 信令一致
