### PR TITLE
fix(ci): PR 审查安全加固 + fork 支持（含 Actions 钉版、依赖守卫评论放行）

### DIFF
--- a/.ci/Dockerfile.pr-review
+++ b/.ci/Dockerfile.pr-review
@@ -16,6 +16,7 @@ RUN apt-get update \
 
 # pr-agent: self-contained streaming wrapper for non-interactive CI usage.
 # - 映射 PR_AGENT_MODEL 到底层 CLI 的多个模型 env 变量
+# - 用 dontAsk 模式（仅执行 allow 列表的命令）+ --tools 白名单，纵深防御
 # - 跑底层 CLI 的 stream-json 输出，再用 jq 转成可读行
 # Usage: pr-agent "<prompt>"
 RUN cat > /usr/local/bin/pr-agent <<'EOF' && chmod +x /usr/local/bin/pr-agent
@@ -29,7 +30,11 @@ if [ -n "${PR_AGENT_MODEL:-}" ]; then
     export ANTHROPIC_DEFAULT_SONNET_MODEL="${ANTHROPIC_DEFAULT_SONNET_MODEL:-$PR_AGENT_MODEL}"
     export ANTHROPIC_DEFAULT_HAIKU_MODEL="${ANTHROPIC_DEFAULT_HAIKU_MODEL:-$PR_AGENT_MODEL}"
 fi
-stdbuf -oL claude --permission-mode bypassPermissions --verbose --output-format stream-json -p "$@" \
+stdbuf -oL claude \
+  --permission-mode dontAsk \
+  --tools "Bash,Read,Glob,Grep" \
+  ${PR_AGENT_FALLBACK_USED:+--append-system-prompt "审查报告末尾 <sub> 行里的版本号后追加 (降级模式)"} \
+  --verbose --output-format stream-json -p "$@" \
   | jq --unbuffered -rc '
       def T: if length>300 then .[:300]+"…" else . end;
       if .type=="assistant" then .message.content[]?
@@ -45,7 +50,7 @@ EOF
 
 # UID 必须是 1001：GitHub-hosted runner 以 runner 用户(UID 1001)创建 /__w 及 _temp 下的
 # runner_file_commands 文件，容器用户 UID 不一致时 actions/checkout 写 save_state 会 EACCES。
-# 同时必须保持非 root——底层 CLI 的 bypassPermissions 权限模式拒绝以 root 运行。
+# 同时必须保持非 root——dontAsk 模式同样拒绝以 root 运行。
 RUN useradd -m -s /bin/bash -u 1001 agent
 USER agent
 WORKDIR /home/agent
@@ -69,7 +74,10 @@ RUN git config --global --add safe.directory '*'
 # 运行时通过 GitHub Actions secrets / env 按需注入：
 #   ANTHROPIC_API_KEY   —— 必填
 #   ANTHROPIC_BASE_URL  —— 可选；**不在此 ENV 声明空值**，否则空字符串会被 SDK 当成有效 base URL 解析失败，而不是回退到默认端点
-#   PR_AGENT_MODEL      —— 可选，由 pr-agent 映射到 ANTHROPIC_MODEL / ANTHROPIC_SMALL_FAST_MODEL
-#   GH_TOKEN            —— gh 用来读 / 发 PR 评论（workflow 注入 github.token）
+#   PR_AGENT_MODEL             —— 可选，由 pr-agent 映射到 ANTHROPIC_MODEL / ANTHROPIC_SMALL_FAST_MODEL
+#   ANTHROPIC_FALLBACK_API_KEY —— 可选；降级链路用，主 key/endpoint 不可用时切到备用（见 pr-review-gate.sh）
+#   ANTHROPIC_FALLBACK_BASE_URL—— 可选；降级链路用的备用 endpoint，不配则降级时沿用默认端点
+#   PR_AGENT_FALLBACK_MODEL    —— 可选；降级链路用的备用模型；须与 ANTHROPIC_FALLBACK_API_KEY 同时配齐才触发降级
+#   GH_TOKEN                   —— gh 用来读 / 发 PR 评论（workflow 注入 github.token）
 ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["/bin/bash"]

