### PR TITLE
支持米家事件触发感知，并新增感知触发管理页

### DIFF
--- a/backend/miloco/src/miloco/automation/__init__.py
+++ b/backend/miloco/src/miloco/automation/__init__.py
@@ -1,0 +1,2 @@
+"""Automation module."""
+

--- a/backend/miloco/src/miloco/automation/router.py
+++ b/backend/miloco/src/miloco/automation/router.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import re
 import logging
+import re
 import time
 from pathlib import Path as _Path
 

--- a/backend/miloco/src/miloco/automation/router.py
+++ b/backend/miloco/src/miloco/automation/router.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import re
+import logging
+import time
+from pathlib import Path as _Path
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import FileResponse
+
+from miloco.automation.schema import (
+    MiotEventManualTriggerRequest,
+    MiotEventMapping,
+    MiotEventMappingUpdate,
+    MiotEventTrigger,
+)
+from miloco.manager import get_manager
+from miloco.middleware import verify_token
+from miloco.rule.schema import RuleTriggerType
+from miloco.schema.common_schema import NormalResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/automation", tags=["Automation"])
+
+
+def manager():
+    return get_manager()
+
+
+@router.get("/catalog", response_model=NormalResponse, summary="Automation source catalog")
+async def get_catalog(current_user: str = Depends(verify_token)):
+    manager = get_manager()
+    data = await manager.automation_service.list_catalog(manager.miot_service)
+    return NormalResponse(code=0, message="ok", data=data)
+
+
+@router.get("/mappings", response_model=NormalResponse, summary="List MiOT event mappings")
+async def list_mappings(current_user: str = Depends(verify_token)):
+    return NormalResponse(
+        code=0,
+        message="ok",
+        data=manager().automation_service.list_mappings(),
+    )
+
+
+@router.post("/mappings", response_model=NormalResponse, summary="Create MiOT event mapping")
+async def create_mapping(mapping: MiotEventMapping, current_user: str = Depends(verify_token)):
+    data = manager().automation_service.create_mapping(mapping)
+    return NormalResponse(code=0, message="created", data=data)
+
+
+@router.patch("/mappings/{mapping_id}", response_model=NormalResponse, summary="Update MiOT event mapping")
+async def update_mapping(
+    mapping_id: str,
+    update: MiotEventMappingUpdate,
+    current_user: str = Depends(verify_token),
+):
+    data = manager().automation_service.update_mapping(mapping_id, update)
+    return NormalResponse(code=0, message="updated", data=data)
+
+
+@router.delete("/mappings/{mapping_id}", response_model=NormalResponse, summary="Delete MiOT event mapping")
+async def delete_mapping(mapping_id: str, current_user: str = Depends(verify_token)):
+    manager().automation_service.delete_mapping(mapping_id)
+    return NormalResponse(code=0, message="deleted", data=None)
+
+
+@router.get("/snapshots/{filename}", summary="Serve automation snapshot image")
+async def serve_snapshot(filename: str):
+    """Serve a saved automation snapshot JPEG."""
+    # Sanitize: only allow safe filename characters, prevent path traversal
+    if not re.match(r'^[A-Za-z0-9_.\-]+\.jpg$', filename):
+        return NormalResponse(code=400, message="invalid filename", data=None)
+    import os
+    home = os.environ.get("MILOCO_HOME", "/root/.openclaw/miloco")
+    snap_path = _Path(home) / "static" / "clips" / "automation" / _Path(filename).name
+    if not snap_path.exists():
+        return NormalResponse(code=404, message="not found", data=None)
+    return FileResponse(str(snap_path), media_type="image/jpeg")
+
+
+@router.get("/devices/{did}/properties", response_model=NormalResponse, summary="Device property keys from recent logs")
+async def list_device_properties(did: str, current_user: str = Depends(verify_token)):
+    """Return known property keys for a device, sourced from recent trigger logs.
+    Used by the frontend to suggest property filter keys when editing miot_event rules."""
+    data = manager().automation_service.get_device_property_keys(did)
+    return NormalResponse(code=0, message="ok", data=data)
+
+
+@router.get("/logs", response_model=NormalResponse, summary="Recent MiOT event trigger logs")
+async def list_logs(
+    limit: int = Query(50, ge=1, le=200),
+    current_user: str = Depends(verify_token),
+):
+    return NormalResponse(
+        code=0,
+        message="ok",
+        data=manager().automation_service.list_logs(limit),
+    )
+
+
+@router.post("/test-trigger", response_model=NormalResponse, summary="Manual test trigger")
+async def test_trigger(
+    request: MiotEventManualTriggerRequest,
+    current_user: str = Depends(verify_token),
+):
+    mgr = manager()
+    log_item = await mgr.automation_service.handle_trigger(
+        trigger=MiotEventTrigger(
+            source_type=request.source_type,
+            source_id=request.source_id,
+            source_name=request.source_name,
+            home_id=request.home_id,
+            room_name=request.room_name,
+            event_name=request.event_name or (
+                "device_prop" if request.source_type == "device" else "scene"
+            ),
+            changed_properties=request.changed_properties,
+            occurred_at=time.time_ns() // 1_000_000,
+            raw=request.model_dump(mode="json"),
+        ),
+        perception_service=mgr.perception_service,
+        rule_service=mgr.rule_service,
+        miot_service=mgr.miot_service,
+        meaningful_events_dao=mgr.meaningful_events_dao,
+        pipeline=mgr.perception_service._pipeline,
+    )
+    return NormalResponse(code=0, message="ok", data=log_item)
+
+
+@router.post("/rules", response_model=NormalResponse, summary="Create miot_event rule with property filters")
+async def create_miot_event_rule(
+    request: dict,
+    current_user: str = Depends(verify_token),
+):
+    """Create a miot_event rule from the automation page.
+    Accepts a simplified payload with property_filters baked in."""
+    from miloco.manager import get_manager
+
+    mgr = get_manager()
+    service = mgr.automation_service
+    from miloco.rule.schema import Rule
+
+    payload = service.build_miot_event_rule_payload(
+        task_id=request.get("task_id", ""),
+        name=request.get("name", ""),
+        source_ids=request.get("source_ids", []),
+        event_kinds=request.get("event_kinds", ["device_prop"]),
+        query=request.get("query", ""),
+        property_filters=request.get("property_filters", {}),
+        action_descriptions=request.get("action_descriptions"),
+    )
+    rule = Rule.model_validate(payload)
+    rule_id = await mgr.rule_service.create_rule(rule)
+    return NormalResponse(code=0, message="created", data={"rule_id": rule_id})
+
+
+@router.get("/device-spec/{did}", response_model=NormalResponse, summary="Get device spec properties for automation filtering")
+async def device_spec(did: str, current_user: str = Depends(verify_token)):
+    """Return device spec with property names, value lists and value ranges.
+    Uses the miot-spec parser (same data source as ha_xiaomi_home)."""
+    try:
+        mgr = get_manager()
+        proxy = mgr.miot_service._miot_proxy
+        devices = proxy._device_info_dict
+        device = devices.get(did)
+        if not device:
+            return NormalResponse(code=404, message="device not found", data=None)
+
+        urn = getattr(device, "urn", "") or ""
+        model = device.model
+        if not urn:
+            return NormalResponse(code=0, message="no_spec",
+                data={"model": model, "name": device.name, "properties": []})
+
+        # Reuse Miloco's existing spec fetch path, which is already compatible
+        # with vendor/custom services and value-list/value-range extraction.
+        spec = await proxy._fetch_device_spec(urn=urn)
+        if not spec:
+            return NormalResponse(code=0, message="no_spec_data",
+                data={"model": model, "name": device.name, "properties": []})
+
+        props = []
+        for iid, item in spec.items():
+            if not iid.startswith("prop."):
+                continue
+            parts = iid.split(".")
+            if len(parts) != 3:
+                continue
+            _, siid, piid = parts
+            entry = {
+                "siid": int(siid),
+                "piid": int(piid),
+                "key": iid,
+                "name": item.get("description") or item.get("prop_description") or iid,
+                "description": item.get("description") or "",
+                "format": item.get("format") or "",
+                "access": [
+                    access
+                    for enabled, access in (
+                        (item.get("readable"), "read"),
+                        (item.get("writeable"), "write"),
+                    )
+                    if enabled
+                ],
+                "unit": item.get("unit") or "",
+            }
+
+            value_list = item.get("value_list") or []
+            if value_list:
+                entry["value_list"] = [
+                    {
+                        "value": str(v.get("value", "")),
+                        "description": v.get("description") or v.get("name") or str(v.get("value", "")),
+                    }
+                    for v in value_list
+                ]
+            elif entry["format"] == "bool":
+                entry["value_list"] = [
+                    {"value": "0", "description": "关"},
+                    {"value": "1", "description": "开"},
+                ]
+
+            value_range = item.get("value_range")
+            if value_range and len(value_range) == 3:
+                entry["value_range"] = {
+                    "min": value_range[0],
+                    "max": value_range[1],
+                    "step": value_range[2],
+                }
+
+            props.append(entry)
+
+        props.sort(key=lambda item: (item["siid"], item["piid"]))
+
+        return NormalResponse(code=0, message="ok", data={
+            "model": model, "name": device.name, "properties": props
+        })
+    except Exception as e:
+        safe_did = re.sub(r"[^\w.\-]", "_", did or "")
+        logger.warning("device_spec failed for did=%s: %s", safe_did, e)
+        return NormalResponse(code=500, message=str(e), data=None)
+
+
+@router.get("/rules", response_model=NormalResponse, summary="List miot_event rules")
+async def list_miot_event_rules(current_user: str = Depends(verify_token)):
+    rules = await manager().rule_service.get_all_rules(enabled_only=False)
+    data = [rule for rule in rules if rule.trigger_type == RuleTriggerType.MIOT_EVENT]
+    return NormalResponse(code=0, message="ok", data=data)

--- a/backend/miloco/src/miloco/automation/schema.py
+++ b/backend/miloco/src/miloco/automation/schema.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class MiotPropertyFilterCondition(BaseModel):
+    op: Literal["eq", "ne", "gt", "lt", "gte", "lte", "any"] = Field(default="eq")
+    value: Any = Field(default="*")
+
+
+class MiotEventTrigger(BaseModel):
+    trigger_kind: str = Field(default="miot_event")
+    source_type: Literal["device", "scene"] = Field(...)
+    source_id: str = Field(...)
+    source_name: str = Field(default="")
+    home_id: str | None = Field(default=None)
+    room_name: str | None = Field(default=None)
+    event_name: str = Field(default="")
+    changed_properties: dict[str, Any] = Field(default_factory=dict)
+    occurred_at: int = Field(default=0)
+    raw: dict[str, Any] = Field(default_factory=dict)
+
+
+class MiotEventSource(BaseModel):
+    source_type: Literal["device", "scene"] = Field(...)
+    source_id: str = Field(...)
+    source_name: str = Field(...)
+    home_id: str | None = Field(default=None)
+    room_name: str | None = Field(default=None)
+
+
+class MiotEventMapping(BaseModel):
+    id: str = Field(default="")
+    source_type: Literal["device", "scene"] = Field(...)
+    source_id: str = Field(...)
+    source_name_snapshot: str = Field(default="")
+    camera_dids: list[str] = Field(default_factory=list)
+    enabled: bool = Field(default=True)
+    query_template: str = Field(default="")
+    event_kinds: list[str] = Field(default_factory=list)
+    property_filters: dict[str, Any] = Field(default_factory=dict)
+    cooldown_seconds: int = Field(default=30, ge=0)
+    notes: str = Field(default="")
+    snapshot_paths: list[str] = Field(default_factory=list)
+    created_at: int | None = Field(default=None)
+    updated_at: int | None = Field(default=None)
+
+
+class MiotEventMappingUpdate(BaseModel):
+    source_type: Literal["device", "scene"] | None = Field(default=None)
+    source_id: str | None = Field(default=None)
+    source_name_snapshot: str | None = Field(default=None)
+    camera_dids: list[str] | None = Field(default=None)
+    enabled: bool | None = Field(default=None)
+    query_template: str | None = Field(default=None)
+    event_kinds: list[str] | None = Field(default=None)
+    property_filters: dict[str, Any] | None = Field(default=None)
+    cooldown_seconds: int | None = Field(default=None, ge=0)
+    notes: str | None = Field(default=None)
+
+
+class MiotEventTriggerLog(BaseModel):
+    id: str
+    trigger: MiotEventTrigger
+    mapping_ids: list[str] = Field(default_factory=list)
+    candidate_rule_ids: list[str] = Field(default_factory=list)
+    camera_dids: list[str] = Field(default_factory=list)
+    clip_device_ids: list[str] = Field(default_factory=list)
+    clip_kind: str = Field(default="")
+    perception_started: bool = Field(default=False)
+    perception_answer: str = Field(default="")
+    matched_rule_ids: list[str] = Field(default_factory=list)
+    skipped_reason: str = Field(default="")
+    error: str = Field(default="")
+    snapshot_paths: list[str] = Field(default_factory=list)
+    created_at: int
+
+
+class MiotEventManualTriggerRequest(BaseModel):
+    source_type: Literal["device", "scene"] = Field(...)
+    source_id: str = Field(...)
+    source_name: str = Field(default="")
+    home_id: str | None = Field(default=None)
+    room_name: str | None = Field(default=None)
+    event_name: str = Field(default="")
+    changed_properties: dict[str, Any] = Field(default_factory=dict)
+
+
+class MiotEventCatalog(BaseModel):
+    devices: list[MiotEventSource] = Field(default_factory=list)
+    scenes: list[MiotEventSource] = Field(default_factory=list)
+    cameras: list[dict[str, Any]] = Field(default_factory=list)
+

