### PR TITLE
fix(camera): refresh stale cloud online status after backend restart

### DIFF
--- a/backend/miloco/src/miloco/perception/collect/camera_adapter.py
+++ b/backend/miloco/src/miloco/perception/collect/camera_adapter.py
@@ -57,6 +57,12 @@ _CAMERA_TRACKS = ["decoded_video", "decoded_audio"]
 # 不节流会变成每秒一次重 SDK 调用 + 建连尝试。10s 足够让相机就绪后及时恢复。
 _ONDEMAND_REFRESH_MIN_INTERVAL_MS = 10_000
 
+# 云端 online 状态自愈刷新的最小间隔：后端重启时 _camera_info_dict 缓存了
+# 重启瞬间的云端 online 状态，若此时摄像头恰好断连（online=false），sync 循环
+# 永远认为摄像头不可连。LAN 探测到摄像头上线后，需主动刷新一次云端状态。
+# 30s 足够让云端 SDK 更新状态，同时避免频繁调用。
+_STALE_STATUS_REFRESH_MIN_INTERVAL_MS = 30_000
+
 # TODO: 多通道支持
 DEFAULT_VIDEO_CHANNEL = 0
 DEFAULT_AUDIO_CHANNEL = 0
@@ -93,6 +99,7 @@ class CameraDeviceAdapter(BaseDeviceAdapter):
         self._on_window_ready = on_window_ready
         self._devices: dict[str, _CameraDeviceState] = {}
         self._last_ondemand_refresh_ms = 0
