### PR TITLE
fix(camera): use cloud online status for perception gating

### DIFF
--- a/backend/miloco/src/miloco/miot/service.py
+++ b/backend/miloco/src/miloco/miot/service.py
@@ -944,9 +944,11 @@ class MiotService:
         cameras = {did: info for did, info in cameras.items() if did in devices}
         out: list[dict] = []
         for did, info in cameras.items():
-            online = bool(getattr(info, "online", False)) and bool(
-                getattr(info, "lan_online", False)
-            )
+            # Cloud online is the source of truth for device reachability here.
+            # LAN discovery can be false/unknown under WSL/NAT while MIoT can
+            # still reach the camera over relay, so it must not mark the camera
+            # offline in the UI.
+            online = bool(getattr(info, "online", False))
             out.append(
                 {
                     "did": did,
@@ -978,15 +980,12 @@ class MiotService:
             )
 
         if enable_dids:
-            # 离线设备禁止「开启」投喂:它被感知接入层 online_only 过滤、永远连不上,
-            # 开了也不出画面、徒占上限名额。只拦「开启」——已启用的设备掉线后仍保留
-            # inUse=true(允许态不被强制改),且可正常被「关闭」(disable 不走这条校验)。
-            # 在线口径 = online && lan_online,与 list_cameras_with_state 的 is_online 一致。
+            # 离线设备禁止「开启」投喂:只看云端 online。lan_online 仅表示局域网
+            # 发现结果,在 WSL/NAT 等环境可能为 false/unknown,但 MIoT 仍可经 relay
+            # 出流；实际出帧失败由连接/watchdog 路径处理。
             def _online(did: str) -> bool:
                 info = cameras[did]
-                return bool(getattr(info, "online", False)) and bool(
-                    getattr(info, "lan_online", False)
-                )
+                return bool(getattr(info, "online", False))
 
             offline_enable = [d for d in enable_dids if not _online(d)]
             if offline_enable:

--- a/backend/miloco/src/miloco/perception/collect/camera_adapter.py
+++ b/backend/miloco/src/miloco/perception/collect/camera_adapter.py
@@ -98,7 +98,7 @@ class CameraDeviceAdapter(BaseDeviceAdapter):
         self,
         all_devices: dict | None = None,
         online_only: bool = True,
-        require_lan: bool = True,
+        require_lan: bool = False,
         cap: bool = True,
     ) -> dict[str, PerceptionDevice]:
         if not self._miot_proxy.is_authenticated:
@@ -115,7 +115,7 @@ class CameraDeviceAdapter(BaseDeviceAdapter):
         all_devices: dict,
         *,
         online_only: bool = True,
