### PR TITLE
test(identity): add pet behavior tests across tracking pipeline

### DIFF
--- a/backend/miloco/tests/perception/engine/edge/test_build_response_pet.py
+++ b/backend/miloco/tests/perception/engine/edge/test_build_response_pet.py
@@ -1,0 +1,179 @@
+"""tracking_service._build_response 与 _convert_type 宠物行为测试。
+
+覆盖:
+- _build_response 当前将所有 track 硬编码为 HUMAN_BODY（记录当前行为）
+- _convert_type 对 "pet" 的正确映射
+- _convert_type 对未知类型的 fallback 行为
+- convert_response 对 pet 类型的解析（边界 case 扩展）
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from miloco.perception.engine.identity.tracking_service import (
+    _build_response,
+    _convert_type,
+    convert_response,
+)
+from miloco.perception.engine.types import ObjectType
+
+
+# =============================================================================
+# _convert_type
+# =============================================================================
+
+
+class TestConvertType:
+    def test_pet_maps_to_pet(self):
+        assert _convert_type("pet") == ObjectType.PET
+
+    def test_human_with_face(self):
+        assert _convert_type("human_with_face") == ObjectType.HUMAN_WITH_FACE
+
+    def test_human_body(self):
+        assert _convert_type("human_body") == ObjectType.HUMAN_BODY
+
+    def test_human_face(self):
+        assert _convert_type("human_face") == ObjectType.HUMAN_FACE
+
+    def test_human(self):
+        assert _convert_type("human") == ObjectType.HUMAN
+
+    def test_unknown_type_defaults_to_human(self):
+        """未知类型 fallback 到 HUMAN（包括 "cat"/"dog" 等无独立映射的类型）。"""
+        assert _convert_type("cat") == ObjectType.HUMAN
+        assert _convert_type("dog") == ObjectType.HUMAN
+        assert _convert_type("unknown") == ObjectType.HUMAN
+        assert _convert_type("") == ObjectType.HUMAN
+
+
+# =============================================================================
+# _build_response — 当前行为记录（硬编码 HUMAN_BODY）
+# =============================================================================
+
+
+class TestBuildResponse:
+    def test_empty_results(self):
+        """空结果返回空 object_info。"""
+        resp = _build_response([], n_frames=6, fps=2)
+        assert len(resp.object_info) == 0
+        assert resp.frame_info.fps == 2
+
+    def test_single_human_track(self):
+        """单个 human track 正确转换。"""
+        results = [{"id": 0, "xyxy": (100, 200, 300, 400)}]
+        resp = _build_response(results, n_frames=6, fps=2)
+        assert len(resp.object_info) == 1
+        obj = resp.object_info[0]
+        assert obj.type == ObjectType.HUMAN_BODY
+        assert obj.track_id == 0
+        assert obj.face_id == "none"
+
+    def test_all_tracks_mapped_to_human_body(self):
+        """当前实现：所有 track（不论实际 class_id）都映射为 HUMAN_BODY。
+
+        这是已知的设计限制——当 track_human_only=False 启用后，
+        _build_response 需要根据 class_id 映射到正确的 ObjectType。
+        """
+        results = [
+            {"id": 0, "xyxy": (100, 200, 300, 400)},
+            {"id": 1, "xyxy": (300, 100, 400, 200)},
+        ]
+        resp = _build_response(results, n_frames=6, fps=2)
+        assert all(obj.type == ObjectType.HUMAN_BODY for obj in resp.object_info)
+
+    def test_box_info_uses_last_frame_index(self):
+        """box_info 的 frame_index 应为最后一帧的索引。"""
+        results = [{"id": 0, "xyxy": (10, 20, 110, 120)}]
+        resp = _build_response(results, n_frames=6, fps=2)
+        box = resp.object_info[0].box_info[0]
+        assert box.frame_index == 5  # 0-indexed last = n_frames - 1
+
+    def test_box_coords_converted_to_xywh(self):
+        """xyxy 坐标被转换为 (x, y, w, h) 存入 box_info。"""
+        results = [{"id": 0, "xyxy": (100, 200, 350, 500)}]
+        resp = _build_response(results, n_frames=4, fps=1)
+        box = resp.object_info[0].box_info[0]
+        assert box.boxes["human_body"] == (100, 200, 250, 300)
+
+    def test_frame_info_timestamps(self):
+        """frame_info 的时间戳区间与帧数/fps 一致。"""
+        results = [{"id": 0, "xyxy": (0, 0, 10, 10)}]
+        resp = _build_response(results, n_frames=10, fps=5)
+        # duration = 10/5 = 2 seconds = 2000 ms
+        duration_ms = resp.frame_info.end_timestamp - resp.frame_info.start_timestamp
+        assert abs(duration_ms - 2000) < 50  # 允许小误差
+
+
+# =============================================================================
+# convert_response — pet 类型边界 case
+# =============================================================================
+
+
+class TestConvertResponsePetCases:
+    def test_pet_with_empty_box_info(self):
+        """pet 对象 box_info 为空时不崩溃。"""
+        raw = {
+            "frames_info": {"start_timestamp": 0, "end_timestamp": 3000, "fps": 2},
+            "objects_info": [
+                {
+                    "type": "pet",
+                    "face_id": "none",
+                    "track_id": 1,
+                    "box_info": [],
+                }
+            ],
+        }
+        resp = convert_response(raw)
+        assert len(resp.object_info) == 1
+        assert resp.object_info[0].type == ObjectType.PET
+        assert resp.object_info[0].box_info == []
+
+    def test_multiple_pets_different_tracks(self):
+        """多只宠物各自有不同 track_id。"""
+        raw = {
+            "frames_info": {"start_timestamp": 0, "end_timestamp": 3000, "fps": 2},
+            "objects_info": [
+                {
+                    "type": "pet",
+                    "face_id": "none",
+                    "track_id": 1,
+                    "box_info": [[0, {"pet_body": [100, 200, 50, 50]}]],
+                },
+                {
+                    "type": "pet",
+                    "face_id": "none",
+                    "track_id": 2,
+                    "box_info": [[0, {"pet_body": [300, 400, 60, 60]}]],
+                },
+            ],
+        }
+        resp = convert_response(raw)
+        assert len(resp.object_info) == 2
+        track_ids = {obj.track_id for obj in resp.object_info}
+        assert track_ids == {1, 2}
+
+    def test_pet_and_human_coexist(self):
+        """人和宠物混合解析。"""
+        raw = {
+            "frames_info": {"start_timestamp": 0, "end_timestamp": 3000, "fps": 2},
+            "objects_info": [
+                {
+                    "type": "human_with_face",
+                    "face_id": "person_a",
+                    "track_id": 0,
+                    "box_info": [[0, {"human_body": [100, 100, 200, 400]}]],
+                },
+                {
+                    "type": "pet",
+                    "face_id": "none",
+                    "track_id": 1,
+                    "box_info": [[1, {"pet_body": [400, 300, 80, 60]}]],
+                },
+            ],
+        }
+        resp = convert_response(raw)
+        assert len(resp.object_info) == 2
+        types = {obj.type for obj in resp.object_info}
+        assert types == {ObjectType.HUMAN_WITH_FACE, ObjectType.PET}

--- a/backend/miloco/tests/perception/engine/identity/test_deep_sort_pet_filtering.py
+++ b/backend/miloco/tests/perception/engine/identity/test_deep_sort_pet_filtering.py
@@ -1,0 +1,221 @@
+"""DeepSortTracker 宠物过滤行为测试。
+
+验证 DeepSortTracker 的 update() / update_with_detections() 正确剔除 pet track，
+与 SortTracker 的 test_sort_pet_tracking.py 形成对称覆盖。
+
+实现方式：mock MultiObjectTracker 内部状态，避免依赖 ONNX 模型文件。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+
+# =============================================================================
+# Fake Track (模拟 DeepSORT 内部 Track 对象)
+# =============================================================================
+
+
+@dataclass
+class _FakeTrack:
+    track_id: int
+    class_id: int
+    confidence: float = 0.9
+    is_confirmed: bool = True
+    time_since_update: int = 0
+    hits: int = 3
+    age: int = 5
+    features: list = None
+
+    def __post_init__(self):
+        if self.features is None:
+            self.features = [np.random.randn(128).astype(np.float32)]
+
+    @property
+    def bbox(self):
+        return (100 + self.track_id * 50, 100, 80, 80)
+
+
+def _frame():
+    return np.zeros((480, 640, 3), dtype=np.uint8)
+
+
+# =============================================================================
+# Helper: 构造 mock DeepSortTracker
+# =============================================================================
+
+
+def _make_deep_sort_tracker():
+    """构造 DeepSortTracker，mock 掉所有模型依赖。"""
+    with patch("miloco.perception.inference.ort_utils.make_session") as mock_make:
+        mock_session = MagicMock()
+        mock_input = MagicMock()
+        mock_input.name = "images"
+        mock_input.shape = [1, 3, 640, 640]
+        mock_session.get_inputs.return_value = [mock_input]
+        mock_output = MagicMock()
+        mock_output.name = "output0"
+        mock_session.get_outputs.return_value = [mock_output]
+        mock_make.return_value = mock_session
+
+        from miloco.perception.engine.identity.tracker.detector import Detector
+        detector = Detector(model_path="fake.onnx", use_gpu=False)
+
+    with patch("miloco.perception.engine.identity.tracker.human_reid.HumanReID.__init__", return_value=None):
+        from miloco.perception.engine.identity.deep_sort import DeepSortTracker
+        from miloco.perception.engine.config import DeepSortConfigDC
+        tracker = DeepSortTracker(
+            detector=detector,
+            config=DeepSortConfigDC(),
+            fps=1,
+            reid_model_path="fake_reid.onnx",
+        )
+
+    return tracker
+
+
+# =============================================================================
+# update_with_detections 宠物过滤
+# =============================================================================
+
+
+class TestUpdateWithDetectionsPetFiltering:
+    """验证 update_with_detections() 后 tracks 中不含 pet。"""
+
+    def test_pet_tracks_filtered_after_update_with_detections(self):
+        """update_with_detections 后 pet track 被剔除。"""
+        tracker = _make_deep_sort_tracker()
+
+        from miloco.perception.engine.identity.tracker.detector import Detection
+
+        # 模拟 MOT 内部产生了 human + cat + dog tracks
+        human_track = _FakeTrack(track_id=0, class_id=Detection.CLASS_HUMAN)
+        cat_track = _FakeTrack(track_id=1, class_id=Detection.CLASS_CAT)
+        dog_track = _FakeTrack(track_id=2, class_id=Detection.CLASS_DOG)
+
+        # mock _mot.update_with_detections 直接设置 tracks
+        def fake_update(frame, dets):
+            tracker._mot.tracks = [human_track, cat_track, dog_track]
+
+        tracker._mot.update_with_detections = fake_update
+        tracker._mot.tracks = []
+
+        tracker.update_with_detections(_frame(), [])
+
+        # 验证只剩 human track
+        assert len(tracker._mot.tracks) == 1
+        assert tracker._mot.tracks[0].class_id == Detection.CLASS_HUMAN
+
+    def test_all_pets_removed_no_human(self):
+        """只有 pet 时，tracks 为空。"""
+        tracker = _make_deep_sort_tracker()
+
+        from miloco.perception.engine.identity.tracker.detector import Detection
+
+        cat_track = _FakeTrack(track_id=0, class_id=Detection.CLASS_CAT)
+        dog_track = _FakeTrack(track_id=1, class_id=Detection.CLASS_DOG)
+
+        def fake_update(frame, dets):
+            tracker._mot.tracks = [cat_track, dog_track]
+
+        tracker._mot.update_with_detections = fake_update
+        tracker._mot.tracks = []
+
+        tracker.update_with_detections(_frame(), [])
+        assert len(tracker._mot.tracks) == 0
+
+
+# =============================================================================
+# update() 宠物过滤
+# =============================================================================
+
+
+class TestUpdatePetFiltering:
+    """验证 update() 后 tracks 中不含 pet。"""
+
+    def test_pet_tracks_filtered_after_update(self):
+        """update() 后 pet track 被剔除。"""
+        tracker = _make_deep_sort_tracker()
+
+        from miloco.perception.engine.identity.tracker.detector import Detection
+
+        human_track = _FakeTrack(track_id=0, class_id=Detection.CLASS_HUMAN)
+        cat_track = _FakeTrack(track_id=1, class_id=Detection.CLASS_CAT)
+
+        def fake_update(frame):
+            tracker._mot.tracks = [human_track, cat_track]
+
+        tracker._mot.update = fake_update
+        tracker._mot.tracks = []
+
+        tracker.update(_frame())
+
+        assert len(tracker._mot.tracks) == 1
+        assert tracker._mot.tracks[0].class_id == Detection.CLASS_HUMAN
+
+
+# =============================================================================
+# last_detections 保留所有类别
+# =============================================================================
+
+
+class TestLastDetectionsPreservesAll:
+    """验证 last_detections 不受 pet 过滤影响。"""
+
+    def test_last_detections_includes_pets(self):
+        """last_detections 应包含所有类别（含 cat/dog）。"""
+        tracker = _make_deep_sort_tracker()
+
+        from miloco.perception.engine.identity.tracker.detector import Detection
+
+        fake_dets = [
+            Detection(x=100, y=100, w=50, h=50, confidence=0.9, class_id=Detection.CLASS_HUMAN),
+            Detection(x=200, y=200, w=40, h=40, confidence=0.8, class_id=Detection.CLASS_CAT),
+            Detection(x=300, y=300, w=60, h=60, confidence=0.7, class_id=Detection.CLASS_DOG),
+        ]
+        # last_detections 是只读 property，mock 底层属性
+        tracker._mot._last_detections = fake_dets
+
+        assert len(tracker.last_detections) == 3
+        class_ids = {d.class_id for d in tracker.last_detections}
+        assert Detection.CLASS_CAT in class_ids
+        assert Detection.CLASS_DOG in class_ids
+
+
+# =============================================================================
+# get_tracking_results 输出
+# =============================================================================
+
+
+class TestGetTrackingResultsNoPets:
+    """验证 get_tracking_results() 输出无 pet 类 track。"""
+
+    def test_only_confirmed_human_tracks_returned(self):
+        """只有 confirmed 的 human track 出现在结果中。"""
+        tracker = _make_deep_sort_tracker()
+
+        from miloco.perception.engine.identity.tracker.detector import Detection
+
+        # 设置 _mot.tracks 只含 human（因为 update 时已过滤）
+        human_track = _FakeTrack(track_id=0, class_id=Detection.CLASS_HUMAN, is_confirmed=True)
+        tracker._mot.tracks = [human_track]
+
+        results = tracker.get_tracking_results()
+        assert len(results) == 1
+        assert results[0]["class_id"] == Detection.CLASS_HUMAN
+
+    def test_unconfirmed_tracks_excluded(self):
+        """未确认的 track 不出现在结果中。"""
+        tracker = _make_deep_sort_tracker()
+
+        from miloco.perception.engine.identity.tracker.detector import Detection
+
+        unconfirmed = _FakeTrack(track_id=0, class_id=Detection.CLASS_HUMAN, is_confirmed=False)
+        tracker._mot.tracks = [unconfirmed]
+
+        results = tracker.get_tracking_results()
+        assert len(results) == 0

