### PR TITLE
fix: drop stale miloco-suggest notifications

### DIFF
--- a/backend/miloco/src/miloco/config/settings.py
+++ b/backend/miloco/src/miloco/config/settings.py
@@ -250,6 +250,19 @@ class PerceptionCollectSettings(BaseModel):
     )
 
 
+class PerceptionPushSettings(BaseModel):
+    """感知事件推送时效控制。"""
+
+    max_delay_minutes: float = Field(
+        default=5.0,
+        ge=0.0,
+        description=(
+            "suggestion 推送最大允许延迟（分钟）。超过该阈值的 suggestion "
+            "在进入 agent webhook 前丢弃并打 [DROPPED] 日志；0 表示不做时效丢弃。"
+        ),
+    )
+
+
 class PerceptionSettings(BaseModel):
     """感知管线相关配置。"""
 
@@ -285,6 +298,10 @@ class PerceptionSettings(BaseModel):
     collect: PerceptionCollectSettings = Field(
         default_factory=PerceptionCollectSettings,
         description="采集窗口策略",
+    )
+    push: PerceptionPushSettings = Field(
+        default_factory=PerceptionPushSettings,
+        description="感知事件推送时效控制",
     )
     engine: dict[str, Any] = Field(
         default_factory=dict,

--- a/backend/miloco/src/miloco/config/settings.schema.json
+++ b/backend/miloco/src/miloco/config/settings.schema.json
@@ -68,6 +68,26 @@
       },
       "required": ["webhook_url", "auth_bearer"]
     },
+    "perception": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "感知管线配置",
+      "properties": {
+        "push": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "感知事件推送时效控制",
+          "properties": {
+            "max_delay_minutes": {
+              "type": "number",
+              "minimum": 0,
+              "default": 5,
+              "description": "suggestion 推送最大允许延迟（分钟）；超过该阈值的 suggestion 在进入 agent webhook 前丢弃并打 [DROPPED] 日志，0 表示不做时效丢弃"
+            }
+          }
+        }
+      }
+    },
     "model": {
       "type": "object",
       "additionalProperties": true,

--- a/backend/miloco/src/miloco/config/settings.yaml
+++ b/backend/miloco/src/miloco/config/settings.yaml
@@ -69,6 +69,8 @@ rule:
 perception:
   log_ttl: 30                  # 感知日志保留天数
   tier_u_dump_enable: false    # POST /api/identity/pool/dump 调试端点开关（生产保持 false，本地调试可设 true）
+  push:
+    max_delay_minutes: 5       # suggestion 推送最大允许延迟；超过则 [DROPPED] 丢弃，0 表示禁用
   collect:
     window_size: 4           # 时间窗口大小（秒）
     max_windows: 3           # 最大待处理窗口数

--- a/backend/miloco/src/miloco/dispatch/dispatcher.py
+++ b/backend/miloco/src/miloco/dispatch/dispatcher.py
@@ -58,6 +58,19 @@ class _QueuedEvent:
     priority: int  # 类型级优先级（来自 _ROUTE，数字小=优先）
     enqueued_at: float  # time.monotonic()，用于同类合并排序 + 淘汰判旧
     intra_priority: int = 0  # 条目级优先级（数字小=优先）；无内层优先级的类型恒 0，仅参与淘汰、不改渲染序
+    event_timestamp_ms: int = 0  # 业务事件发生时间；suggestion 用感知窗口时间，其它类型用入队时间兜底
+
+
+def _event_timestamp_ms(event_type: EventType, items: list[Any]) -> int:
+    if event_type == "suggestion":
+        timestamps = [
+            ts
+            for ts in (getattr(item, "_event_timestamp_ms", None) for item in items)
+            if isinstance(ts, int) and ts > 0
+        ]
+        if timestamps:
+            return min(timestamps)
+    return int(time.time() * 1000)
 
 
 class AgentDispatcher:
@@ -117,6 +130,7 @@ class AgentDispatcher:
             priority=priority,
             enqueued_at=time.monotonic(),
             intra_priority=intra_priority,
+            event_timestamp_ms=_event_timestamp_ms(event_type, items),
         )
         q = self._queues.setdefault(session_key, [])
         q.append(ev)
@@ -185,6 +199,10 @@ class AgentDispatcher:
     async def _send_batch(self, session_key: str, batch: list[_QueuedEvent]) -> None:
         event_type = batch[0].event_type
         lane = _ROUTE[event_type][1]