-        require_lan: bool = True,
+        require_lan: bool = False,
         cap: bool = True,
     ) -> dict[str, PerceptionDevice]:
         """Filter camera-type devices from a full device dict.
@@ -152,11 +152,14 @@ class CameraDeviceAdapter(BaseDeviceAdapter):
 
             camera_info = CameraInfo.model_validate(info.model_dump())
 
-            device_online = camera_info.online and camera_info.lan_online
-            # require_lan=False 时只看云端 online：放过 lan_online 陈旧成 false 的
-            # 卡死态相机（云端 online=True，refresh 能救活），但排除云端就离线
-            # （拔电/断网）的相机——给「应连数」判据用，避免离线相机致 refresh 空转。
-            connectable = device_online if require_lan else camera_info.online
+            cloud_online = bool(camera_info.online)
+            lan_reachable = bool(camera_info.lan_online)
+            # 默认只看云端 online。lan_online 仅表示 LAN 发现结果，WSL/NAT 或
+            # relay 场景下可能为 false/unknown；真正不可出帧由连接/watchdog 判定。
+            # require_lan=True 保留给需要强制 LAN 可达的内部调用。
+            connectable = (
+                cloud_online and lan_reachable if require_lan else cloud_online
+            )
             if online_only and not connectable:
                 continue
 
@@ -166,7 +169,7 @@ class CameraDeviceAdapter(BaseDeviceAdapter):
                 device_type="camera",
                 room_id=camera_info.room_name,
                 room_name=camera_info.room_name,
-                online=device_online,
+                online=cloud_online,
             )
 
         if not cap or len(result) <= MAX_ENABLED_CAMERAS:
@@ -361,7 +364,7 @@ class CameraDeviceAdapter(BaseDeviceAdapter):
             device_type="camera",
             room_id=camera.room_name,
             room_name=camera.room_name,
-            online=camera.online and camera.lan_online,
+            online=bool(camera.online),
         )
 
     def _build_device_data(

--- a/backend/miloco/tests/perception/test_camera_adapter_decode_latency.py
+++ b/backend/miloco/tests/perception/test_camera_adapter_decode_latency.py
@@ -30,13 +30,19 @@ def _make_state(
 
 class _CachedCamera:
     def __init__(
-        self, *, did: str = "cam1", name: str = "cam1", room_name: str = "r2"
+        self,
+        *,
+        did: str = "cam1",
+        name: str = "cam1",
+        room_name: str = "r2",
+        online: bool = True,
+        lan_online: bool | None = True,
     ):
         self._payload = {
             "did": did,
             "name": name,
-            "online": True,
-            "lan_online": True,
+            "online": online,
+            "lan_online": lan_online,
             "room_name": room_name,
         }
 
@@ -233,6 +239,32 @@ class TestBuildDeviceDataAggregation:
         assert dd.meta.name == "cam-new"
         assert dd.meta.room_name == "r-new"
 
+    def test_current_source_uses_cloud_online_when_lan_unavailable(self):
+        adapter = CameraDeviceAdapter(
+            miot_proxy=_Proxy(
+                _CachedCamera(
+                    name="cam-new", room_name="r-new", online=True, lan_online=False
+                )
+            )
+        )  # type: ignore[arg-type]
+        state = _make_state()
+        frame = DecodedVideoFrame(
+            frame=np.zeros((2, 2, 3), dtype=np.uint8),
+            stream_ts=100,
+            wall_ms=100,
+            unix_ms=100,
+            decode_latency_ms=10.0,
+        )
+        tracks = {
+            "decoded_video": [self._fragment(frame, frame.stream_ts, frame.wall_ms)],
+            "decoded_audio": [],
+        }
+
+        dd = adapter._build_device_data(state, tracks, 100, 200)
+
+        assert dd is not None
+        assert dd.meta.online is True
+
     def test_get_connected_devices_reads_latest_cached_metadata(self):
         proxy = _Proxy(_CachedCamera(name="cam-old", room_name="r-old"))
         adapter = CameraDeviceAdapter(miot_proxy=proxy)  # type: ignore[arg-type]
@@ -246,6 +278,15 @@ class TestBuildDeviceDataAggregation:
         assert first.room_name == "r-old"
         assert second.name == "cam-new"
         assert second.room_name == "r-new"
+
+    def test_get_connected_devices_uses_cloud_online_when_lan_unavailable(self):
+        proxy = _Proxy(_CachedCamera(online=True, lan_online=False))
+        adapter = CameraDeviceAdapter(miot_proxy=proxy)  # type: ignore[arg-type]
+        adapter._devices["cam1"] = _make_state()
+
+        source = adapter.get_connected_devices()["cam1"]
+
+        assert source.online is True
 
     def test_current_source_falls_back_to_did_without_cache(self):
         adapter = CameraDeviceAdapter(miot_proxy=object())  # type: ignore[arg-type]

--- a/backend/miloco/tests/perception/test_online_connected_separation.py
+++ b/backend/miloco/tests/perception/test_online_connected_separation.py
@@ -5,7 +5,8 @@ Verifies that:
 * ``CameraInfo.connected`` derives from ``camera_status == CONNECTED``.
 * ``PerceptionDevice`` carries both ``online`` and ``connected`` fields.
 * ``CameraDeviceAdapter.discover_devices`` correctly populates both fields
-  and filters only by ``online`` (cloud status).
+  and filters by cloud ``online`` by default. Callers can opt into LAN
+  reachability filtering with ``require_lan=True``.
 """
 
 from __future__ import annotations
