### PR TITLE
feat(dashboard): add rules management panel

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -14,6 +14,7 @@ import {
   listScopeCameras,
   listScopeHomes,
   listTasks,
+  listRules,
   refreshCameraOnline,
   pausePerception,
   resumePerception,
@@ -33,6 +34,7 @@ import { PersonDrawer } from "./components/PersonDrawer";
 import { PersonProfilePanel } from "./components/PersonProfilePanel";
 import { HomeKnowledgePanel } from "./components/HomeKnowledgePanel";
 import { TaskListPanel } from "./components/TaskListPanel";
+import { RuleListPanel } from "./components/RuleListPanel";
 import { CandidateReviewPanel } from "./components/CandidateReviewPanel";
 import { MiotBindDialog } from "./components/MiotBindDialog";
 import { ToastHost, toast } from "./components/Toast";
@@ -152,6 +154,10 @@ function MainApp() {
   // miloco 为家庭创建的持续任务——家庭 tab 家庭档案卡下方展示。
   const tasks = useAsync(() => listTasks(homeId), [homeId], {
     errorLabel: t("app.loadTasksFail"),
+  });
+  // 规则列表
+  const rules = useAsync(() => listRules(homeId), [homeId], {
+    errorLabel: "加载规则失败",
   });
 
   // ── 字号 / 抽屉 / 弹层 ─────────────────────────
@@ -351,6 +357,14 @@ function MainApp() {
       }
       case "usage":
         return <UsagePage />;
+      case "rules":
+        return (
+          <RuleListPanel
+            rules={rules.data ?? []}
+            loading={rules.loading}
+            onChanged={() => rules.reload()}
+          />
+        );
     }
   };
 

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -508,3 +508,21 @@ export async function getMemorySeries(
     `/api/monitor/memory/series?window=${w}&bucket=${bucket}`,
   );
 }
+
+// ── 规则（rule）─────────────────────────────────────────────
+import type { Rule } from "@/lib/types";
+export type { Rule };
+
+export async function listRules(homeId?: HomeId): Promise<Rule[]> {
+  if (!isPrimary(homeId)) return [];
+  return impl.realListRules();
+}
+
+export async function toggleRule(ruleId: string, enabled: boolean): Promise<void> {
+  return impl.realToggleRule(ruleId, enabled);
+}
+
+export async function triggerRule(ruleId: string): Promise<void> {
+  return impl.realTriggerRule(ruleId);
+}
+

--- a/web/src/api/real.ts
+++ b/web/src/api/real.ts
@@ -11,6 +11,7 @@ import i18n from "@/i18n";
 import type {
   ActivityEvent,
   Device,
+  Rule,
   DeviceCategory,
   DeviceProperty,
   HomeEntries,
@@ -1510,3 +1511,27 @@ export async function realDeleteTask(taskId: string): Promise<void> {
     { method: "DELETE" },
   );
 }
+
+// ── 规则（rule）─────────────────────────────────────────────
+export async function realListRules(): Promise<Rule[]> {
+  const r = await apiFetch<Normal<Rule[]>>("/api/rules");
+  return r.data ?? [];
+}
+
+export async function realToggleRule(
+  ruleId: string,
+  enabled: boolean,
+): Promise<void> {
+  await apiFetch<Normal<unknown>>(`/api/rules/${encodeURIComponent(ruleId)}`, {
+    method: "PATCH",
+    body: JSON.stringify({ enabled }),
+  });
+}
+
+export async function realTriggerRule(ruleId: string): Promise<void> {
+  await apiFetch<Normal<unknown>>(
+    `/api/rules/${encodeURIComponent(ruleId)}/trigger`,
+    { method: "POST", body: JSON.stringify({ context: "manual_trigger_from_dashboard" }) },
+  );
+}
+