+        batch = self._drop_stale_suggestions(session_key, batch)
+        if not batch:
+            return
+        created_at_ms, expires_at_ms = self._suggestion_expiry_payload(batch)
         merged: list[Any] = [it for ev in batch for it in ev.items]
         try:
             msg = batch[0].builder(merged)
@@ -203,13 +221,17 @@ class AgentDispatcher:
         rtt_ms: float = 0.0
         for attempt in range(self._TRANSPORT_RETRIES + 1):
             try:
-                run_id, status, rtt_ms = await run_agent_turn(
-                    msg,
-                    session_key=session_key,
-                    lane=lane,
-                    trace_id=trace_id,
-                    wait_timeout_ms=wait_ms,
-                )
+                kwargs: dict[str, Any] = {
+                    "session_key": session_key,
+                    "lane": lane,
+                    "trace_id": trace_id,
+                    "wait_timeout_ms": wait_ms,
+                }
+                if created_at_ms is not None:
+                    kwargs["created_at_ms"] = created_at_ms
+                if expires_at_ms is not None:
+                    kwargs["expires_at_ms"] = expires_at_ms
+                run_id, status, rtt_ms = await run_agent_turn(msg, **kwargs)
                 break
             except AgentWebhookException as e:
                 # 传输失败（连接 / 5xx / HTTP 超时）→ 有限短退避重试,
@@ -240,6 +262,54 @@ class AgentDispatcher:
             track_agent_run(
                 trace_id, run_id, cast(AgentRunSource, event_type), rtt_ms
             )
+
+    def _drop_stale_suggestions(
+        self, session_key: str, batch: list[_QueuedEvent]
+    ) -> list[_QueuedEvent]:
+        if not batch or batch[0].event_type != "suggestion":
+            return batch
+
+        max_delay_minutes = get_settings().perception.push.max_delay_minutes
+        if max_delay_minutes <= 0:
+            return batch
+
+        now_ms = int(time.time() * 1000)
+        max_delay_ms = int(max_delay_minutes * 60 * 1000)
+        fresh: list[_QueuedEvent] = []
+        for ev in batch:
+            if ev.event_timestamp_ms <= 0:
+                fresh.append(ev)
+                continue
+            delay_ms = max(0, now_ms - ev.event_timestamp_ms)
+            if delay_ms <= max_delay_ms:
+                fresh.append(ev)
+                continue
+            logger.warning(
+                "[DROPPED] stale suggestion batch skipped before agent webhook "
+                "session=%s delay_ms=%d max_delay_minutes=%.2f items=%d",
+                session_key,
+                delay_ms,
+                max_delay_minutes,
+                len(ev.items),
+            )
+        return fresh
+
+    def _suggestion_expiry_payload(
+        self, batch: list[_QueuedEvent]
+    ) -> tuple[int | None, int | None]:
+        if not batch or batch[0].event_type != "suggestion":
+            return None, None
+
+        max_delay_minutes = get_settings().perception.push.max_delay_minutes
+        if max_delay_minutes <= 0:
+            return None, None
+
+        timestamps = [ev.event_timestamp_ms for ev in batch if ev.event_timestamp_ms > 0]
+        if not timestamps:
+            return None, None
+        created_at_ms = min(timestamps)
+        expires_at_ms = created_at_ms + int(max_delay_minutes * 60 * 1000)
+        return created_at_ms, expires_at_ms
 
 
 _singleton: AgentDispatcher | None = None

--- a/backend/miloco/src/miloco/perception/client.py
+++ b/backend/miloco/src/miloco/perception/client.py
@@ -80,6 +80,18 @@ def _ms_since(start: float) -> float:
     return (time.monotonic() - start) * 1000
 
 
+def _stamp_suggestion_event_time(
+    suggestions: list[Suggestion],
+    event_timestamp_ms: float | int,
+) -> None:
+    if not suggestions or event_timestamp_ms <= 0:
+        return
+    event_ts = int(event_timestamp_ms)
+    for s in suggestions:
+        if s._event_timestamp_ms is None:
+            s._event_timestamp_ms = event_ts
+
+
 def _filter_completed_event_rules(
     rules: list[dict],
 ) -> tuple[list[dict], list[str]]:
@@ -422,6 +434,7 @@ class PerceptionEngineProxy:
             # 这里收到的已是经事件链闸门过滤后的「新链」suggestion——心跳/重复在
             # pipeline 层（_wrap_suggestions_cb → assign_id_and_update_link）已抑制。
             # 剔除 engine 内部字段（id）后外发。