@@ -166,29 +167,37 @@ class TestDiscoverDevicesOnlineConnected:
         assert result["cam1"].online is True
 
     @pytest.mark.asyncio
-    async def test_online_but_not_on_lan_filtered_out(self, adapter):
-        """Cloud-online but NOT LAN-reachable should be filtered."""
-        cam = _make_camera_info(did="cam1", online=True, lan_online=False)
+    async def test_online_but_not_on_lan_included_by_default(self, adapter):
+        """Cloud-online cameras are included even when LAN discovery is false."""
+        cam = _make_camera_info(did="cam1", online=True, lan_online=False).model_copy(
+            update={"home_id": "H1"}
+        )
         adapter._miot_proxy.get_cameras.return_value = {"cam1": cam}
 
         result = await adapter.discover_devices(online_only=True)
 
-        assert "cam1" not in result
+        assert "cam1" in result
+        assert result["cam1"].online is True
 
     @pytest.mark.asyncio
-    async def test_online_lan_none_filtered_out(self, adapter):
-        """Cloud-online but lan_online=None should be filtered."""
-        cam = _make_camera_info(did="cam1", online=True, lan_online=None)
+    async def test_online_lan_none_included_by_default(self, adapter):
+        """Cloud-online cameras are included when LAN status is unknown."""
+        cam = _make_camera_info(did="cam1", online=True, lan_online=None).model_copy(
+            update={"home_id": "H1"}
+        )
         adapter._miot_proxy.get_cameras.return_value = {"cam1": cam}
 
         result = await adapter.discover_devices(online_only=True)
 
-        assert "cam1" not in result
+        assert "cam1" in result
+        assert result["cam1"].online is True
 
     @pytest.mark.asyncio
     async def test_offline_camera_filtered_out(self, adapter):
         """Cloud-offline camera should be filtered when online_only=True."""
-        cam = _make_camera_info(did="cam1", online=False, lan_online=True)
+        cam = _make_camera_info(did="cam1", online=False, lan_online=True).model_copy(
+            update={"home_id": "H1"}
+        )
         adapter._miot_proxy.get_cameras.return_value = {"cam1": cam}
 
         result = await adapter.discover_devices(online_only=True)
@@ -208,8 +217,7 @@ class TestDiscoverDevicesOnlineConnected:
 
     @pytest.mark.asyncio
     async def test_require_lan_false_keeps_stale_lan_camera(self, adapter):
-        """A2 应连数判据(online_only=True, require_lan=False)放过 lan_online 陈旧
-        成 false 的卡死态相机(云端 online=True)——它正是要靠 refresh 救活的。"""
+        """Default/require_lan=False uses cloud online, not LAN discovery."""
         cam = _make_camera_info(did="cam1", online=True, lan_online=False).model_copy(
             update={"home_id": "H1"}
         )
@@ -218,6 +226,18 @@ class TestDiscoverDevicesOnlineConnected:
         result = await adapter.discover_devices(online_only=True, require_lan=False)
 
         assert "cam1" in result
+
+    @pytest.mark.asyncio
+    async def test_require_lan_true_filters_stale_lan_camera(self, adapter):
+        """Explicit LAN-gated callers can still require LAN reachability."""
+        cam = _make_camera_info(did="cam1", online=True, lan_online=False).model_copy(
+            update={"home_id": "H1"}
+        )
+        adapter._miot_proxy.get_cameras.return_value = {"cam1": cam}
+
+        result = await adapter.discover_devices(online_only=True, require_lan=True)
+
+        assert "cam1" not in result
 
     @pytest.mark.asyncio
     async def test_require_lan_false_still_excludes_offline_camera(self, adapter):