--- a/backend/miloco/src/miloco/automation/service.py
+++ b/backend/miloco/src/miloco/automation/service.py
@@ -1,0 +1,573 @@
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+from typing import Any
+
+from miloco.automation.schema import (
+    MiotEventCatalog,
+    MiotEventMapping,
+    MiotEventMappingUpdate,
+    MiotEventSource,
+    MiotEventTrigger,
+    MiotEventTriggerLog,
+    MiotPropertyFilterCondition,
+)
+from miloco.config import get_settings
+from miloco.database.kv_repo import KVRepo
+from miloco.middleware.exceptions import ResourceNotFoundException
+from miloco.perception.schema import OnDemandPerceptionRequest
+from miloco.perception.snapshot_writer import (
+    check_disk_space,
+    get_snapshot_root,
+    save_clips,
+)
+from miloco.rule.schema import RuleTriggerType
+from miloco.utils.time_utils import now_ms
+
+logger = logging.getLogger(__name__)
+
+_KV_MAPPINGS = "AUTOMATION_MIOT_EVENT_MAPPINGS"
+_KV_LOGS = "AUTOMATION_MIOT_EVENT_LOGS"
+_MAX_LOGS = 200
+
+
+def _normalize_filter_condition(expected: Any) -> MiotPropertyFilterCondition:
+    if isinstance(expected, MiotPropertyFilterCondition):
+        return expected
+    if isinstance(expected, dict):
+        try:
+            return MiotPropertyFilterCondition.model_validate(expected)
+        except Exception:
+            pass
+    if expected == "*":
+        return MiotPropertyFilterCondition(op="any", value="*")
+    return MiotPropertyFilterCondition(op="eq", value=expected)
+
+
+def _coerce_number(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            return float(text)
+        except ValueError:
+            return None
+    return None
+
+
+def _match_condition(actual: Any, expected: Any) -> bool:
+    cond = _normalize_filter_condition(expected)
+    if cond.op == "any":
+        return actual is not None
+    if cond.op == "eq":
+        return str(actual) == str(cond.value)
+    if cond.op == "ne":
+        return actual is not None and str(actual) != str(cond.value)
+    actual_num = _coerce_number(actual)
+    expected_num = _coerce_number(cond.value)
+    if actual_num is None or expected_num is None:
+        return False
+    if cond.op == "gt":
+        return actual_num > expected_num
+    if cond.op == "lt":
+        return actual_num < expected_num
+    if cond.op == "gte":
+        return actual_num >= expected_num
+    if cond.op == "lte":
+        return actual_num <= expected_num
+    return False
+
+
+class AutomationService:
+    def __init__(self, kv_repo: KVRepo):
+        self._kv_repo = kv_repo
+        self._cooldowns: dict[str, float] = {}
+
+    def _load_mappings(self) -> list[MiotEventMapping]:
+        raw = self._kv_repo.get(_KV_MAPPINGS, "[]") or "[]"
+        try:
+            return [MiotEventMapping.model_validate(item) for item in json.loads(raw)]
+        except Exception as e:  # noqa: BLE001
+            logger.error("Failed to load automation mappings: %s", e)
+            return []
+
+    def _save_mappings(self, mappings: list[MiotEventMapping]) -> None:
+        self._kv_repo.set(
+            _KV_MAPPINGS,
+            json.dumps([m.model_dump(mode="json") for m in mappings], ensure_ascii=False),
+        )
+
+    def _load_logs(self) -> list[MiotEventTriggerLog]:
+        raw = self._kv_repo.get(_KV_LOGS, "[]") or "[]"
+        try:
+            return [MiotEventTriggerLog.model_validate(item) for item in json.loads(raw)]
+        except Exception as e:  # noqa: BLE001
+            logger.error("Failed to load automation logs: %s", e)
+            return []
+
+    def _append_log(self, item: MiotEventTriggerLog) -> None:
+        logs = self._load_logs()
+        logs.insert(0, item)
+        self._kv_repo.set(
+            _KV_LOGS,
+            json.dumps(
+                [log.model_dump(mode="json") for log in logs[:_MAX_LOGS]],
+                ensure_ascii=False,
+            ),
+        )
+
+    async def list_catalog(self, miot_service) -> MiotEventCatalog:
+        devices = await miot_service.get_miot_device_list()
+        scenes = await miot_service.get_miot_scene_list()
+        cameras = await miot_service.list_cameras_with_state()
+        return MiotEventCatalog(
+            devices=[
+                MiotEventSource(
+                    source_type="device",
+                    source_id=d.did,
+                    source_name=d.name,
+                    home_id=d.home_id,
+                    room_name=d.room_name,
+                )
+                for d in devices
+            ],
+            scenes=[
+                MiotEventSource(
+                    source_type="scene",
+                    source_id=s.scene_id,
+                    source_name=s.scene_name,
+                )
+                for s in scenes
+            ],
+            cameras=cameras,
+        )
+
+    def list_mappings(self) -> list[MiotEventMapping]:
+        return self._load_mappings()
+
+    def create_mapping(self, mapping: MiotEventMapping) -> MiotEventMapping:
+        mappings = self._load_mappings()
+        current = now_ms()
+        mapping.id = mapping.id or str(uuid.uuid4())
+        mapping.created_at = current
+        mapping.updated_at = current
+        mappings.insert(0, mapping)
+        self._save_mappings(mappings)
+        return mapping
+
+    def update_mapping(self, mapping_id: str, update: MiotEventMappingUpdate) -> MiotEventMapping:
+        mappings = self._load_mappings()
+        for mapping in mappings:
+            if mapping.id != mapping_id:
+                continue
+            fields = update.model_fields_set
+            for field in fields:
+                setattr(mapping, field, getattr(update, field))
+            mapping.updated_at = now_ms()
+            self._save_mappings(mappings)
+            return mapping
+        raise ResourceNotFoundException(f"Mapping '{mapping_id}' not found")
+
+    def build_miot_event_rule_payload(
+        self,
+        task_id: str,
+        name: str,
+        source_ids: list[str],
+        event_kinds: list[str],
+        query: str,
+        property_filters: dict[str, Any],
+        action_descriptions: list[str] | None = None,
+    ) -> dict:
+        return {
+            "name": name,
+            "task_id": task_id,
+            "trigger_type": "miot_event",
+            "mode": "event",
+            "lifecycle": "permanent",
+            "enabled": True,
+            "condition": {
+                "perceive_device_ids": [],
+                "query": query,
+                "source_ids": source_ids,
+                "event_kinds": event_kinds,
+                "property_filters": property_filters,
+                "mapping_ids": [],
+                "use_global_mapping": True,
+            },
+            "actions": [],
+            "action_descriptions": action_descriptions or ["米家事件触发规则命中"],
+            "on_enter_actions": [],
+            "on_enter_desc": None,
+            "on_exit_actions": [],
+            "on_exit_desc": None,
+            "on_target_desc": None,
+            "terminate_when": None,
+            "exit_debounce_seconds": 60,
+            "duration_seconds": None,
+            "duration_ratio": None,
+            "created_at": None,
+            "updated_at": None,
+        }
+
+    def delete_mapping(self, mapping_id: str) -> None:
+        mappings = [m for m in self._load_mappings() if m.id != mapping_id]
+        self._save_mappings(mappings)
+
+    def list_logs(self, limit: int = 50) -> list[MiotEventTriggerLog]:
+        return self._load_logs()[:limit]
+
+    def get_device_property_keys(self, did: str) -> list[dict]:
+        """Return known property keys for a device from recent trigger logs,
+        with recent observed values for each key."""
+        logs = self._load_logs()
+        counter: dict[str, int] = {}
+        values: dict[str, list[str]] = {}
+        for item in logs:
+            if item.trigger.source_id != did:
+                continue
+            for k, v in item.trigger.changed_properties.items():
+                counter[k] = counter.get(k, 0) + 1
+                sv = str(v)
+                if k not in values:
+                    values[k] = []
+                if sv not in values[k]:
+                    values[k].append(sv)
+        result = []
+        for k, v in sorted(counter.items(), key=lambda x: -x[1]):
+            entry = {"key": k, "count": v, "recent_values": values.get(k, [])[:5]}
+            result.append(entry)
+        return result
+
+
+    def _match_rule(self, rule, trigger: MiotEventTrigger) -> bool:
+        if getattr(rule, "trigger_type", RuleTriggerType.PERCEPTION) != RuleTriggerType.MIOT_EVENT:
+            return False
+        cond = rule.condition
+        if cond.source_ids and trigger.source_id not in cond.source_ids:
+            return False
+        if cond.event_kinds and trigger.event_name not in cond.event_kinds:
+            return False
+        for key, expected in cond.property_filters.items():
+            actual = trigger.changed_properties.get(key)
+            if actual is None:
+                actual = trigger.raw.get(key)
+            if not _match_condition(actual, expected):
+                return False
+        return True
+
+    def _match_property_filters(
+        self,
+        filters: dict[str, Any],
+        trigger: MiotEventTrigger,
+    ) -> bool:
+        for key, expected in filters.items():
+            actual = trigger.changed_properties.get(key)
+            if actual is None:
+                actual = trigger.raw.get(key)
+            if not _match_condition(actual, expected):
+                return False
+        return True
+
+    def _match_mapping(self, mapping: MiotEventMapping, trigger: MiotEventTrigger) -> bool:
+        if not mapping.enabled:
+            return False
+        if mapping.source_type != trigger.source_type:
+            return False
+        if mapping.source_id != trigger.source_id:
+            return False
+        if mapping.event_kinds and trigger.event_name not in mapping.event_kinds:
+            return False
+        return self._match_property_filters(mapping.property_filters, trigger)
+
+    def _collect_mappings_for_rules(
+        self,
+        trigger: MiotEventTrigger,
+        candidate_rules: list[Any],
+    ) -> list[MiotEventMapping]:
+        all_mappings = self._load_mappings()
+        source_mappings = [
+            m
+            for m in all_mappings
+            if m.enabled
+            and m.source_type == trigger.source_type
+            and m.source_id == trigger.source_id
+        ]
+        source_index = {m.id: m for m in source_mappings}
+        selected: dict[str, MiotEventMapping] = {}
+        for rule in candidate_rules:
+            if rule.condition.mapping_ids:
+                for mapping_id in rule.condition.mapping_ids:
+                    mapping = source_index.get(mapping_id)
+                    if mapping is not None:
+                        selected[mapping.id] = mapping
+            elif rule.condition.use_global_mapping:
+                for mapping in source_mappings:
+                        selected[mapping.id] = mapping
+        return list(selected.values())
+
+    def _collect_direct_mappings(
+        self,
+        trigger: MiotEventTrigger,
+    ) -> list[MiotEventMapping]:
+        return [
+            mapping
+            for mapping in self._load_mappings()
+            if self._match_mapping(mapping, trigger)
+        ]
+
+    def _cooldown_key(self, trigger: MiotEventTrigger, mapping: MiotEventMapping) -> str:
+        return f"{trigger.source_type}:{trigger.source_id}:{mapping.id}"
+
+    async def handle_trigger(
+        self,
+        *,
+        trigger: MiotEventTrigger,
+        perception_service,
+        rule_service,
+        miot_service,
+        meaningful_events_dao,
+        pipeline=None,
+    ) -> MiotEventTriggerLog:
+        all_rules = await rule_service.get_all_rules(enabled_only=True)
+        candidate_rules = [rule for rule in all_rules if self._match_rule(rule, trigger)]
+        mapping_by_id = {
+            mapping.id: mapping
+            for mapping in self._collect_direct_mappings(trigger)
+        }
+        for mapping in self._collect_mappings_for_rules(trigger, candidate_rules):
+            mapping_by_id[mapping.id] = mapping
+        mappings = list(mapping_by_id.values())
+        log_item = MiotEventTriggerLog(
+            id=str(uuid.uuid4()),
+            trigger=trigger,
+            mapping_ids=[m.id for m in mappings],
+            candidate_rule_ids=[r.id for r in candidate_rules],
+            created_at=now_ms(),
+        )
+        if not mappings:
+            log_item.skipped_reason = "no_mapping"
+            self._append_log(log_item)
+            return log_item
+
+        now = time.monotonic()
+        active_mappings: list[MiotEventMapping] = []
+        for mapping in mappings:
+            cooldown_key = self._cooldown_key(trigger, mapping)
+            if now < self._cooldowns.get(cooldown_key, 0.0):
+                continue
+            self._cooldowns[cooldown_key] = now + float(mapping.cooldown_seconds)
+            active_mappings.append(mapping)
+        if not active_mappings:
+            log_item.skipped_reason = "cooldown"
+            self._append_log(log_item)
+            return log_item
+
+        camera_ids: list[str] = []
+        seen: set[str] = set()
+        for mapping in active_mappings:
+            for did in mapping.camera_dids:
+                if did not in seen:
+                    seen.add(did)
+                    camera_ids.append(did)
+        log_item.camera_dids = camera_ids
+        if not camera_ids:
+            log_item.skipped_reason = "no_camera"
+            self._append_log(log_item)
+            return log_item
+
+        query_parts = [
+            f"这是一次由米家事件触发的主动感知。事件源：{trigger.source_name or trigger.source_id}。",
+            f"事件类型：{trigger.event_name or trigger.source_type}。",
+        ]
+        if trigger.changed_properties:
+            query_parts.append(f"属性变化：{trigger.changed_properties}")
+        if candidate_rules:
+            query_parts.extend(
+                [f"- {rule.name}: {rule.condition.query}" for rule in candidate_rules]
+            )
+        mapping_query = next((m.query_template for m in active_mappings if m.query_template), "")
+        if mapping_query:
+            query_parts.append(mapping_query)
+        query_parts.append("请结合当前画面简明回答，并重点说明与触发事件相关的观察。")
+        log_item.perception_started = True
+        clips_by_device: dict[str, tuple[bytes, str]] = {}
+        try:
+            result = await perception_service.on_demand_perceive(
+                OnDemandPerceptionRequest(
+                    sources=camera_ids,
+                    query="\n".join(query_parts),
+                    trigger_context={
+                        "trigger_kind": trigger.trigger_kind,
+                        "trigger_source_id": trigger.source_id,
+                        "trigger_source_name": trigger.source_name,
+                        "trigger_event_name": trigger.event_name,
+                        "trigger_props": trigger.changed_properties,
+                        "trigger_time": trigger.occurred_at,
+                    },
+                ),
+                snapshot_sink=clips_by_device,
+            )
+        except Exception as e:  # noqa: BLE001
+            log_item.error = str(e)
+            self._append_log(log_item)
+            return log_item
+
+        answer = result.answer if result else ""
+        # Save a snapshot frame from the on-demand collected batch for video replay
+        snapshot_paths: list[str] = []
+        try:
+            import os
+            from pathlib import Path as _Path
+
+            import cv2
+            import numpy as np
+
+            miloco_home = os.environ.get("MILOCO_HOME", "/root/.openclaw/miloco")
+            clips_dir = _Path(miloco_home) / "static" / "clips" / "automation"
+            clips_dir.mkdir(parents=True, exist_ok=True)
+
+            batch = pipeline._collector.collect_batch(camera_ids, drain=False) if pipeline else None
+            if batch and not batch.empty:
+                for device_id in camera_ids:
+                    data = batch.devices.get(device_id)
+                    if data and data.video:
+                        frame = data.video[-1].frame
+                        if isinstance(frame, np.ndarray) and frame.size > 0:
+                            snap_path = clips_dir / f"{log_item.id}_{device_id}.jpg"
+                            cv2.imwrite(str(snap_path), frame)
+                            snapshot_paths.append(str(snap_path))
+            if not snapshot_paths:
+                logger.debug("snapshot: no frames available for %s", camera_ids)
+        except Exception as e:
+            logger.debug("snapshot save failed: %s", e)
+
+        log_item.perception_answer = answer
+        log_item.snapshot_paths = snapshot_paths
+
+        clip_count = 0
+        clip_kind = ""
+        clip_device_ids: list[str] = []
+        if clips_by_device:
+            settings = get_settings()
+            snapshot_root = get_snapshot_root()
+            if check_disk_space(
+                snapshot_root, settings.perception.snapshot_min_free_disk_mb
+            ):
+                clip_count = save_clips(log_item.id, clips_by_device)
+                if clip_count > 0:
+                    clip_kind = next(iter(clips_by_device.values()))[1]
+                    clip_device_ids = [
+                        device_id for device_id in camera_ids if device_id in clips_by_device
+                    ]
+            else:
+                logger.error(
+                    "automation clip disk low (< %d MB free), skip save for event %s",
+                    settings.perception.snapshot_min_free_disk_mb,
+                    log_item.id,
+                )
+        log_item.clip_kind = clip_kind
+        log_item.clip_device_ids = clip_device_ids
+
+        matched_rule_ids: list[str] = []
+        context = (
+            f"米家事件触发感知\n"
+            f"来源: {trigger.source_name or trigger.source_id}\n"
+            f"事件: {trigger.event_name}\n"
+            f"属性: {trigger.changed_properties}\n"
+            f"感知结果: {answer}"
+        )
+        for rule in candidate_rules:
+            exec_result = await rule_service.trigger_rule(rule.id, context)
+            if exec_result is not None:
+                matched_rule_ids.append(rule.id)
+        log_item.matched_rule_ids = matched_rule_ids
+
+        if answer:
+            text = (
+                f"[米家事件触发]\n"
+                f"来源：{trigger.source_name or trigger.source_id}\n"
+                f"事件：{trigger.event_name}\n"
+                f"结果：{answer}"
+            )
+            meaningful_events_dao.insert(
+                event_id=log_item.id,
+                timestamp=trigger.occurred_at or now_ms(),
+                text=text,
+                payload_json=json.dumps(
+                    {
+                        "trigger": trigger.model_dump(mode="json"),
+                        "matched_rule_ids": matched_rule_ids,
+                    },
+                    ensure_ascii=False,
+                ),
+                has_rule_hit=bool(matched_rule_ids),
+                has_suggestion=False,
+                has_asr=False,
+                device_ids=camera_ids,
+                snapshot_count=clip_count,
+                rule_names={rule.id: rule.name for rule in candidate_rules},
+                home_id=trigger.home_id,
+            )
+            if clip_count > 0:
+                meaningful_events_dao.update_snapshot_count(log_item.id, clip_count)
+        self._append_log(log_item)
+        if pipeline is not None and answer:
+            pipeline._publish(
+                "meaningful_event",
+                {
+                    "event_id": log_item.id,
+                    "timestamp": trigger.occurred_at or now_ms(),
+                    "text": text,
+                    "has_rule_hit": bool(matched_rule_ids),
+                    "has_suggestion": False,
+                    "has_asr": False,
+                    "snapshot_count": clip_count,
+                    "device_ids": camera_ids,
+                    "rule_names": {rule.id: rule.name for rule in candidate_rules},
+                    "clip_kind": clip_kind or None,
+                },
+            )
+        return log_item
+
+    async def emit_scene_trigger(
+        self,
+        *,
+        home_id: str,
+        scene_id: str | None,
+        event_name: str,
+        raw: dict[str, Any],
+        miot_service,
+        perception_service,
+        rule_service,
+        meaningful_events_dao,
+        pipeline=None,
+    ) -> None:
+        if not scene_id:
+            return
+        scenes = await miot_service.get_miot_scene_list()
+        scene = next((item for item in scenes if item.scene_id == scene_id), None)
+        trigger = MiotEventTrigger(
+            source_type="scene",
+            source_id=scene_id,
+            source_name=scene.scene_name if scene else scene_id,
+            home_id=home_id,
+            event_name="scene",
+            occurred_at=now_ms(),
+            raw={"scene_event": event_name, **raw},
+        )
+        await self.handle_trigger(
+            trigger=trigger,
+            perception_service=perception_service,
+            rule_service=rule_service,
+            miot_service=miot_service,
+            meaningful_events_dao=meaningful_events_dao,
+            pipeline=pipeline,
+        )

--- a/backend/miloco/src/miloco/main.py
+++ b/backend/miloco/src/miloco/main.py
@@ -28,6 +28,7 @@ from fastapi.responses import (
 )
 
 from miloco.admin.router import router as admin_router
+from miloco.automation.router import router as automation_router
 from miloco.config import get_settings, register_reset_hook
 from miloco.database.connector import init_database
 from miloco.dispatch import AgentDispatcher, set_agent_dispatcher
@@ -465,6 +466,7 @@ app.include_router(miot_router, prefix="/api")
 app.include_router(person_router, prefix="/api")
 app.include_router(home_profile_router, prefix="/api")
 app.include_router(rule_router, prefix="/api")
+app.include_router(automation_router, prefix="/api")
 app.include_router(task_router, prefix="/api")
 app.include_router(task_record_router, prefix="/api")
 app.include_router(perception_router, prefix="/api")

--- a/backend/miloco/src/miloco/manager.py
+++ b/backend/miloco/src/miloco/manager.py
@@ -8,6 +8,7 @@ Service manager module
 import logging
 import uuid
 
+from miloco.automation.service import AutomationService
 from miloco.config import get_settings
 from miloco.database.kv_repo import KVRepo, SystemConfigKeys
 from miloco.database.person_repo import PersonRepo
@@ -88,6 +89,7 @@ class Manager:
         )
         self._person_service = PersonService(self._person_repo)
         self._home_profile_service = HomeProfileService(self._person_service)
