### PR TITLE
feat(mips): event-driven camera cloud online/offline state

### DIFF
--- a/backend/miloco/src/miloco/miot/client.py
+++ b/backend/miloco/src/miloco/miot/client.py
@@ -22,6 +22,7 @@ from miot.types import (
     MIoTCameraInfo,
     MIoTDeviceBindEvent,
     MIoTDeviceInfo,
+    MIoTDeviceStateEvent,
     MIoTGetPropertyParam,
     MIoTLanDeviceInfo,
     MIoTManualSceneInfo,
@@ -38,6 +39,7 @@ from miloco.miot.camera_handler import CameraVisionHandler
 from miloco.miot.filter import is_home_allowed
 from miloco.miot.mips_listeners import (
     BindEventListener,
+    CameraStateEventListener,
     DeviceMetaEventListener,
     SceneEventListener,
 )
@@ -142,12 +144,24 @@ class MiotProxy:
 
         # Listener for home-level scene changes (rename/delete/edit). Debounces
         # then refreshes the scene list.
-        self._scene_listener = SceneEventListener(
-            refresh_scenes=self.refresh_scenes
-        )
+        self._scene_listener = SceneEventListener(refresh_scenes=self.refresh_scenes)
         # Home ids whose home/{home_id}/scene/{rename,delete,edit} topics this
         # proxy intends to subscribe. Mirrors _subscribed_meta_dids but per home.
         self._subscribed_scene_home_ids: set[str] = set()
+
+        # Listener for device-level cloud online/offline state. Each event
+        # updates _camera_info_dict[did].online directly (in
+        # _on_camera_state_changed_event); this listener is the trailing
+        # reconciliation that re-fetches the authoritative cloud status once
+        # the burst settles.
+        self._camera_state_listener = CameraStateEventListener(
+            refresh_camera_online_status=self.refresh_camera_online_status
+        )
+        # Dids whose device/{did}/state/{online,offline} topics this proxy
+        # intends to subscribe. Mirrors _subscribed_meta_dids but for cloud
+        # online/offline state; drives the diff in
+        # _sync_camera_state_subscriptions.
+        self._subscribed_state_dids: set[str] = set()
 
     def _build_bind_listener(self) -> BindEventListener:
         """Build a fresh BindEventListener.
@@ -221,20 +235,26 @@ class MiotProxy:
             welcome=self._welcome_service.welcome,
         )
         self._subscribed_meta_dids = set()
-        self._scene_listener = SceneEventListener(
-            refresh_scenes=self.refresh_scenes
-        )
+        self._scene_listener = SceneEventListener(refresh_scenes=self.refresh_scenes)
         self._subscribed_scene_home_ids = set()
+        self._camera_state_listener = CameraStateEventListener(
+            refresh_camera_online_status=self.refresh_camera_online_status
+        )
+        self._subscribed_state_dids = set()
         self._miot_client.register_user_bind_callback(self._on_user_bind_event)
         # Device meta change (rename/hr_change): refresh the list so the new
         # name/room/home propagates. Kept off the bind welcome path.
         self._miot_client.register_device_meta_changed_callback(
             self._on_device_meta_changed_event
         )
-        # Home scene change (rename/delete/edit): refresh the scene list.
-        self._miot_client.register_scene_changed_callback(
-            self._on_scene_changed_event
+        # Device cloud online/offline state: update the cached `online` field
+        # directly (event-driven recovery for cameras that went stale across a
+        # backend restart), plus a trailing reconciliation.
+        self._miot_client.register_device_state_changed_callback(
+            self._on_camera_state_changed_event
         )
+        # Home scene change (rename/delete/edit): refresh the scene list.
+        self._miot_client.register_scene_changed_callback(self._on_scene_changed_event)
 
         await self._miot_client.init_async()
 
@@ -264,6 +284,7 @@ class MiotProxy:
         self._bind_listener.deinit()
         self._meta_listener.deinit()
         self._scene_listener.deinit()
+        self._camera_state_listener.deinit()
 
         # 2. Destroy all camera_img_managers
         for mgr in self._camera_img_managers.values():
@@ -295,6 +316,7 @@ class MiotProxy:
         self._scene_info_dict = {}
         self._user_info = None
         self._subscribed_meta_dids = set()
+        self._subscribed_state_dids = set()
         self._subscribed_scene_home_ids = set()
         # Welcome service survives deinit (rebuilt only in __init__), but its
         # dedup window state must reset alongside the other in-memory caches —
@@ -333,9 +355,7 @@ class MiotProxy:
                 result["errors"].append(f"{label}: {e}")
 
         if result["errors"]:
-            logger.warning(
-                "MiOT info refresh completed with errors: %s", result
-            )
+            logger.warning("MiOT info refresh completed with errors: %s", result)
         else:
             logger.info("MiOT info refresh completed: %s", result)
         return result
@@ -539,7 +559,8 @@ class MiotProxy:
             raise
 
     async def _create_camera_img_manager(
-        self, camera_info: MIoTCameraInfo,
+        self,
+        camera_info: MIoTCameraInfo,
     ) -> CameraVisionHandler | None:
         # scope 不影响 manager 的建立——watch 视频流需要 camera instance 无论 inUse 状态。
         # toggle_scope 只改 KV,不触发 refresh_cameras,所以这里只在启动/摄像头首次发现时调用,
@@ -606,9 +627,7 @@ class MiotProxy:
             await self.refresh_devices()
         return self._device_info_dict
 
-    async def _on_lan_device_changed(
-        self, did: str, info: MIoTLanDeviceInfo
-    ) -> None:
+    async def _on_lan_device_changed(self, did: str, info: MIoTLanDeviceInfo) -> None:
         # refresh_cameras deep-copies SDK state, so post-init lan_online
         # changes only reach _camera_info_dict via this hook.
         cam = self._camera_info_dict.get(did)
@@ -632,7 +651,9 @@ class MiotProxy:
                 self._camera_info_dict = cameras
                 for camera_did in cameras.keys():
                     if camera_did not in self._camera_img_managers:
-                        if not is_home_allowed(self._kv_repo, cameras[camera_did].home_id):
+                        if not is_home_allowed(
+                            self._kv_repo, cameras[camera_did].home_id
+                        ):
                             continue
                         manager = await self._create_camera_img_manager(
                             cameras[camera_did]
@@ -659,7 +680,10 @@ class MiotProxy:
                         del self._camera_img_managers[camera_did]
                     else:
                         # cam 仍在账号里,manager 保活(无论 scope 状态)。
-                        logger.debug("Manager %s kept alive for watch stream", camera_did)
+                        logger.debug(
+                            "Manager %s kept alive for watch stream", camera_did
+                        )
+                await self._sync_camera_state_subscriptions()
                 return cameras
 
             except Exception as e:
@@ -700,9 +724,7 @@ class MiotProxy:
                 return None
 
     @staticmethod
-    def _log_device_diff(
-        action: str, dev: MIoTDeviceInfo | None, did: str
-    ) -> None:
+    def _log_device_diff(action: str, dev: MIoTDeviceInfo | None, did: str) -> None:
         """Pretty-print one ADDED/REMOVED device line with all relevant
         identity fields (name, home, room, model, online, sub-devices, etc.)
         so the operator can tell *which* physical device was bound/unbound
@@ -759,6 +781,27 @@ class MiotProxy:
         welcome = msg.event == "hr_change" and self._is_move_into_scope(msg)
         await self._meta_listener.on_event(msg, welcome=welcome)
 
+    async def _on_camera_state_changed_event(self, msg: MIoTDeviceStateEvent) -> None:
+        """Handle a device cloud online/offline state push.
+
+        Updates the cached ``online`` field of the matching camera directly
+        from the event (online→True / offline→False), mirroring how
+        ``_on_lan_device_changed`` updates ``lan_online``. No cloud re-fetch
+        here — the authoritative reconciliation is deferred to the trailing
+        debounce (refresh_camera_online_status once the burst settles). Non-
+        camera devices are ignored (their state events carry no camera info).
+        """
+        cam = self._camera_info_dict.get(msg.did)
+        if cam is not None:
+            cam.online = msg.event == "online"
+            logger.info(
+                "camera cloud state updated: did=%s online=%s (event=%s)",
+                msg.did,
+                cam.online,
+                msg.event,
+            )
+        await self._camera_state_listener.on_event(msg)
+
     def _is_move_into_scope(self, msg: MIoTDeviceBindEvent) -> bool:
         """True if an hr_change moved a device into a managed home from an
         unmanaged one.
@@ -805,7 +848,9 @@ class MiotProxy:
         target = {did for did in self._device_info_dict if "/" not in did}
         skipped = [did for did in self._device_info_dict if "/" in did]
         if skipped:
-            logger.debug("device-meta: skipping %d did(s) with '/': %s", len(skipped), skipped)
+            logger.debug(
+                "device-meta: skipping %d did(s) with '/': %s", len(skipped), skipped
+            )
         to_add = target - self._subscribed_meta_dids
         to_remove = self._subscribed_meta_dids - target
         if not to_add and not to_remove:
@@ -835,6 +880,60 @@ class MiotProxy:
             len([d for d in added if d]),
             len([d for d in removed if d]),
             len(self._subscribed_meta_dids),
+        )
+
+    async def _sync_camera_state_subscriptions(self) -> None:
+        """Reconcile per-device cloud state (online/offline) subs to the
+        camera list.
+
+        Called at the tail of refresh_cameras (under _refresh_cameras_lock, so
+        the diff against _subscribed_state_dids is race-free). New dids are
+        subscribed, removed dids unsubscribed; both run concurrently and
+        per-did failures only log — they never abort the refresh. Mirrors
+        _sync_meta_subscriptions but scoped to cameras (we only care about
+        camera cloud online state).
+
+        Dids containing '/' (Huami/Zepp-bridged sub-devices) are skipped:
+        the '/' breaks the topic path AND the decoder regex, and the broker
+        rejects them with 0x87 — same rationale as _sync_meta_subscriptions.
+        """
+        target = {did for did in self._camera_info_dict if "/" not in did}
+        skipped = [did for did in self._camera_info_dict if "/" in did]
+        if skipped:
+            logger.debug(
+                "camera-state: skipping %d did(s) with '/': %s",
+                len(skipped),
+                skipped,
+            )
+        to_add = target - self._subscribed_state_dids
+        to_remove = self._subscribed_state_dids - target
+        if not to_add and not to_remove:
+            return
+
+        async def _sub(did: str) -> str | None:
+            try:
+                await self._miot_client.sub_device_state_async(did)
+                return did
+            except Exception as e:
+                logger.error("subscribe device-state failed did=%s: %s", did, e)
+                return None
+
+        async def _unsub(did: str) -> str | None:
+            try:
+                await self._miot_client.unsub_device_state_async(did)
+            except Exception as e:
+                logger.error("unsubscribe device-state failed did=%s: %s", did, e)
+            return did
+
+        added = await asyncio.gather(*(_sub(d) for d in to_add))
+        removed = await asyncio.gather(*(_unsub(d) for d in to_remove))
+        self._subscribed_state_dids |= {d for d in added if d}
+        self._subscribed_state_dids -= {d for d in removed if d}
+        logger.info(
+            "camera-state subscriptions synced: +%d -%d (total=%d)",
+            len([d for d in added if d]),
+            len([d for d in removed if d]),
+            len(self._subscribed_state_dids),
         )
 
     async def _on_scene_changed_event(self, msg: MIoTSceneChangedEvent) -> None:
@@ -886,8 +985,7 @@ class MiotProxy:
         unsubscribed on the next sync.
         """
         target = {
-            h for h in self._collect_home_ids()
-            if is_home_allowed(self._kv_repo, h)
+            h for h in self._collect_home_ids() if is_home_allowed(self._kv_repo, h)
         }
         to_add = target - self._subscribed_scene_home_ids
         to_remove = self._subscribed_scene_home_ids - target
@@ -1014,9 +1112,7 @@ class MiotProxy:
             oauth_info = await self._miot_client.get_access_token_async(
                 code=code, state=state
             )
-            logger.info(
-                "Retrieved MIoT auth info, code: %s, state: %s", code, state
-            )
+            logger.info("Retrieved MIoT auth info, code: %s, state: %s", code, state)
             self.reset_miot_token_info(oauth_info)
             await self.refresh_miot_info()
             return oauth_info
@@ -1294,4 +1390,6 @@ class MiotProxy:
             if result:
                 logger.info("Token refresh completed successfully")
             else:
-                logger.error("Token refresh failed, re-login required: miloco-cli account bind")
+                logger.error(
+                    "Token refresh failed, re-login required: miloco-cli account bind"
+                )

--- a/backend/miloco/src/miloco/miot/mips_listeners.py
+++ b/backend/miloco/src/miloco/miot/mips_listeners.py
@@ -29,7 +29,12 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
 
-from miot.types import MIoTDeviceBindEvent, MIoTDeviceInfo, MIoTSceneChangedEvent
+from miot.types import (
+    MIoTDeviceBindEvent,
+    MIoTDeviceInfo,
+    MIoTDeviceStateEvent,
+    MIoTSceneChangedEvent,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +44,13 @@ logger = logging.getLogger(__name__)
 BIND_DEBOUNCE_SEC: float = 5.0
 META_DEBOUNCE_SEC: float = 5.0
 SCENE_DEBOUNCE_SEC: float = 5.0
+# Cloud online/offline state events settle quickly under normal flapping, but
+# the trailing full reconciliation (refresh_camera_online_status) is what makes
+# the event-driven path trustworthy: each event updates the cached `online`
+# field directly, and once the burst settles we re-fetch the authoritative
+# cloud state once. 60s matches the maintainer's spec (re-set on every event
+# via _schedule).
+CAMERA_STATE_DEBOUNCE_SEC: float = 60.0
 
 # Single key used by the global (non-per-did) debouncers (meta / scene).
 _GLOBAL_KEY = "_global"
@@ -49,6 +61,9 @@ RefreshDevices = Callable[[], Awaitable[Any]]
 RefreshCameras = Callable[[], Awaitable[Any]]
 RefreshScenes = Callable[[], Awaitable[Any]]
 RefreshScenesOnly = Callable[[], Awaitable[Any]]
+# Lightweight cloud-status re-fetch (refresh_camera_online_status): updates
+# _camera_info_dict metadata only, does NOT touch stream connections.
+RefreshCameraOnlineStatus = Callable[[], Awaitable[Any]]
 GetDevice = Callable[[str], MIoTDeviceInfo | None]
 # Greets a device by did (owned by DeviceWelcomeService); returns whether a
 # welcome was sent.
@@ -170,7 +185,11 @@ class BindEventListener(_TrailingDebounce):
         logger.info(
             "mips user-bind event received: uid=%s event=%s did=%s raw=%r; "
             "scheduling %ss debounce",
-            msg.uid, msg.event, msg.did, msg.raw, BIND_DEBOUNCE_SEC,
+            msg.uid,
+            msg.event,
+            msg.did,
+            msg.raw,
+            BIND_DEBOUNCE_SEC,
         )
         self._schedule(msg.did)
 
@@ -181,7 +200,8 @@ class BindEventListener(_TrailingDebounce):
         except Exception as e:
             logger.error(
                 "bind debounce settled but refresh_devices failed: did=%s err=%s",
-                did, e,
+                did,
+                e,
             )
             return
         if self._closed:
@@ -193,7 +213,9 @@ class BindEventListener(_TrailingDebounce):
         )
         logger.info(
             "bind debounce settled: did=%s cameras_ok=%s scenes_ok=%s",
-            did, status.get("cameras", "N/A"), status.get("scenes", "N/A"),
+            did,
+            status.get("cameras", "N/A"),
+            status.get("scenes", "N/A"),
         )
 
         if self._get_device(did) is None:
@@ -243,7 +265,11 @@ class DeviceMetaEventListener(_TrailingDebounce):
         logger.info(
             "mips device-meta event received: uid=%s event=%s did=%s raw=%r; "
             "scheduling %ss debounce",
-            msg.uid, msg.event, msg.did, msg.raw, META_DEBOUNCE_SEC,
+            msg.uid,
+            msg.event,
+            msg.did,
+            msg.raw,
+            META_DEBOUNCE_SEC,
         )
         self._schedule(_GLOBAL_KEY)
 
@@ -275,7 +301,8 @@ class DeviceMetaEventListener(_TrailingDebounce):
         )
         logger.info(
             "meta debounce settled: devices refreshed cameras_ok=%s scenes_ok=%s",
-            status.get("cameras", "N/A"), status.get("scenes", "N/A"),
+            status.get("cameras", "N/A"),
+            status.get("scenes", "N/A"),
         )
 
         # Greet devices that moved INTO a managed home — the refresh above now