@@ -234,7 +254,7 @@ class TestDiscoverDevicesOnlineConnected:
 
     @pytest.mark.asyncio
     async def test_filter_cameras_from_all(self, adapter):
-        """_filter_cameras_from_all requires online AND lan_online."""
+        """_filter_cameras_from_all includes cloud-online cameras by default."""
         cam = _make_camera_info(
             did="cam1",
             online=True,
@@ -250,14 +270,32 @@ class TestDiscoverDevicesOnlineConnected:
         assert result["cam1"].online is True
 
     @pytest.mark.asyncio
-    async def test_filter_cameras_from_all_no_lan(self, adapter):
-        """_filter_cameras_from_all filters when lan_online is False."""
+    async def test_filter_cameras_from_all_no_lan_default(self, adapter):
+        """_filter_cameras_from_all does not treat LAN-missing as offline."""
         cam = _make_camera_info(
-            did="cam1", online=True, lan_online=False,
-        )
+            did="cam1",
+            online=True,
+            lan_online=False,
+        ).model_copy(update={"home_id": "H1"})
         result = adapter._filter_cameras_from_all(
             {"cam1": cam},
             online_only=True,
+        )
+        assert "cam1" in result
+        assert result["cam1"].online is True
+
+    @pytest.mark.asyncio
+    async def test_filter_cameras_from_all_no_lan_when_required(self, adapter):
+        """_filter_cameras_from_all can still enforce LAN reachability."""
+        cam = _make_camera_info(
+            did="cam1",
+            online=True,
+            lan_online=False,
+        ).model_copy(update={"home_id": "H1"})
+        result = adapter._filter_cameras_from_all(
+            {"cam1": cam},
+            online_only=True,
+            require_lan=True,
         )
         assert "cam1" not in result
 
@@ -315,5 +353,4 @@ class TestCameraInfoLanStatus:
         ci = CameraInfo.model_validate(cam.model_dump())
         assert ci.lan_online is False
         assert ci.local_ip is None
-
 

--- a/backend/miloco/tests/test_miot_filter_and_cameras.py
+++ b/backend/miloco/tests/test_miot_filter_and_cameras.py
@@ -25,6 +25,7 @@ from miloco.middleware.exceptions import (
 )
 from miloco.miot import filter as miot_filter
 from miloco.miot.service import MiotService
+from miot.types import MIoTCameraStatus
 
 
 class _FakeKV:
@@ -48,13 +49,14 @@ def _home(home_id: str, name: str = "Home"):
     return SimpleNamespace(home_id=home_id, home_name=name)
 
 
-def _camera(did: str, home_id: str = "H1", *, online: bool = True, lan_online: bool = True):
+def _camera(did: str, home_id: str = "H1", *, online: bool = True, lan_online: bool = True, camera_status: MIoTCameraStatus = MIoTCameraStatus.CONNECTED):
     return SimpleNamespace(
         did=did,
         home_id=home_id,
         name=f"cam-{did}",
         online=online,
         lan_online=lan_online,
+        camera_status=camera_status,
     )
 
 
@@ -288,7 +290,7 @@ async def test_list_cameras_with_state_flags():
     assert by_did["c1"]["is_online"] is True
     assert by_did["c1"]["connected"] is False
     assert by_did["c2"]["in_use"] is True
-    assert by_did["c2"]["is_online"] is False  # lan_online=False
+    assert by_did["c2"]["is_online"] is True  # cloud online; LAN may be unavailable
     assert by_did["c2"]["connected"] is True
 
 
@@ -307,6 +309,62 @@ async def test_toggle_camera_writes_disabled():
     res = await svc.toggle_camera([{"did": "c1", "in_use": True}])
     assert isinstance(res, list)
     assert any(c["did"] == "c1" and c["in_use"] is True for c in res)
