### PR TITLE
fix: align event time display with agent prompt & improve datetime picker UX

### DIFF
--- a/backend/miloco/src/miloco/perception/engine/api.py
+++ b/backend/miloco/src/miloco/perception/engine/api.py
@@ -837,7 +837,7 @@ class PerceptionEngine(BasePerceptionEngine):
                 contexts[did] = OmniContext(
                     rule_conditions=device_rules,
                     pending_speech=self._pending_speech.get(did),
-                    current_time=datetime.now().strftime("%H:%M:%S"),
+                    current_time=datetime.fromtimestamp(snapshot.start_timestamp / 1000).strftime("%H:%M:%S"),
                     room_name=room_name,
                 )
 

--- a/backend/miloco/src/miloco/perception/engine/types.py
+++ b/backend/miloco/src/miloco/perception/engine/types.py
@@ -253,7 +253,7 @@ class OmniContext:
     # 幻觉已停止注入；caption 变化去重与 suggestion 事件链去重均下沉到代码（见 api.py）。
     rule_conditions: list[RuleCondition] = field(default_factory=list)
     pending_speech: list[dict] | None = None  # [{"speaker": "xx", "content": "打开"}]
-    current_time: str | None = None  # "HH:MM:SS" injected system time
+    current_time: str | None = None  # "HH:MM:SS" window start time (aligned with event text)
     room_name: str | None = None  # 设备所在房间名，作场景参考注入 U4（如"厨房""书房"）
 
 

--- a/backend/miloco/src/miloco/perception/event_text_builder.py
+++ b/backend/miloco/src/miloco/perception/event_text_builder.py
@@ -31,11 +31,11 @@ HEADER_MATCHED_RULE = "[感知引擎]规则提醒："
 
 
 def _fmt_time_field(time_window: str) -> str:
-    """竖排 key:value 用的纯时间字符串：去掉 [] 包裹，范围取结束时刻。"""
+    """竖排 key:value 用的纯时间字符串：去掉 [] 包裹，取窗口开始时刻（与注入 agent 的 current_time 对齐）。"""
     if not time_window:
         return ""
     tw = time_window.strip("[]")
-    return tw.split("-")[-1] if "-" in tw else tw
+    return tw.split("-")[0] if "-" in tw else tw
 
 
 def _fmt_source_field(

--- a/backend/miloco/tests/perception/engine/test_part2_source_meta.py
+++ b/backend/miloco/tests/perception/engine/test_part2_source_meta.py
@@ -58,7 +58,7 @@ def test_suggestion_msg_natural_language():
         device_name="小米智能摄像机C700", time_window="[20:42:25-20:42:28]",
     )
     text = build_suggestions_text([s])
-    assert "时间：20:42:28" in text
+    assert "时间：20:42:25" in text
     assert "来源：客厅的小米智能摄像机C700(did=1178866901)" in text
     assert "检测到：老人摔倒" in text
     assert "事件优先级：high" in text
@@ -74,7 +74,7 @@ def test_speech_msg_natural_language():
     assert "来源：卧室的小米4C(did=did1)" in text
     assert "说话人：彭于晏" in text
     assert "语音指令：关灯" in text
-    assert "时间：b" in text
+    assert "时间：a" in text
 
 
 def test_suggestion_no_meta_minimal():

--- a/backend/miloco/tests/test_event_text_builder.py
+++ b/backend/miloco/tests/test_event_text_builder.py
@@ -95,7 +95,7 @@ class TestBuildSpeechesText:
         )
         text = build_speeches_text([i])
         assert "来源：客厅的小米C700" in text
-        assert "时间：20:42:28" in text
+        assert "时间：20:42:25" in text
 
 
 class TestBuildSuggestionsText:

--- a/web/src/components/ActivityFeed.tsx
+++ b/web/src/components/ActivityFeed.tsx
@@ -402,7 +402,7 @@ function TimeRangeFilter({
         type="datetime-local"
         value={fmt(since)}
         onChange={(e) => onSinceChange(parse(e.target.value))}
-        onClick={(e) => e.currentTarget.showPicker()}
+        onClick={(e) => e.currentTarget.showPicker?.()}
         className={inputCls}
         aria-label={t("activity.filterSince")}
         placeholder={t("activity.filterSincePlaceholder")}
@@ -430,10 +430,11 @@ function TimeRangeFilter({
           onChange={(e) => {
             const v = parse(e.target.value);
             onBeforeChange(v);
-            if (v === undefined) setBeforeEditing(false);
+            if (v === undefined) setBeforeEditing(false); // 清空后回到"至现在"按钮
           }}
-          onClick={(e) => e.currentTarget.showPicker()}
+          onClick={(e) => e.currentTarget.showPicker?.()}
           onBlur={(e) => {
+            // 失焦时如果还是空值,退回按钮态(避免空 input 留在 UI 上)
             if (!e.target.value) setBeforeEditing(false);
           }}
           className={inputCls}

--- a/web/src/components/ActivityFeed.tsx
+++ b/web/src/components/ActivityFeed.tsx
@@ -402,6 +402,7 @@ function TimeRangeFilter({
         type="datetime-local"
         value={fmt(since)}
         onChange={(e) => onSinceChange(parse(e.target.value))}
+        onClick={(e) => e.currentTarget.showPicker()}
         className={inputCls}
         aria-label={t("activity.filterSince")}
         placeholder={t("activity.filterSincePlaceholder")}
@@ -429,10 +430,10 @@ function TimeRangeFilter({
           onChange={(e) => {
             const v = parse(e.target.value);
             onBeforeChange(v);
-            if (v === undefined) setBeforeEditing(false); // 清空后回到"至现在"按钮
+            if (v === undefined) setBeforeEditing(false);
           }}
+          onClick={(e) => e.currentTarget.showPicker()}
           onBlur={(e) => {
-            // 失焦时如果还是空值,退回按钮态(避免空 input 留在 UI 上)
             if (!e.target.value) setBeforeEditing(false);
           }}
           className={inputCls}


### PR DESCRIPTION
## Summary

- **Web**: Safari only opens the native date picker when clicking the calendar icon. Add `onClick` → `showPicker?.()` so the entire input area is clickable, with optional chaining guard for older browsers.

- **Backend**: Align agent prompt `current_time` and event text time field to both use the capture window start timestamp (`snapshot.start_timestamp`), ensuring consistency between what the agent sees and what users see in the activity feed.