+        self._last_stale_status_refresh_ms = 0
 
     async def discover_devices(
         self,
@@ -185,6 +192,11 @@ class CameraDeviceAdapter(BaseDeviceAdapter):
         `online_only=True, require_lan=False`：放过 lan_online 陈旧成 false 的卡死态
         相机（要救），但排除云端就离线的相机（救不活，避免它让判据永真致 refresh
         空转）。scope 内相机要么已连、要么云端离线时不触发，零额外开销。
+
+        云端 online 状态自愈：后端重启时 `_camera_info_dict` 缓存了重启瞬间的云端
+        online 状态，若此时摄像头恰好断连（online=false），sync 循环永远认为摄像头
+        不可连。当 on-demand 检查发现无相机可连且本地也无设备时，主动调一次
+        `refresh_camera_online_status()` 刷新云端状态，让 LAN 已上线的摄像头能被发现。
         """
         if all_devices is None and self._miot_proxy.is_authenticated:
             try:
@@ -198,6 +210,22 @@ class CameraDeviceAdapter(BaseDeviceAdapter):
                 ):
                     self._last_ondemand_refresh_ms = now_ms
                     await self._miot_proxy.refresh_cameras()
+                elif (
+                    not expected
+                    and not self._devices
+                    and now_ms - self._last_stale_status_refresh_ms
+                    >= _STALE_STATUS_REFRESH_MIN_INTERVAL_MS
+                ):
+                    # 云端 online 缓存可能 stale（后端重启时摄像头恰好断连）。
+                    # LAN 探测到摄像头上线后 _on_lan_device_changed 只更新
+                    # lan_online，不更新 online。这里主动刷新一次云端状态，
+                    # 让下一轮 sync 能发现摄像头。
+                    self._last_stale_status_refresh_ms = now_ms
+                    await self._miot_proxy.refresh_camera_online_status()
+                    logger.info(
+                        "Stale camera online status refreshed, "
+                        "retrying discover on next sync cycle"
+                    )
             except Exception as e:  # noqa: BLE001
                 logger.warning("On-demand camera manager refresh failed: %s", e)
         await super().sync_devices(all_devices)

--- a/backend/miloco/tests/perception/test_camera_adapter_reconnect.py
+++ b/backend/miloco/tests/perception/test_camera_adapter_reconnect.py
@@ -119,3 +119,90 @@ class TestSyncDevicesOnDemandRefresh:
         clock[0] = 116_000  # 距上次 +11s >= 10s
         asyncio.run(adapter.sync_devices())  # 再次触发
         assert proxy.refresh_cameras.await_count == 2
+
+
+class TestSyncDevicesStaleStatusRefresh:
+    """sync_devices 云端 online 状态自愈：后端重启时摄像头恰好断连的恢复。
+
+    场景：后端重启 → _camera_info_dict 缓存 online=false → sync 循环永远
+    认为摄像头不可连。当 expected 为空且无设备时，应主动刷新云端状态。
+    """
+
+    def _adapter_with_mocked_connect(self, monkeypatch, proxy):
+        adapter = CameraDeviceAdapter(miot_proxy=proxy)
+        monkeypatch.setattr(adapter, "connect_device", AsyncMock())
+        monkeypatch.setattr(adapter, "disconnect_device", AsyncMock())
+        return adapter
+
+    def test_refresh_when_expected_empty_and_no_devices(self, monkeypatch):
+        """expected=0 且无设备 → 应调 refresh_camera_online_status。"""
+        proxy = MagicMock()
+        proxy.is_authenticated = True
+        proxy.refresh_cameras = AsyncMock()
+        proxy.refresh_camera_online_status = AsyncMock()
+        adapter = self._adapter_with_mocked_connect(monkeypatch, proxy)
+        monkeypatch.setattr(
+            adapter, "discover_devices", AsyncMock(return_value={})
+        )
+
+        asyncio.run(adapter.sync_devices())
+
+        proxy.refresh_camera_online_status.assert_awaited_once()
+        proxy.refresh_cameras.assert_not_awaited()
+
+    def test_no_stale_refresh_when_expected_nonempty(self, monkeypatch):
+        """expected 非空 → 不应调 refresh_camera_online_status。"""
+        proxy = MagicMock()
+        proxy.is_authenticated = True
+        proxy.refresh_cameras = AsyncMock()
+        proxy.refresh_camera_online_status = AsyncMock()
+        adapter = self._adapter_with_mocked_connect(monkeypatch, proxy)
+        monkeypatch.setattr(
+            adapter, "discover_devices",
+            AsyncMock(return_value={"cam1": _source()}),
+        )
+
+        asyncio.run(adapter.sync_devices())
+
+        proxy.refresh_camera_online_status.assert_not_awaited()
+
+    def test_no_stale_refresh_when_has_connected_devices(self, monkeypatch):
+        """有已连设备 → 不应调 refresh_camera_online_status。"""
+        proxy = MagicMock()
+        proxy.is_authenticated = True
+        proxy.refresh_cameras = AsyncMock()
+        proxy.refresh_camera_online_status = AsyncMock()
+        proxy.get_cached_camera = MagicMock(return_value=None)
+        adapter = self._adapter_with_mocked_connect(monkeypatch, proxy)
+        adapter._devices["cam1"] = _CameraDeviceState(did="cam1")
+        monkeypatch.setattr(
+            adapter, "discover_devices", AsyncMock(return_value={})
+        )
+
+        asyncio.run(adapter.sync_devices())
+
+        proxy.refresh_camera_online_status.assert_not_awaited()
+
+    def test_throttle_stale_status_refresh(self, monkeypatch):
+        """节流：refresh_camera_online_status 最多每 30s 一次。"""
+        proxy = MagicMock()
+        proxy.is_authenticated = True
+        proxy.refresh_cameras = AsyncMock()
+        proxy.refresh_camera_online_status = AsyncMock()
+        adapter = self._adapter_with_mocked_connect(monkeypatch, proxy)
+        monkeypatch.setattr(
+            adapter, "discover_devices", AsyncMock(return_value={})
+        )
+        clock = [100_000]
+        monkeypatch.setattr(
+            "miloco.perception.collect.camera_adapter._monotonic_ms", lambda: clock[0]
+        )
+
+        asyncio.run(adapter.sync_devices())  # 首次：触发
+        assert proxy.refresh_camera_online_status.await_count == 1
+        clock[0] = 115_000  # +15s < 30s
+        asyncio.run(adapter.sync_devices())  # 节流：跳过
+        assert proxy.refresh_camera_online_status.await_count == 1
+        clock[0] = 135_000  # 距上次 +35s >= 30s
+        asyncio.run(adapter.sync_devices())  # 再次触发
+        assert proxy.refresh_camera_online_status.await_count == 2


### PR DESCRIPTION
## Bug

Camera never reconnects to perception engine after backend restart if it was temporarily disconnected at restart time.

## Root Cause

When the backend restarts while a camera is temporarily disconnected, `_camera_info_dict` caches the stale cloud `online=false` status. The `_sync_devices_loop` only checks this cached status via `discover_devices(online_only=True)`, so the camera is permanently considered unreachable — even after LAN probes detect it as online. The `_on_lan_device_changed` callback updates `lan_online` but not the cloud `online` field.

Recovery only happens when the web UI is opened (which triggers `refresh_camera_online` via frontend), or after a manual restart when the camera happens to be online at that moment.

## Timeline from Production

| Time | Event |
|---|---|
| 03:01:51 | Camera video/audio streams disconnected |
| 03:34:30 | Backend restart, `refresh_miot_info()` caches `online=false` |
| 03:34:38 | Perception engine starts, sync loop begins |
| 08:05:53 | LAN probe detects camera online → `lan_online=True`, but `online` still stale |
| 09:14~15:42 | LAN continuously sees camera, but perception engine never connects |
| 15:42:07 | User opens web UI → frontend calls `refresh_camera_online` → `online=true` |
| 15:42:13 | Next sync cycle connects the camera |

## Fix

Add a stale status recovery path in `sync_devices()`: when `discover_devices` returns no cameras AND no devices are connected, call `refresh_camera_online_status()` to update the cloud status. This is throttled to once per 30 seconds to avoid excessive SDK calls.

The fix is lightweight (`refresh_camera_online_status` only updates metadata, doesn't touch stream connections) and only triggers when the system is in a stuck state (no cameras discoverable, no devices connected).

## Tests

Added `TestSyncDevicesStaleStatusRefresh` test class covering:
- Refresh triggered when expected=0 and no devices
- No refresh when expected is non-empty
- No refresh when devices are already connected
- Throttling (30s interval)