+        self._automation_service = AutomationService(self._kv_repo)
 
         # Initialize rule module
         async with mon.track_async(NodeName.RULE_SERVICE, "init"):
@@ -137,6 +139,10 @@ class Manager:
     @property
     def task_service(self) -> TaskService:
         return self._task_service
+
+    @property
+    def automation_service(self) -> AutomationService:
+        return self._automation_service
 
     # Repo layer access properties
     @property

--- a/backend/miloco/src/miloco/miot/client.py
+++ b/backend/miloco/src/miloco/miot/client.py
@@ -22,6 +22,7 @@ from miot.types import (
     MIoTCameraInfo,
     MIoTDeviceBindEvent,
     MIoTDeviceInfo,
+    MIoTDevicePropertyChangedEvent,
     MIoTGetPropertyParam,
     MIoTLanDeviceInfo,
     MIoTManualSceneInfo,
@@ -32,6 +33,7 @@ from miot.types import (
 )
 from pydantic_core import to_jsonable_python
 
+from miloco.automation.schema import MiotEventTrigger
 from miloco.config import get_settings
 from miloco.database.kv_repo import AuthConfigKeys, DeviceInfoKeys, KVRepo
 from miloco.miot.camera_handler import CameraVisionHandler
@@ -221,6 +223,7 @@ class MiotProxy:
             welcome=self._welcome_service.welcome,
         )
         self._subscribed_meta_dids = set()
+        self._subscribed_property_dids = set()
         self._scene_listener = SceneEventListener(
             refresh_scenes=self.refresh_scenes
         )
@@ -230,6 +233,9 @@ class MiotProxy:
         # name/room/home propagates. Kept off the bind welcome path.
         self._miot_client.register_device_meta_changed_callback(
             self._on_device_meta_changed_event
+        )
+        self._miot_client.register_device_property_changed_callback(
+            self._on_device_property_changed_event
         )
         # Home scene change (rename/delete/edit): refresh the scene list.
         self._miot_client.register_scene_changed_callback(
@@ -693,6 +699,7 @@ class MiotProxy:
                 devices = await self._miot_client.get_devices_async()
                 self._device_info_dict = devices
                 await self._sync_meta_subscriptions()
+                await self._sync_property_subscriptions()
                 await self._sync_scene_subscriptions()
                 return devices
             except Exception as e:
@@ -837,6 +844,75 @@ class MiotProxy:
             len(self._subscribed_meta_dids),
         )
 
+    async def _on_device_property_changed_event(
+        self, msg: MIoTDevicePropertyChangedEvent
+    ) -> None:
+        try:
+            from miloco.manager import get_manager
+
+            mgr = get_manager()
+            if not getattr(mgr, "_initialized", False):
+                return
+            device = self._device_info_dict.get(msg.did)
+            if device is None:
+                device = (await self.get_devices()).get(msg.did)
+            if device is None:
+                logger.debug("Property change ignored for unknown did=%s", msg.did)
+                return
+            await mgr.automation_service.handle_trigger(
+                trigger=MiotEventTrigger(
+                    source_type="device",
+                    source_id=msg.did,
+                    source_name=device.name,
+                    home_id=device.home_id,
+                    room_name=device.room_name,
+                    event_name="device_prop",
+                    changed_properties=msg.changed_properties,
+                    occurred_at=msg.timestamp_ms,
+                    raw=msg.raw,
+                ),
+                perception_service=mgr.perception_service,
+                rule_service=mgr.rule_service,
+                miot_service=mgr.miot_service,
+                meaningful_events_dao=mgr.meaningful_events_dao,
+                pipeline=mgr.perception_service._pipeline,
+            )
+        except Exception as e:
+            logger.error("Failed to dispatch device-property automation trigger: %s", e)
+
+    async def _sync_property_subscriptions(self) -> None:
+        target = {did for did in self._device_info_dict if "/" not in did}
+        to_add = target - self._subscribed_property_dids
+        to_remove = self._subscribed_property_dids - target
+        if not to_add and not to_remove:
+            return
+
+        async def _sub(did: str) -> str | None:
+            try:
+                await self._miot_client.sub_device_property_changed_async(did)
+                return did
+            except Exception as e:
+                logger.error("subscribe device-property failed did=%s: %s", did, e)
+                return None
+
+        async def _unsub(did: str) -> str | None:
+            try:
+                await self._miot_client.unsub_device_property_changed_async(did)
+            except Exception as e:
+                logger.error("unsubscribe device-property failed did=%s: %s", did, e)
+            return did
+
+        added = await asyncio.gather(*(_sub(d) for d in to_add))
+        removed = await asyncio.gather(*(_unsub(d) for d in to_remove))
+        self._subscribed_property_dids |= {d for d in added if d}
+        self._subscribed_property_dids -= {d for d in removed if d}
+        logger.info(
+            "device-property subscriptions synced: +%d -%d (total=%d)",
+            len([d for d in added if d]),
+            len([d for d in removed if d]),
+            len(self._subscribed_property_dids),
+        )
+
     async def _on_scene_changed_event(self, msg: MIoTSceneChangedEvent) -> None:
         """Forward home scene-change push events to the dedicated listener.
 
@@ -845,6 +921,24 @@ class MiotProxy:
         thin shim, mirroring ``_on_user_bind_event``.
         """
         await self._scene_listener.on_event(msg)
