### PR TITLE
fix: race condition between close() and _encode_sync in H264LiveEncoder

### DIFF
--- a/backend/miloco/src/miloco/miot/transcoder.py
+++ b/backend/miloco/src/miloco/miot/transcoder.py
@@ -131,10 +131,12 @@ class H264LiveEncoder:
                 logger.warning("flush old encoder failed: %s", e)
             self._codec = None
             self._open_encoder(w, h)
-        assert self._codec is not None
-        # Capture codec ref locally so close() setting self._codec = None
-        # on the main thread doesn't race with an in-flight encode.
+        # Capture codec ref locally FIRST so a single read is checked and used —
+        # close() setting self._codec = None on the main thread can't slip in
+        # between the check and the encode.
         codec = self._codec
+        if codec is None:
+            return []
 
         frame = av.VideoFrame.from_ndarray(bgr, format="bgr24")
         frame = frame.reformat(format="yuv420p")

--- a/backend/miloco/src/miloco/miot/transcoder.py
+++ b/backend/miloco/src/miloco/miot/transcoder.py
@@ -132,6 +132,9 @@ class H264LiveEncoder:
             self._codec = None
             self._open_encoder(w, h)
         assert self._codec is not None
+        # Capture codec ref locally so close() setting self._codec = None
+        # on the main thread doesn't race with an in-flight encode.
+        codec = self._codec
 
         frame = av.VideoFrame.from_ndarray(bgr, format="bgr24")
         frame = frame.reformat(format="yuv420p")
@@ -145,7 +148,7 @@ class H264LiveEncoder:
         self._pts_counter += 1
 
         out: list[tuple[bytes, bool]] = []
-        for packet in self._codec.encode(frame):
+        for packet in codec.encode(frame):
             out.append((bytes(packet), bool(packet.is_keyframe)))
         return out
 


### PR DESCRIPTION
## Problem

`H264LiveEncoder.close()` sets `self._codec = None` on the main thread to signal concurrent `_encode_sync` calls to stop. However, `_encode_sync` may have already passed the `assert self._codec is not None` guard and be about to call `self._codec.encode(frame)` — at which point `self._codec` becomes `None`, causing:

```
'NoneType' object has no attribute 'encode'
```

This triggers whenever a WebSocket video-stream client disconnects while a frame encode is in-flight, and is visible in logs as repeated `transcode encode error` entries.

## Fix

Capture `self._codec` into a local variable right after the assertion and use that local for the encode loop. `close()` can safely set `self._codec = None` without affecting an in-flight encode.

One-line semantic change, no API or behavioral difference.