+            _stamp_suggestion_event_time(suggestions, batched_snapshot.captured_at)
             for s in suggestions:
                 if s.id is not None:
                     early_sent_sugg_ids.add(s.id)  # 终态 merge 会把同一新链保留进 result，发送侧据此跳过
@@ -464,6 +477,7 @@ class PerceptionEngineProxy:
         pipeline_ms = _ms_since(t)
 
         if result:
+            _stamp_suggestion_event_time(result.suggestions, batched_snapshot.captured_at)
             # Inject proxy-level timing into result.timing (prefixed with _ to
             # distinguish from engine-internal keys).
             timing = result.timing or {}

--- a/backend/miloco/src/miloco/perception/types.py
+++ b/backend/miloco/src/miloco/perception/types.py
@@ -12,7 +12,7 @@ from typing import Any
 
 import numpy as np
 from numpy.typing import NDArray
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, PrivateAttr
 
 
 @dataclass
@@ -310,6 +310,7 @@ class Suggestion(BaseModel):
     device_name: str = Field(default="", description="Source camera display name (engine-injected, human-readable; NOT sent as raw did)")
     time_window: str = Field(default="", description="Picture capture window [HH:MM:SS-HH:MM:SS] (engine-injected)")
     caption: str = Field(default="", description="Caption from same-window CaptionEntry (attached before dispatch)")
+    _event_timestamp_ms: int | None = PrivateAttr(default=None)
 
 
 # urgency 排名（数字大 = 更紧急）；engine 事件链与调度器条目级优先级共用此单一真值。

--- a/backend/miloco/src/miloco/utils/agent_client.py
+++ b/backend/miloco/src/miloco/utils/agent_client.py
@@ -94,6 +94,8 @@ async def run_agent_turn(
     lane: str,
     trace_id: str,
     wait_timeout_ms: int,
+    created_at_ms: int | None = None,
+    expires_at_ms: int | None = None,
 ) -> tuple[str | None, str, float]:
     """投递一条消息并**同步等待**该 turn 结束(或超时),返回 ``(run_id, status, rtt_ms)``。
 
@@ -106,18 +108,23 @@ async def run_agent_turn(
     抛 :class:`AgentWebhookException`,由调用方(drainer)捕获跳过,本函数不兜底。
     """
     started_at = time.monotonic()
+    payload: dict[str, Any] = {
+        "message": text,
+        "sessionKey": session_key,
+        "lane": lane,
+        "traceId": trace_id,
+        # 批次稳定幂等键:HTTP 真断(turn 已起但响应丢)后 dispatcher 重试会发新
+        # 请求,平台按此键去重,避免同会话并发起第二个 turn 击穿 "在途 turn ≤ 1"。
+        "idempotencyKey": trace_id,
+        "timeoutMs": wait_timeout_ms,
+    }
+    if created_at_ms is not None:
+        payload["createdAtMs"] = created_at_ms
+    if expires_at_ms is not None:
+        payload["expiresAtMs"] = expires_at_ms
     data = await call_agent_webhook(
         "agent",
-        {
-            "message": text,
-            "sessionKey": session_key,
-            "lane": lane,
-            "traceId": trace_id,
-            # 批次稳定幂等键:HTTP 真断(turn 已起但响应丢)后 dispatcher 重试会发新
-            # 请求,平台按此键去重,避免同会话并发起第二个 turn 击穿 "在途 turn ≤ 1"。
-            "idempotencyKey": trace_id,
-            "timeoutMs": wait_timeout_ms,
-        },
+        payload,
         timeout=wait_timeout_ms / 1000 + _HTTP_BUFFER_S,
     )
     rtt_ms = (time.monotonic() - started_at) * 1000

--- a/backend/miloco/tests/dispatch/test_dispatcher.py
+++ b/backend/miloco/tests/dispatch/test_dispatcher.py
@@ -18,6 +18,7 @@ Behaviors under test:
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 import uuid
 from types import SimpleNamespace