+        try:
+            from miloco.manager import get_manager
+
+            mgr = get_manager()
+            if getattr(mgr, "_initialized", False):
+                await mgr.automation_service.emit_scene_trigger(
+                    home_id=msg.home_id,
+                    scene_id=msg.scene_id,
+                    event_name=msg.event,
+                    raw=msg.raw,
+                    miot_service=mgr.miot_service,
+                    perception_service=mgr.perception_service,
+                    rule_service=mgr.rule_service,
+                    meaningful_events_dao=mgr.meaningful_events_dao,
+                    pipeline=mgr.perception_service._pipeline,
+                )
+        except Exception as e:
+            logger.error("Failed to dispatch scene automation trigger: %s", e)
 
     def _collect_home_ids(self) -> set[str]:
         """Union of home_ids across cached devices / cameras / scenes.

--- a/backend/miloco/src/miloco/perception/client.py
+++ b/backend/miloco/src/miloco/perception/client.py
@@ -608,7 +608,10 @@ class PerceptionEngineProxy:
             )
 
     async def on_demand_perceive(
-        self, batch: PerceptionBatch, query: str
+        self,
+        batch: PerceptionBatch,
+        query: str,
+        snapshot_sink: dict | None = None,
     ) -> OnDemandPerceptionResult | None:
         """Run on-demand query pipeline — offloaded to inference thread."""
         async with get_monitor().track_async(NodeName.ENGINE, "on_demand") as _eng_h:
@@ -635,9 +638,15 @@ class PerceptionEngineProxy:
                         _run_with_trace_id(
                             trace_id,
                             self._on_demand_perceive_impl(batched_snapshot, query),
+                            snapshot_sink=snapshot_sink,
                         )
                     ),
                 )
+            if snapshot_sink is not None:
+                from miloco.perception.snapshot_context import snapshot_collector_scope
+
+                with snapshot_collector_scope(snapshot_sink):
+                    return await self._on_demand_perceive_impl(batched_snapshot, query)
 
             return await self._on_demand_perceive_impl(batched_snapshot, query)
 

--- a/backend/miloco/src/miloco/perception/engine/api.py
+++ b/backend/miloco/src/miloco/perception/engine/api.py
@@ -819,6 +819,7 @@ class PerceptionEngine(BasePerceptionEngine):
                 did = snapshot.device.did
                 dispatched = [
                     r for r in rules
+                    if r.get("trigger_type", "perception") == "perception"
                     if not r.get("condition", {}).get("perceive_device_ids")
                     or did in r["condition"]["perceive_device_ids"]
                 ]

--- a/backend/miloco/src/miloco/perception/engine/pipeline.py
+++ b/backend/miloco/src/miloco/perception/engine/pipeline.py
@@ -800,6 +800,7 @@ async def run_query_pipeline(
         room_name: str, snapshots: list[DeviceSnapshot]
     ) -> "tuple[str, QueryOutput] | None":
         room_identity_packets: list[IdentityPacket] = []
+        query_device_snapshot: DeviceSnapshot | None = None
 
         for snapshot in snapshots:
             # Downsample to target fps at pipeline entry
@@ -842,19 +843,34 @@ async def run_query_pipeline(
                 identity_packet, config.input.fps, config.input.omni_fps
             )
             room_identity_packets.append(identity_packet)
+            if query_device_snapshot is None and identity_packet.all_frames:
+                query_device_snapshot = snapshot
 
         if not room_identity_packets:
             return None
+        if query_device_snapshot is None:
+            query_device_snapshot = snapshots[0]
 
-        # Build query prompt from IdentityPackets and call Omni
-        payload = build_query_prompt(
-            identity_packets=room_identity_packets,
-            query=query,
-            last_caption=captions.get(room_name),
+        device_ctx_token = set_device_context(
+            DeviceContext(
+                device_trace_id=f"query_{uuid.uuid4()}",
+                device_id=query_device_snapshot.device.did,
+                room_name=room_name,
+            )
         )
-        raw_response = await call_omni(
-            payload, resolve_live_omni_config(config.omni), type="on_demand"
-        )
+        try:
+            # query 路径的 clip 字节在 build_query_prompt -> _encode_batch_video
+            # 阶段就会旁路 push，因此设备上下文需要覆盖 prompt 构建 + omni 调用整段。
+            payload = build_query_prompt(
+                identity_packets=room_identity_packets,
+                query=query,
+                last_caption=captions.get(room_name),
+            )
+            raw_response = await call_omni(
+                payload, resolve_live_omni_config(config.omni), type="on_demand"
+            )
+        finally:
+            reset_device_context(device_ctx_token)
         answer = parse_query_response(raw_response)
         if not answer:
             return None
@@ -862,8 +878,8 @@ async def run_query_pipeline(
 
     # 各 room 并发（与 run_batch_pipeline 同源：per-room omni 墙钟 Σ→max）。单房间查询
     # 无变化；多房间/全屋查询省 Σ。return_exceptions=True + _reraise_first 保持原"任一
-    # room 失败即整体失败"语义（上层 on_demand_perceive 捕获→空答案）。query 路径不走
-    # fused、无 set_device_context，并发面比主路径更窄（run_identity 池写仍是原子同步段）。
+    # room 失败即整体失败"语义（上层 on_demand_perceive 捕获→空答案）。query 路径在
+    # omni 调用前补 set_device_context，使 on-demand 的 clip/snapshot 收集也能按设备落盘。
     room_results = await asyncio.gather(
         *(_run_room_query(rn, snaps) for rn, snaps in batch.by_room().items()),
         return_exceptions=True,

--- a/backend/miloco/src/miloco/perception/processor.py
+++ b/backend/miloco/src/miloco/perception/processor.py
@@ -635,7 +635,10 @@ class PipelineProcessor:
         )
 
     async def process_on_demand(
-        self, dids: list[str] | None, query: str
+        self,
+        dids: list[str] | None,
+        query: str,
+        snapshot_sink: dict | None = None,
     ) -> OnDemandPerceptionResult | None:
         """Active perception pipeline — multi-device batch query.
 
@@ -656,7 +659,11 @@ class PipelineProcessor:
                 _proc_h.add_window_ms(batch.end_timestamp - batch.start_timestamp)
 
             try:
-                return await self._perception_engine_proxy.on_demand_perceive(batch, query)
+                return await self._perception_engine_proxy.on_demand_perceive(
+                    batch,
+                    query,
+                    snapshot_sink=snapshot_sink,
+                )
             except Exception as e:
                 logger.error("[processor] 主动查询感知失败 | %s", e, exc_info=True)
                 return None

--- a/backend/miloco/src/miloco/perception/schema.py
+++ b/backend/miloco/src/miloco/perception/schema.py
@@ -456,6 +456,10 @@ class OnDemandPerceptionRequest(BaseModel):
 
     sources: list[str] = Field(..., description="Device did list", min_length=1)
     query: str = Field(..., description="Natural language question", min_length=1)
+    trigger_context: dict | None = Field(
+        default=None,
+        description="Optional trigger metadata injected into the on-demand prompt",
+    )
 
 
 class OnDemandPerceptionResultItem(BaseModel):

--- a/backend/miloco/src/miloco/perception/service.py
+++ b/backend/miloco/src/miloco/perception/service.py
@@ -27,6 +27,27 @@ from miloco.utils.time_utils import ms_to_iso_local, now_ms
 logger = logging.getLogger(__name__)
 
 
+def _augment_query_with_trigger_context(query: str, trigger_context: dict | None) -> str:
+    if not trigger_context:
+        return query
+    lines = ["以下是本次主动感知的触发上下文，请结合画面回答："]
+    for key in (
+        "trigger_kind",
+        "trigger_source_id",
+        "trigger_source_name",
+        "trigger_event_name",
+        "trigger_props",
+        "trigger_time",
+    ):
+        value = trigger_context.get(key)
+        if value in (None, "", [], {}):
+            continue
+        lines.append(f"- {key}: {value}")
+    lines.append("")
+    lines.append(query)
+    return "\n".join(lines)
+
+
 class PerceptionService:
     """Service for all perception operations."""
 
@@ -102,7 +123,9 @@ class PerceptionService:
     # ---- Active perception ----
 
     async def on_demand_perceive(
-        self, request: OnDemandPerceptionRequest
+        self,
+        request: OnDemandPerceptionRequest,
+        snapshot_sink: dict | None = None,
     ) -> OnDemandPerceptionResultItem | None:
         """On-demand perception: batch-collects requested devices and runs
         a single fusion inference via pipeline.
@@ -129,7 +152,11 @@ class PerceptionService:
             )
 
         # Single batch inference call — collector assembles batch, processor infers
-        result = await self._pipeline.process_on_demand(valid_dids, request.query)
+        result = await self._pipeline.process_on_demand(
+            valid_dids,
+            _augment_query_with_trigger_context(request.query, request.trigger_context),
+            snapshot_sink=snapshot_sink,
+        )
 
         if not result:
             raise BusinessException(

--- a/backend/miloco/src/miloco/rule/schema.py
+++ b/backend/miloco/src/miloco/rule/schema.py
@@ -44,6 +44,13 @@ class RuleLifecycle(str, Enum):
     TEMPORARY = "temporary"
 
 
+class RuleTriggerType(str, Enum):
+    """Rule trigger source."""
+
+    PERCEPTION = "perception"
+    MIOT_EVENT = "miot_event"
+
+
 class RuleEvent(str, Enum):
     """Frame-diff events emitted by RuleRunner."""
 
@@ -103,9 +110,30 @@ class RuleCondition(BaseModel):
     """Rule condition: which perception devices to watch + what to look for."""
 
     perceive_device_ids: list[str] = Field(
-        ..., description="Perception device IDs (OR semantics: any match triggers)"
+        default_factory=list,
+        description="Perception device IDs (OR semantics: any match triggers)",
     )
     query: str = Field(..., description="Natural language condition description")
+    source_ids: list[str] = Field(
+        default_factory=list,
+        description="MiOT event source IDs (device did / scene id)",
+    )
+    event_kinds: list[str] = Field(
+        default_factory=list,
+        description="MiOT event kinds, e.g. device_prop / scene",
+    )
+    property_filters: dict[str, str] = Field(
+        default_factory=dict,
+        description="MiOT property filters keyed by property path/name",
+    )
+    mapping_ids: list[str] = Field(
+        default_factory=list,
+        description="Explicit mapping IDs used by miot_event trigger",
+    )
+    use_global_mapping: bool = Field(
+        default=True,
+        description="Whether the rule should use source-level global mapping",
+    )
 
 
 class Rule(BaseModel):
@@ -114,6 +142,10 @@ class Rule(BaseModel):
     id: str = Field("", description="Rule ID (UUID)")
     name: str = Field(..., description="Rule display name (free text)")
     task_id: str = Field(..., description="Task id (snake_case)")
+    trigger_type: RuleTriggerType = Field(
+        RuleTriggerType.PERCEPTION,
+        description="Trigger source: perception or miot_event",
+    )
     mode: RuleMode = Field(RuleMode.EVENT, description="event or state")
     lifecycle: RuleLifecycle = Field(
         RuleLifecycle.PERMANENT, description="permanent or temporary"
@@ -203,6 +235,11 @@ class RuleConditionUpdate(BaseModel):
 
     perceive_device_ids: list[str] | None = Field(None)
     query: str | None = Field(None)
+    source_ids: list[str] | None = Field(None)
+    event_kinds: list[str] | None = Field(None)
+    property_filters: dict[str, str] | None = Field(None)
+    mapping_ids: list[str] | None = Field(None)
+    use_global_mapping: bool | None = Field(None)
 
 
 class RuleUpdate(BaseModel):
@@ -213,6 +250,7 @@ class RuleUpdate(BaseModel):
 
     name: str | None = Field(None)
     task_id: str | None = Field(None)
+    trigger_type: RuleTriggerType | None = Field(None)
     mode: RuleMode | None = Field(None)
     lifecycle: RuleLifecycle | None = Field(None)
     enabled: bool | None = Field(None)

--- a/backend/miloco/src/miloco/rule/service.py
+++ b/backend/miloco/src/miloco/rule/service.py
@@ -38,6 +38,7 @@ from miloco.rule.schema import (
     RuleLog,
     RuleLogKind,
     RuleMode,
+    RuleTriggerType,
     RuleUpdate,
 )
 
@@ -87,6 +88,20 @@ def _validate_rule_consistency(rule: Rule) -> None:
     """
     # ---- 1. condition.query 措辞 ----
     _validate_query_phrasing(rule.condition.query)
+
+    if rule.trigger_type == RuleTriggerType.PERCEPTION and not rule.condition.perceive_device_ids:
+        raise ValidationException(
+            "perception trigger requires condition.perceive_device_ids"
+        )
+    if rule.trigger_type == RuleTriggerType.MIOT_EVENT:
+        if not rule.condition.source_ids:
+            raise ValidationException(
+                "miot_event trigger requires condition.source_ids"
+            )
+        if not rule.condition.event_kinds:
+            raise ValidationException(
+                "miot_event trigger requires condition.event_kinds"
+            )
 
     # ---- 2. mode matrix（执行路径由 actions / action_descriptions 哪个非空决定）----
     if rule.mode == RuleMode.EVENT:
@@ -282,7 +297,8 @@ class RuleService:
 
         self._fill_default_duration_ratio(rule)
 
-        await self._validate_perceive_device_ids(rule.condition.perceive_device_ids)
+        if rule.trigger_type == RuleTriggerType.PERCEPTION:
+            await self._validate_perceive_device_ids(rule.condition.perceive_device_ids)
         _validate_rule_consistency(rule)
         self._validate_on_target_desc_compat(rule)
 
@@ -335,7 +351,8 @@ class RuleService:
 
         self._fill_default_duration_ratio(rule)
 
-        await self._validate_perceive_device_ids(rule.condition.perceive_device_ids)
+        if rule.trigger_type == RuleTriggerType.PERCEPTION:
+            await self._validate_perceive_device_ids(rule.condition.perceive_device_ids)
         _validate_rule_consistency(rule)
         self._validate_on_target_desc_compat(rule)
 
@@ -374,6 +391,9 @@ class RuleService:
         if "task_id" in fields and update.task_id is not None:
             existing.task_id = update.task_id
 
+        if "trigger_type" in fields and update.trigger_type is not None:
+            existing.trigger_type = update.trigger_type
+
         if "mode" in fields and update.mode is not None:
             existing.mode = update.mode
 
@@ -398,14 +418,33 @@ class RuleService:
                 "perceive_device_ids" in cond_fields
                 and cond_update.perceive_device_ids is not None
             ):
-                await self._validate_perceive_device_ids(
-                    cond_update.perceive_device_ids
-                )
+                if existing.trigger_type == RuleTriggerType.PERCEPTION:
+                    await self._validate_perceive_device_ids(
+                        cond_update.perceive_device_ids
+                    )
                 existing.condition.perceive_device_ids = (
                     cond_update.perceive_device_ids
                 )
             if "query" in cond_fields and cond_update.query is not None:
                 existing.condition.query = cond_update.query
+            if "source_ids" in cond_fields and cond_update.source_ids is not None:
+                existing.condition.source_ids = cond_update.source_ids
+            if "event_kinds" in cond_fields and cond_update.event_kinds is not None:
+                existing.condition.event_kinds = cond_update.event_kinds
+            if (
+                "property_filters" in cond_fields
+                and cond_update.property_filters is not None
+            ):
+                existing.condition.property_filters = cond_update.property_filters
+            if "mapping_ids" in cond_fields and cond_update.mapping_ids is not None:
+                existing.condition.mapping_ids = cond_update.mapping_ids
+            if (
+                "use_global_mapping" in cond_fields
+                and cond_update.use_global_mapping is not None
+            ):
+                existing.condition.use_global_mapping = (
+                    cond_update.use_global_mapping
+                )
 
         # list 字段：CLI 用 [] 表达"清空"；不传 → 不动。
         if "actions" in fields and update.actions is not None:

--- a/backend/miot/src/miot/client.py
+++ b/backend/miot/src/miot/client.py
@@ -37,6 +37,7 @@ from .types import (
     MIoTCameraStatus,
     MIoTDeviceBindEvent,
     MIoTDeviceInfo,
+    MIoTDevicePropertyChangedEvent,
     MIoTHomeInfo,
     MIoTLanDeviceInfo,
     MIoTManualSceneInfo,
@@ -94,11 +95,15 @@ class MIoTClient:
     # path — the did is still present after refresh and would be misreported
     # as a new device.
     _callback_device_meta_changed: Optional[Callable[[MIoTDeviceBindEvent], Any]]
+    _callback_device_property_changed: Optional[
+        Callable[[MIoTDevicePropertyChangedEvent], Any]
+    ]
     # Dids whose `device/{did}/g_op/#` meta topic is (intended to be)
     # subscribed. This client owns the per-device meta subs: it re-issues them
     # on _setup_mips_async (re-OAuth / fresh setup); plain reconnects are
     # handled by mips_cloud's own _subs replay.
     _meta_sub_dids: set
+    _property_sub_dids: set
     # Home ids whose `home/{home_id}/scene/#` topic is (intended to be)
     # subscribed. Same ownership model as _meta_sub_dids, but per home.
     _scene_sub_home_ids: set
@@ -160,7 +165,9 @@ class MIoTClient:
         self._mips_user_sub_error = None
         self._callback_user_bind = None
         self._callback_device_meta_changed = None
+        self._callback_device_property_changed = None
         self._meta_sub_dids = set()
+        self._property_sub_dids = set()
         self._scene_sub_home_ids = set()
         self._callback_scene_changed = None
         self._callback_mips_connect: Optional[Callable[[], Any]] = None
@@ -401,6 +408,7 @@ class MIoTClient:
             self._callback_user_bind = None
             self._callback_device_meta_changed = None
             self._meta_sub_dids = set()
+            self._property_sub_dids = set()
             self._scene_sub_home_ids = set()
             self._callback_scene_changed = None
             self._callback_mips_connect = None
@@ -858,6 +866,26 @@ class MIoTClient:
                 len(dids),
             )
 
+        if self._property_sub_dids:
+            dids = sorted(self._property_sub_dids)
+            self._property_sub_dids = set()
+            ok = 0
+            for did in dids:
+                try:
+                    await self.sub_device_property_changed_async(did)
+                    ok += 1
+                except Exception as e:
+                    _LOGGER.error(
+                        "mips_cloud re-subscribe device-property FAILED did=%s: %s",
+                        did,
+                        e,
+                    )
+            _LOGGER.info(
+                "mips_cloud re-subscribed device-property for %d/%d devices",
+                ok,
+                len(dids),
+            )
+
         # Same replay for per-home scene subscriptions.
         if self._scene_sub_home_ids:
             home_ids = sorted(self._scene_sub_home_ids)
@@ -917,6 +945,21 @@ class MIoTClient:
         if asyncio.iscoroutine(ret):
             asyncio.ensure_future(ret)
 
