### PR TITLE
fix(ci): opengrep 在改动全被 .semgrepignore 排除时确定性跳过

### DIFF
--- a/.ci/run-opengrep.sh
+++ b/.ci/run-opengrep.sh
@@ -43,10 +43,32 @@ cd "$REPO_ROOT"
 # 第一方源码目录（与 CI paths 一致）
 FIRST_PARTY_RE='^(backend|cli|plugins/openclaw/src|web/src|scripts)/'
 
-# .semgrepignore 同时是 opengrep 与本脚本的排除单一来源。下面用它做 check-ignore，
-# 让"空集跳过"判断与 opengrep 实际扫描集合对齐——否则当改动全是被忽略的文件
-# （如纯测试 PR）时，SCAN_PATHS 非空但 opengrep 无目标可扫，会以非零码退出而误失败。
+# .semgrepignore 同时是 opengrep 与本脚本的排除单一来源。下面据它把会被忽略的
+# 路径从 SCAN_PATHS 中剔除，让"空集跳过"判断与 opengrep 实际扫描集合对齐——否则
+# 当改动全是被忽略的文件（如纯测试 PR）时，SCAN_PATHS 非空但 opengrep 无目标可扫，
+# 退出码不稳定会使 job 间歇性误失败。
+#
+# opengrep 以 --no-git-ignore 运行，忽略集 = 仅 .semgrepignore。但 git check-ignore
+# 即便指定 core.excludesFile 仍会叠加读取仓库各级 .gitignore 与 .git/info/exclude，
+# 其剔除集会成为 opengrep 忽略集的超集（artifact 目录如 coverage/temp/target/out 等
+# 只在 .gitignore、不在 .semgrepignore）——一旦这类目录下放了 tracked 源码，就会被
+# 脚本误剔、被 opengrep 漏扫。为与 opengrep 严格对齐，在仓库外建一个隔离的 git 环境，
+# 只喂 .semgrepignore 作为 excludes，check-ignore 便只认它、不读仓库 .gitignore。
 SEMGREPIGNORE="$REPO_ROOT/.semgrepignore"
+ISOLATED_IGNORE_DIR=""
+if [[ -f "$SEMGREPIGNORE" ]]; then
+  ISOLATED_IGNORE_DIR="$(mktemp -d)"
+  trap 'rm -rf "$ISOLATED_IGNORE_DIR"' EXIT
+  cp "$SEMGREPIGNORE" "$ISOLATED_IGNORE_DIR/.exclude"
+  git -C "$ISOLATED_IGNORE_DIR" init -q
+fi
+
+# 仅按 .semgrepignore 判定路径是否会被 opengrep 忽略（不叠加仓库 .gitignore）。
+semgrep_ignored() {
+  [[ -n "$ISOLATED_IGNORE_DIR" ]] || return 1
+  git -C "$ISOLATED_IGNORE_DIR" -c core.excludesFile="$ISOLATED_IGNORE_DIR/.exclude" \
+    check-ignore -q --no-index "$1" 2>/dev/null
+}
 
 if (( CHANGED_ONLY )); then
   DIFF_REF="${MILOCO_OPENGREP_BASE_REF:-origin/main...HEAD}"
@@ -55,10 +77,7 @@ if (( CHANGED_ONLY )); then
     [[ -L "$p" ]] && continue
     [[ -f "$p" || -d "$p" ]] || continue
     # 与 opengrep 内部行为对齐：会被 .semgrepignore 排除的路径不计入扫描集