@@ -312,7 +339,11 @@ class SceneEventListener(_TrailingDebounce):
         logger.info(
             "mips scene event received: home=%s event=%s scene_id=%s raw=%r; "
             "scheduling %ss debounce",
-            msg.home_id, msg.event, msg.scene_id, msg.raw, SCENE_DEBOUNCE_SEC,
+            msg.home_id,
+            msg.event,
+            msg.scene_id,
+            msg.raw,
+            SCENE_DEBOUNCE_SEC,
         )
         self._schedule(_GLOBAL_KEY)
 
@@ -323,3 +354,55 @@ class SceneEventListener(_TrailingDebounce):
             logger.error("scene debounce settled but refresh_scenes failed: %s", e)
             return
         logger.info("scene debounce settled: scene list refreshed")
+
+
+class CameraStateEventListener(_TrailingDebounce):
+    """Global debounce for `device/{did}/state/{online,offline}`.
+
+    Each state event already updated the cached `online` field directly (in
+    MiotProxy._on_camera_state_changed_event) — this listener is the trailing
+    reconciliation: once the burst settles it re-fetches the authoritative
+    cloud camera status once, so a missed or stale event can't strand a
+    camera. refresh_camera_online_status is lightweight (metadata only, no
+    stream disturbance). Any state event (any did) re-arms the single global
+    timer.
+    """
+
+    def __init__(
+        self,
+        refresh_camera_online_status: RefreshCameraOnlineStatus,
+        loop: asyncio.AbstractEventLoop | None = None,
+    ) -> None:
+        super().__init__(loop)
+        self._refresh = refresh_camera_online_status
+
+    def _window(self) -> float:
+        return CAMERA_STATE_DEBOUNCE_SEC
+
+    async def on_event(self, msg: MIoTDeviceStateEvent) -> None:
+        if self._closed:
+            logger.debug(
+                "camera-state event ignored: listener closed (did=%s)", msg.did
+            )
+            return
+        logger.info(
+            "mips device-state event received: did=%s event=%s raw=%r; "
+            "scheduling %ss reconciliation",
+            msg.did,
+            msg.event,
+            msg.raw,
+            CAMERA_STATE_DEBOUNCE_SEC,
+        )
+        self._schedule(_GLOBAL_KEY)
+
+    async def _fire(self, key: Any) -> None:
+        try:
+            await self._refresh()
+        except Exception as e:
+            logger.error(
+                "camera-state debounce settled but "
+                "refresh_camera_online_status failed: %s",
+                e,
+            )
+            return
+        logger.info("camera-state debounce settled: cloud online status reconciled")