--- a/backend/miloco/tests/perception/engine/synthetic_scenes.py
+++ b/backend/miloco/tests/perception/engine/synthetic_scenes.py
@@ -70,6 +70,32 @@ def pet_moving(w: int = 640, h: int = 480, step: int = 0) -> NDArray[np.uint8]:
     return frame
 
 
+def pet_stationary(w: int = 640, h: int = 480) -> NDArray[np.uint8]:
+    """宠物静坐不动：固定位置橙色小块。"""
+    frame = empty_room(w, h)
+    # 宠物（橙色小块，静止在地面）
+    frame[380:420, 200:260] = [50, 120, 220]
+    return frame
+
+
+def pet_and_person(w: int = 640, h: int = 480) -> NDArray[np.uint8]:
+    """人宠同框：人坐在左侧，宠物在右侧地面。"""
+    frame = person_sitting(w, h, x_offset=180)
+    # 宠物（橙色小块在右侧）
+    frame[390:425, 420:490] = [50, 120, 220]
+    return frame
+
+
+def two_pets(w: int = 640, h: int = 480) -> NDArray[np.uint8]:
+    """两只宠物：左侧橙色（猫），右侧黄绿色（狗）。"""
+    frame = empty_room(w, h)
+    # 猫（橙色小块）
+    frame[380:415, 100:160] = [50, 120, 220]
+    # 狗（黄绿色，略大）
+    frame[370:420, 380:460] = [60, 180, 180]
+    return frame
+
+
 def two_people(w: int = 640, h: int = 480) -> NDArray[np.uint8]:
     """两人在房间里。"""
     frame = empty_room(w, h)