@@ -65,7 +66,16 @@ def patched(monkeypatch):
     """
     rec = SimpleNamespace(turns=[], tracks=[])
 
-    async def default_turn(msg, *, session_key, lane, trace_id, wait_timeout_ms):
+    async def default_turn(
+        msg,
+        *,
+        session_key,
+        lane,
+        trace_id,
+        wait_timeout_ms,
+        created_at_ms=None,
+        expires_at_ms=None,
+    ):
         rec.turns.append(
             SimpleNamespace(
                 msg=msg,
@@ -73,6 +83,8 @@ def patched(monkeypatch):
                 lane=lane,
                 trace_id=trace_id,
                 wait_timeout_ms=wait_timeout_ms,
+                created_at_ms=created_at_ms,
+                expires_at_ms=expires_at_ms,
             )
         )
         return f"run-{len(rec.turns)}", "ok", 1.0
@@ -93,7 +105,10 @@ def patched(monkeypatch):
         lambda: SimpleNamespace(
             dispatcher=SimpleNamespace(
                 turn_wait_timeout_ms=30_000, max_queue=MAX_QUEUE
-            )
+            ),
+            perception=SimpleNamespace(
+                push=SimpleNamespace(max_delay_minutes=5),
+            ),
         ),
     )
     return rec
@@ -318,6 +333,42 @@ async def test_bind_not_tracked(patched):
 
     assert len(patched.turns) == 1  # turn still sent
     assert patched.tracks == []  # but not recorded to agent_runs
+
+
+@pytest.mark.asyncio
+async def test_stale_suggestion_dropped_before_agent_webhook(patched, caplog):
+    stale = SimpleNamespace(_event_timestamp_ms=int((time.time() - 3600) * 1000))
+    d = AgentDispatcher()
+    await d.start()
+    try:
+        with caplog.at_level(logging.WARNING):
+            accepted = await d.dispatch("suggestion", [stale], _join)
+            await _settle(d)
+    finally:
+        await d.stop()
+
+    assert accepted is True
+    assert patched.turns == []
+    assert patched.tracks == []
+    assert "[DROPPED]" in caplog.text
+    assert "delay_ms=" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_fresh_suggestion_forwards_expiry_payload(patched):
+    event_ts = int(time.time() * 1000)
+    fresh = SimpleNamespace(_event_timestamp_ms=event_ts)
+    d = AgentDispatcher()
+    await d.start()
+    try:
+        await d.dispatch("suggestion", [fresh], _join)
+        await _settle(d)
+    finally:
+        await d.stop()
+
+    assert len(patched.turns) == 1
+    assert patched.turns[0].created_at_ms == event_ts
+    assert patched.turns[0].expires_at_ms == event_ts + 5 * 60 * 1000
 
 
 @pytest.mark.asyncio

--- a/backend/miloco/tests/test_perception_client.py
+++ b/backend/miloco/tests/test_perception_client.py
@@ -236,6 +236,27 @@ async def test_no_executor_fallback_runs_callback_inline(proxy):
     assert seen == [(id(main_loop), main_thread)]
 
 
+async def test_realtime_impl_stamps_suggestion_event_time(proxy):
+    from miloco.perception.types import BatchedSnapshot, Suggestion
+
+    captured_at = 1_700_000_000_000
+    main_loop = asyncio.get_running_loop()
+
+    async def engine_realtime(*args, **kwargs):
+        return RealtimePerceptionResult(
+            suggestions=[Suggestion(event="婴儿哭声", action="查看", urgency="high", id=1)]
+        )
+
+    proxy.perception_engine.realtime_perceive = engine_realtime
+
+    result, *_ = await proxy._realtime_perceive_impl(
+        BatchedSnapshot(captured_at=captured_at), [], 0, 0.0, main_loop, [],
+    )
+
+    assert result is not None
+    assert result.suggestions[0]._event_timestamp_ms == captured_at
+
+
 async def test_handle_realtime_skips_early_sent_suggestions(proxy):
     """per-omni:result.suggestions 含本窗全部新链(供 dump/上下文完整),但已早送的
     (id ∈ early_sent_sugg_ids)在发送侧跳过、不对 Agent 重发;未早送的(batch 新链)照常发。

