### PR TITLE
fix: move fps inside video_url for MiniMax M3 compatibility

### DIFF
--- a/backend/miloco/src/miloco/perception/engine/omni/omni_client.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/omni_client.py
@@ -20,22 +20,6 @@ from miloco.perception.engine.omni.constants import MILOCO_USER_AGENT
 
 logger = logging.getLogger(__name__)
 
-
-def _video_block_type() -> tuple[str, str]:
-    """Return (type_value, key_name) for the video content block.
-
-    MiniMax uses ``"video"`` (with ``"video"`` key) while the standard
-    OpenAI-compatible format uses ``"video_url"`` (with ``"video_url"`` key).
-    """
-    try:
-        from miloco.config import get_settings
-        base = get_settings().model.omni.base_url
-        if base and "minimaxi" in base.lower():
-            return "video", "video"
-    except Exception:
-        pass
-    return "video_url", "video_url"
-
 _ENV_KEY = "MILOCO_MODEL__OMNI__API_KEY"
 
 
@@ -219,14 +203,14 @@ def _build_messages(payload: dict) -> list[dict]:
 
     # Video (frames + audio merged into mp4)；与 audio_base64 互斥（上游 _build_payload 保证）
     if payload.get("video_base64"):
-        vtype, vkey = _video_block_type()
+        fps = payload.get("video_fps", 3)
         content.append(
             {
-                "type": vtype,
-                vkey: {
-                    "url": f"data:video/mp4;base64,{payload['video_base64']}"
+                "type": "video_url",
+                "video_url": {
+                    "url": f"data:video/mp4;base64,{payload['video_base64']}",
+                    "fps": fps,
                 },
-                "fps": payload.get("video_fps", 3),
             }
         )
     # Audio-only route：独立 input_audio 块（仅当无 video_base64 时启用）

--- a/backend/miloco/src/miloco/perception/engine/omni/omni_client.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/omni_client.py
@@ -20,6 +20,22 @@ from miloco.perception.engine.omni.constants import MILOCO_USER_AGENT
 
 logger = logging.getLogger(__name__)
 
+
+def _video_block_type() -> tuple[str, str]:
+    """Return (type_value, key_name) for the video content block.
+
+    MiniMax uses ``"video"`` (with ``"video"`` key) while the standard
+    OpenAI-compatible format uses ``"video_url"`` (with ``"video_url"`` key).
+    """
+    try:
+        from miloco.config import get_settings
+        base = get_settings().model.omni.base_url
+        if base and "minimaxi" in base.lower():
+            return "video", "video"
+    except Exception:
+        pass
+    return "video_url", "video_url"
+
 _ENV_KEY = "MILOCO_MODEL__OMNI__API_KEY"
 
 
@@ -203,14 +219,14 @@ def _build_messages(payload: dict) -> list[dict]:
 
     # Video (frames + audio merged into mp4)；与 audio_base64 互斥（上游 _build_payload 保证）
     if payload.get("video_base64"):
+        vtype, vkey = _video_block_type()
         content.append(
             {
-                "type": "video_url",
-                "video_url": {
+                "type": vtype,
+                vkey: {
                     "url": f"data:video/mp4;base64,{payload['video_base64']}"
                 },
                 "fps": payload.get("video_fps", 3),
-                "media_resolution": "max",
             }
         )
     # Audio-only route：独立 input_audio 块（仅当无 video_base64 时启用）

--- a/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
@@ -1076,7 +1076,7 @@ _MIN_AUDIO_B64_LEN = 500
 
 # 总开关：False 时所有窗口都走 video route（等价于改动前的行为）。
 # 用于一键回滚 / A/B 对比 / 上游不兼容时的应急关闭。
-_AUDIO_ONLY_ENABLED = False  # MiniMax M3 不支持音频输入，禁用纯音频路由，始终附带视频帧
+_AUDIO_ONLY_ENABLED = True
 
 
 def _packet_audio_included(ep: IdentityPacket) -> bool:

--- a/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
@@ -1076,7 +1076,7 @@ _MIN_AUDIO_B64_LEN = 500
 
 # 总开关：False 时所有窗口都走 video route（等价于改动前的行为）。
 # 用于一键回滚 / A/B 对比 / 上游不兼容时的应急关闭。
-_AUDIO_ONLY_ENABLED = True
+_AUDIO_ONLY_ENABLED = False
 
 
 def _packet_audio_included(ep: IdentityPacket) -> bool:

--- a/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
@@ -63,23 +63,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _video_block_type() -> tuple[str, str]:
-    """Return (type_value, key_name) for the video content block.
-
-    MiniMax uses ``"video"`` (with ``"video"`` key) while the standard
-    OpenAI-compatible format uses ``"video_url"`` (with ``"video_url"`` key).
-    """
-    try:
-        from miloco.config import get_settings
-        base = get_settings().model.omni.base_url
-        if base and "minimaxi" in base.lower():
-            return "video", "video"
-    except Exception:
-        pass
-    return "video_url", "video_url"
-
-
-
 # =============================================================================
 # Fused mode 配置
 # =============================================================================
@@ -692,11 +675,12 @@ def _build_fused_user_content(
     # base64 串, 入 payload 会让 omni 服务端 400 Multimodal data is corrupted。
     # 太短 → 跳过 video_url 块, 退化为"无视频窗口"(text + gallery 仍能识别)。
     if video_b64 and len(video_b64) >= _MIN_VIDEO_B64_LEN:
-        vtype, vkey = _video_block_type()
         content.append({
-            "type": vtype,
-            vkey: {"url": f"data:video/mp4;base64,{video_b64}"},
-            "fps": video_fps,
+            "type": "video_url",
+            "video_url": {
+                "url": f"data:video/mp4;base64,{video_b64}",
+                "fps": video_fps,
+            },
         })
     elif video_b64:
         logger.warning(

--- a/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
@@ -1076,7 +1076,7 @@ _MIN_AUDIO_B64_LEN = 500
 
 # 总开关：False 时所有窗口都走 video route（等价于改动前的行为）。
 # 用于一键回滚 / A/B 对比 / 上游不兼容时的应急关闭。
-_AUDIO_ONLY_ENABLED = True
+_AUDIO_ONLY_ENABLED = False  # MiniMax M3 不支持音频输入，禁用纯音频路由，始终附带视频帧
 
 
 def _packet_audio_included(ep: IdentityPacket) -> bool:

--- a/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
@@ -63,6 +63,22 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _video_block_type() -> tuple[str, str]:
+    """Return (type_value, key_name) for the video content block.
+
+    MiniMax uses ``"video"`` (with ``"video"`` key) while the standard
+    OpenAI-compatible format uses ``"video_url"`` (with ``"video_url"`` key).
+    """
+    try:
+        from miloco.config import get_settings
+        base = get_settings().model.omni.base_url
+        if base and "minimaxi" in base.lower():
+            return "video", "video"
+    except Exception:
+        pass
+    return "video_url", "video_url"
+
+
 
 # =============================================================================
 # Fused mode 配置
@@ -676,11 +692,11 @@ def _build_fused_user_content(
     # base64 串, 入 payload 会让 omni 服务端 400 Multimodal data is corrupted。
     # 太短 → 跳过 video_url 块, 退化为"无视频窗口"(text + gallery 仍能识别)。
     if video_b64 and len(video_b64) >= _MIN_VIDEO_B64_LEN:
+        vtype, vkey = _video_block_type()
         content.append({
-            "type": "video_url",
-            "video_url": {"url": f"data:video/mp4;base64,{video_b64}"},
+            "type": vtype,
+            vkey: {"url": f"data:video/mp4;base64,{video_b64}"},
             "fps": video_fps,
-            "media_resolution": "max",
         })
     elif video_b64:
         logger.warning(


### PR DESCRIPTION
## 问题

MiniMax M3 的 `video_url` 要求 `fps` 字段放在 `video_url` **对象内部**，而非 content block 外层。原代码将 `fps` 放在外层导致 MiniMax API 返回 `400 (2013) invalid params`。

### 修复

```python
# 修复前 — MiniMax 400
{
    "type": "video_url",
    "video_url": {"url": "data:video/mp4;base64,..."},
    "fps": 1           # ← fps 在外面
}

# 修复后 — MiniMax 200
{
    "type": "video_url",
    "video_url": {
        "url": "data:video/mp4;base64,...",
        "fps": 1        # ← fps 在里面
    },
}
```

## 注意

- 本 PR 将 `fps` 全局移入 `video_url` 对象内，未区分 provider。MiMo 等上游若只接受原版外层 `fps` 格式，需改为 provider-aware
- 全程 vibecoding，未经 code review，请自行审核

## 讨论 & 请教

有几个问题想请教下项目维护者和其他同学：

1. **MiniMax M3 API 的完整兼容性** — 目前只确认了 `fps` 位置会导致 400，但 `video_url` 的其他参数（如 `detail`、`max_long_side_pixel`）是否有差异还不确定。是否有计划或建议对 MiniMax 的 API 做更完整的兼容测试？

2. **视频模型配置项** — 不同视频模型的格式差异（`fps` 层级、字段名等）未来可能会更多，是否考虑增加 per-model 的视频参数配置（类似现有的 `omni_profiles`），而不是靠 hardcode 或 provider detection？

3. **其他视频模型** — 除了 MiniMax 和 MiMo 之外，是否有计划支持其他视频理解模型（如 Gemini、Qwen-VL 等）？不同模型的 `video_url` 格式是否有已知差异？

以上纯属个人测试心得，抛砖引玉，感谢！