--- a/web/src/components/RuleListPanel.tsx
+++ b/web/src/components/RuleListPanel.tsx
@@ -1,0 +1,165 @@
+/**
+ * 规则管理面板 — 展示已配置的规则列表，支持启停和手动触发。
+ */
+
+import { useTranslation } from "react-i18next";
+import type { Rule } from "@/lib/types";
+import { toggleRule, triggerRule } from "@/api";
+import { toast } from "./Toast";
+
+interface Props {
+  rules: Rule[];
+  loading: boolean;
+  onChanged: () => void;
+}
+
+function stripTagName(name: string): { tag: string; label: string } {
+  const m = name.match(/^\[([^\]]+)\]\s*(.*)/);
+  return m ? { tag: m[1], label: m[2] } : { tag: "", label: name };
+}
+
+function formatDuration(rule: Rule): string | null {
+  if (!rule.duration_seconds) return null;
+  const secs = rule.duration_seconds;
+  const ratio = rule.duration_ratio != null ? `${Math.round(rule.duration_ratio * 100)}%` : "";
+  return `${secs}s${ratio ? ` / ${ratio}` : ""}`;
+}
+
+export function RuleListPanel({ rules, loading, onChanged }: Props) {
+  const { t } = useTranslation();
+
+  if (loading) {
+    return (
+      <div className="rounded-xl bg-bg-secondary border border-border shadow-sm p-6 anim-in">
+        <h2 className="text-title text-text-primary mb-4">{t("rules.title")}</h2>
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-24 rounded-lg bg-bg-primary animate-pulse" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (rules.length === 0) {
+    return (
+      <div className="rounded-xl bg-bg-secondary border border-border shadow-sm p-6 anim-in">
+        <h2 className="text-title text-text-primary mb-4">{t("rules.title")}</h2>
+        <p className="text-text-tertiary text-center py-8">{t("rules.empty")}</p>
+      </div>
+    );
+  }
+
+  const handleToggle = async (rule: Rule) => {
+    try {
+      await toggleRule(rule.id, !rule.enabled);
+      onChanged();
+    } catch (e) {
+      toast(e instanceof Error ? e.message : t("common.switchFailed"), "warn");
+    }
+  };
+
+  const handleTrigger = async (rule: Rule) => {
+    try {
+      await triggerRule(rule.id);
+      toast(`${t("rules.trigger")}: ${stripTagName(rule.name).label}`, "ok");
+    } catch (e) {
+      toast(e instanceof Error ? e.message : t("common.switchFailed"), "warn");
+    }
+  };
+
+  return (
+    <div className="rounded-xl bg-bg-secondary border border-border shadow-sm p-6 anim-in">
+      <h2 className="text-title text-text-primary mb-4">{t("rules.title")}</h2>
+      <div className="space-y-3">
+        {rules.map((rule) => {
+          const { tag, label } = stripTagName(rule.name);
+          const duration = formatDuration(rule);
+          return (
+            <div
+              key={rule.id}
+              className={`rounded-lg border p-4 transition-colors ${
+                rule.enabled
+                  ? "bg-bg-primary border-border"
+                  : "bg-bg-primary border-border opacity-60"
+              }`}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 mb-1.5 flex-wrap">
+                    {tag && (
+                      <span className="inline-flex items-center px-2 py-0.5 rounded text-caption font-medium bg-brand-soft text-brand-primary">
+                        {tag}
+                      </span>
+                    )}
+                    <span
+                      className={`inline-flex items-center px-2 py-0.5 rounded text-caption ${
+                        rule.mode === "event"
+                          ? "bg-blue-50 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400"
+                          : "bg-green-50 text-green-600 dark:bg-green-900/30 dark:text-green-400"
+                      }`}
+                    >
+                      {rule.mode === "event" ? t("rules.event") : t("rules.state")}
+                    </span>
+                    {duration && (
+                      <span className="text-caption text-text-tertiary">
+                        {duration}
+                      </span>
+                    )}
+                  </div>
+                  {label && (
+                    <div className="text-body text-text-primary font-medium mb-1">
+                      {label}
+                    </div>
+                  )}
+                  <div className="text-caption text-text-tertiary line-clamp-2">
+                    {rule.condition.query}
+                  </div>
+                  {rule.on_enter_desc && (
+                    <div className="text-caption text-text-tertiary mt-1">
+                      {t("rules.enterAction")}: {rule.on_enter_desc}
+                    </div>
+                  )}
+                  {rule.action_descriptions.length > 0 && (
+                    <div className="text-caption text-text-tertiary mt-1">
+                      {rule.action_descriptions[0]}
+                    </div>
+                  )}
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                  <button
+                    type="button"
+                    onClick={() => handleTrigger(rule)}
+                    className="inline-flex items-center justify-center rounded-md text-text-tertiary hover:text-text-primary hover:bg-bg-tertiary transition-colors"
+                    style={{ width: 32, height: 32 }}
+                    title={t("rules.trigger")}
+                    disabled={!rule.enabled}
+                  >
+                    <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                      <path d="M4 2l10 6-10 6V2z" />
+                    </svg>
+                  </button>
+                  <button
+                    type="button"
+                    role="switch"
+                    aria-checked={rule.enabled}
+                    onClick={() => handleToggle(rule)}
+                    className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                      rule.enabled ? "bg-brand-primary" : "bg-text-tertiary"
+                    }`}
+                  >
+                    <span
+                      className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                        rule.enabled ? "translate-x-6" : "translate-x-1"
+                      }`}
+                    />
+                  </button>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -32,7 +32,8 @@ export type TabKey =
   | "devices"
   | "family"
   | "activity"
-  | "usage";
+  | "usage"
+  | "rules";
 
 type NavIcon = ComponentType<SVGProps<SVGSVGElement> & { active?: boolean }>;
 
@@ -78,6 +79,12 @@ export const TABS: TabDef[] = [
     hintKey: "nav.usageHint",
     Icon: IconUsage,
   },
+  {
+    key: "rules",
+    labelKey: "nav.rules",
+    hintKey: "nav.rulesHint",
+    Icon: IconRules,
+  },
   // 性能 tab 不再列入主导航 — 改为通过 URL hash "#perf" 进入独立调试视图,
   // 普通用户看不到入口。详见 App.tsx 的 PerfView。
 ];
@@ -88,6 +95,17 @@ interface Props {
   miot?: HomeStatus["miot"];
   onOpenMiotBind: () => void;
   onMiotChanged: () => void;
+}
+
+
+/** 规则图标 */
+function IconRules({ active, width = 24, height = 24, ...props }: { active?: boolean; width?: number; height?: number } & React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg width={width} height={height} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <path d="M12 20h9" />
+      <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
+    </svg>
+  );
 }
 
 export function Sidebar({ active, onChange, miot, onOpenMiotBind, onMiotChanged }: Props) {

--- a/web/src/i18n/locales/en/nav.json
+++ b/web/src/i18n/locales/en/nav.json
@@ -13,5 +13,5 @@
     "usageHint": "Model & token usage",
     "loginMiot": "Tap to sign in to Xiaomi Home",
     "bound": "Connected"
-  }
-}
+  ,"rules":"Rules","rulesHint":"Automation rules"}
+,"rules":"Rules","rulesHint":"Automation rules"}