--- a/backend/miloco/tests/test_camera_state_subscriptions.py
+++ b/backend/miloco/tests/test_camera_state_subscriptions.py
@@ -1,0 +1,150 @@
+# Copyright (C) 2025 Xiaomi Corporation
+# This software may be used and distributed according to the terms of the Xiaomi Miloco License Agreement.
+
+"""Tests for MiotProxy cloud online/offline state handling.
+
+Behavior under test:
+
+* _sync_camera_state_subscriptions reconciles the per-camera cloud state
+  (online/offline) subscription set to the camera list: new dids subscribed,
+  removed dids unsubscribed, tracked set updated.
+* A no-op sync issues no sub/unsub calls.
+* A subscribe failure does not record the did as subscribed (so a later
+  refresh retries it).
+* _on_camera_state_changed_event updates _camera_info_dict[did].online
+  directly from the event (online→True / offline→False) and forwards to the
+  trailing-reconciliation listener. Non-camera devices are ignored.
+
+A bare MiotProxy is built via __new__ with only the attributes these methods
+touch, so no MIoTClient / camera / OAuth stack is required.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from miloco.miot.client import MiotProxy
+from miot.types import MIoTDeviceStateEvent
+
+
+def _bare_proxy() -> MiotProxy:
+    proxy = MiotProxy.__new__(MiotProxy)
+    proxy._subscribed_state_dids = set()
+    proxy._camera_info_dict = {}
+    proxy._miot_client = AsyncMock()
+    proxy._camera_state_listener = SimpleNamespace(on_event=AsyncMock())
+    return proxy
+
+
+def _cam(did: str, online: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(did=did, online=online)
+
+
+def _state_evt(did: str, event: str = "online") -> MIoTDeviceStateEvent:
+    return MIoTDeviceStateEvent(
+        did=did, event=event, raw={"device_id": did, "event": event}
+    )
+
+
+# ----------------------------------------------------- _sync_camera_state_subscriptions
+
+
+@pytest.mark.asyncio
+async def test_sync_subscribes_new_and_unsubscribes_removed():
+    proxy = _bare_proxy()
+    # Already subscribed to A and B; camera list now has B and C.
+    proxy._subscribed_state_dids = {"A", "B"}
+    proxy._camera_info_dict = {"B": _cam("B"), "C": _cam("C")}
+
+    await proxy._sync_camera_state_subscriptions()
+
+    proxy._miot_client.sub_device_state_async.assert_awaited_once_with("C")
+    proxy._miot_client.unsub_device_state_async.assert_awaited_once_with("A")
+    assert proxy._subscribed_state_dids == {"B", "C"}
+
+
+@pytest.mark.asyncio
+async def test_sync_skips_dids_containing_slash():
+    """Bridged sub-device dids with '/' are never subscribed — the '/' breaks
+    the topic and the broker rejects them (same rationale as meta subs)."""
+    proxy = _bare_proxy()
+    proxy._camera_info_dict = {
+        "938000855": _cam("938000855"),
+        "huami.32098/12264203": _cam("huami.32098/12264203"),
+    }
+
+    await proxy._sync_camera_state_subscriptions()
+
+    proxy._miot_client.sub_device_state_async.assert_awaited_once_with("938000855")
+    assert proxy._subscribed_state_dids == {"938000855"}
+
+
+@pytest.mark.asyncio
+async def test_sync_noop_when_already_in_sync():
+    proxy = _bare_proxy()
+    proxy._subscribed_state_dids = {"A", "B"}
+    proxy._camera_info_dict = {"A": _cam("A"), "B": _cam("B")}
+
+    await proxy._sync_camera_state_subscriptions()
+
+    proxy._miot_client.sub_device_state_async.assert_not_awaited()
+    proxy._miot_client.unsub_device_state_async.assert_not_awaited()
+    assert proxy._subscribed_state_dids == {"A", "B"}
+
+
+@pytest.mark.asyncio
+async def test_sync_subscribe_failure_keeps_did_untracked():
+    proxy = _bare_proxy()
+    proxy._camera_info_dict = {"C": _cam("C")}
+    proxy._miot_client.sub_device_state_async = AsyncMock(
+        side_effect=RuntimeError("ACL rejected")
+    )
+
+    # Must not raise — failure only logs.
+    await proxy._sync_camera_state_subscriptions()
+
+    # Failed subscribe must not be recorded as subscribed.
+    assert proxy._subscribed_state_dids == set()
+
+
+# ----------------------------------------- _on_camera_state_changed_event
+
+
+@pytest.mark.asyncio
+async def test_online_event_sets_camera_online_true():
+    proxy = _bare_proxy()
+    proxy._camera_info_dict = {"cam-1": _cam("cam-1", online=False)}
+
+    await proxy._on_camera_state_changed_event(_state_evt("cam-1", "online"))
+
+    assert proxy._camera_info_dict["cam-1"].online is True
+    proxy._camera_state_listener.on_event.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_offline_event_sets_camera_online_false():
+    proxy = _bare_proxy()
+    proxy._camera_info_dict = {"cam-1": _cam("cam-1", online=True)}
+
+    await proxy._on_camera_state_changed_event(_state_evt("cam-1", "offline"))
+
+    assert proxy._camera_info_dict["cam-1"].online is False
+    proxy._camera_state_listener.on_event.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_state_event_for_unknown_did_is_ignored():
+    """A state event for a device that is not a camera (or not yet cached)
+    must not raise and must still forward to the reconciliation listener —
+    the burst itself may warrant a reconciliation even if this did is a no-op
+    for the camera cache."""
+    proxy = _bare_proxy()
+    proxy._camera_info_dict = {"cam-1": _cam("cam-1", online=False)}
+
+    await proxy._on_camera_state_changed_event(_state_evt("non-camera", "online"))
+
+    # cam-1 untouched.
+    assert proxy._camera_info_dict["cam-1"].online is False
+    proxy._camera_state_listener.on_event.assert_awaited_once()

--- a/backend/miloco/tests/test_mips_listeners.py
+++ b/backend/miloco/tests/test_mips_listeners.py
@@ -27,15 +27,22 @@ import pytest
 from miloco.miot import mips_listeners as ml
 from miloco.miot.mips_listeners import (
     BindEventListener,
+    CameraStateEventListener,
     DeviceMetaEventListener,
     SceneEventListener,
 )
-from miot.types import MIoTDeviceBindEvent, MIoTSceneChangedEvent
+from miot.types import (
+    MIoTDeviceBindEvent,
+    MIoTDeviceStateEvent,
+    MIoTSceneChangedEvent,
+)
 
 
 def _device(did: str, name: str = "测试设备", room: str = "卧室", home: str = "测试家"):
     """Stub that quacks like MIoTDeviceInfo for the listener."""
-    return SimpleNamespace(did=did, name=name, home_id="H1", home_name=home, room_name=room)
+    return SimpleNamespace(
+        did=did, name=name, home_id="H1", home_name=home, room_name=room
+    )
 
 
 async def _wait_did(listener, did: str, *, timeout: float = 1.0):
@@ -96,7 +103,9 @@ def bind_env(monkeypatch):
 
 
 def _bind_evt(did: str, event: str = "bind") -> MIoTDeviceBindEvent:
-    return MIoTDeviceBindEvent(uid="42", event=event, did=did, raw={"uid": "42", "did": did})
+    return MIoTDeviceBindEvent(
+        uid="42", event=event, did=did, raw={"uid": "42", "did": did}
+    )
 
 
 @pytest.mark.asyncio
@@ -215,7 +224,9 @@ async def test_bind_on_event_after_deinit_is_ignored(bind_env):
 @pytest.mark.asyncio
 async def test_bind_event_with_empty_did_is_ignored(bind_env):
     env = bind_env
-    await env.listener.on_event(MIoTDeviceBindEvent(uid="42", event="bind", did=None, raw={}))
+    await env.listener.on_event(
+        MIoTDeviceBindEvent(uid="42", event="bind", did=None, raw={})
+    )
     assert env.listener._timers == {}
     await asyncio.sleep(0.1)
     assert env.refresh_calls == 0
@@ -229,9 +240,7 @@ async def test_bind_event_with_empty_did_is_ignored(bind_env):
 def meta_env(monkeypatch):
     """DeviceMetaEventListener with devices/cameras/scenes/welcome stubbed."""
     monkeypatch.setattr(ml, "META_DEBOUNCE_SEC", 0.05)
-    state = SimpleNamespace(
-        refresh_calls=0, camera_calls=0, scene_calls=0, welcomed=[]
-    )
+    state = SimpleNamespace(refresh_calls=0, camera_calls=0, scene_calls=0, welcomed=[])
 
     async def fake_refresh():
         state.refresh_calls += 1
@@ -259,7 +268,9 @@ def meta_env(monkeypatch):
 
 
 def _meta_evt(did: str, event: str = "rename") -> MIoTDeviceBindEvent:
-    return MIoTDeviceBindEvent(uid="42", event=event, did=did, raw={"uid": "42", "did": did})
+    return MIoTDeviceBindEvent(
+        uid="42", event=event, did=did, raw={"uid": "42", "did": did}
+    )
 
 
 @pytest.mark.parametrize("event", ["rename", "hr_change"])
@@ -374,7 +385,9 @@ def scene_env(monkeypatch):
 
 
 def _scene_evt(home_id: str, event: str = "edit", scene_id: str = "sc-1"):
-    return MIoTSceneChangedEvent(home_id=home_id, event=event, scene_id=scene_id, raw={})
+    return MIoTSceneChangedEvent(
+        home_id=home_id, event=event, scene_id=scene_id, raw={}
+    )
 
 
 @pytest.mark.parametrize("event", ["rename", "delete", "edit"])
@@ -409,5 +422,89 @@ async def test_scene_deinit_cancels_pending_refresh(scene_env):
     assert env.refresh_calls == 0
     # A post-deinit event is ignored (listener fenced).
     await env.listener.on_event(_scene_evt("home-2", event="delete"))
+    await asyncio.sleep(0.1)
+    assert env.refresh_calls == 0
+
+
+# ================================================ Camera state (global debounce)
+
+
+@pytest.fixture
+def camera_state_env(monkeypatch):
+    """CameraStateEventListener with refresh_camera_online_status stubbed and
+    a tight window. Each event already updated the cached `online` field in
+    MiotProxy; this listener only does the trailing reconciliation."""
+    monkeypatch.setattr(ml, "CAMERA_STATE_DEBOUNCE_SEC", 0.05)
+    state = SimpleNamespace(refresh_calls=0)
+
+    async def fake_refresh():
+        state.refresh_calls += 1
+
+    state.listener = CameraStateEventListener(refresh_camera_online_status=fake_refresh)
+    return state
+
+
+def _state_evt(did: str, event: str = "online") -> MIoTDeviceStateEvent:
+    return MIoTDeviceStateEvent(
+        did=did, event=event, raw={"device_id": did, "event": event}
+    )
+
+
+@pytest.mark.parametrize("event", ["online", "offline"])
+@pytest.mark.asyncio
+async def test_camera_state_single_refreshes_after_debounce(camera_state_env, event):
+    env = camera_state_env
+    await env.listener.on_event(_state_evt("cam-1", event=event))
+    assert env.refresh_calls == 0  # before the window settles
+
+    await _wait_global(env.listener)
+    assert env.refresh_calls == 1  # trailing reconciliation fired
+
+
+@pytest.mark.asyncio
+async def test_camera_state_burst_collapses_to_single_refresh(camera_state_env):
+    """A flapping camera (online→offline→online) within the window triggers
+    only one reconciliation, re-armed on each event."""
+    env = camera_state_env
+    await env.listener.on_event(_state_evt("cam-1", event="online"))
+    await env.listener.on_event(_state_evt("cam-1", event="offline"))
+    await env.listener.on_event(_state_evt("cam-1", event="online"))
+
+    await _wait_global(env.listener)
+    assert env.refresh_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_camera_state_multi_did_collapses_globally(camera_state_env):
+    """State events from different dids share the single global timer — one
+    reconciliation covers the whole burst."""
+    env = camera_state_env
+    await env.listener.on_event(_state_evt("cam-1", event="online"))
+    await env.listener.on_event(_state_evt("cam-2", event="offline"))
+
+    await _wait_global(env.listener)
+    assert env.refresh_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_camera_state_deinit_cancels_pending_refresh(camera_state_env):
+    env = camera_state_env
+    await env.listener.on_event(_state_evt("cam-1"))
+    env.listener.deinit()
+
+    await asyncio.sleep(0.1)
+    assert env.refresh_calls == 0
+    # A post-deinit event is ignored (listener fenced).
+    await env.listener.on_event(_state_evt("cam-2", event="offline"))
+    await asyncio.sleep(0.1)
+    assert env.refresh_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_camera_state_event_after_deinit_is_ignored(camera_state_env):
+    env = camera_state_env
+    env.listener.deinit()
+    await env.listener.on_event(_state_evt("cam-1"))
+    assert env.listener._timers == {}
     await asyncio.sleep(0.1)
     assert env.refresh_calls == 0

--- a/backend/miot/src/miot/client.py
+++ b/backend/miot/src/miot/client.py
@@ -37,6 +37,7 @@ from .types import (
     MIoTCameraStatus,
     MIoTDeviceBindEvent,
     MIoTDeviceInfo,
+    MIoTDeviceStateEvent,
     MIoTHomeInfo,
     MIoTLanDeviceInfo,
     MIoTManualSceneInfo,
@@ -94,11 +95,20 @@ class MIoTClient:
     # path — the did is still present after refresh and would be misreported
     # as a new device.
     _callback_device_meta_changed: Optional[Callable[[MIoTDeviceBindEvent], Any]]
+    # Device-level cloud state-change handler (online / offline). Separate
+    # from _callback_device_meta_changed: a state push updates the cached
+    # `online` field directly (event-driven recovery), not the meta refresh
+    # path.
+    _callback_device_state_changed: Optional[Callable[[MIoTDeviceStateEvent], Any]]
     # Dids whose `device/{did}/g_op/#` meta topic is (intended to be)
     # subscribed. This client owns the per-device meta subs: it re-issues them
     # on _setup_mips_async (re-OAuth / fresh setup); plain reconnects are
     # handled by mips_cloud's own _subs replay.
     _meta_sub_dids: set
+    # Dids whose `device/{did}/state/#` cloud online/offline topic is
+    # (intended to be) subscribed. Same ownership/replay model as
+    # _meta_sub_dids.
+    _state_sub_dids: set
     # Home ids whose `home/{home_id}/scene/#` topic is (intended to be)
     # subscribed. Same ownership model as _meta_sub_dids, but per home.
     _scene_sub_home_ids: set
@@ -160,7 +170,9 @@ class MIoTClient:
         self._mips_user_sub_error = None
         self._callback_user_bind = None
         self._callback_device_meta_changed = None
+        self._callback_device_state_changed = None
         self._meta_sub_dids = set()
+        self._state_sub_dids = set()
         self._scene_sub_home_ids = set()
         self._callback_scene_changed = None
         self._callback_mips_connect: Optional[Callable[[], Any]] = None
@@ -258,7 +270,9 @@ class MIoTClient:
                 )
                 self._http_client = MIoTHttpClient(
                     cloud_server=self._cloud_server,
-                    access_token=self._oauth_info.access_token if self._oauth_info else "",
+                    access_token=self._oauth_info.access_token
+                    if self._oauth_info
+                    else "",
                     loop=self._main_loop,
                 )
                 self._network_client = MIoTNetwork(loop=self._main_loop)
@@ -274,7 +288,9 @@ class MIoTClient:
                 )
                 self._camera_client = MIoTCamera(
                     cloud_server=self._cloud_server,
-                    access_token=self._oauth_info.access_token if self._oauth_info else "",
+                    access_token=self._oauth_info.access_token
+                    if self._oauth_info
+                    else "",
                     loop=self._main_loop,
                 )
                 await self._camera_client.init_async()
@@ -349,7 +365,9 @@ class MIoTClient:
             )
             await _safe(
                 "oauth_client",
-                lambda: self._oauth_client.deinit_async() if self._oauth_client else None,
+                lambda: (
+                    self._oauth_client.deinit_async() if self._oauth_client else None
+                ),
             )
             await _safe(
                 "http_client",
@@ -357,13 +375,17 @@ class MIoTClient:
             )
             await _safe(
                 "camera_client",
-                lambda: self._camera_client.deinit_async() if self._camera_client else None,
+                lambda: (
+                    self._camera_client.deinit_async() if self._camera_client else None
+                ),
             )
             await _safe(
                 "lan_unregister",
-                lambda: self._lan_client.unregister_status_changed_async("miot_client")
-                if self._lan_client
-                else None,
+                lambda: (
+                    self._lan_client.unregister_status_changed_async("miot_client")
+                    if self._lan_client
+                    else None
+                ),
             )
             await _safe(
                 "lan_client",
@@ -371,7 +393,11 @@ class MIoTClient:
             )
             await _safe(
                 "network_client",
-                lambda: self._network_client.deinit_async() if self._network_client else None,
+                lambda: (
+                    self._network_client.deinit_async()
+                    if self._network_client
+                    else None
+                ),
             )
             await _safe(
                 "spec_parser",
@@ -400,7 +426,9 @@ class MIoTClient:
             self._mips_user_sub_error = None
             self._callback_user_bind = None
             self._callback_device_meta_changed = None
+            self._callback_device_state_changed = None
             self._meta_sub_dids = set()
+            self._state_sub_dids = set()
             self._scene_sub_home_ids = set()
             self._callback_scene_changed = None
             self._callback_mips_connect = None
@@ -879,6 +907,27 @@ class MIoTClient:
                 len(home_ids),
             )
 
+        # Same replay for per-device cloud state (online/offline) subs.
+        if self._state_sub_dids:
+            dids = sorted(self._state_sub_dids)
+            self._state_sub_dids = set()
+            ok = 0
+            for did in dids:
+                try:
+                    await self.sub_device_state_async(did)
+                    ok += 1
+                except Exception as e:
+                    _LOGGER.error(
+                        "mips_cloud re-subscribe device-state FAILED did=%s: %s",
+                        did,
+                        e,
+                    )
+            _LOGGER.info(
+                "mips_cloud re-subscribed device-state for %d/%d devices",
+                ok,
+                len(dids),
+            )
+
     def register_user_bind_callback(
         self, callback: Optional[Callable[[MIoTDeviceBindEvent], Any]]
     ) -> None:
@@ -938,9 +987,7 @@ class MIoTClient:
         if mips is None or not mips.is_connected:
             self._meta_sub_dids.add(did)
             return
-        await mips.sub_device_meta_changed_async(
-            did, self._on_device_meta_changed_msg
-        )
+        await mips.sub_device_meta_changed_async(did, self._on_device_meta_changed_msg)
         self._meta_sub_dids.add(did)
 
     async def unsub_device_meta_async(self, did: str) -> None:
@@ -950,6 +997,53 @@ class MIoTClient:
         if mips is None:
             return
         await mips.unsub_device_meta_changed_async(did)
+
+    def register_device_state_changed_callback(
+        self, callback: Optional[Callable[[MIoTDeviceStateEvent], Any]]
+    ) -> None:
+        """Register the single device cloud state-change handler.
+
+        Fires for every subscribed device's online / offline events
+        (event.event distinguishes them). Pass None to clear. The handler
+        updates the cached cloud ``online`` field directly from the event —
+        this is the event-driven recovery path for cameras that went stale
+        across a backend restart (no device-list re-fetch).
+        """
+        self._callback_device_state_changed = callback
+
+    def _on_device_state_msg(self, msg: MIoTDeviceStateEvent) -> None:
+        cb = self._callback_device_state_changed
+        if cb is None:
+            return
+        ret = cb(msg)
+        if asyncio.iscoroutine(ret):
+            asyncio.ensure_future(ret)
+
+    async def sub_device_state_async(self, did: str) -> None:
+        """Subscribe one device's `device/{did}/state/{online,offline}` cloud
+        state topics (idempotent).
+
+        Same ownership/replay contract as sub_device_meta_async: failed
+        SUBACK propagates WITHOUT recording the did (so the proxy diff
+        retries it); if mips is not connected yet only the intent is
+        recorded and the actual subscribe happens at the next setup.
+        """
+        if did in self._state_sub_dids:
+            return
+        mips = self._mips_cloud
+        if mips is None or not mips.is_connected:
+            self._state_sub_dids.add(did)
+            return
+        await mips.sub_device_state_async(did, self._on_device_state_msg)
+        self._state_sub_dids.add(did)
+
+    async def unsub_device_state_async(self, did: str) -> None:
+        """Unsubscribe one device's cloud state topic."""
+        self._state_sub_dids.discard(did)
+        mips = self._mips_cloud
+        if mips is None:
+            return
+        await mips.unsub_device_state_async(did)
 
     def register_scene_changed_callback(
         self, callback: Optional[Callable[[MIoTSceneChangedEvent], Any]]
@@ -1038,9 +1132,7 @@ class MIoTClient:
                 f"topic={topic} {reason}(0x{code:02x}) (after reconnect)"
             )
         else:
-            self._mips_user_sub_error = (
-                f"topic={topic} {reason} (after reconnect)"
-            )
+            self._mips_user_sub_error = f"topic={topic} {reason} (after reconnect)"
         _LOGGER.error(
             "mips_cloud subscribe (after reconnect) REJECTED: %s. "
             "Real-time device-bind detection disabled until next setup.",

--- a/backend/miot/src/miot/mips_cloud.py
+++ b/backend/miot/src/miot/mips_cloud.py
@@ -17,6 +17,7 @@ Connection params:
   password   = OAuth2 access_token  (rotated via update_access_token_async)
   keepalive  = 60s
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -46,6 +47,7 @@ from .const import (
 )
 from .types import (
     MIoTDeviceBindEvent,
+    MIoTDeviceStateEvent,
     MIoTSceneChangedEvent,
     MipsConnectionError,
     MipsSubscribeRejectedError,
@@ -65,13 +67,15 @@ _SUBACK_SUCCESS_CODES = frozenset({0x00, 0x01, 0x02})
 
 # SUBACK rejections that retry can't fix; other failures (incl. timeout) are
 # kept in _subs so the next reconnect retries automatically.
-_PERMANENT_SUBACK_FAILURES = frozenset({
-    0x87,  # Not authorized (ACL)
-    0x8F,  # Topic filter invalid
-    0x9E,  # Shared subscriptions not supported
-    0xA1,  # Subscription identifiers not supported
-    0xA2,  # Wildcard subscriptions not supported
-})
+_PERMANENT_SUBACK_FAILURES = frozenset(
+    {
+        0x87,  # Not authorized (ACL)
+        0x8F,  # Topic filter invalid
+        0x9E,  # Shared subscriptions not supported
+        0xA1,  # Subscription identifiers not supported
+        0xA2,  # Wildcard subscriptions not supported
+    }
+)
 
 # Account-level g_op bind/unbind: `user/{uid}/g_op/{bind,unbind}`.
 _TOPIC_USER_OP = re.compile(r"^user/([^/]+)/g_op/(bind|unbind)$")
@@ -95,14 +99,23 @@ _TOPIC_HOME_SCENE = re.compile(
     r"^home/([^/]+)/scene/(" + "|".join(_HOME_SCENE_OPS) + r")$"
 )
 
+# Device-level cloud online/offline state: `device/{did}/state/{online,
+# offline}`. did = group(1), event = group(2). Subscribed as EXACT leaf
+# topics (one per op) — the broker ACL rejects the `device/{did}/state/#`
+# wildcard with 0x87 Not authorized, same as the g_op/# case above. The
+# Literal in MIoTDeviceStateEvent.event must stay in sync with these ops.
+_DEVICE_STATE_OPS = ("online", "offline")
+_TOPIC_DEVICE_STATE = re.compile(
+    r"^device/([^/]+)/state/(" + "|".join(_DEVICE_STATE_OPS) + r")$"
+)
+
 
 # Handler signatures accepted by sub_*_async methods. They receive a fully
 # decoded message object and may be sync or async — both are dispatched on the
 # main asyncio loop.
 BindHandler = Callable[[MIoTDeviceBindEvent], Union[None, Awaitable[None]]]
-SceneChangedHandler = Callable[
-    [MIoTSceneChangedEvent], Union[None, Awaitable[None]]
-]
+SceneChangedHandler = Callable[[MIoTSceneChangedEvent], Union[None, Awaitable[None]]]
+DeviceStateHandler = Callable[[MIoTDeviceStateEvent], Union[None, Awaitable[None]]]
 MipsStateHandler = Callable[[bool], Union[None, Awaitable[None]]]
 # Fired when an unattended subscribe (no awaiter, e.g. the reconnect-time
 # re-issue in _on_connect) fails. Arg tuple = (topic, reason_code,
@@ -110,9 +123,7 @@ MipsStateHandler = Callable[[bool], Union[None, Awaitable[None]]]
 # authorized); -1 if the local subscribe() call itself failed before
 # reaching the broker. First-time subscribes have an awaiter and raise
 # MipsSubscribeRejectedError directly — those don't go through this handler.
-SubscribeErrorHandler = Callable[
-    [tuple[str, int, str]], Union[None, Awaitable[None]]
-]
+SubscribeErrorHandler = Callable[[tuple[str, int, str]], Union[None, Awaitable[None]]]
 # Fired when an unattended subscribe succeeds (SUBACK with success code).
 # Arg = topic string. Symmetric with SubscribeErrorHandler — allows the
 # caller to clear a stale error flag on successful reconnect resubscribe.
@@ -282,9 +293,7 @@ class MIoTMipsCloud:
         except Exception as e:
             self._connect_future = None
             self._mqtt = None
-            raise MipsConnectionError(
-                f"mips_cloud TCP/TLS connect failed: {e}"
-            ) from e
+            raise MipsConnectionError(f"mips_cloud TCP/TLS connect failed: {e}") from e
 
         mqtt.loop_start()
 
@@ -374,9 +383,7 @@ class MIoTMipsCloud:
             except ValueError:
                 pass
 
-    def register_subscribe_error_handler(
-        self, handler: SubscribeErrorHandler
-    ) -> None:
+    def register_subscribe_error_handler(self, handler: SubscribeErrorHandler) -> None:
         """Register a callback for unattended-subscribe failures.
 
         The handler fires with (topic, reason_code, reason_string) when an
@@ -420,9 +427,7 @@ class MIoTMipsCloud:
 
     # ------------------------------------------------------- public sub APIs
 
-    async def sub_user_bind_async(
-        self, uid: str, handler: BindHandler
-    ) -> None:
+    async def sub_user_bind_async(self, uid: str, handler: BindHandler) -> None:
         """Subscribe to `user/{uid}/g_op/bind`.
 
         SUBACK rejection raises MipsSubscribeRejectedError. The caller is
@@ -431,9 +436,7 @@ class MIoTMipsCloud:
         topic = f"user/{uid}/g_op/bind"
         await self._subscribe_async(topic, handler, self._make_bind_decoder("bind"))
 
-    async def sub_user_unbind_async(
-        self, uid: str, handler: BindHandler
-    ) -> None:
+    async def sub_user_unbind_async(self, uid: str, handler: BindHandler) -> None:
         topic = f"user/{uid}/g_op/unbind"
         await self._subscribe_async(topic, handler, self._make_bind_decoder("unbind"))
 
@@ -455,9 +458,7 @@ class MIoTMipsCloud:
         """
         decoder = self._make_device_meta_decoder()
         for op in _DEVICE_META_OPS:
-            await self._subscribe_async(
-                f"device/{did}/g_op/{op}", handler, decoder
-            )
+            await self._subscribe_async(f"device/{did}/g_op/{op}", handler, decoder)
 
     async def unsub_device_meta_changed_async(self, did: str) -> None:
         for op in _DEVICE_META_OPS:
@@ -475,13 +476,30 @@ class MIoTMipsCloud:
         """
         decoder = self._make_scene_decoder()
         for op in _HOME_SCENE_OPS:
-            await self._subscribe_async(
-                f"home/{home_id}/scene/{op}", handler, decoder
-            )
+            await self._subscribe_async(f"home/{home_id}/scene/{op}", handler, decoder)
 
     async def unsub_home_scene_changed_async(self, home_id: str) -> None:
         for op in _HOME_SCENE_OPS:
             await self._unsubscribe_async(f"home/{home_id}/scene/{op}")
+
+    async def sub_device_state_async(
+        self, did: str, handler: DeviceStateHandler
+    ) -> None:
+        """Subscribe a device's state topics: `device/{did}/state/{online,
+        offline}`.
+
+        One SUBSCRIBE per exact op leaf — the broker ACL rejects the
+        `device/{did}/state/#` wildcard (same as the g_op/# case). Ops share
+        one decoder. SUBACK rejection on any op raises
+        MipsSubscribeRejectedError.
+        """
+        decoder = self._make_device_state_decoder()
+        for op in _DEVICE_STATE_OPS:
+            await self._subscribe_async(f"device/{did}/state/{op}", handler, decoder)
+
+    async def unsub_device_state_async(self, did: str) -> None:
+        for op in _DEVICE_STATE_OPS:
+            await self._unsubscribe_async(f"device/{did}/state/{op}")
 
     # ------------------------------------------------------- subscribe core
 
@@ -556,9 +574,13 @@ class MIoTMipsCloud:
                 _LOGGER.error(
                     "mips_cloud subscribe (after reconnect) REJECTED "
                     "topic=%s code=0x%02x reason=%s",
-                    exc.topic, exc.reason_code, exc.reason_string,
+                    exc.topic,
+                    exc.reason_code,
+                    exc.reason_string,
                 )
-                self._fire_subscribe_error(exc.topic, exc.reason_code, exc.reason_string)
+                self._fire_subscribe_error(
+                    exc.topic, exc.reason_code, exc.reason_string
+                )
             elif isinstance(exc, MipsSubscribeTimeoutError):
                 _LOGGER.error(
                     "mips_cloud subscribe (after reconnect) SUBACK timeout topic=%s",
@@ -569,7 +591,8 @@ class MIoTMipsCloud:
                 _LOGGER.error(
                     "mips_cloud subscribe (after reconnect) failed unexpectedly "
                     "topic=%s: %s",
-                    topic, exc,
+                    topic,
+                    exc,
                 )
                 self._fire_subscribe_error(topic, -1, f"subscribe failed: {exc}")
         else:
@@ -625,9 +648,7 @@ class MIoTMipsCloud:
         with self._subs_lock:
             active = list(self._subs.values())
         for sub in active:
-            self._main_loop.call_soon_threadsafe(
-                self._spawn_resubscribe, sub
-            )
+            self._main_loop.call_soon_threadsafe(self._spawn_resubscribe, sub)
 
         self._fire_connect_future(None)
         self._dispatch_state_handlers(True)
@@ -636,7 +657,11 @@ class MIoTMipsCloud:
         """Spawn an unattended resubscribe task. Called via call_soon_threadsafe."""
         asyncio.create_task(
             self._subscribe_async(
-                sub.topic, sub.handler, sub.decoder, sub.qos, unattended=True,
+                sub.topic,
+                sub.handler,
+                sub.decoder,
+                sub.qos,
+                unattended=True,
             )
         )
 
@@ -815,6 +840,31 @@ class MIoTMipsCloud:
                 home_id=home_id,
                 event=op,  # type: ignore[arg-type]  # op ∈ {rename,delete,edit}
                 scene_id=str(scene_id) if scene_id is not None else None,
+                raw=raw if isinstance(raw, dict) else {},
+                timestamp_ms=_now_ms(),
+            )
+
+        return decode
+
+    @staticmethod
+    def _make_device_state_decoder() -> Callable[
+        [str, bytes], Optional[MIoTDeviceStateEvent]
+    ]:
+        # Device-level cloud online/offline: did + event come from the topic;
+        # the payload is undocumented and kept verbatim in `raw`. Only the
+        # exact op leaves are subscribed (no `#` wildcard), so a non-matching
+        # topic should never arrive — the `if not m` guard is purely
+        # defensive.
+        def decode(topic: str, payload: bytes) -> Optional[MIoTDeviceStateEvent]:
+            m = _TOPIC_DEVICE_STATE.match(topic)
+            if not m:
+                return None
+            did = m.group(1)
+            op = m.group(2)  # online | offline
+            raw = _parse_json_payload(payload) or {}
+            return MIoTDeviceStateEvent(
+                did=did,
+                event=op,  # type: ignore[arg-type]  # op ∈ {online,offline}
                 raw=raw if isinstance(raw, dict) else {},
                 timestamp_ms=_now_ms(),
             )

--- a/backend/miot/src/miot/types.py
+++ b/backend/miot/src/miot/types.py
@@ -122,7 +122,9 @@ class MIoTDeviceInfo(BaseModel):
     room_name: Optional[str] = Field(default=None, description="Device room name")
 
     rssi: Optional[int] = Field(default=None, description="Device rssi")
-    lan_online: Optional[bool] = Field(default=None, description="LAN device online status")
+    lan_online: Optional[bool] = Field(
+        default=None, description="LAN device online status"
+    )
     local_ip: Optional[str] = Field(default=None, description="Device local ip")
     ssid: Optional[str] = Field(default=None, description="Device ssid")
     bssid: Optional[str] = Field(default=None, description="Device bssid")
@@ -146,7 +148,7 @@ class MIoTCameraInfo(MIoTDeviceInfo):
 
     channel_count: int = Field(description="Camera channel count")
     camera_status: MIoTCameraStatus = Field(description="Camera status")
-    
+
     @property
     def connected(self) -> bool:
         """Whether the local camera stream is connected."""
@@ -399,6 +401,27 @@ class MIoTSceneChangedEvent(BaseModel):
         description="Scene op: rename / delete / edit"
     )
     scene_id: Optional[str] = Field(default=None, description="Scene id if present")
+    raw: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Raw decoded payload (broker schema is undocumented)",
+    )
+    timestamp_ms: int = Field(default=0)
+
+
+class MIoTDeviceStateEvent(BaseModel):
+    """Decoded `device/{did}/state/{online,offline}` payload.
+
+    Device-level cloud online/offline state push. `did` and `event` come from
+    the topic; the payload is undocumented and kept in `raw`. The handler
+    updates the cached cloud ``online`` field directly from ``event`` rather
+    than re-fetching the device list — this is the event-driven recovery path
+    for cameras that went stale (online=false) across a backend restart.
+    """
+
+    did: str = Field(description="Device id")
+    event: Literal["online", "offline"] = Field(
+        description="Cloud state: online / offline"
+    )
     raw: Dict[str, Any] = Field(
         default_factory=dict,
         description="Raw decoded payload (broker schema is undocumented)",

--- a/backend/miot/tests/test_client_meta_sub.py
+++ b/backend/miot/tests/test_client_meta_sub.py
@@ -33,10 +33,9 @@ class _FakeMips:
     def __init__(self, *, connected: bool = True, fail: bool = False) -> None:
         self.is_connected = connected
         self._fail = fail
-        self.sub_device_meta_changed_async = AsyncMock(
-            side_effect=self._maybe_fail
-        )
+        self.sub_device_meta_changed_async = AsyncMock(side_effect=self._maybe_fail)
         self.sub_home_scene_changed_async = AsyncMock(side_effect=self._maybe_fail)
+        self.sub_device_state_async = AsyncMock(side_effect=self._maybe_fail)
 
     async def _maybe_fail(self, *args, **kwargs) -> None:
         if self._fail:
@@ -47,9 +46,11 @@ def _bare_client(mips: _FakeMips | None) -> MIoTClient:
     client = MIoTClient.__new__(MIoTClient)
     client._meta_sub_dids = set()
     client._scene_sub_home_ids = set()
+    client._state_sub_dids = set()
     client._mips_cloud = mips
     client._callback_device_meta_changed = None
     client._callback_scene_changed = None
+    client._callback_device_state_changed = None
     return client
 
 
@@ -162,14 +163,20 @@ class _SetupFakeMips:
     def __init__(self, *, fail_meta_dids: frozenset[str] = frozenset()) -> None:
         self.is_connected = True
         self._fail_meta_dids = set(fail_meta_dids)
+        self._fail_state_dids: set[str] = set()
         self.init_async = AsyncMock()
         self.sub_user_bind_async = AsyncMock()
         self.sub_user_unbind_async = AsyncMock()
         self.sub_device_meta_changed_async = AsyncMock(side_effect=self._meta)
         self.sub_home_scene_changed_async = AsyncMock()
+        self.sub_device_state_async = AsyncMock(side_effect=self._state)
 
     async def _meta(self, did: str, handler) -> None:
         if did in self._fail_meta_dids:
+            raise RuntimeError(f"SUBACK rejected for {did}")
+
+    async def _state(self, did: str, handler) -> None:
+        if did in self._fail_state_dids:
             raise RuntimeError(f"SUBACK rejected for {did}")
 
     def register_subscribe_error_handler(self, cb) -> None: ...
@@ -177,7 +184,9 @@ class _SetupFakeMips:
     def register_mips_state_handler(self, cb) -> None: ...
 
 
-def _setup_client(monkeypatch, fake, *, meta_dids, scene_home_ids) -> MIoTClient:
+def _setup_client(
+    monkeypatch, fake, *, meta_dids, scene_home_ids, state_dids=()
+) -> MIoTClient:
     monkeypatch.setattr(client_mod, "MIoTMipsCloud", lambda **kw: fake)
     client = MIoTClient.__new__(MIoTClient)
     client._oauth_info = SimpleNamespace(
@@ -190,8 +199,10 @@ def _setup_client(monkeypatch, fake, *, meta_dids, scene_home_ids) -> MIoTClient
     client._mips_user_sub_error = "stale"
     client._meta_sub_dids = set(meta_dids)
     client._scene_sub_home_ids = set(scene_home_ids)
+    client._state_sub_dids = set(state_dids)
     client._callback_device_meta_changed = None
     client._callback_scene_changed = None
+    client._callback_device_state_changed = None
     return client
 
 
@@ -205,9 +216,10 @@ async def test_setup_replays_tracked_subscriptions(monkeypatch):
     await client._setup_mips_async()
 
     # Every tracked did/home re-subscribed exactly once at the broker.
-    assert {
-        c.args[0] for c in fake.sub_device_meta_changed_async.await_args_list
-    } == {"dev-1", "dev-2"}
+    assert {c.args[0] for c in fake.sub_device_meta_changed_async.await_args_list} == {
+        "dev-1",
+        "dev-2",
+    }
     fake.sub_home_scene_changed_async.assert_awaited_once()
     assert fake.sub_home_scene_changed_async.await_args.args[0] == "home-9"
     # Records cleared then re-filled — the mirror stays accurate.
@@ -225,12 +237,115 @@ async def test_setup_replay_partial_failure_keeps_failed_untracked(monkeypatch):
     # A per-did replay failure is caught + logged; setup must not raise.
     await client._setup_mips_async()
 
-    assert {
-        c.args[0] for c in fake.sub_device_meta_changed_async.await_args_list
-    } == {"dev-ok", "dev-bad"}
+    assert {c.args[0] for c in fake.sub_device_meta_changed_async.await_args_list} == {
+        "dev-ok",
+        "dev-bad",
+    }
     # dev-bad's SUBACK failed → not re-recorded, so the next refresh sync retries
     # it; dev-ok succeeded and is tracked.
     assert client._meta_sub_dids == {"dev-ok"}
+
+
+# ------------------------------------------------------------ device cloud state
+#
+# `_state_sub_dids` mirrors what is actually subscribed at the broker, same
+# contract as _meta_sub_dids: success records, failure does not, disconnected
+# records intent only, idempotent for already-tracked dids.
+
+
+@pytest.mark.asyncio
+async def test_sub_device_state_records_on_success():
+    mips = _FakeMips(connected=True)
+    client = _bare_client(mips)
+
+    await client.sub_device_state_async("dev-1")
+
+    mips.sub_device_state_async.assert_awaited_once()
+    assert client._state_sub_dids == {"dev-1"}
+
+
+@pytest.mark.asyncio
+async def test_sub_device_state_failure_leaves_untracked_and_raises():
+    mips = _FakeMips(connected=True, fail=True)
+    client = _bare_client(mips)
+
+    with pytest.raises(RuntimeError):
+        await client.sub_device_state_async("dev-1")
+
+    assert client._state_sub_dids == set()
+
+    mips._fail = False
+    await client.sub_device_state_async("dev-1")
+    assert client._state_sub_dids == {"dev-1"}
+
+
+@pytest.mark.asyncio
+async def test_sub_device_state_disconnected_records_intent_only():
+    mips = _FakeMips(connected=False)
+    client = _bare_client(mips)
+
+    await client.sub_device_state_async("dev-1")
+
+    mips.sub_device_state_async.assert_not_awaited()
+    assert client._state_sub_dids == {"dev-1"}
+
+
+@pytest.mark.asyncio
+async def test_sub_device_state_idempotent():
+    mips = _FakeMips(connected=True)
+    client = _bare_client(mips)
+    client._state_sub_dids = {"dev-1"}
+
+    await client.sub_device_state_async("dev-1")
+
+    mips.sub_device_state_async.assert_not_awaited()
+
+
+# ------------------------------------------- _setup_mips_async state replay
+
+
+@pytest.mark.asyncio
+async def test_setup_replays_state_subscriptions(monkeypatch):
+    fake = _SetupFakeMips()
+    client = _setup_client(
+        monkeypatch,
+        fake,
+        meta_dids=set(),
+        scene_home_ids=set(),
+        state_dids={"dev-1", "dev-2"},
+    )
+
+    await client._setup_mips_async()
+
+    assert {c.args[0] for c in fake.sub_device_state_async.await_args_list} == {
+        "dev-1",
+        "dev-2",
+    }
+    assert client._state_sub_dids == {"dev-1", "dev-2"}
+
+
+@pytest.mark.asyncio
+async def test_setup_replay_state_partial_failure_keeps_failed_untracked(
+    monkeypatch,
+):
+    fake = _SetupFakeMips()
+    fake._fail_state_dids = {"dev-bad"}
+    client = _setup_client(
+        monkeypatch,
+        fake,
+        meta_dids=set(),
+        scene_home_ids=set(),
+        state_dids={"dev-ok", "dev-bad"},
+    )
+
+    await client._setup_mips_async()
+
+    assert {c.args[0] for c in fake.sub_device_state_async.await_args_list} == {
+        "dev-ok",
+        "dev-bad",
+    }
+    # dev-bad failed → not re-recorded; dev-ok succeeded and is tracked.
+    assert client._state_sub_dids == {"dev-ok"}
 
 
 # ------------------------------------ mips_user_sub_error scoping (reconnect)
@@ -279,7 +394,9 @@ def test_device_meta_subscribe_error_does_not_set_user_error():
     """Regression: a device-meta SUBACK rejection must not raise a user-bind
     health alarm (it has its own per-did retry path)."""
     client = _err_client()
-    client._on_mips_subscribe_error(("device/dev-1/g_op/hr_change", 0x87, "Not authorized"))
+    client._on_mips_subscribe_error(
+        ("device/dev-1/g_op/hr_change", 0x87, "Not authorized")
+    )
     assert client._mips_user_sub_error is None
 
 

--- a/backend/miot/tests/test_mips_cloud.py
+++ b/backend/miot/tests/test_mips_cloud.py
@@ -17,6 +17,7 @@ Coverage:
   - Token rotate calls username_pw_set with new password + reconnect
   - Reconnect resubscribes all active topics
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -27,6 +28,7 @@ import pytest
 from miot.mips_cloud import MIoTMipsCloud
 from miot.types import (
     MIoTDeviceBindEvent,
+    MIoTDeviceStateEvent,
     MIoTSceneChangedEvent,
     MipsSubscribeRejectedError,
     MipsSubscribeTimeoutError,
@@ -75,7 +77,9 @@ class _FakeMqttClient:
 
     # ------------------------------------------------------------- paho API
 
-    def username_pw_set(self, username: str | None = None, password: str | None = None) -> None:
+    def username_pw_set(
+        self, username: str | None = None, password: str | None = None
+    ) -> None:
         self.username = username
         self.password = password
         self.username_pw_set_history.append((username, password))
@@ -315,9 +319,7 @@ async def test_user_bind_decoded_event_dispatched():
         await asyncio.gather(
             mips.sub_user_bind_async("uid-42", handler=on_bind), driver()
         )
-        fake.fire_message(
-            "user/uid-42/g_op/bind", b'{"did": "new-device-123"}'
-        )
+        fake.fire_message("user/uid-42/g_op/bind", b'{"did": "new-device-123"}')
         await asyncio.sleep(0.05)
         assert len(received) == 1
         assert received[0].uid == "uid-42"
@@ -733,6 +735,136 @@ async def test_subscribe_transient_rejection_keeps_topic_and_reconnect_retries()
         assert fake.subscribed[-1][0] == "user/uid-q/g_op/bind"
         _, _, new_mid = fake.subscribed[-1]
         fake.fire_suback(new_mid, [2])
+        await asyncio.sleep(0.01)
+    finally:
+        await mips.deinit_async()
+
+
+# ============================================================================
+# device/{did}/state/{online,offline} — cloud online/offline state subs
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_device_state_subscribes_exact_topics():
+    """sub_device_state_async subscribes the exact per-op leaf topics
+    (NOT a `state/#` wildcard — the broker ACL rejects the wildcard, same as
+    the g_op/# case)."""
+    mips, _ = _make_mips()
+    holder: dict[str, _FakeMqttClient] = {}
+
+    def factory(client_id: str) -> _FakeMqttClient:
+        holder["c"] = _FakeMqttClient(client_id)
+        return holder["c"]  # type: ignore[return-value]
+
+    mips._client_factory = factory  # type: ignore[assignment]
+    fake = await _connect(mips, holder)
+
+    try:
+        await asyncio.gather(
+            mips.sub_device_state_async("dev-1", handler=lambda _m: None),
+            _ack_subscribes(fake, 2),
+        )
+        topics = {t for t, _, _ in fake.subscribed}
+        assert "device/dev-1/state/online" in topics
+        assert "device/dev-1/state/offline" in topics
+        assert "device/dev-1/state/#" not in topics
+    finally:
+        await mips.deinit_async()
+
+
+@pytest.mark.parametrize("op", ["online", "offline"])
+@pytest.mark.asyncio
+async def test_device_state_decoded_event_dispatched(op):
+    """device/{did}/state/{online,offline} → MIoTDeviceStateEvent with
+    event=op and did parsed from the topic; payload kept in `raw`."""
+    mips, _ = _make_mips()
+    holder: dict[str, _FakeMqttClient] = {}
+
+    def factory(client_id: str) -> _FakeMqttClient:
+        holder["c"] = _FakeMqttClient(client_id)
+        return holder["c"]  # type: ignore[return-value]
+
+    mips._client_factory = factory  # type: ignore[assignment]
+    fake = await _connect(mips, holder)
+
+    received: list[MIoTDeviceStateEvent] = []
+
+    try:
+        await asyncio.gather(
+            mips.sub_device_state_async("dev-42", handler=received.append),
+            _ack_subscribes(fake, 2),
+        )
+        fake.fire_message(
+            f"device/dev-42/state/{op}",
+            b'{"device_id": "dev-42", "event": "' + op.encode() + b'"}',
+        )
+        await asyncio.sleep(0.05)
+        assert len(received) == 1
+        assert received[0].event == op
+        assert received[0].did == "dev-42"
+        assert received[0].raw.get("device_id") == "dev-42"
+    finally:
+        await mips.deinit_async()
+
+
+@pytest.mark.asyncio
+async def test_device_state_unsubscribes_exact_topics():
+    """unsub_device_state_async removes both online + offline leaf topics."""
+    mips, _ = _make_mips()
+    holder: dict[str, _FakeMqttClient] = {}
+
+    def factory(client_id: str) -> _FakeMqttClient:
+        holder["c"] = _FakeMqttClient(client_id)
+        return holder["c"]  # type: ignore[return-value]
+
+    mips._client_factory = factory  # type: ignore[assignment]
+    fake = await _connect(mips, holder)
+
+    try:
+        await asyncio.gather(
+            mips.sub_device_state_async("dev-7", handler=lambda _m: None),
+            _ack_subscribes(fake, 2),
+        )
+        await mips.unsub_device_state_async("dev-7")
+        unsubbed = set(fake.unsubscribed)
+        assert "device/dev-7/state/online" in unsubbed
+        assert "device/dev-7/state/offline" in unsubbed
+    finally:
+        await mips.deinit_async()
+
+
+@pytest.mark.asyncio
+async def test_device_state_reconnect_resubscribes_both_topics():
+    """After disconnect/reconnect both online + offline leaf topics are
+    re-issued by the _subs replay."""
+    mips, _ = _make_mips()
+    holder: dict[str, _FakeMqttClient] = {}
+
+    def factory(client_id: str) -> _FakeMqttClient:
+        holder["c"] = _FakeMqttClient(client_id)
+        return holder["c"]  # type: ignore[return-value]
+
+    mips._client_factory = factory  # type: ignore[assignment]
+    fake = await _connect(mips, holder)
+
+    try:
+        await asyncio.gather(
+            mips.sub_device_state_async("dev-rec", handler=lambda _m: None),
+            _ack_subscribes(fake, 2),
+        )
+        before = len(fake.subscribed)
+        fake.fire_disconnect(reason_code=1)
+        fake.fire_connect(reason_code=0)
+        for _ in range(10):
+            await asyncio.sleep(0)
+            if len(fake.subscribed) >= before + 2:
+                break
+        resub_topics = {t for t, _, _ in fake.subscribed[before:]}
+        assert "device/dev-rec/state/online" in resub_topics
+        assert "device/dev-rec/state/offline" in resub_topics
+        for _, _, mid in fake.subscribed[before:]:
+            fake.fire_suback(mid, [2])
         await asyncio.sleep(0.01)
     finally:
         await mips.deinit_async()


### PR DESCRIPTION
## Bug

Camera never reconnects to perception engine after backend restart if it was temporarily disconnected at restart time. This is the same root cause as #301, re-implemented per the maintainer's event-driven direction.

## Root Cause

When the backend restarts while a camera is temporarily disconnected, `_camera_info_dict` caches the stale cloud `online=false`. The `_sync_devices_loop` only checks this cached status via `discover_devices(online_only=True)`, so the camera is permanently considered unreachable — even after LAN probes detect it as online. The `_on_lan_device_changed` callback updates `lan_online` but not the cloud `online` field.

Recovery only happens when the web UI is opened (which triggers `refresh_camera_online` via frontend).

## Fix

Implements the **event-driven** path Ada-xia specified in #301, subscribing `device/{did}/state/online` and `device/{did}/state/offline` and updating `_camera_info_dict[did].online` directly from the push — no polling, no cloud re-fetch per event.

The implementation mirrors the existing `device-meta` (rename/hr_change) subscription chain, layer by layer:

- **SDK `miot`**:
  - `MIoTDeviceStateEvent` (did / event `online`|`offline` / raw / timestamp).
  - `mips_cloud.sub_device_state_async` / `unsub_device_state_async` — one SUBSCRIBE per **exact op leaf** (`device/{did}/state/online` + `.../offline`), because the broker ACL rejects the `state/#` wildcard (same as the `g_op/#` precedent). Decoder reuses `_parse_json_payload`; did + event come from the topic.
  - `MIoTClient.register_device_state_changed_callback` + `sub_device_state_async` / `unsub_device_state_async` + `_state_sub_dids` replay on `_setup_mips_async` (re-OAuth) + cleanup in `_deinit_locked`. Plain-reconnect replay is handled by `mips_cloud._subs` automatically.

- **Miloco `MiotProxy`**:
  - `_sync_camera_state_subscriptions` — per-camera diff (new dids subscribed, removed dids unsubscribed) at the tail of `refresh_cameras`, under `_refresh_cameras_lock`. dids containing `/` are skipped (same rationale as meta). Per-did failures only log, never abort.
  - `_on_camera_state_changed_event` — updates `_camera_info_dict[did].online` directly from the event (online→True / offline→False), **symmetric with `_on_lan_device_changed` updating `lan_online`**. Non-camera devices are ignored. No cloud re-fetch here.
  - `CameraStateEventListener` — global trailing-edge debounce (60s, re-armed on every event) that calls `refresh_camera_online_status` once the burst settles, as the全量对账 fallback for a missed/stale event. This is the lightweight metadata-only refresh that does not disturb watch streams.

The sync loop / `discover_devices` / `_filter_cameras_from_all` are **untouched** — once `online` is event-driven, the existing `discover_devices(online_only=True, require_lan=False)` path naturally reconnects the camera on the next sync cycle.

## Tests

- `test_mips_cloud.py`: sub/unsub exact leaf topics, decoded event dispatch (online + offline), reconnect resubscribes both topics.
- `test_client_meta_sub.py`: `sub_device_state_async` tracking contract (success records, failure leaves untracked + raises, disconnected records intent only, idempotent) + `_setup_mips_async` replay (full + partial failure).
- `test_mips_listeners.py`: `CameraStateEventListener` debounce (single event fires after window, burst collapses, multi-did collapses globally, deinit cancels, post-deinit ignored).
- `test_camera_state_subscriptions.py`: `_sync_camera_state_subscriptions` diff (add/remove, skip `/` dids, noop when in sync, failure keeps untracked) + `_on_camera_state_changed_event` (online→True, offline→False, unknown did ignored).

## Verification

- `cd backend && uv run ruff check .` — passes.
- `uv run pytest miot/tests/test_mips_cloud.py miot/tests/test_client_meta_sub.py miloco/tests/test_mips_listeners.py miloco/tests/test_camera_state_subscriptions.py miloco/tests/perception/test_camera_adapter_reconnect.py` — all green.