### PR TITLE
fix(camera): 归一化 sub_devices 避免带子设备的设备致 CameraInfo 校验崩

### DIFF
--- a/backend/miloco/src/miloco/miot/client.py
+++ b/backend/miloco/src/miloco/miot/client.py
@@ -41,7 +41,7 @@ from miloco.miot.mips_listeners import (
     DeviceMetaEventListener,
     SceneEventListener,
 )
-from miloco.miot.schema import CameraImgSeq
+from miloco.miot.schema import CameraImgSeq, normalize_sub_devices
 from miloco.miot.welcome_service import DeviceWelcomeService
 
 logger = logging.getLogger(__name__)
@@ -53,19 +53,7 @@ def build_sub_device_names(device: MIoTDeviceInfo) -> dict[str, str]:
     Strips the parent device name suffix (e.g. "三楼书房-客厅多路开关" → "三楼书房")
     so callers consistently see the user-customized portion only.
     """
-    if not device.sub_devices:
-        return {}
-    dev_name_suffix = f"-{device.name}" if device.name else ""
-    result: dict[str, str] = {}
-    for key, sub_dev in device.sub_devices.items():
-        siid = key.lstrip("s")
-        if not siid.isdigit():
-            continue
-        name = sub_dev.name
-        if dev_name_suffix and name.endswith(dev_name_suffix):
-            name = name[: -len(dev_name_suffix)]
-        result[siid] = name
-    return result
+    return normalize_sub_devices(device.sub_devices, device.name)
 
 
 class MiotProxy:

--- a/backend/miloco/src/miloco/miot/schema.py
+++ b/backend/miloco/src/miloco/miot/schema.py
@@ -11,13 +11,47 @@ from __future__ import annotations
 from typing import Any, Literal
 
 from miot.types import MIoTCameraInfo, MIoTCameraStatus
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationInfo, field_validator
 
 from miloco.utils.media import image_bytes_to_base64, image_manager
 
 
+def normalize_sub_devices(
+    raw: dict | None, parent_name: str | None
+) -> dict[str, str]:
+    """Normalize a MIoT sub-device container into {siid: user_alias}.
+
+    Accepts both value shapes:
+      - MIoTDeviceInfo objects (raw ``MIoTDeviceInfo.sub_devices``), or
+      - plain dicts (after ``model_dump()``).
+    The siid key drops its 's' prefix and must be numeric; the alias strips
+    the parent device name suffix (e.g. "三楼书房-客厅多路开关" → "三楼书房")
+    so callers consistently see the user-customized portion only.
+    """
+    if not raw:
+        return {}
+    suffix = f"-{parent_name}" if parent_name else ""
+    result: dict[str, str] = {}
+    for key, sub in raw.items():
+        siid = key.lstrip("s")
+        if not siid.isdigit():
+            continue
+        name = sub["name"] if isinstance(sub, dict) else sub.name
+        if not isinstance(name, str):
+            continue
+        if suffix and name.endswith(suffix):
+            name = name[: -len(suffix)]
+        result[siid] = name
+    return result
+
+
 class DeviceInfo(BaseModel):
     did: str = Field(..., description="Device ID")
+    # NOTE: keep ``name`` declared before ``sub_devices`` — the latter's
+    # before-validator reads ``info.data["name"]`` to strip the parent-name
+    # suffix from sub-device aliases. Pydantic only exposes already-validated
+    # fields in ``info.data``, so reordering would silently make the strip a
+    # no-op (aliases keep the redundant "-<device name>" suffix; no error).
     name: str = Field(..., description="Device name")
     online: bool = Field(False, description="Whether device is online")
     model: str | None = Field(None, description="Device model")
@@ -32,6 +66,21 @@ class DeviceInfo(BaseModel):
     sub_devices: dict[str, str] | None = Field(
         None, description="Sub-device custom names keyed by siid (e.g. {'3': '三楼书房'})"
     )
+
+    @field_validator("sub_devices", mode="before")
+    @classmethod
+    def _coerce_sub_devices(cls, v: Any, info: ValidationInfo) -> Any:
+        # None / empty → None (consistent with the `... or None` convention
+        # used by build_sub_device_names callers, e.g. service.py).
+        if not v:
+            return None
+        # Already {siid: str} (e.g. service.py pre-converts via
+        # build_sub_device_names) → pass through; don't re-strip the suffix.
+        if all(isinstance(x, str) for x in v.values()):
+            return v
+        # dict-of-dict from MIoT*.model_dump() → normalize. ``name`` is
+        # declared before ``sub_devices`` so it's already validated here.
+        return normalize_sub_devices(v, info.data.get("name")) or None
 
 
 class CameraInfo(DeviceInfo):

--- a/backend/miloco/tests/test_device_info_sub_devices.py
+++ b/backend/miloco/tests/test_device_info_sub_devices.py
@@ -1,0 +1,85 @@
+# Copyright (C) 2025 Xiaomi Corporation
+# This software may be used and distributed according to the terms of the Xiaomi Miloco License Agreement.
+
+"""Regression guard for sub_devices normalization in DeviceInfo/CameraInfo.
+
+Background: devices that carry sub-devices (e.g. 小米智能中控屏 Max,
+``xiaomi.controller.oh10p``, matched into the camera allowlist) expose
+``MIoTDeviceInfo.sub_devices`` as a ``dict[str, MIoTDeviceInfo]``. After
+``model_dump()`` that becomes a dict-of-dict, which failed to validate
+against ``DeviceInfo.sub_devices: dict[str, str]`` and raised
+ValidationError. The camera discovery loop has no per-device guard, so a
+single such device crashed the whole discover pass and silently took every
+camera offline for perception.
+
+The ``sub_devices`` before-validator normalizes the MIoT shape to
+``{siid: alias}`` so validation no longer crashes. These tests pin the
+three branches (dict-of-dict / already-converted / empty) and the
+parent-name suffix stripping.
+"""
+
+from __future__ import annotations
+
+from miloco.miot.schema import CameraInfo, DeviceInfo, normalize_sub_devices
+
+
+def test_dict_of_dict_is_normalized_and_does_not_crash():
+    """The exact shape from MIoTCameraInfo.model_dump() — the bug trigger."""
+    dumped = {
+        "did": "1108865025",
+        "name": "中控屏Max",
+        "model": "xiaomi.controller.oh10p",
+        "camera_status": "3",
+        "channel_count": 1,
+        "sub_devices": {
+            "s10": {"did": "1108865025.s10", "name": "开关1-中控屏Max", "online": None},
+            "s11": {"did": "1108865025.s11", "name": "开关2-中控屏Max"},
+            "s12": {"did": "1108865025.s12", "name": "开关3-中控屏Max"},
+        },
+    }
+    ci = CameraInfo.model_validate(dumped)
+    # siid 's' prefix dropped, parent-name suffix stripped.
+    assert ci.sub_devices == {"10": "开关1", "11": "开关2", "12": "开关3"}
+
+
+def test_already_converted_passes_through_without_restripping():
+    """service.py pre-converts via build_sub_device_names → {siid: str}."""
+    di = DeviceInfo.model_validate(
+        {"did": "x", "name": "多路开关", "sub_devices": {"3": "三楼书房"}}
+    )
+    assert di.sub_devices == {"3": "三楼书房"}
+
+
+def test_empty_and_missing_normalize_to_none():
+    assert (
+        CameraInfo.model_validate(
+            {"did": "1", "name": "客厅", "sub_devices": {}}
+        ).sub_devices
+        is None
+    )
+    assert CameraInfo.model_validate({"did": "y", "name": "z"}).sub_devices is None
+
+
+def test_non_numeric_siid_keys_are_dropped():
+    di = DeviceInfo.model_validate(
+        {
+            "did": "x",
+            "name": "网关",
+            "sub_devices": {
+                "s2": {"did": "x.s2", "name": "子设备A-网关"},
+                "sx": {"did": "x.sx", "name": "脏数据"},
+            },
+        }
+    )
+    assert di.sub_devices == {"2": "子设备A"}
+
+
+def test_normalize_accepts_object_values():
+    """normalize_sub_devices also takes raw MIoTDeviceInfo-like objects."""
+
+    class _Sub:
+        def __init__(self, name):
+            self.name = name
+
+    out = normalize_sub_devices({"s5": _Sub("书房-客厅多路开关")}, "客厅多路开关")
+    assert out == {"5": "书房"}


### PR DESCRIPTION
## 问题

接入**带子设备的设备**（如小米智能中控屏 Max `xiaomi.controller.oh10p`，被 controller allowlist 纳入相机）后，感知发现整批失败、所有相机均无法接入感知。日志反复刷：

```
[camera] Failed to discover devices: 3 validation errors for CameraInfo
sub_devices.s10/s11/s12
  Input should be a valid string [input_value={'did': '...', ...}, input_type=dict]
```

## 根因

- `MIoTDeviceInfo.sub_devices` 是 `Dict[str, MIoTDeviceInfo]`（云端把 `父did.sN` 子设备挂成嵌套对象）。
- miloco 侧 `DeviceInfo.sub_devices` 声明 `dict[str, str]`。`CameraInfo.model_validate(info.model_dump())` 时 `sub_devices` dump 成 dict-of-dict，校验成 str 抛 `ValidationError`。
- 相机发现循环 `_filter_cameras_from_all` **无 per-device try/except**，一台异常即整个 `discover_devices` 失败 → 该轮所有相机都没被发现 → 谁都没 connect → 解码帧回调没注册 → 感知全灭（不只触发设备）。
- `get_miot_device_list` 不崩是因为它先 `build_sub_device_names` 转过；相机的转换路径漏了这步。

## 改动

- `DeviceInfo` 加 `sub_devices` 的 `before`-validator：校验前把 MIoT 的 dict-of-dict 归一化成 `{siid: 别名}`；已是 `{siid: str}` 的预处理路径（service.py）放过、不二次剥后缀；空/缺失 → None。
- 抽出共享 `normalize_sub_devices`，`build_sub_device_names` 收敛复用，避免两套行为漂移。一处覆盖全部 `CameraInfo.model_validate` 调用点。
- 新增回归测试，覆盖 dict-of-dict / 已转 / 空 / 非数字 siid / 对象值五种输入。

## 验证

- 新增单测覆盖 `sub_devices` 归一化五种输入分支。
- macOS arm64 真机验证：修复前带子设备的设备接入导致整批相机 discover 失败、感知设备列表为空；修复后该设备与其它相机同时正常接入感知，无 validation error。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