+
+
+@pytest.mark.asyncio
+async def test_toggle_camera_enable_allows_cloud_online_without_lan():
+    """LAN discovery false must not block enabling a cloud-online camera."""
+    kv = _FakeKV(
+        {
+            ScopeConfigKeys.HOME_WHITE_LIST_KEY: json.dumps(["H1"]),
+            ScopeConfigKeys.CAMERA_BLACK_LIST_KEY: json.dumps(["c1"]),
+        }
+    )
+    svc = _make_service(
+        devices={"c1": _camera("c1", lan_online=False)},
+        cameras={"c1": _camera("c1", lan_online=False)},
+        kv=kv,
+    )
+
+    res = await svc.toggle_camera([{"did": "c1", "in_use": True}])
+
+    assert isinstance(res, list)
+    assert any(c["did"] == "c1" and c["in_use"] is True for c in res)
+
+
+@pytest.mark.asyncio
+async def test_toggle_camera_enable_rejects_cloud_offline():
+    """Cloud-offline cameras are still rejected when enabling perception."""
+    kv = _FakeKV({ScopeConfigKeys.HOME_WHITE_LIST_KEY: json.dumps(["H1"])})
+    svc = _make_service(
+        devices={"c1": _camera("c1", online=False, lan_online=True)},
+        cameras={"c1": _camera("c1", online=False, lan_online=True)},
+        kv=kv,
+    )
+
+    with pytest.raises(ValidationException, match="摄像头当前离线"):
+        await svc.toggle_camera([{"did": "c1", "in_use": True}])
+
+
+@pytest.mark.asyncio
+async def test_list_cameras_online_independent_from_camera_status():
+    """A disconnected stream status must not make a cloud-online camera offline."""
+    camera = _camera("c1", online=True, camera_status=MIoTCameraStatus.DISCONNECTED)
+    svc = _make_service(devices={"c1": camera}, cameras={"c1": camera})
+    svc._connected_camera_dids = lambda: set()  # type: ignore[assignment]
+
+    out = await svc.list_cameras_with_state()
+
+    assert out == [
+        {
+            "did": "c1",
+            "name": "cam-c1",
+            "room_name": None,
+            "is_online": True,
+            "in_use": True,
+            "connected": False,
+        }
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Treat cloud `online` as the camera reachability source of truth in camera list state and perception enable validation
- Stop default perception discovery/current metadata from treating missing LAN discovery as offline, while preserving explicit `require_lan=True` filtering
- Add regression coverage for cloud-online/LAN-unavailable cameras, cloud-offline rejection, and camera stream status remaining separate from online state

Fixes #319.

## Validation
- `git diff --check`
- `PYTHONDONTWRITEBYTECODE=1 UV_CACHE_DIR=/Users/haoqian/Documents/Codex/2026-06-26/https-linear-app-dark-legion-issue-2/work/uv-cache uv run pytest -q -p no:cacheprovider miloco/tests/test_miot_filter_and_cameras.py miloco/tests/perception/test_online_connected_separation.py miloco/tests/perception/test_camera_adapter_decode_latency.py` (92 passed)
- `UV_CACHE_DIR=/Users/haoqian/Documents/Codex/2026-06-26/https-linear-app-dark-legion-issue-2/work/uv-cache uv run ruff check . /Users/haoqian/Documents/Codex/2026-06-26/https-linear-app-dark-legion-issue-2/work/xiaomi-miloco/cli`
- Full backend pytest: 2064 passed, 1 xfailed, 4 failed. Failures are outside touched files: `miloco/tests/node_monitor/test_resource_monitor.py::TestMemoryCollect::test_smaps_parse_failure_keeps_old_latest`, `miloco/tests/node_monitor/test_resource_monitor.py::TestMemoryCollect::test_both_failed_skips_ring`, `miloco/tests/node_monitor/test_router_memory.py::TestMemoryEndpoint::test_200_full_snapshot`, `miloco/tests/perception/engine/identity/test_deep_sort_v12.py::TestV2ReIDModel::test_load_under_600ms`.