--- a/web/src/i18n/locales/en/rules.json
+++ b/web/src/i18n/locales/en/rules.json
@@ -1,0 +1,1 @@
+{"rules":{"title":"Rules","empty":"No rules configured","loading":"Loading rules…","event":"Event","state":"State","trigger":"Trigger","duration":"Duration","ratio":"Ratio","condition":"Condition","enterAction":"On enter","exitAction":"On exit","seconds":"s","permanently":"Permanent","temporary":"Temporary"}}

--- a/web/src/i18n/locales/zh/nav.json
+++ b/web/src/i18n/locales/zh/nav.json
@@ -13,5 +13,5 @@
     "usageHint": "看模型和 Token 开销",
     "loginMiot": "点击登录米家",
     "bound": "已绑定"
-  }
-}
+  ,"rules":"规则","rulesHint":"自动化规则管理"}
+,"rules":"规则","rulesHint":"自动化规则管理"}

--- a/web/src/i18n/locales/zh/rules.json
+++ b/web/src/i18n/locales/zh/rules.json
@@ -1,0 +1,1 @@
+{"rules":{"title":"规则管理","empty":"暂无规则","loading":"加载规则中…","event":"事件","state":"状态","trigger":"触发","duration":"持续","ratio":"比例","condition":"触发条件","enterAction":"进入时","exitAction":"退出时","seconds":"秒","permanently":"永久","temporary":"临时"}}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -554,6 +554,48 @@ export interface MemorySeries {
   points: MemoryPoint[];
 }
 
