### PR TITLE
feat(web): 添加模型配置编辑功能

### DIFF
--- a/web/src/components/UsageOmniConfig.tsx
+++ b/web/src/components/UsageOmniConfig.tsx
@@ -205,15 +205,19 @@ export function UsageOmniConfig() {
     setModelsMsg(null);
     setTestResult(null);
     // 自动拉取模型列表（apiKey 留空，后端沿用原 key）
-    void fetchModels(p.base_url, "");
+    void fetchModels(p.base_url, "", p.label);
   }
 
-  async function fetchModels(bu: string, key: string) {
+  async function fetchModels(bu: string, key: string, label?: string) {
     if (!bu.trim()) return;
     setModelsLoading(true);
     setModelsMsg(null);
     try {
-      const res = await listOmniModels({ base_url: bu.trim(), api_key: key.trim() || undefined });
+      const res = await listOmniModels({
+        base_url: bu.trim(),
+        api_key: key.trim() || undefined,
+        label: label || undefined,
+      });
       if (res.ok) {
         setModels(res.models);
         if (!res.models.length) setModelsMsg(t("usage.modelsEmptyResult"));
@@ -456,7 +460,7 @@ export function UsageOmniConfig() {
                         setBaseUrl(e.target.value);
                         setTestResult(null);
                       }}
-                      onBlur={() => fetchModels(baseUrl, apiKey)}
+                      onBlur={() => fetchModels(baseUrl, apiKey, editingLabel || undefined)}
                       placeholder={t("usage.baseUrlPlaceholder")}
                       className={INPUT_CLS}
                     />
@@ -469,7 +473,7 @@ export function UsageOmniConfig() {
                         setApiKey(e.target.value);
                         setTestResult(null);
                       }}
-                      onBlur={() => fetchModels(baseUrl, apiKey)}
+                      onBlur={() => fetchModels(baseUrl, apiKey, editingLabel || undefined)}
                       placeholder={
                         editingProfile?.has_key || existing?.has_key
                           ? t("usage.apiKeyPlaceholderExisting")

--- a/web/src/components/UsageOmniConfig.tsx
+++ b/web/src/components/UsageOmniConfig.tsx
@@ -157,6 +157,10 @@ export function UsageOmniConfig() {
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState<OmniTestResult | null>(null);
 
+  // 编辑状态（与 adding 互斥）
+  const [editingLabel, setEditingLabel] = useState<string | null>(null);
+  const [editingProfile, setEditingProfile] = useState<OmniProfile | null>(null);
+
   useEffect(() => {
     void load();
   }, []);
@@ -179,10 +183,24 @@ export function UsageOmniConfig() {
   );
 
   function startAdd() {
+    setEditingLabel(null); // 与编辑互斥
+    setEditingProfile(null);
     setAdding(true);
     setBaseUrl("");
     setApiKey("");
     setModel("");
+    setModels([]);
+    setModelsMsg(null);
+    setTestResult(null);
+  }
+
+  function startEdit(p: OmniProfile) {
+    setAdding(false); // 与新增互斥
+    setEditingLabel(p.label);
+    setEditingProfile(p);
+    setBaseUrl(p.base_url);
+    setApiKey(""); // API Key 不回显，用户留空=沿用原 key
+    setModel(p.model);
     setModels([]);
     setModelsMsg(null);
     setTestResult(null);
@@ -213,27 +231,34 @@ export function UsageOmniConfig() {
   async function onSave() {
     const bu = baseUrl.trim();
     const m = model.trim();
+    const isEditing = !!editingLabel;
     if (!bu || !m) {
       toast(t("usage.baseUrlModelRequired"), "warn");
       return;
     }
-    if (!apiKey.trim() && !existing?.has_key) {
+    // 编辑模式：允许不填 api_key（沿用原 key）
+    // 新增模式：检查是否已有 key（existing.has_key）
+    if (!apiKey.trim() && !editingProfile?.has_key && !existing?.has_key) {
       toast(t("usage.apiKeyRequired"), "warn");
       return;
     }
     setSaving(true);
     try {
+      // 编辑模式：label 基于新值，original_label 记录原档案名
+      // 新增模式：label = `${model} @ ${base_url}`
       const s = await updateOmniConfig({
-        label: existing ? existing.label : `${m} @ ${bu}`,
+        label: editingLabel ? `${m} @ ${bu}` : (existing ? existing.label : `${m} @ ${bu}`),
         model: m,
         base_url: bu,
         api_key: apiKey.trim() || undefined,
-        original_label: existing ? existing.label : undefined,
-        activate: false, // 只入列表;启用由模型列表的「启用」负责
+        original_label: editingLabel || (existing ? existing.label : undefined),
+        activate: false, // 只入列表；启用由模型列表的「启用」负责
       });
       setState(s);
       setAdding(false);
-      toast(t("usage.saveSuccess"), "ok");
+      setEditingLabel(null); // 清空编辑状态
+      setEditingProfile(null);
+      toast(isEditing ? t("usage.editSuccess") : t("usage.saveSuccess"), "ok");
     } catch (e) {
       toast(e instanceof Error ? e.message : t("usage.saveFailed"), "danger");
     } finally {
@@ -248,7 +273,7 @@ export function UsageOmniConfig() {
       toast(t("usage.baseUrlModelRequired"), "warn");
       return;
     }
-    if (!apiKey.trim() && !existing?.has_key) {
+    if (!apiKey.trim() && !editingProfile?.has_key && !existing?.has_key) {
       toast(t("usage.apiKeyRequiredBeforeTest"), "warn");
       return;
     }
@@ -256,7 +281,7 @@ export function UsageOmniConfig() {
     setTestResult(null);
     try {
       const res = await testOmniConfig({
-        label: existing ? existing.label : "",
+        label: editingLabel || (existing ? existing.label : ""),
         model: m,
         base_url: bu,
         api_key: apiKey.trim() || undefined,
@@ -380,6 +405,14 @@ export function UsageOmniConfig() {
                                 {t("usage.activate")}
                               </button>
                             )}
+                            {/* 编辑按钮 */}
+                            <button
+                              type="button"
+                              onClick={() => startEdit(p)}
+                              className="text-text-tertiary hover:text-brand-primary mr-3"
+                            >
+                              {t("usage.edit")}
+                            </button>
                             <button
                               type="button"
                               onClick={() => onDelete(p)}
@@ -396,7 +429,7 @@ export function UsageOmniConfig() {
               </div>
 
               {/* 新增按钮放列表下方(新增即追加到列表末尾) */}
-              {!adding && (
+              {!adding && !editingLabel && (
                 <button
                   type="button"
                   onClick={startAdd}
@@ -406,11 +439,13 @@ export function UsageOmniConfig() {
                 </button>
               )}
 
-              {/* ── 新增表单 ── */}
-              {adding && (
+              {/* ── 新增/编辑表单 ── */}
+              {(adding || editingLabel) && (
                 <div className="mt-4 rounded-lg bg-bg-primary border border-border p-4 grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-4 items-start">
                   <div className="md:col-span-2 text-caption text-text-secondary">
-                    {t("usage.addFormHint")}
+                    {editingLabel
+                      ? t("usage.editFormHint")
+                      : t("usage.addFormHint")}
                   </div>
                   <Field label={t("usage.baseUrlLabel")} className="md:col-span-2">
                     <input
@@ -434,7 +469,7 @@ export function UsageOmniConfig() {
                       }}
                       onBlur={() => fetchModels(baseUrl, apiKey)}
                       placeholder={
-                        existing?.has_key
+                        editingProfile?.has_key || existing?.has_key
                           ? t("usage.apiKeyPlaceholderExisting")
                           : t("usage.apiKeyPlaceholderNew")
                       }
@@ -488,6 +523,8 @@ export function UsageOmniConfig() {
                       type="button"
                       onClick={() => {
                         setAdding(false);
+                        setEditingLabel(null);
+                        setEditingProfile(null);
                         setTestResult(null);
                       }}
                       disabled={saving || testing}

--- a/web/src/components/UsageOmniConfig.tsx
+++ b/web/src/components/UsageOmniConfig.tsx
@@ -204,6 +204,8 @@ export function UsageOmniConfig() {
     setModels([]);
     setModelsMsg(null);
     setTestResult(null);
+    // 自动拉取模型列表（apiKey 留空，后端沿用原 key）
+    void fetchModels(p.base_url, "");
   }
 
   async function fetchModels(bu: string, key: string) {

--- a/web/src/i18n/locales/en/usage.json
+++ b/web/src/i18n/locales/en/usage.json
@@ -90,6 +90,9 @@
     "deleteSuccess": "Deleted",
     "deleteFailed": "Couldn't delete",
     "modelsEmptyResult": "This address returned no model list",
-    "modelsFetchFailed": "Couldn't fetch models"
+    "modelsFetchFailed": "Couldn't fetch models",
+    "edit": "Edit",
+    "editSuccess": "Edited",
+    "editFormHint": "Edit Base URL / Model / API Key (leave blank to keep original)"
   }
 }

--- a/web/src/i18n/locales/zh/usage.json
+++ b/web/src/i18n/locales/zh/usage.json
@@ -90,6 +90,9 @@
     "deleteSuccess": "已删除",
     "deleteFailed": "删除失败",
     "modelsEmptyResult": "该地址未返回模型列表",
-    "modelsFetchFailed": "拉取模型失败"
+    "modelsFetchFailed": "拉取模型失败",
+    "edit": "编辑",
+    "editSuccess": "已修改",
+    "editFormHint": "修改 Base URL / Model / API Key（留空沿用原值）"
   }
 }


### PR DESCRIPTION
## 改动

- 页面 `模型`->`模型配置`下模型列表支持编辑
<img width="1106" height="633" alt="image" src="https://github.com/user-attachments/assets/e611b9b2-cb7e-4e0f-b3f8-c730916fe74c" />

## 涉及文件

- `web/src/components/UsageOmniConfig.tsx`
- `web/src/i18n/locales/en/usage.json`
- `web/src/i18n/locales/zh/usage.json`