-    if [[ -f "$SEMGREPIGNORE" ]] \
-      && git -c core.excludesFile="$SEMGREPIGNORE" check-ignore -q --no-index "$p" 2>/dev/null; then
-      continue
-    fi
+    semgrep_ignored "$p" && continue
     SCAN_PATHS+=( "$p" )
   done < <(
     {
@@ -75,4 +94,9 @@ else
 fi
 
 echo "→ opengrep 扫描：${SCAN_PATHS[*]}（排除项见 .semgrepignore）" >&2
+# exec 会替换当前进程，EXIT trap 不再触发，故在此显式清理隔离目录后再 exec
+# （把 opengrep 退出码原样透传给调用方）。
+if [[ -n "$ISOLATED_IGNORE_DIR" ]]; then
+  rm -rf "$ISOLATED_IGNORE_DIR"
+fi
 exec opengrep scan --no-strict --config "$CONFIG" --no-git-ignore "${EXTRA_ARGS[@]}" "${SCAN_PATHS[@]}"

--- a/.ci/run-opengrep.sh
+++ b/.ci/run-opengrep.sh
@@ -43,12 +43,22 @@ cd "$REPO_ROOT"
 # 第一方源码目录（与 CI paths 一致）
 FIRST_PARTY_RE='^(backend|cli|plugins/openclaw/src|web/src|scripts)/'
 
+# .semgrepignore 同时是 opengrep 与本脚本的排除单一来源。下面用它做 check-ignore，
+# 让"空集跳过"判断与 opengrep 实际扫描集合对齐——否则当改动全是被忽略的文件
+# （如纯测试 PR）时，SCAN_PATHS 非空但 opengrep 无目标可扫，会以非零码退出而误失败。
+SEMGREPIGNORE="$REPO_ROOT/.semgrepignore"
+
 if (( CHANGED_ONLY )); then
   DIFF_REF="${MILOCO_OPENGREP_BASE_REF:-origin/main...HEAD}"
   SCAN_PATHS=()
   while IFS= read -r p; do
     [[ -L "$p" ]] && continue
     [[ -f "$p" || -d "$p" ]] || continue
+    # 与 opengrep 内部行为对齐：会被 .semgrepignore 排除的路径不计入扫描集
+    if [[ -f "$SEMGREPIGNORE" ]] \
+      && git -c core.excludesFile="$SEMGREPIGNORE" check-ignore -q --no-index "$p" 2>/dev/null; then
+      continue
+    fi
     SCAN_PATHS+=( "$p" )
   done < <(
     {
@@ -57,7 +67,7 @@ if (( CHANGED_ONLY )); then
     } | grep -E "$FIRST_PARTY_RE" | sort -u
   )
   if (( ${#SCAN_PATHS[@]} == 0 )); then
-    echo "→ 本次无改动的第一方源码，跳过 opengrep。" >&2
+    echo "→ 本次无需扫描的第一方源码（无改动或改动均被 .semgrepignore 排除），跳过 opengrep。" >&2
     exit 0
   fi
 else


### PR DESCRIPTION
## 问题

CHANGED_ONLY 模式下，`run-opengrep.sh` 的「空集跳过」判断早于 `.semgrepignore` 过滤。当一个 PR 的改动**全部**是被忽略的文件（如纯测试 PR——`.semgrepignore` 排除 `test_*.py` / `tests/`），`SCAN_PATHS` 仍非空，opengrep 拿到的路径会被其内部全部忽略、无目标可扫。此时 opengrep 退出码不稳定，导致 `Scan changed paths` job **间歇性误失败**。

实测：PR #294（唯一改动是一个测试文件）同一 commit 重跑即从红翻绿——脚本与 `.semgrepignore` 在此期间均未变更，diff 集合也相同，可排除 base/规则命中等因素，定性为 flaky。

## 改动

收集 `SCAN_PATHS` 时用 `.semgrepignore` 作 `git check-ignore`，把会被排除的路径提前剔除，使「空集跳过」判断与 opengrep 实际扫描集合对齐：

- 全被忽略时脚本走**确定性的 `exit 0`**，不再把空目标交给 opengrep；
- 混合改动（源码 + 测试）中的源码仍正常入扫；
- 纯源码改动不受影响。

## 验证

- `bash -n` 语法通过；
- 模拟 PR #294 场景（仅测试文件）→ `SCAN_PATHS` 为空 → 跳过 `exit 0`；
- 混合改动（源码+测试）→ 源码保留入扫，仅剔测试；
- 纯源码改动 → 全保留，零副作用。

注：未用真实 opengrep 二进制端到端跑（本地未装），验证覆盖脚本的路径计算逻辑——即 bug 所在层。