--- a/.ci/dependency-guard.mjs
+++ b/.ci/dependency-guard.mjs
@@ -55,7 +55,12 @@ const basename = (p) => p.split("/").pop();
 
 async function main() {
   const event = JSON.parse(await readFile(process.env.GITHUB_EVENT_PATH, "utf8"));
-  const pr = event.pull_request;
+  const pr = event.pull_request
+    ?? await gh(`/repos/${OWNER}/${REPO}/pulls/${event.issue.number}`);
+  if (!pr) {
+    console.log("⚠ 无法获取 PR 信息，跳过。");
+    return;
+  }
 
   const files = await paginate(`/repos/${OWNER}/${REPO}/pulls/${pr.number}/files`);
   const names = files.map((f) => f.filename);

--- a/.ci/dependency-guard.mjs
+++ b/.ci/dependency-guard.mjs
@@ -55,12 +55,7 @@ const basename = (p) => p.split("/").pop();
 
 async function main() {
   const event = JSON.parse(await readFile(process.env.GITHUB_EVENT_PATH, "utf8"));
-  const pr = event.pull_request
-    ?? await gh(`/repos/${OWNER}/${REPO}/pulls/${event.issue.number}`);
-  if (!pr) {
-    console.log("⚠ 无法获取 PR 信息，跳过。");
-    return;
-  }
+  const pr = event.pull_request;
 
   const files = await paginate(`/repos/${OWNER}/${REPO}/pulls/${pr.number}/files`);
   const names = files.map((f) => f.filename);

--- a/.ci/pr-review-gate.sh
+++ b/.ci/pr-review-gate.sh
@@ -31,21 +31,45 @@ git show "origin/main:.agents/commands/review-pr.md" \
   | sed "s#XiaoMi/xiaomi-miloco#${REPO}#g" \
   > .claude/commands/review-pr.md
 
-# 跑审查：infra 故障（API 宕机/超时/限流）直接放行，避免 infra 问题阻塞 merge。
+# 写死 Bash 子命令白名单到 .claude/settings.json。
+# dontAsk 模式下只有 permissions.allow 名单内的命令能执行，其余自拒；
+# 与 --tools "Bash,Read,Glob,Grep" 工具白名单形成纵深防御。
+cat > .claude/settings.json <<'SETEOF'
+{"permissions": {"allow": ["Bash(gh *)", "Bash(git *)", "Bash(md5sum *)", "Bash(diff *)"]}}
+SETEOF
+
+# 跑审查：主模型失败时降级到备用模型/endpoint 重试一次。
+# 主备均失败或审查结果未产出时直接阻断 merge，确保无审查覆盖的 PR 不能合入。
 # < /dev/null 必须：本脚本以 `git show ...:pr-review-gate.sh | bash` 方式（脚本走 bash stdin）调用，
 # 而审查 CLI 的 -p 模式在非 TTY 下会读 stdin 当输入，会把 bash 尚未读完的后续脚本（含下面的门禁逻辑）吞掉，
 # 导致 pr-agent 后整段门禁被静默跳过、门禁恒放行。隔到 /dev/null 杜绝它消费脚本流。
-if ! /usr/local/bin/pr-agent "/review-pr $PR_NUMBER --ci" < /dev/null; then
-  echo "[WARN] 审查执行失败，跳过严重度检查"
-  exit 0
+REVIEW_OK=0
+if /usr/local/bin/pr-agent "/review-pr $PR_NUMBER --ci" < /dev/null; then
+  REVIEW_OK=1
+elif [ -n "${ANTHROPIC_FALLBACK_API_KEY:-}" ] && [ -n "${PR_AGENT_FALLBACK_MODEL:-}" ]; then
+  echo "[WARN] 主模型不可用，尝试降级到备用模型"
+  export ANTHROPIC_API_KEY="$ANTHROPIC_FALLBACK_API_KEY"
+  [ -n "${ANTHROPIC_FALLBACK_BASE_URL:-}" ] && export ANTHROPIC_BASE_URL="$ANTHROPIC_FALLBACK_BASE_URL"
+  export PR_AGENT_MODEL="$PR_AGENT_FALLBACK_MODEL"
+  export PR_AGENT_FALLBACK_USED=1
+  if /usr/local/bin/pr-agent "/review-pr $PR_NUMBER --ci" < /dev/null; then
+    REVIEW_OK=1
+  fi
+fi
+# 运维须知：主备模型同时不可用（或未配 ANTHROPIC_FALLBACK_* secrets）时，下面 exit 1 会让 pr-review
+# 这条 required check 变红、阻断全仓 merge。Anthropic 长时间 outage 期间若需放行，可临时在分支保护里
+# 摘掉 pr-review required check 解封，恢复后再加回。
+if [ "$REVIEW_OK" -ne 1 ]; then
+  echo "[FAIL] 审查执行失败（主备均不可用），阻断 merge"
+  exit 1
 fi
 
 # 拉刚发布的 review-pr-ci 评论；gh api 瞬断时 || 回退空串，交给下方空值分支放行
 NOTE_BODY=$(gh api "/repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
   | jq -rs 'add | .[] | select((.body // "") | startswith("<!-- review-pr-ci -->")) | .body') || NOTE_BODY=""
 if [ -z "$NOTE_BODY" ]; then
-  echo "[WARN] 未找到 review-pr-ci 评论，跳过严重度检查"
-  exit 0
+  echo "[FAIL] 未找到 review-pr-ci 评论（审查结果未产出），阻断 merge"
+  exit 1
 fi
 
 # 锚定到 Markdown 小节标题（review-pr 约定 #### 开头，留 1~4 个 # 余量），避免概述里的提法被误判

--- a/.github/workflows/auto-response.yml
+++ b/.github/workflows/auto-response.yml
@@ -20,7 +20,7 @@ jobs:
   welcome:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         with:
           script: |
             const target = context.payload.issue || context.payload.pull_request;

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -17,13 +17,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/login-action@v3
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: .ci/Dockerfile.pr-review

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   workflow-sanity:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: 检查 workflow YAML 无 tab 缩进
         run: |
           if grep -Pnl '\t' .github/workflows/*.yml; then
@@ -31,8 +31,8 @@ jobs:
   backend-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
         with:
           enable-cache: true
           cache-dependency-glob: backend/uv.lock
@@ -44,8 +44,8 @@ jobs:
   cli-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
         with:
           enable-cache: true
           cache-dependency-glob: cli/uv.lock
@@ -55,7 +55,7 @@ jobs:
   plugin-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: ./.github/actions/setup-all
       - name: openclaw 插件测试
         run: cd plugins/openclaw && pnpm install --frozen-lockfile && pnpm test
@@ -63,7 +63,7 @@ jobs:
   web-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: ./.github/actions/setup-all
       - name: 安装依赖
         run: cd web && pnpm install --frozen-lockfile
@@ -77,7 +77,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: ./.github/actions/setup-all
       - name: ruff（backend + cli）
         # 用 backend 环境的 ruff 一次扫两处：ruff 是纯静态分析无需装 cli 依赖，

--- a/.github/workflows/codeql-critical-quality.yml
+++ b/.github/workflows/codeql-critical-quality.yml
@@ -38,14 +38,14 @@ jobs:
             language: javascript-typescript
             config: ./.github/codeql/codeql-ts.yml
     steps:
-      - uses: actions/checkout@v4
-      - uses: github/codeql-action/init@v3
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: github/codeql-action/init@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
         with:
           languages: ${{ matrix.language }}
           config-file: ${{ matrix.config }}
           queries: security-and-quality
-      - uses: github/codeql-action/autobuild@v3
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/autobuild@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
+      - uses: github/codeql-action/analyze@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
         continue-on-error: true # 未开 Code Scanning 时上传会失败；不阻塞（findings 不影响退出码）
         with:
           category: "/quality/${{ matrix.shard }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,14 +46,14 @@ jobs:
             config: ./.github/codeql/codeql-ts.yml
           - language: actions
     steps:
-      - uses: actions/checkout@v4
-      - uses: github/codeql-action/init@v3
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: github/codeql-action/init@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
         with:
           languages: ${{ matrix.language }}
           config-file: ${{ matrix.config }}
           queries: security-extended
-      - uses: github/codeql-action/autobuild@v3
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/autobuild@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
+      - uses: github/codeql-action/analyze@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
         continue-on-error: true # 未开 Code Scanning 时上传会失败；不阻塞（findings 不影响退出码）
         with:
           category: "/security/${{ matrix.language }}"

--- a/.github/workflows/dependency-guard-reapprove.yml
+++ b/.github/workflows/dependency-guard-reapprove.yml
@@ -1,0 +1,46 @@
+# 依赖守卫放行：授权人在 PR 评论 `/allow-dependencies-change <head_sha>` 后，
+# 重跑该 PR head 上的 “Dependency Guard / guard” run——重跑带着放行评论重新判定，把红 check 刷绿。
+#
+# 单独成文件（而非与 guard 同 workflow 的第二个 job）：issue_comment 与 pull_request_target 同 workflow 时，
+# PR 上会留一条 skipped 的 reapprove check；拆开后 PR 只显示 guard，本 workflow 的 run 挂在 main 不进 PR。
+name: Dependency Guard Reapprove
+
+on:
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  contents: read
+  pull-requests: read
+  actions: write # 重跑 workflow run
+
+concurrency:
+  group: dependency-guard-reapprove-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  reapprove:
+    if: >-
+      github.event.issue.pull_request != null
+      && startsWith(github.event.comment.body, '/allow-dependencies-change')
+      && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: 重跑 PR head 上的 dependency-guard
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.issue.number }}
+        run: |
+          HEAD_SHA=$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')
+          # 取该 head SHA 上最近一次 pull_request_target 的 guard run
+          RUN_ID=$(gh api \
+            "repos/$REPO/actions/workflows/dependency-guard.yml/runs?event=pull_request_target&head_sha=$HEAD_SHA&per_page=1" \
+            --jq '.workflow_runs[0].id // empty')
+          if [ -z "$RUN_ID" ]; then
+            echo "::notice::未找到 head=$HEAD_SHA 的 pull_request_target run（可能尚未跑完），可重 push 触发"
+            exit 0
+          fi
+          echo "重跑 run $RUN_ID（带放行评论重新判定 head=$HEAD_SHA）"
+          gh api -X POST "repos/$REPO/actions/runs/$RUN_ID/rerun"

--- a/.github/workflows/dependency-guard.yml
+++ b/.github/workflows/dependency-guard.yml
@@ -7,6 +7,8 @@ name: Dependency Guard
 on:
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review]
+  issue_comment:
+    types: [created, edited]
 
 permissions:
   contents: read
@@ -14,28 +16,33 @@ permissions:
   issues: read
 
 concurrency:
-  group: dependency-guard-${{ github.event.pull_request.number }}
+  group: dependency-guard-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: true
 
 jobs:
   guard:
-    if: ${{ !github.event.pull_request.draft }}
+    # pull_request_target: 非草稿 PR 触发
+    # issue_comment: 仅 /allow-dependencies-change 评论触发（含编辑后匹配的场景）
+    if: >-
+      (github.event_name == 'pull_request_target' && !github.event.pull_request.draft)
+      || (github.event_name == 'issue_comment'
+          && github.event.issue.pull_request != null
+          && startsWith(github.event.comment.body, '/allow-dependencies-change'))
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: 检出可信 base 上的守卫脚本
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ github.event.pull_request.base.sha || 'main' }}
           persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
 
       - name: 执行依赖守卫
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          # 填本项目维护者的 GitHub 用户名（逗号分隔）；留空则只认 OWNER/MEMBER/COLLABORATOR
           MILOCO_SECURITY_APPROVERS: ""
         run: node .ci/dependency-guard.mjs

--- a/.github/workflows/dependency-guard.yml
+++ b/.github/workflows/dependency-guard.yml
@@ -1,5 +1,6 @@
 # 依赖变更准入守卫：PR 改动锁文件 / 依赖清单时阻塞，需维护者评论
-# `/allow-dependencies-change` 放行。逻辑见 .ci/dependency-guard.mjs。
+# `/allow-dependencies-change <head_sha>` 放行。逻辑见 .ci/dependency-guard.mjs。
+# 放行机制见 dependency-guard-reapprove.yml：授权人评论后重跑本 workflow 的 guard run，带评论重判即翻绿。
 #
 # pull_request_target 在可信的 base 上下文运行；脚本只读 PR 元数据，不 checkout PR head 代码。
 name: Dependency Guard
@@ -7,8 +8,6 @@ name: Dependency Guard
 on:
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review]
-  issue_comment:
-    types: [created, edited]
 
 permissions:
   contents: read
@@ -16,25 +15,19 @@ permissions:
   issues: read
 
 concurrency:
-  group: dependency-guard-${{ github.event.pull_request.number || github.event.issue.number }}
+  group: dependency-guard-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   guard:
-    # pull_request_target: 非草稿 PR 触发
-    # issue_comment: 仅 /allow-dependencies-change 评论触发（含编辑后匹配的场景）
-    if: >-
-      (github.event_name == 'pull_request_target' && !github.event.pull_request.draft)
-      || (github.event_name == 'issue_comment'
-          && github.event.issue.pull_request != null
-          && startsWith(github.event.comment.body, '/allow-dependencies-change'))
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: 检出可信 base 上的守卫脚本
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
-          ref: ${{ github.event.pull_request.base.sha || 'main' }}
+          ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,8 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
 

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -28,7 +28,7 @@ jobs:
           apt-get update
           apt-get install -y curl ca-certificates git
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: install.sh 引导冒烟（装 uv + 供给 Python，校验入口可执行）
         run: bash scripts/install.sh -h

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -18,14 +18,14 @@ jobs:
   path-labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
         with:
           sync-labels: true
 
   size-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/opengrep-precise-full.yml
+++ b/.github/workflows/opengrep-precise-full.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: 安装 opengrep
         env:
@@ -40,7 +40,7 @@ jobs:
       - name: 上传 SARIF 到 Code Scanning
         if: always() && hashFiles('.opengrep-out/precise.sarif') != ''
         continue-on-error: true # 未开 Code Scanning 时上传会失败；扫描结论由前一步 --error 决定，上传不阻塞
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
         with:
           sarif_file: .opengrep-out/precise.sarif
           category: opengrep-full

--- a/.github/workflows/opengrep-precise.yml
+++ b/.github/workflows/opengrep-precise.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0 # 需要 base commit 做 diff
 
@@ -57,7 +57,7 @@ jobs:
       - name: 上传 SARIF 到 Code Scanning
         if: always() && hashFiles('.opengrep-out/precise.sarif') != ''
         continue-on-error: true # 未开 Code Scanning 时上传会失败；扫描结论由前一步 --error 决定，上传不阻塞
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
         with:
           sarif_file: .opengrep-out/precise.sarif
           category: opengrep-pr-diff

--- a/.github/workflows/pr-review-command.yml
+++ b/.github/workflows/pr-review-command.yml
@@ -1,6 +1,6 @@
 # 维护者手动触发的 PR 审查：在 PR 评论里发 "/review" 即对该 PR 跑一次 /review-pr。
-# 用途：fork PR 拿不到 secrets，被 pr-review.yml 的同仓门控跳过；改由维护者人工过目后评论触发，
-# 在 base 仓上下文里跑（issue_comment 自带 secrets）。安全边界 = 评论者须有 write+ 权限 + 钉死触发时刻的 head SHA。
+# 用途：维护者手动对任意 PR（含 fork）跑审查；在 base 仓上下文里通过 issue_comment 触发。
+# 安全边界 = 评论者须有 write+ 权限 + 钉死触发时刻的 head SHA。
 name: PR Review (command)
 
 on:
@@ -82,6 +82,9 @@ jobs:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
       PR_AGENT_MODEL: ${{ vars.PR_AGENT_MODEL }}
+      ANTHROPIC_FALLBACK_API_KEY: ${{ secrets.ANTHROPIC_FALLBACK_API_KEY }}
+      ANTHROPIC_FALLBACK_BASE_URL: ${{ secrets.ANTHROPIC_FALLBACK_BASE_URL }}
+      PR_AGENT_FALLBACK_MODEL: ${{ vars.PR_AGENT_FALLBACK_MODEL }}
       GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr-review-command.yml
+++ b/.github/workflows/pr-review-command.yml
@@ -87,7 +87,7 @@ jobs:
       PR_AGENT_FALLBACK_MODEL: ${{ vars.PR_AGENT_FALLBACK_MODEL }}
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           # 钉死 head SHA：refs/pull/<n>/head 在 base 仓里对 fork PR 也可拉；fetch-depth 0 供命令内 merge-base 比对
           ref: refs/pull/${{ github.event.issue.number }}/head

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,10 +1,10 @@
-# PR AI 审查门禁：对同仓 PR 跑 /review-pr，把结果发成一条可更新的 PR 评论，
+# PR AI 审查门禁：PR 事件自动触发 /review-pr（含 fork），把结果发成一条可更新的 PR 评论，
 # 并按严重度阻断 merge。
 # 审查方法论 + 评论格式见 .agents/commands/review-pr.md；本 workflow 只负责调度与门禁。
 name: PR Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
 
 # 同一 PR 连续 push 时取消上一次审查，只留最新
@@ -20,10 +20,8 @@ permissions:
 
 jobs:
   pr-review:
-    # 只审同仓（非 fork）非草稿 PR：fork PR 拿不到 secrets，跳过避免无 key 空跑
-    if: >-
-      github.event.pull_request.head.repo.full_name == github.repository
-      && github.event.pull_request.draft == false
+    # 审所有非草稿 PR（pull_request_target 下 fork 也可用 secrets）
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 30
     container:
@@ -35,12 +33,17 @@ jobs:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
       PR_AGENT_MODEL: ${{ vars.PR_AGENT_MODEL }}
+      ANTHROPIC_FALLBACK_API_KEY: ${{ secrets.ANTHROPIC_FALLBACK_API_KEY }}
+      ANTHROPIC_FALLBACK_BASE_URL: ${{ secrets.ANTHROPIC_FALLBACK_BASE_URL }}
+      PR_AGENT_FALLBACK_MODEL: ${{ vars.PR_AGENT_FALLBACK_MODEL }}
       GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4
         with:
-          # pull_request 默认 checkout 的是 merge ref（= 合并后状态，正合 review-pr 要求看到合并后代码）；
+          # pull_request_target 默认 checkout 的是 base 分支最后一个 commit；
+          # 显式指定 merge ref 拿到合并后状态，正合 review-pr 要求。
           # fetch-depth: 0 保留完整历史，供命令内的 git fetch origin main + merge-base 比对
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
           fetch-depth: 0
 
       # 容器内 GitHub 把 HOME 指到 /github/home，镜像里的 safe.directory 不生效，需在运行时 HOME 再设一次

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -38,7 +38,7 @@ jobs:
       PR_AGENT_FALLBACK_MODEL: ${{ vars.PR_AGENT_FALLBACK_MODEL }}
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           # pull_request_target 默认 checkout 的是 base 分支最后一个 commit；
           # 显式指定 merge ref 拿到合并后状态，正合 review-pr 要求。

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,18 +46,18 @@ jobs:
     outputs:
       version: ${{ steps.ver.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
         with:
           enable-cache: true
           cache-dependency-glob: |
             backend/uv.lock
             cli/uv.lock
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b0f76dfb45f55f8421693e4803ac7bb65143bd34 # v6
         with: { version: 11 }
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           cache: pnpm
@@ -79,7 +79,7 @@ jobs:
       - name: 构建全部产物到 dist/（--version 统一 stamp + 平台归档 + manifest.bundles）
         run: bash scripts/build.sh --version "${{ steps.ver.outputs.version }}"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: dist
           path: dist/
@@ -112,7 +112,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         with: { name: dist, path: dist }
 
       - name: 暂存 release 资产（4 平台归档 + 自包含安装脚本，归档名取自 manifest.bundles）
@@ -158,7 +158,7 @@ jobs:
     if: ${{ github.event.inputs.dry_run == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         with: { name: dist, path: dist }
       - name: 组装并汇总（dry-run，不发布）
         run: |
@@ -177,7 +177,7 @@ jobs:
           for n in names:
               shutil.copy2(dist / n, pathlib.Path("assets") / n)
           PY
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: release-assets-dryrun
           path: assets/

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,7 +19,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
         with:
           days-before-stale: 30
           days-before-close: 7


### PR DESCRIPTION
## 改动概览

本 PR 含三组 CI 改动（对应 3 个 commit）：

### 1. PR 审查链路加固 + fork 支持
- `pr-agent` 从 `bypassPermissions` 收紧为 `dontAsk` + `--tools` 工具白名单 + `.claude/settings.json` 命令白名单（纵深防御）
- `pr-review.yml`：`pull_request` → `pull_request_target`，支持对 fork PR 自动审查
- 降级链路：主模型/endpoint 不可用时切备用 key/base-url/model 重试一次；降级成功在评论页脚标注「(降级模式)」
- gate 从 fail-open 改为 fail-closed：主备均不可用或无审查产出时阻断 merge（运维须知见 `pr-review-gate.sh` 注释：Anthropic 长 outage 期间可临时摘除 pr-review required check）
- `pr-review-command.yml`：本 PR 仅补 `ANTHROPIC_FALLBACK_*` env 及 checkout 钉 SHA（命令前缀校验 / eyes reaction `success()` 守卫 / notice 防注入为既有能力）
- `Dockerfile.pr-review` env 文档补齐 `ANTHROPIC_FALLBACK_*` / `PR_AGENT_FALLBACK_MODEL` 说明

### 2. Actions 供应链加固
- 把 12 个 workflow 里的 GitHub Actions 全部钉到 commit SHA（带版本注释），防 tag 被移动

### 3. 依赖守卫评论放行
- 新增 `dependency-guard-reapprove.yml`（`issue_comment` 触发）：授权人评论 `/allow-dependencies-change <head_sha>` 后，重跑该 head 上最近一次 dependency-guard run，重跑时守卫读到放行评论即翻绿
- `dependency-guard.yml` 仍只 `pull_request_target` 触发，判定逻辑不变

## 说明
- 原计划的「CodeQL 自建门禁」已移除——改用 GitHub 原生 `Code scanning results / CodeQL` check（本身就 diff-aware，只报本 PR 新增）做门禁，接受的告警走 Security 面板 dismiss，不在本 PR 内重复造轮子。