+    def register_device_property_changed_callback(
+        self, callback: Optional[Callable[[MIoTDevicePropertyChangedEvent], Any]]
+    ) -> None:
+        self._callback_device_property_changed = callback
+
+    def _on_device_property_changed_msg(
+        self, msg: MIoTDevicePropertyChangedEvent
+    ) -> None:
+        cb = self._callback_device_property_changed
+        if cb is None:
+            return
+        ret = cb(msg)
+        if asyncio.iscoroutine(ret):
+            asyncio.ensure_future(ret)
+
     async def sub_device_meta_async(self, did: str) -> None:
         """Subscribe one device's `device/{did}/g_op/{rename,hr_change}` meta
         topics (idempotent).
@@ -950,6 +993,25 @@ class MIoTClient:
         if mips is None:
             return
         await mips.unsub_device_meta_changed_async(did)
+
+    async def sub_device_property_changed_async(self, did: str) -> None:
+        if did in self._property_sub_dids:
+            return
+        mips = self._mips_cloud
+        if mips is None or not mips.is_connected:
+            self._property_sub_dids.add(did)
+            return
+        await mips.sub_device_property_changed_async(
+            did, self._on_device_property_changed_msg
+        )
+        self._property_sub_dids.add(did)
+
+    async def unsub_device_property_changed_async(self, did: str) -> None:
+        self._property_sub_dids.discard(did)
+        mips = self._mips_cloud
+        if mips is None:
+            return
+        await mips.unsub_device_property_changed_async(did)
 
     def register_scene_changed_callback(
         self, callback: Optional[Callable[[MIoTSceneChangedEvent], Any]]

--- a/backend/miot/src/miot/mips_cloud.py
+++ b/backend/miot/src/miot/mips_cloud.py
@@ -46,6 +46,7 @@ from .const import (
 )
 from .types import (
     MIoTDeviceBindEvent,
+    MIoTDevicePropertyChangedEvent,
     MIoTSceneChangedEvent,
     MipsConnectionError,
     MipsSubscribeRejectedError,
@@ -95,6 +96,11 @@ _TOPIC_HOME_SCENE = re.compile(
     r"^home/([^/]+)/scene/(" + "|".join(_HOME_SCENE_OPS) + r")$"
 )
 
+# Device property push: `device/{did}/up/properties_changed/#`.
+_TOPIC_DEVICE_PROPERTIES_CHANGED = re.compile(
+    r"^device/([^/]+)/up/properties_changed(?:/.*)?$"
+)
+
 
 # Handler signatures accepted by sub_*_async methods. They receive a fully
 # decoded message object and may be sync or async — both are dispatched on the
@@ -102,6 +108,9 @@ _TOPIC_HOME_SCENE = re.compile(
 BindHandler = Callable[[MIoTDeviceBindEvent], Union[None, Awaitable[None]]]
 SceneChangedHandler = Callable[
     [MIoTSceneChangedEvent], Union[None, Awaitable[None]]
+]
+PropertyChangedHandler = Callable[
+    [MIoTDevicePropertyChangedEvent], Union[None, Awaitable[None]]
 ]
 MipsStateHandler = Callable[[bool], Union[None, Awaitable[None]]]
 # Fired when an unattended subscribe (no awaiter, e.g. the reconnect-time
@@ -483,6 +492,18 @@ class MIoTMipsCloud:
         for op in _HOME_SCENE_OPS:
             await self._unsubscribe_async(f"home/{home_id}/scene/{op}")
 
+    async def sub_device_property_changed_async(
+        self, did: str, handler: PropertyChangedHandler
+    ) -> None:
+        await self._subscribe_async(
+            f"device/{did}/up/properties_changed/#",
+            handler,
+            self._make_property_changed_decoder(),
+        )
+
+    async def unsub_device_property_changed_async(self, did: str) -> None:
+        await self._unsubscribe_async(f"device/{did}/up/properties_changed/#")
+
     # ------------------------------------------------------- subscribe core
 
     async def _subscribe_async(
@@ -815,6 +836,48 @@ class MIoTMipsCloud:
                 home_id=home_id,
                 event=op,  # type: ignore[arg-type]  # op ∈ {rename,delete,edit}
                 scene_id=str(scene_id) if scene_id is not None else None,
+                raw=raw if isinstance(raw, dict) else {},
+                timestamp_ms=_now_ms(),
+            )
+
+        return decode
+
+    @staticmethod
+    def _make_property_changed_decoder() -> Callable[
+        [str, bytes], Optional[MIoTDevicePropertyChangedEvent]
+    ]:
+        def decode(
+            topic: str, payload: bytes
+        ) -> Optional[MIoTDevicePropertyChangedEvent]:
+            m = _TOPIC_DEVICE_PROPERTIES_CHANGED.match(topic)
+            if not m:
+                return None
+            did = m.group(1)
+            raw = _parse_json_payload(payload) or {}
+            changed: dict[str, Any] = {}
+            params = raw.get("params")
+            if isinstance(params, dict):
+                if all(k in params for k in ("siid", "piid")):
+                    changed[f"prop.{params['siid']}.{params['piid']}"] = params.get("value")
+                else:
+                    for key, value in params.items():
+                        changed[str(key)] = value
+            elif isinstance(params, list):
+                for item in params:
+                    if not isinstance(item, dict):
+                        continue
+                    if "siid" in item and "piid" in item:
+                        changed[f"prop.{item['siid']}.{item['piid']}"] = item.get("value")
+                    elif "key" in item:
+                        changed[str(item["key"])] = item.get("value")
+            for key, value in raw.items():
+                if key == "params":
+                    continue
+                if key not in changed and key not in {"did", "method", "tid", "ts"}:
+                    changed[str(key)] = value
+            return MIoTDevicePropertyChangedEvent(
+                did=did,
+                changed_properties=changed,
                 raw=raw if isinstance(raw, dict) else {},
                 timestamp_ms=_now_ms(),
             )

--- a/backend/miot/src/miot/types.py
+++ b/backend/miot/src/miot/types.py
@@ -406,6 +406,21 @@ class MIoTSceneChangedEvent(BaseModel):
     timestamp_ms: int = Field(default=0)
 
 
+class MIoTDevicePropertyChangedEvent(BaseModel):
+    """Decoded `device/{did}/up/properties_changed/#` payload."""
+
+    did: str = Field(description="Device id")
+    changed_properties: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Flattened property map keyed by prop.{siid}.{piid} / raw key",
+    )
+    raw: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Raw decoded payload",
+    )
+    timestamp_ms: int = Field(default=0)
+
+
 class MipsConnectionError(Exception):
     """MIPS cloud client failed to connect."""
 

--- a/knowledge/03-features/triggered-perception.md
+++ b/knowledge/03-features/triggered-perception.md
@@ -1,0 +1,221 @@
+# 感知触发
+
+## 背景与目标
+
+传统感知流水线主要依赖摄像头画面变化来决定何时分析画面，但很多家庭事件本身是先由米家设备上报的，例如门锁状态变化、人体传感器数值变化、晾衣机状态变化、场景执行等。
+
+“感知触发”能力让 Miloco 可以在这些米家事件发生时，按用户配置主动查看关联摄像头，把“设备事件”转换成“带视觉上下文的感知结果”，用于后续规则判断、事件沉淀和 Agent 处理。
+
+---
+
+## 产品面
+
+### 能做什么
+
+- **设备属性变化触发感知**：当指定设备的某个属性发生变化时，触发关联摄像头感知
+- **场景触发感知**：当指定米家场景执行时，触发关联摄像头感知
+- **属性条件筛选**：可按属性和值配置触发条件，避免任意事件都触发感知
+- **感知提示**：可为每条映射附加默认提示，引导模型重点关注某类画面信息
+- **最近触发日志**：查看事件是否命中映射、是否发起感知、是否成功产生结果
+- **快照与视频回放**：触发后可回看本次感知对应的快照和视频片段
+
+### 典型场景
+
+**场景 1 — 智能晾衣机状态变化**：当“米家智能晾衣机Pro”的工作状态变成“上升中”时，触发阳台关联摄像头感知，判断附近是否有人、是否存在异常操作。
+
+**场景 2 — 传感器数值越界**：当人体/亮度/其他数值型属性高于某阈值时，触发对应摄像头感知，补充视觉信息，帮助 Agent 判断现场情况。
+
+**场景 3 — 场景执行后的确认**：当“回家模式”“观影模式”等米家场景执行后，触发摄像头感知，确认现场是否与预期一致。
+
+### 能力边界
+
+- 第一版支持两类事件源：**设备属性变化** 和 **场景触发**
+- 是否触发感知由“事件映射 + 属性条件”共同决定；未配置映射时不会触发
+- 一个事件可以关联多个摄像头，但只会对本次命中的事件做一次主动感知编排
+- 高频重复事件可通过“冷却时间”抑制，避免短时间内重复触发
+- 当前 CLI 侧**还没有独立的 `miloco-cli automation ...` 子命令**，命令行调试通过读取 `miloco-cli` 配置后直接访问 API 完成
+
+---
+
+## 研发面
+
+### 架构概览（数据流图）
+
+```text
+MiOT MQTT / 业务事件
+  → MiotProxy（miot/client.py）
+  → AutomationService.handle_trigger（automation/service.py）
+      → 事件源匹配
+      → 属性条件匹配
+      → 冷却时间判定
+      → 汇总关联摄像头
+      → 发起主动感知（on-demand）
+      → 写触发日志 / 快照 / 视频回放
+      → 命中规则 / meaningful_events / Agent 回调
+```
+
+### 核心模块
+
+**Automation Router**（`backend/miloco/src/miloco/automation/router.py`）
+
+- 提供感知触发配置与调试 API
+- 提供事件映射 CRUD
+- 提供最近触发日志、手动测试触发、设备属性定义查询
+
+**Automation Service**（`backend/miloco/src/miloco/automation/service.py`）
+
+- 维护事件映射持久化
+- 负责匹配事件源、属性条件和冷却时间
+- 编排一次感知触发对应的主动感知请求
+- 记录日志、快照和视频回放元数据
+
+**MiotProxy 事件分发**（`backend/miloco/src/miloco/miot/client.py`）
+
+- 接收米家设备属性变化事件
+- 接收米家场景事件
+- 标准化为内部 `MiotEventTrigger` 后交给 `AutomationService`
+
+### 属性条件支持
+
+属性筛选支持以下比较运算：
+
+- `等于`
+- `不等于`
+- `大于`
+- `小于`
+- `大于等于`
+- `小于等于`
+
+其中数值比较仅适用于数值型属性；离散枚举/布尔属性仅适合使用“等于 / 不等于”。
+
+### Web 入口
+
+家庭面板左侧导航新增 **“感知触发”** 页面，用于：
+
+- 选择事件源
+- 配置关联摄像头
+- 选择属性与属性值
+- 设置比较运算和冷却时间
+- 填写感知提示
+- 查看最近触发日志、快照和视频回放
+
+---
+
+## CLI / API 调试用法
+
+当前还没有单独的 `miloco-cli automation` 子命令。命令行调试推荐使用 `miloco-cli` 读取服务地址和 token，再通过 `curl` 调用感知触发相关 API。
+
+### 1. 读取服务地址和 token
+
+```bash
+SERVER_URL=$(miloco-cli config get server.url)
+TOKEN=$(miloco-cli config get server.token)
+```
+
+### 2. 查看感知触发目录
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+  "$SERVER_URL/api/automation/catalog"
+```
+
+返回内容包含：
+
+- 可选事件源设备列表
+- 可选场景列表
+- 可关联摄像头列表
+
+### 3. 查询某个设备的属性和值定义
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+  "$SERVER_URL/api/automation/device-spec/<did>"
+```
+
+这个接口会返回：
+
+- 属性 key（如 `prop.2.2`）
+- 属性中文名
+- 可选值列表
+- 数值范围
+
+### 4. 创建一条设备属性变化映射
+
+```bash
+curl -X POST -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "source_type": "device",
+    "source_id": "<device_did>",
+    "source_name_snapshot": "米家智能晾衣机Pro",
+    "camera_dids": ["rtsp_01"],
+    "enabled": true,
+    "query_template": "重点看阳台晾衣机附近是否有人或有异常动作。",
+    "event_kinds": ["device_prop"],
+    "property_filters": {
+      "prop.2.2": { "op": "eq", "value": "1" }
+    },
+    "cooldown_seconds": 30,
+    "notes": "CLI 调试示例"
+  }' \
+  "$SERVER_URL/api/automation/mappings"
+```
+
+### 5. 手动测试一次感知触发
+
+```bash
+curl -X POST -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "source_type": "device",
+    "source_id": "<device_did>",
+    "source_name": "米家智能晾衣机Pro",
+    "event_name": "device_prop",
+    "changed_properties": {
+      "prop.2.2": "1"
+    }
+  }' \
+  "$SERVER_URL/api/automation/test-trigger"
+```
+
+### 6. 查看最近触发日志
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+  "$SERVER_URL/api/automation/logs?limit=20"
+```
+
+重点字段：
+
+- `mapping_ids`：命中了哪些映射
+- `perception_started`：是否发起了感知
+- `skipped_reason`：未触发时的原因
+- `snapshot_paths`：快照路径
+- `clip_device_ids` / `clip_kind`：视频回放信息
+
+---
+
+## 如果我要修改感知触发相关功能
+
+| 修改目标                           | 去看哪个文件                                                                      |
+| ---------------------------------- | --------------------------------------------------------------------------------- |
+| 修改事件映射 API                   | `backend/miloco/src/miloco/automation/router.py`                                  |
+| 修改事件匹配 / 冷却时间 / 触发编排 | `backend/miloco/src/miloco/automation/service.py`                                 |
+| 修改事件结构定义                   | `backend/miloco/src/miloco/automation/schema.py`                                  |
+| 修改米家属性事件接入               | `backend/miloco/src/miloco/miot/client.py`、`backend/miot/src/miot/mips_cloud.py` |
+| 修改页面展示与交互                 | `web/src/components/AutomationPage.tsx`                                           |
+
+## 感知触发相关 API 路径
+
+主要入口：
+
+- `GET /api/automation/catalog`
+- `GET /api/automation/mappings`
+- `POST /api/automation/mappings`
+- `PATCH /api/automation/mappings/{mapping_id}`
+- `DELETE /api/automation/mappings/{mapping_id}`
+- `GET /api/automation/device-spec/{did}`
+- `POST /api/automation/test-trigger`
+- `GET /api/automation/logs`
+
+完整端点见 `backend/miloco/src/miloco/automation/router.py`。

--- a/knowledge/README.md
+++ b/knowledge/README.md
@@ -145,6 +145,7 @@ knowledge/
 - **01-overview** — [系统架构总览](01-overview/overview.md)
 - **02-strategy** — [产品战略](02-strategy/README.md)（内容待产品团队补充）
 - **03-features**
+  - [感知触发](03-features/triggered-perception.md)
   - [感知流水线](03-features/perception-pipeline.md)
   - [身份识别](03-features/person-identity.md)
   - [设备控制](03-features/device-control.md)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,6 +5,7 @@
 import { useEffect, useState } from "react";
 import {
   getHomeStatus,
+  getAutomationCatalog,
   listActivity,
   listCameras,
   listDevices,
@@ -27,6 +28,7 @@ import { HomeSwitcher } from "./components/HomeSwitcher";
 import { StatusRibbon } from "./components/StatusRibbon";
 import { HeroNow } from "./components/HeroNow";
 import { DevicesByRoom } from "./components/DevicesByRoom";
+import { AutomationPage } from "./components/AutomationPage";
 import { ActivityFeed } from "./components/ActivityFeed";
 import { FamilyStrip } from "./components/FamilyStrip";
 import { PersonDrawer } from "./components/PersonDrawer";
@@ -144,6 +146,9 @@ function MainApp() {
   });
   const activity = useAsync(() => listActivity(homeId), [homeId], {
     errorLabel: t("app.loadActivityFail"),
+  });
+  const automationCatalog = useAsync(() => getAutomationCatalog(), [homeId], {
+    errorLabel: "加载感知触发配置失败",
   });
   // 家庭档案（候选区 + 正式区记忆）——家庭 tab 用，成员抽屉与非人面板共享。
   const home = useAsync(() => listHomeEntries(homeId), [homeId], {
@@ -266,6 +271,27 @@ function MainApp() {
               }}
             />
           </div>
+        );
+      }
+      case "automation": {
+        const err = automationCatalog.error;
+        if (err) {
+          return (
+            <TabPanelError
+              message={`感知触发页加载失败：${err.message}`}
+              onRetry={() => automationCatalog.reload()}
+            />
+          );
+        }
+        if (!automationCatalog.data) {
+          return <TabPanelLoading text="正在加载感知触发配置…" />;
+        }
+        return (
+          <AutomationPage
+            devices={automationCatalog.data.devices}
+            scenes={automationCatalog.data.scenes}
+            cameras={automationCatalog.data.cameras}
+          />
         );
       }
       case "family": {

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -36,6 +36,12 @@ import type {
   ScopeCamera,
   ScopeHome,
   Task,
+  MiotEventMapping,
+  MiotPropertyFilterCondition,
+  MiotEventRule,
+  MiotEventSource,
+  MiotEventTriggerLog,
+  DevicePropertyKey,
   UsagePeriod,
   UsageStats,
   OmniConfigState,
@@ -294,6 +300,84 @@ export async function listCameras(homeId?: HomeId): Promise<PerceptionCamera[]> 
   }
   return impl.realListCameras();
 }
+
+export async function getAutomationCatalog(): Promise<{
+  devices: MiotEventSource[];
+  scenes: MiotEventSource[];
+  cameras: ScopeCamera[];
+}> {
+  return impl.realGetAutomationCatalog();
+}
+
+export async function listMiotEventMappings(): Promise<MiotEventMapping[]> {
+  return impl.realListMiotEventMappings();
+}
+
+export async function createMiotEventMapping(
+  input: Omit<MiotEventMapping, "id">,
+): Promise<MiotEventMapping> {
+  return impl.realCreateMiotEventMapping(input);
+}
+
+export async function updateMiotEventMapping(
+  id: string,
+  input: Partial<MiotEventMapping>,
+): Promise<MiotEventMapping> {
+  return impl.realUpdateMiotEventMapping(id, input);
+}
+
+export async function deleteMiotEventMapping(id: string): Promise<void> {
+  return impl.realDeleteMiotEventMapping(id);
+}
+
+export async function listMiotEventRules(): Promise<MiotEventRule[]> {
+  return impl.realListMiotEventRules();
+}
+
+export async function listMiotEventLogs(): Promise<MiotEventTriggerLog[]> {
+  return impl.realListMiotEventLogs();
+}
+
+export async function testMiotEventTrigger(input: {
+  source_type: "device" | "scene";
+  source_id: string;
+  source_name: string;
+  event_name?: string;
+  changed_properties?: Record<string, unknown>;
+}): Promise<MiotEventTriggerLog> {
+  return impl.realTestMiotEventTrigger(input);
+}
+
+export async function fetchDeviceSpec(did: string): Promise<{ model: string; name: string; properties: import("@/lib/types").DeviceSpecProperty[] }> {
+  return impl.realFetchDeviceSpec(did);
+}
+
+export async function listDeviceProperties(did: string): Promise<DevicePropertyKey[]> {
+  return impl.realListDeviceProperties(did);
+}
+
+export async function patchRulePropertyFilters(
+  ruleId: string,
+  propertyFilters: Record<string, string | MiotPropertyFilterCondition>,
+): Promise<void> {
+  return impl.realPatchRule(ruleId, {
+    condition: { property_filters: propertyFilters },
+  });
+}
+
+export async function createMiotEventRule(input: {
+  task_id: string;
+  name: string;
+  source_ids: string[];
+  event_kinds: string[];
+  query: string;
+  property_filters: Record<string, string | MiotPropertyFilterCondition>;
+  action_descriptions?: string[];
+}): Promise<{ rule_id: string }> {
+  return impl.realCreateMiotEventRule(input);
+}
+
+
 
 // ── 让它休息 / 唤醒 ────────────────────────────────────────
 // backend 当前只有 stop/start 两态，永久暂停直到手动唤醒，不支持定时恢复。

--- a/web/src/api/real.ts
+++ b/web/src/api/real.ts
@@ -24,6 +24,11 @@ import type {
   ScopeCamera,
   ScopeHome,
   Task,
+  MiotEventMapping,
+  MiotEventRule,
+  MiotEventSource,
+  MiotEventTriggerLog,
+  DevicePropertyKey,
   TokenBreakdown,
   UsageCallType,
   UsageGroup,
@@ -856,7 +861,121 @@ export async function realListCameras(): Promise<PerceptionCamera[]> {
     }));
 }
 
+export async function realGetAutomationCatalog(): Promise<{
+  devices: MiotEventSource[];
+  scenes: MiotEventSource[];
+  cameras: ScopeCamera[];
+}> {
+  const r = await apiFetch<
+    Normal<{ devices: MiotEventSource[]; scenes: MiotEventSource[]; cameras: ScopeCamera[] }>
+  >("/api/automation/catalog");
+  return r.data;
+}
+
+export async function realListMiotEventMappings(): Promise<MiotEventMapping[]> {
+  const r = await apiFetch<Normal<MiotEventMapping[]>>("/api/automation/mappings");
+  return r.data;
+}
+
+export async function realCreateMiotEventMapping(
+  input: Omit<MiotEventMapping, "id">,
+): Promise<MiotEventMapping> {
+  const r = await apiFetch<Normal<MiotEventMapping>>("/api/automation/mappings", {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+  return r.data;
+}
+
+export async function realUpdateMiotEventMapping(
+  id: string,
+  input: Partial<MiotEventMapping>,
+): Promise<MiotEventMapping> {
+  const r = await apiFetch<Normal<MiotEventMapping>>(`/api/automation/mappings/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify(input),
+  });
+  return r.data;
+}
+
+export async function realDeleteMiotEventMapping(id: string): Promise<void> {
+  await apiFetch<Normal<null>>(`/api/automation/mappings/${id}`, {
+    method: "DELETE",
+  });
+}
+
+export async function realListMiotEventRules(): Promise<MiotEventRule[]> {
+  const r = await apiFetch<Normal<MiotEventRule[]>>("/api/automation/rules");
+  return r.data;
+}
+
+export async function realListMiotEventLogs(): Promise<MiotEventTriggerLog[]> {
+  const r = await apiFetch<Normal<MiotEventTriggerLog[]>>("/api/automation/logs");
+  return r.data;
+}
+
+export async function realTestMiotEventTrigger(input: {
+  source_type: "device" | "scene";
+  source_id: string;
+  source_name: string;
+  event_name?: string;
+  changed_properties?: Record<string, unknown>;
+}): Promise<MiotEventTriggerLog> {
+  const r = await apiFetch<Normal<MiotEventTriggerLog>>("/api/automation/test-trigger", {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+  return r.data;
+}
+
 // ── 米家账号绑定 OAuth ────────────────────────────────────
+// ── Automation: create miot_event rule ─────────
+export async function realCreateMiotEventRule(input: {
+  task_id: string;
+  name: string;
+  source_ids: string[];
+  event_kinds: string[];
+  query: string;
+  property_filters: Record<string, string | import("@/lib/types").MiotPropertyFilterCondition>;
+  action_descriptions?: string[];
+}): Promise<{ rule_id: string }> {
+  const r = await apiFetch<Normal<{ rule_id: string }>>(
+    "/api/automation/rules",
+    { method: "POST", body: JSON.stringify(input) },
+  );
+  return r.data;
+}
+
+// ── Automation: device spec ───────────────────────────────
+export async function realFetchDeviceSpec(
+  did: string,
+): Promise<{ model: string; name: string; properties: import("@/lib/types").DeviceSpecProperty[] }> {
+  const r = await apiFetch<Normal<{ model: string; name: string; properties: import("@/lib/types").DeviceSpecProperty[] }>>(
+    `/api/automation/device-spec/${did}`,
+  );
+  return r.data;
+}
+
+// ── Automation: device properties lookup ──────────────────
+export async function realListDeviceProperties(
+  did: string,
+): Promise<DevicePropertyKey[]> {
+  const r = await apiFetch<Normal<DevicePropertyKey[]>>(
+    `/api/automation/devices/${did}/properties`,
+  );
+  return r.data;
+}
+
+export async function realPatchRule(
+  ruleId: string,
+  patch: Record<string, unknown>,
+): Promise<void> {
+  await apiFetch(`/api/rules/${ruleId}`, {
+    method: "PATCH",
+    body: JSON.stringify(patch),
+  });
+}
+
 // 流程跟 cli/src/miloco_cli/commands/account.py 同源：
 //   ① POST /api/miot/bind → backend 返 oauth_url（小米授权页）
 //   ② 用户浏览器打开 oauth_url 走授权 → 回调到

--- a/web/src/components/AutomationPage.tsx
+++ b/web/src/components/AutomationPage.tsx
@@ -1,0 +1,657 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  createMiotEventMapping,
+  deleteMiotEventMapping,
+  fetchDeviceSpec,
+  listMiotEventLogs,
+  listMiotEventMappings,
+  testMiotEventTrigger,
+  updateMiotEventMapping,
+} from "@/api";
+import type {
+  MiotEventMapping,
+  MiotEventSource,
+  MiotPropertyFilterCondition,
+  MiotPropertyFilterOp,
+  MiotEventTriggerLog,
+  ScopeCamera,
+} from "@/lib/types";
+import { useAsync } from "@/hooks/useAsync";
+import { resolveToken } from "@/api/client";
+import { toast } from "./Toast";
+
+interface Props {
+  devices: MiotEventSource[];
+  scenes: MiotEventSource[];
+  cameras: ScopeCamera[];
+}
+
+interface SpecProperty {
+  key: string;
+  name: string;
+  value_list?: { value: string; description: string }[];
+  value_range?: { min: number; max: number; step: number };
+  description: string;
+  format: string;
+  unit: string;
+}
+
+interface EditingPropFilter {
+  key: string;
+  op: MiotPropertyFilterOp;
+  value: string;
+}
+
+interface MappingSpecMeta {
+  names: Record<string, string>;
+  values: Record<string, Record<string, string>>;
+}
+
+const FILTER_OP_OPTIONS: { value: MiotPropertyFilterOp; label: string }[] = [
+  { value: "eq", label: "等于" },
+  { value: "ne", label: "不等于" },
+  { value: "gt", label: "大于" },
+  { value: "lt", label: "小于" },
+  { value: "gte", label: "大于等于" },
+  { value: "lte", label: "小于等于" },
+];
+
+function normalizeFilterCondition(
+  condition: string | MiotPropertyFilterCondition,
+): MiotPropertyFilterCondition {
+  if (typeof condition === "string") {
+    return condition === "*"
+      ? { op: "any", value: "*" }
+      : { op: "eq", value: condition };
+  }
+  return {
+    op: condition.op ?? "eq",
+    value: condition.value ?? "",
+  };
+}
+
+function getFilterOpLabel(op: MiotPropertyFilterOp): string {
+  switch (op) {
+    case "eq":
+      return "等于";
+    case "ne":
+      return "不等于";
+    case "gt":
+      return "大于";
+    case "lt":
+      return "小于";
+    case "gte":
+      return "大于等于";
+    case "lte":
+      return "小于等于";
+    case "any":
+      return "任意值";
+    default:
+      return op;
+  }
+}
+
+function isNumericProperty(prop?: SpecProperty | null): boolean {
+  if (!prop) return false;
+  if (prop.value_range) return true;
+  return ["int", "float", "uint8", "uint16", "uint32", "uint64", "integer", "double", "number"].includes(
+    prop.format,
+  );
+}
+
+function getPropertyDisplayName(prop?: SpecProperty | null, key?: string): string {
+  if (!prop) return key ?? "";
+  return prop.description || prop.name || prop.key || key || "";
+}
+
+function getPropertyValueDisplayName(
+  specMeta: MappingSpecMeta | undefined,
+  key: string,
+  value: string,
+): string {
+  return specMeta?.values[key]?.[value] || value;
+}
+
+export function AutomationPage({ devices, scenes, cameras }: Props) {
+  const mappings = useAsync(() => listMiotEventMappings(), [devices.length, scenes.length]);
+  const logs = useAsync(() => listMiotEventLogs(), []);
+
+  const [sourceType, setSourceType] = useState<"device" | "scene">("device");
+  const [sourceId, setSourceId] = useState("");
+  const [cameraIds, setCameraIds] = useState<string[]>([]);
+  const [queryTemplate, setQueryTemplate] = useState("");
+  const [cooldownSeconds, setCooldownSeconds] = useState(30);
+  const [notes, setNotes] = useState("");
+
+  // Device spec: properties + value options
+  const [deviceSpec, setDeviceSpec] = useState<{ model: string; name: string; properties: SpecProperty[] } | null>(null);
+  const [specLoading, setSpecLoading] = useState(false);
+  const [mappingSpecMeta, setMappingSpecMeta] = useState<Record<string, MappingSpecMeta>>({});
+  // Selected property filters: array of { key, value }
+  const [propFilters, setPropFilters] = useState<EditingPropFilter[]>([]);
+
+  const sourceOptions = useMemo(
+    () => (sourceType === "device" ? devices : scenes),
+    [devices, scenes, sourceType],
+  );
+
+  async function reloadAll() {
+    mappings.reload();
+    logs.reload();
+  }
+
+  useEffect(() => {
+    const deviceIds = Array.from(
+      new Set(
+        (mappings.data ?? [])
+          .filter((item) => item.source_type === "device")
+          .map((item) => item.source_id),
+      ),
+    ).filter((did) => !mappingSpecMeta[did]);
+    if (deviceIds.length === 0) return;
+    let cancelled = false;
+    void Promise.all(
+      deviceIds.map(async (did) => {
+        try {
+          const spec = await fetchDeviceSpec(did);
+          return {
+            did,
+            meta: {
+              names: Object.fromEntries(
+                (spec.properties ?? []).map((prop) => [
+                  prop.key,
+                  prop.description || prop.name || prop.key,
+                ]),
+              ),
+              values: Object.fromEntries(
+                (spec.properties ?? []).map((prop) => [
+                  prop.key,
+                  Object.fromEntries(
+                    (prop.value_list ?? []).map((item) => [item.value, item.description || item.value]),
+                  ),
+                ]),
+              ),
+            },
+          };
+        } catch {
+          return { did, meta: { names: {}, values: {} } };
+        }
+      }),
+    ).then((items) => {
+      if (cancelled) return;
+      setMappingSpecMeta((prev) => {
+        const next = { ...prev };
+        for (const item of items) next[item.did] = item.meta;
+        return next;
+      });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [mappings.data, mappingSpecMeta]);
+
+  async function onSourceChange(did: string) {
+    setSourceId(did);
+    setPropFilters([]);
+    if (sourceType !== "device" || !did) { setDeviceSpec(null); return; }
+    setSpecLoading(true);
+    try {
+      const spec = await fetchDeviceSpec(did);
+      setDeviceSpec(spec as { model: string; name: string; properties: SpecProperty[] });
+    } catch {
+      setDeviceSpec(null);
+    } finally {
+      setSpecLoading(false);
+    }
+  }
+
+  function addPropFilter() {
+    setPropFilters((prev) => [...prev, { key: "", op: "eq", value: "" }]);
+  }
+
+  function updatePropFilter(idx: number, field: "key" | "op" | "value", val: string) {
+    setPropFilters((prev) => prev.map((f, i) => i === idx ? { ...f, [field]: val } : f));
+  }
+
+  function removePropFilter(idx: number) {
+    setPropFilters((prev) => prev.filter((_, i) => i !== idx));
+  }
+
+  function getSelectedProp(): Record<string, MiotPropertyFilterCondition> {
+    const pf: Record<string, MiotPropertyFilterCondition> = {};
+    for (const f of propFilters) {
+      if (f.key) pf[f.key] = { op: f.op, value: f.value };
+    }
+    return pf;
+  }
+
+  // Get value options for a selected property key
+  function getValueOptions(key: string): { value: string; description: string }[] {
+    if (!deviceSpec) return [];
+    const prop = deviceSpec.properties.find((p) => p.key === key);
+    if (!prop) return [];
+    if (prop.value_list && prop.value_list.length > 0) return prop.value_list;
+    return [];
+  }
+
+  async function handleCreate() {
+    const source = sourceOptions.find((item) => item.source_id === sourceId);
+    if (!source) { toast("请选择事件源", "warn"); return; }
+    // Create mapping
+    await createMiotEventMapping({
+      source_type: sourceType,
+      source_id: source.source_id,
+      source_name_snapshot: source.source_name,
+      camera_dids: cameraIds,
+      enabled: true,
+      query_template: queryTemplate,
+      event_kinds: [sourceType === "device" ? "device_prop" : "scene"],
+      property_filters: sourceType === "device" ? getSelectedProp() : {},
+      cooldown_seconds: cooldownSeconds,
+      notes,
+      created_at: null,
+      updated_at: null,
+    });
+    setCameraIds([]);
+    setQueryTemplate("");
+    setCooldownSeconds(30);
+    setNotes("");
+    setPropFilters([]);
+    setDeviceSpec(null);
+    await reloadAll();
+  }
+
+  async function toggleEnabled(item: MiotEventMapping) {
+    await updateMiotEventMapping(item.id, { enabled: !item.enabled });
+    await reloadAll();
+  }
+
+  async function runTest(item: MiotEventMapping) {
+    const changedProperties =
+      item.source_type === "device"
+        ? Object.fromEntries(
+            Object.entries(item.property_filters ?? {}).map(([key, value]) => {
+              const cond = normalizeFilterCondition(value);
+              let sample = cond.value;
+              if (cond.op === "any") sample = "1";
+              if (cond.op === "ne") sample = cond.value === "1" ? "0" : "1";
+              if (cond.op === "gt") sample = String(Number(cond.value || 0) + 1);
+              if (cond.op === "lt") sample = String(Number(cond.value || 0) - 1);
+              if (cond.op === "gte") sample = String(Number(cond.value || 0));
+              if (cond.op === "lte") sample = String(Number(cond.value || 0));
+              return [key, sample];
+            }),
+          )
+        : {};
+    await testMiotEventTrigger({
+      source_type: item.source_type,
+      source_id: item.source_id,
+      source_name: item.source_name_snapshot,
+      event_name: item.source_type === "device" ? "device_prop" : "scene",
+      changed_properties: changedProperties,
+    });
+    await reloadAll();
+  }
+
+  function fmtTs(ts: number): string {
+    if (!ts) return "-";
+    return new Date(ts).toLocaleString("zh-CN");
+  }
+
+  const token = resolveToken();
+
+  function getClipUrl(logId: string, deviceId: string): string {
+    const base = `/api/events/${encodeURIComponent(logId)}/clip/${encodeURIComponent(deviceId)}`;
+    return token ? `${base}?token=${encodeURIComponent(token)}` : base;
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-6 px-4 py-6">
+      <section className="space-y-1">
+        <h1 className="text-title text-text-primary">感知触发</h1>
+        <p className="text-caption text-text-tertiary">
+          用米家设备事件或场景触发一次摄像头主动感知，并附带可选的属性和值筛选。
+        </p>
+      </section>
+
+      {/* Event Mapping Creation Form */}
+      <section className="rounded-xl border border-border bg-bg-secondary p-5 space-y-4">
+        <div>
+          <h2 className="text-title text-text-primary">事件映射</h2>
+          <p className="text-caption text-text-tertiary">
+            配置米家事件源对应触发哪些摄像头感知。创建时自动生成关联规则。
+          </p>
+        </div>
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <div>
+            <label className="block text-caption text-text-secondary mb-1">事件源类型</label>
+            <select
+              className="w-full rounded-md border border-border bg-bg-primary px-3 py-2 text-caption"
+              value={sourceType}
+              onChange={(e) => {
+                const nextType = e.target.value as "device" | "scene";
+                setSourceType(nextType);
+                setSourceId("");
+                setDeviceSpec(null);
+                setPropFilters([]);
+              }}
+            >
+              <option value="device">设备属性变化</option>
+              <option value="scene">场景触发</option>
+            </select>
+          </div>
+          <div>
+            <label className="block text-caption text-text-secondary mb-1">事件源</label>
+            <select
+              className="w-full rounded-md border border-border bg-bg-primary px-3 py-2 text-caption"
+              value={sourceId}
+              onChange={(e) => onSourceChange(e.target.value)}
+            >
+              <option value="">-- 请选择 --</option>
+              {sourceOptions.map((item) => (
+                <option key={item.source_id} value={item.source_id}>
+                  {item.source_name}
+                  {item.room_name ? `（${item.room_name}）` : ""}
+                  {` (${item.source_id.slice(-6)})`}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="md:col-span-2">
+            <label className="block text-caption text-text-secondary mb-1">关联摄像头</label>
+            <div className="flex flex-wrap gap-1.5">
+              {cameras.map((cam) => (
+                <button
+                  key={cam.did}
+                  type="button"
+                  className={
+                    "rounded-full border px-3 py-1 text-xs transition-colors " +
+                    (cameraIds.includes(cam.did)
+                      ? "bg-brand-soft border-brand-primary text-brand-primary"
+                      : "bg-bg-primary border-border text-text-secondary hover:text-text-primary hover:border-border-strong")
+                  }
+                  onClick={() => setCameraIds((prev) => prev.includes(cam.did) ? prev.filter((id) => id !== cam.did) : [...prev, cam.did])}
+                >
+                  {cam.name || cam.did.slice(-6)}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Device Spec Property Filters */}
+          {sourceType === "device" && sourceId && (
+            <div className="md:col-span-2 space-y-2">
+              <label className="block text-caption text-text-secondary">
+                属性筛选 {specLoading ? "(加载spec中...)" : deviceSpec ? `(${deviceSpec.properties.length} 个属性)` : ""}
+              </label>
+              {!specLoading && deviceSpec && deviceSpec.properties.length === 0 ? (
+                <div className="rounded-md border border-dashed border-border bg-bg-primary px-3 py-2 text-caption text-text-tertiary">
+                  还没有取到这个设备的属性定义。这里会按设备 MIoT Spec 展示可选属性和值。
+                </div>
+              ) : null}
+              {propFilters.map((pf, idx) => {
+                const selectedProp = deviceSpec?.properties.find((p) => p.key === pf.key);
+                const valueOptions = getValueOptions(pf.key);
+                const numericProp = isNumericProperty(selectedProp);
+                const allowedOps = numericProp
+                  ? FILTER_OP_OPTIONS
+                  : FILTER_OP_OPTIONS.filter((item) => item.value === "eq" || item.value === "ne");
+                return (
+                  <div key={idx} className="flex gap-2 items-start">
+                    <select
+                      className="flex-1 rounded-md border border-border bg-bg-primary px-3 py-2 text-caption"
+                      value={pf.key}
+                      onChange={(e) => {
+                        const nextKey = e.target.value;
+                        const nextProp = deviceSpec?.properties.find((p) => p.key === nextKey);
+                        const nextNumeric = isNumericProperty(nextProp);
+                        setPropFilters((prev) =>
+                          prev.map((item, i) =>
+                            i !== idx
+                              ? item
+                              : {
+                                  ...item,
+                                  key: nextKey,
+                                  op: nextNumeric
+                                    ? item.op
+                                    : (item.op === "eq" || item.op === "ne" ? item.op : "eq"),
+                                  value: item.value,
+                                },
+                          ),
+                        );
+                      }}
+                    >
+                      <option value="">-- 选择属性 --</option>
+                      {(deviceSpec?.properties ?? []).map((prop) => (
+                        <option key={prop.key} value={prop.key}>
+                          {getPropertyDisplayName(prop, prop.key)} {prop.unit ? "(" + prop.unit + ")" : ""}
+                        </option>
+                      ))}
+                    </select>
+                    <select
+                      className="w-36 rounded-md border border-border bg-bg-primary px-3 py-2 text-caption"
+                      value={pf.op}
+                      onChange={(e) => updatePropFilter(idx, "op", e.target.value)}
+                    >
+                      {allowedOps.map((op) => (
+                        <option key={op.value} value={op.value}>
+                          {op.label}
+                        </option>
+                      ))}
+                    </select>
+                    {valueOptions.length > 0 ? (
+                      <select
+                        className="flex-1 rounded-md border border-border bg-bg-primary px-3 py-2 text-caption"
+                        value={pf.value}
+                        onChange={(e) => updatePropFilter(idx, "value", e.target.value)}
+                      >
+                        {valueOptions.map((vo) => (
+                          <option key={vo.value} value={vo.value}>
+                            {vo.description || vo.value}
+                          </option>
+                        ))}
+                      </select>
+                    ) : (
+                      <input
+                        className="flex-1 rounded-md border border-border bg-bg-primary px-3 py-2 text-caption"
+                        placeholder={selectedProp?.value_range ? `${selectedProp.value_range.min} ~ ${selectedProp.value_range.max}` : numericProp ? "输入数值" : "输入属性值"}
+                        value={pf.value}
+                        onChange={(e) => updatePropFilter(idx, "value", e.target.value)}
+                      />
+                    )}
+                    <button
+                      type="button"
+                      className="rounded-md border border-border px-2 py-2 text-caption text-red-600"
+                      onClick={() => removePropFilter(idx)}
+                    >
+                      ×
+                    </button>
+                  </div>
+                );
+              })}
+              <button
+                type="button"
+                className="rounded-md border border-dashed border-border px-3 py-1.5 text-xs text-text-tertiary"
+                onClick={addPropFilter}
+              >
+                + 添加属性筛选
+              </button>
+            </div>
+          )}
+
+          <div>
+            <label className="block text-caption text-text-secondary mb-1">感知提示（可选）</label>
+            <p className="mb-1 text-xs text-text-tertiary">
+              这是一段会附加到触发感知里的默认提示词，用来告诉模型重点看什么。
+            </p>
+            <input
+              className="w-full rounded-md border border-border bg-bg-primary px-3 py-2 text-caption"
+              placeholder="例如：重点看窗边是否有人、门窗是否打开、有没有异常动作"
+              value={queryTemplate}
+              onChange={(e) => setQueryTemplate(e.target.value)}
+            />
+          </div>
+          <div>
+            <label className="block text-caption text-text-secondary mb-1">冷却时间（秒）</label>
+            <input
+              className="w-full rounded-md border border-border bg-bg-primary px-3 py-2 text-caption"
+              type="number"
+              min={5}
+              max={3600}
+              value={cooldownSeconds}
+              onChange={(e) => setCooldownSeconds(Number(e.target.value))}
+            />
+          </div>
+          <div className="md:col-span-2">
+            <label className="block text-caption text-text-secondary mb-1">备注</label>
+            <input
+              className="w-full rounded-md border border-border bg-bg-primary px-3 py-2 text-caption"
+              placeholder="可选"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+            />
+          </div>
+        </div>
+        <button
+          type="button"
+          className="rounded-md bg-brand px-4 py-2 text-caption text-white"
+          onClick={handleCreate}
+          disabled={!sourceId || cameraIds.length === 0}
+        >
+          创建映射
+        </button>
+      </section>
+
+      {/* Existing Mappings */}
+      <section className="rounded-xl border border-border bg-bg-secondary p-5 space-y-4">
+        <div>
+          <h2 className="text-title text-text-primary">已配置映射</h2>
+          <p className="text-caption text-text-tertiary">
+            {mappings.data?.length ?? 0} 条映射。创建映射时会自动生成关联的 miot_event 规则。
+          </p>
+        </div>
+        <div className="space-y-3">
+          {(mappings.data ?? []).map((item: MiotEventMapping) => (
+            <div key={item.id} className="rounded-lg border border-border bg-bg-primary p-4">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <div className="text-title text-text-primary">
+                    {item.source_name_snapshot || item.source_id}
+                  </div>
+                  <div className="text-caption text-text-tertiary">
+                    {item.source_type === "device" ? "设备" : "场景"} . 摄像头: {item.camera_dids.length} 个 . 冷却: {item.cooldown_seconds}s
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    className="rounded-md border border-border px-3 py-1.5 text-caption"
+                    onClick={() => runTest(item)}
+                  >
+                    测试触发
+                  </button>
+                  <button
+                    type="button"
+                    className={"rounded-md px-3 py-1.5 text-caption " + (item.enabled ? "bg-green-100 text-green-700" : "bg-gray-100 text-gray-500")}
+                    onClick={() => toggleEnabled(item)}
+                  >
+                    {item.enabled ? "已启用" : "已停用"}
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded-md border border-border px-3 py-1.5 text-caption text-red-600"
+                    onClick={async () => {
+                      await deleteMiotEventMapping(item.id);
+                      await reloadAll();
+                    }}
+                  >
+                    删除
+                  </button>
+                </div>
+              </div>
+              {item.query_template ? (
+                <div className="mt-3 text-caption text-text-secondary">
+                  感知提示：{item.query_template}
+                </div>
+              ) : null}
+              {Object.keys(item.property_filters ?? {}).length > 0 ? (
+                <div className="mt-3 flex flex-wrap gap-1.5">
+                  {Object.entries(item.property_filters ?? {}).map(([key, value]) => (
+                    <span
+                      key={key}
+                      className="rounded-full border border-border bg-bg-secondary px-2 py-0.5 text-xs text-text-secondary"
+                    >
+                      {(() => {
+                        const cond = normalizeFilterCondition(value);
+                        const specMeta = mappingSpecMeta[item.source_id];
+                        const displayName = specMeta?.names[key] || key;
+                        const displayValue =
+                          cond.op === "any"
+                            ? "任意值"
+                            : getPropertyValueDisplayName(specMeta, key, String(cond.value));
+                        return `${displayName} ${getFilterOpLabel(cond.op)} ${displayValue}`;
+                      })()}
+                    </span>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Debug & Recent Triggers */}
+      <section className="rounded-xl border border-border bg-bg-secondary p-5 space-y-4">
+        <div>
+          <h2 className="text-title text-text-primary">调试与最近触发</h2>
+          <p className="text-caption text-text-tertiary">
+            查看是否命中映射、是否发起感知、是否进入规则执行，以及跳过原因。
+          </p>
+        </div>
+        <div className="space-y-3">
+          {(logs.data ?? []).map((log: MiotEventTriggerLog) => (
+            <div key={log.id} className="rounded-lg border border-border bg-bg-primary p-4">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <div className="text-title text-text-primary">
+                    {log.trigger.source_name || log.trigger.source_id}
+                  </div>
+                  <div className="text-caption text-text-tertiary">
+                    {log.trigger.event_name} . {fmtTs(log.created_at)}
+                  </div>
+                </div>
+                <div className="text-caption text-text-tertiary">
+                  {log.error || log.skipped_reason || (log.perception_started ? "已感知" : "未感知")}
+                </div>
+              </div>
+              {log.clip_kind && log.clip_device_ids?.length > 0 ? (
+                <div className="mt-2 space-y-2">
+                  {log.clip_device_ids.map((deviceId: string) => (
+                    <video
+                      key={deviceId}
+                      src={getClipUrl(log.id, deviceId)}
+                      controls
+                      preload="metadata"
+                      className="max-h-56 w-full rounded-md border border-border bg-black"
+                    />
+                  ))}
+                </div>
+              ) : log.snapshot_paths?.length > 0 ? (
+                <div className="mt-2 flex gap-2 overflow-x-auto">
+                  {log.snapshot_paths.map((p: string) => (
+                    <img key={p} src={"/api/automation/snapshots/" + p.split("/").pop()} className="max-h-32 rounded-md border border-border" alt="snapshot" />
+                  ))}
+                </div>
+              ) : null}
+              {log.perception_answer ? (
+                <div className="mt-2 text-caption text-text-secondary whitespace-pre-wrap">
+                  {log.perception_answer}
+                </div>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -25,12 +25,14 @@ import {
   IconFamily,
   IconActivity,
   IconUsage,
+  IconDevices as IconAutomation,
 } from "@/lib/navIcons";
 
 export type TabKey =
   | "now"
   | "devices"
   | "family"
+  | "automation"
   | "activity"
   | "usage";
 
@@ -65,6 +67,12 @@ export const TABS: TabDef[] = [
     labelKey: "nav.family",
     hintKey: "nav.familyHint",
     Icon: IconFamily,
+  },
+  {
+    key: "automation",
+    labelKey: "nav.automation",
+    hintKey: "nav.automationHint",
+    Icon: IconAutomation,
   },
   {
     key: "activity",

--- a/web/src/i18n/locales/en/nav.json
+++ b/web/src/i18n/locales/en/nav.json
@@ -5,6 +5,8 @@
     "homeHint": "A glance at home",
     "devices": "Devices",
     "devicesHint": "Manage Xiaomi Home devices",
+    "automation": "Triggered Perception",
+    "automationHint": "Device events trigger perception",
     "family": "Family",
     "familyHint": "Manage family members",
     "activity": "Activity",

--- a/web/src/i18n/locales/zh/nav.json
+++ b/web/src/i18n/locales/zh/nav.json
@@ -5,6 +5,8 @@
     "homeHint": "看一眼家里",
     "devices": "设备",
     "devicesHint": "管理米家设备",
+    "automation": "感知触发",
+    "automationHint": "设备事件触发感知",
     "family": "家庭",
     "familyHint": "管理家庭成员",
     "activity": "日志",

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -197,6 +197,112 @@ export interface ScopeHome {
   inUse: boolean;
 }
 
+export interface MiotEventSource {
+  source_type: "device" | "scene";
+  source_id: string;
+  source_name: string;
+  home_id?: string | null;
+  room_name?: string | null;
+}
+
+export type MiotPropertyFilterOp =
+  | "eq"
+  | "ne"
+  | "gt"
+  | "lt"
+  | "gte"
+  | "lte"
+  | "any";
+
+export interface MiotPropertyFilterCondition {
+  op: MiotPropertyFilterOp;
+  value: string;
+}
+
+export interface MiotEventMapping {
+  id: string;
+  source_type: "device" | "scene";
+  source_id: string;
+  source_name_snapshot: string;
+  camera_dids: string[];
+  enabled: boolean;
+  query_template: string;
+  event_kinds: string[];
+  property_filters: Record<string, string | MiotPropertyFilterCondition>;
+  cooldown_seconds: number;
+  notes: string;
+  created_at?: number | null;
+  updated_at?: number | null;
+}
+
+export interface MiotEventRule {
+  id: string;
+  name: string;
+  task_id: string;
+  trigger_type: "miot_event";
+  enabled: boolean;
+  mode: "event" | "state";
+  condition: {
+    query: string;
+    source_ids: string[];
+    event_kinds: string[];
+    property_filters: Record<string, string | MiotPropertyFilterCondition>;
+    mapping_ids: string[];
+    use_global_mapping: boolean;
+  };
+}
+
+export interface DeviceSpecProperty {
+  siid: number;
+  piid: number;
+  key: string;
+  name: string;
+  description: string;
+  format: string;
+  access: string[];
+  unit: string;
+  value_list?: { value: string; description: string }[];
+  value_range?: { min: number; max: number; step: number };
+}
+
+export interface DeviceSpec {
+  model: string;
+  name: string;
+  properties: DeviceSpecProperty[];
+}
+
+export interface DevicePropertyKey {
+  key: string;
+  count: number;
+  recent_values: string[];
+}
+
+export interface MiotEventTriggerLog {
+  id: string;
+  trigger: {
+    source_type: "device" | "scene";
+    source_id: string;
+    source_name: string;
+    home_id?: string | null;
+    room_name?: string | null;
+    event_name: string;
+    changed_properties: Record<string, unknown>;
+    occurred_at: number;
+  };
+  mapping_ids: string[];
+  candidate_rule_ids: string[];
+  camera_dids: string[];
+  clip_device_ids: string[];
+  clip_kind: string;
+  perception_started: boolean;
+  perception_answer: string;
+  matched_rule_ids: string[];
+  skipped_reason: string;
+  error: string;
+  snapshot_paths: string[];
+  created_at: number;
+}
+
 // ── 多家庭 ─────────────────────────────────────────────────
 // HomeId 仅作 useAsync 缓存 key 占位用("primary"),真 home_id 走 ScopeHome.homeId
 // (已接通 PUT/GET /api/miot/scope/homes,backend 多家庭接入范围已上线)。


### PR DESCRIPTION
## 变更说明

本 PR 为 miloco 新增了“米家事件触发感知”能力，并提供独立的 Web 管理页“感知触发”，用于配置事件源、关联摄像头、属性筛选、感知提示和触发调试。

## 主要改动

### 1. 新增米家事件触发感知链路
- 支持米家设备属性变化触发感知
- 支持米家场景事件触发感知
- 事件会先按映射和属性条件筛选，命中后再发起一次主动感知
- 复用现有规则、meaningful events、Agent 回调链路
- 支持冷却时间，避免高频事件重复触发感知
- 新增事件映射持久化与相关 API
- 支持映射 CRUD、最近触发日志、手动测试触发
- 支持获取设备 MIoT Spec 属性和值定义
- 支持在日志中查看触发原因、快照和视频回放

### 2. Web 新增“感知触发”管理页
- 独立于家庭页任务面板
- 支持选择事件源、关联摄像头、感知提示、冷却时间
- 设备属性变化场景下，支持按设备属性配置触发条件
- 属性筛选支持以下比较运算：
  - 等于
  - 不等于
  - 大于
  - 小于
  - 大于等于
  - 小于等于
- 数值比较仅在数值型属性上开放
- 事件源列表显示房间信息
- 属性名、属性值在界面中优先显示中文

### 3. 增强触发记录与回放能力
- 感知触发日志支持查看触发原因、快照和视频回放
- 触发链路的日志与结果信息更加完整，便于排查和调试

## 验证情况
已完成以下验证：
- 设备属性变化可成功触发感知
- 属性筛选 6 种比较运算全部通过
- 感知触发日志可查看视频回放
- 设备属性和属性值可在 Web 界面正常显示