+
+// ── 规则（rule）────────────────────────────────────────────
+export type RuleMode = "event" | "state";
+export type RuleLifecycle = "permanent" | "temporary";
+
+export interface RuleAction {
+  did: string;
+  iid: string;
+  value?: unknown;
+  params?: unknown[];
+  idempotent: boolean;
+  cooldown_minutes?: number | null;
+}
+
+export interface RuleCondition {
+  perceive_device_ids: string[];
+  query: string;
+}
+
+export interface Rule {
+  id: string;
+  name: string;
+  task_id: string;
+  mode: RuleMode;
+  lifecycle: RuleLifecycle;
+  enabled: boolean;
+  condition: RuleCondition;
+  actions: RuleAction[];
+  action_descriptions: string[];
+  on_enter_actions: RuleAction[];
+  on_enter_desc: string | null;
+  on_exit_actions: RuleAction[];
+  on_exit_desc: string | null;
+  on_target_desc: string | null;
+  terminate_when: string | null;
+  exit_debounce_seconds: number;
+  duration_seconds: number | null;
+  duration_ratio: number | null;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
 // === Monitor meta (/monitor/) ===
 
 export interface MonitorMeta {


### PR DESCRIPTION
## Summary

Add a new "Rules" tab to the home dashboard sidebar, allowing users to view and manage their automation rules.

## Motivation

Currently, rules can only be managed through the CLI (`miloco-cli`) or the Agent. Adding a visual rules panel to the dashboard gives users a quick overview of their configured rules and the ability to enable/disable them or trigger them manually — without needing to open a terminal.

## Changes

### New Files
- `web/src/components/RuleListPanel.tsx` — Main component displaying rule cards
- `web/src/i18n/locales/zh/rules.json` — Chinese translations
- `web/src/i18n/locales/en/rules.json` — English translations

### Modified Files
- `web/src/lib/types.ts` — Add `Rule`, `RuleMode`, `RuleLifecycle`, `RuleAction`, `RuleCondition` type definitions
- `web/src/api/real.ts` — Add `realListRules`, `realToggleRule`, `realTriggerRule` API functions
- `web/src/api/index.ts` — Export `listRules`, `toggleRule`, `triggerRule` functions
- `web/src/components/Sidebar.tsx` — Add "rules" tab to navigation, add `IconRules` SVG icon
- `web/src/App.tsx` — Wire up rules data fetching and render `RuleListPanel` for the rules tab
- `web/src/i18n/locales/zh/nav.json` — Add `nav.rules` / `nav.rulesHint` keys
- `web/src/i18n/locales/en/nav.json` — Add `nav.rules` / `nav.rulesHint` keys

## Features

The rules panel shows each configured rule as a card with:
- **Rule name** with tag badge (e.g. `[study_focus]`)
- **Mode badge**: "事件" (Event) or "状态" (State)
- **Condition query** text (truncated to 2 lines)
- **Duration/ratio info** when configured (e.g. "180s / 60%")
- **Toggle switch** to enable/disable the rule
- **Trigger button** to manually fire the rule for testing

Loading skeleton and empty state are also handled.

## Testing

- Verified the panel renders correctly with the user's 3 existing study focus rules
- Toggle and trigger buttons call the correct backend API endpoints
- i18n translations work for both zh and en locales
