### PR TITLE
fix: auto-generate server.token when missing (resolves #303)

### DIFF
--- a/plugins/openclaw/src/miloco/config.ts
+++ b/plugins/openclaw/src/miloco/config.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import type { FromSchema } from "json-schema-to-ts";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { resolveGatewayAuth } from "openclaw/plugin-sdk/gateway-runtime";
@@ -38,7 +39,7 @@ const SHARED_CONFIG_SCHEMA = {
           type: "string",
           default: "",
           description:
-            "CLI 与插件访问后端时使用的 Bearer Token；为空时由后端首次启动自动生成",
+            "CLI 与插件访问后端时使用的 Bearer Token；为空时由插件首次加载自动生成",
         },
         tls_verify: {
           type: "boolean",
@@ -154,6 +155,7 @@ export function loadSharedConfig(api: OpenClawPluginApi): MilocoSharedConfig {
 
   mergePluginIntoRaw(raw, plugin);
   ensureAgentEssentials(raw, api);
+  ensureServerToken(raw);
 
   // 仅在合并后的内容与磁盘不同才落盘，避免每次 load 都产生冗余 IO / mtime 抖动。
   // 首次启动（文件缺失）或人工手改过格式时会执行一次归一化写入，之后稳态零写入。
@@ -184,6 +186,15 @@ function mergePluginIntoRaw(
     model.omni = omni;
     raw.model = model;
   }
+}
+
+function ensureServerToken(raw: Record<string, unknown>): void {
+  const server = isRecord(raw.server) ? { ...raw.server } : {};
+  if (typeof server.token !== "string" || server.token.length === 0) {
+    // 插件首次加载：自动生成随机 token，确保 CLI 与后端使用同一凭据
+    server.token = crypto.randomUUID();
+  }
+  raw.server = server;
 }
 
 function ensureAgentEssentials(


### PR DESCRIPTION
## Summary

When the Miloco plugin loads shared config, it now auto-generates a `server.token` (random UUID) if one is not already present. This ensures that the CLI and backend share the same authentication token from first boot, fixing "perceive logs" and other CLI commands that fail with 401 auth errors.

## Problem

- `server.token` was only populated by backend first-boot (e.g. install.sh).
- CLI `config.json` was left with empty token on fresh installs.
- CLI commands that use `miloco-cli` (e.g. `perceive logs`) would fail with 401 because no token was set.

## Fix

Added `ensureServerToken()` in `loadSharedConfig()`:
- Checks if `server.token` is empty.
- If empty, generates a UUID via `node:crypto` and writes it.
- First-load only; existing tokens are preserved unchanged.

This mirrors the existing pattern of `ensureAgentEssentials()` which auto-configures `auth_bearer`.

## Related

Closes #303