--- a/plugins/openclaw/src/webhooks/agent.ts
+++ b/plugins/openclaw/src/webhooks/agent.ts
@@ -22,6 +22,8 @@ interface IRequestBody {
   extraSystemPrompt?: string;
   traceId?: string;
   timeoutMs?: number;
+  createdAtMs?: number;
+  expiresAtMs?: number;
 }
 
 interface WaitResult {
@@ -34,6 +36,10 @@ function isContextOverflow(text: string | null | undefined): boolean {
 }
 
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
 
 // 等本 run 的 trace meta 落定(done)后返回;超时仍未 done 返 undefined(按非溢出处理,安全降级)。
 async function waitTurnMeta(runId: string, timeoutMs: number) {
@@ -74,9 +80,30 @@ export const kAgentWebhook: WebhookEntry<IRequestBody> = {
       idempotencyKey = crypto.randomUUID(),
       traceId,
       timeoutMs,
+      createdAtMs,
+      expiresAtMs,
     } = payload;
     // 自愈双 turn 串联须留在 backend HTTP 超时内，startedAt 用于给重试 turn 算剩余等待预算。
     const startedAt = Date.now();
+
+    const dropIfExpired = () => {
+      if (!isFiniteNumber(expiresAtMs) || Date.now() <= expiresAtMs) {
+        return null;
+      }
+      const delayMs = isFiniteNumber(createdAtMs) ? Date.now() - createdAtMs : null;
+      logger.warn(
+        `[DROPPED] stale agent webhook skipped before subagent.run session=${sessionKey} lane=${lane ?? ""} delay_ms=${delayMs ?? ""} expires_at_ms=${expiresAtMs}`,
+      );
+      return {
+        runId: null,
+        status: "ok",
+        dropped: true,
+        reason: "expired",
+      };
+    };
+
+    const expired = dropIfExpired();
+    if (expired) return expired;
 
     const runOnce = async (idem: string, waitMs: number) => {
       const result = await api.runtime.subagent.run({
@@ -117,6 +144,8 @@ export const kAgentWebhook: WebhookEntry<IRequestBody> = {
         // 之上还有 15s 缓冲吸收 deleteSession / 轮询 / HTTP 开销，故插件侧无需硬编码该缓冲。
         // 常规下首个 turn 秒级返回 → 预算充裕 → 取 RETRY_WAIT_MS 上限；首个 turn 慢时自动收窄。
         const elapsed = Date.now() - startedAt;
+        const expiredBeforeRetry = dropIfExpired();
+        if (expiredBeforeRetry) return expiredBeforeRetry;
         const retryWaitMs = Math.max(
           10_000,
           Math.min(

--- a/plugins/openclaw/tests/agent.test.ts
+++ b/plugins/openclaw/tests/agent.test.ts
@@ -58,6 +58,33 @@ afterEach(() => {
 });
 
 describe("kAgentWebhook 上下文溢出自愈", () => {
+  it("过期 payload 在 subagent.run 前丢弃", async () => {
+    const { api, run, waitForRun, deleteSession } = makeApi({});
+
+    const res = (await kAgentWebhook.action({
+      api,
+      payload: {
+        message: "stale",
+        sessionKey: "agent:main:miloco-suggest",
+        lane: "miloco-suggest",
+        idempotencyKey: "stale-1",
+        createdAtMs: Date.now() - 60 * 60 * 1000,
+        expiresAtMs: Date.now() - 1,
+      },
+    } as never)) as {
+      status: string;
+      dropped?: boolean;
+      reason?: string;
+    };
+
+    expect(run).not.toHaveBeenCalled();
+    expect(waitForRun).not.toHaveBeenCalled();
+    expect(deleteSession).not.toHaveBeenCalled();
+    expect(res.status).toBe("ok");
+    expect(res.dropped).toBe(true);
+    expect(res.reason).toBe("expired");
+  });
+
   it("溢出 → deleteSession 一次 → 重试成功 → recovered=true", async () => {
     peekTurnMetaMock.mockImplementation((runId: string) =>
       runId === "t1"


### PR DESCRIPTION
## Summary
- add configurable `perception.push.max_delay_minutes` for stale suggestion notification expiry
- stamp suggestion batches with perception event time and drop expired `miloco-suggest` batches before the backend calls the agent webhook
- pass `createdAtMs` / `expiresAtMs` to the OpenClaw agent webhook and skip expired payloads before `subagent.run()`

Fixes #317.

## Tests
- `PYTHONPATH=backend/miloco/src /Users/haoqian/Documents/Codex/2026-06-26/https-linear-app-dark-legion-issue-15/work/.venv/bin/python -m pytest backend/miloco/tests/dispatch/test_dispatcher.py -q`
- `./node_modules/.bin/vitest run tests/agent.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `python3 -m json.tool backend/miloco/src/miloco/config/settings.schema.json >/dev/null`
- `python3 -m py_compile backend/miloco/src/miloco/config/settings.py backend/miloco/src/miloco/perception/types.py backend/miloco/src/miloco/perception/client.py backend/miloco/src/miloco/dispatch/dispatcher.py backend/miloco/src/miloco/utils/agent_client.py`
- `git diff --check`