@@ -209,6 +235,24 @@ def scene_pet_moving() -> InputSlice:
     return create_input_slice("study-room", frames, silent_audio())
 
 
+def scene_pet_stationary() -> InputSlice:
+    """场景15：宠物静坐不动。Gate 层应判为 static（无显著变化）。"""
+    frame = pet_stationary()
+    return create_input_slice("study-room", [frame] * 6, silent_audio())
+
+
+def scene_pet_and_person() -> InputSlice:
+    """场景16：人宠同框。验证多类型目标同时存在。"""
+    frame = pet_and_person()
+    return create_input_slice("study-room", [frame] * 6, silent_audio())
+
+
+def scene_two_pets() -> InputSlice:
+    """场景17：两只宠物同时在场。验证多宠物检测。"""
+    frame = two_pets()
+    return create_input_slice("study-room", [frame] * 6, silent_audio())
+
+
 def scene_person_leaving() -> InputSlice:
     """场景14：有人坐着 → 站起离开。Omni 应描述 delta。"""
     frames = [
@@ -239,4 +283,7 @@ ALL_SCENES = {
     "11_person_reading": scene_person_reading,
     "12_person_phone": scene_person_phone,
     "14_person_leaving": scene_person_leaving,
+    "15_pet_stationary": scene_pet_stationary,
+    "16_pet_and_person": scene_pet_and_person,
+    "17_two_pets": scene_two_pets,
 }


### PR DESCRIPTION
## Summary

- Add 21 tests covering pet-related behavior across the tracking pipeline
- Expand synthetic scene library with 3 new pet scenarios
- No runtime behavior changes — tests + scene generators only

## Test Coverage

| File | Cases | What it verifies |
|---|---|---|
| `test_deep_sort_pet_filtering.py` | 6 | DeepSortTracker filters pet tracks from update/update_with_detections, preserves them in last_detections |
| `test_build_response_pet.py` | 15 | _convert_type mappings, _build_response HUMAN_BODY hardcoding, convert_response pet edge cases |

## Synthetic Scenes Added

| Scene | Description |
|---|---|
| `15_pet_stationary` | Pet sitting still (Gate should classify as static) |
| `16_pet_and_person` | Human + pet coexisting in frame |
| `17_two_pets` | Two pets (different colors) simultaneously present |

## Notes

- Uses mock objects to avoid ONNX model dependencies
- All 404 existing tests pass without regression
- Documents known limitation: `_build_response` hardcodes all tracks as HUMAN_BODY regardless of class_id