### PR TITLE
fix(perception/gate): hold 默认值 360s→90s,并在 settings.yaml 显式暴露

### DIFF
--- a/backend/miloco/src/miloco/config/settings.yaml
+++ b/backend/miloco/src/miloco/config/settings.yaml
@@ -81,6 +81,12 @@ perception:
       #   omni_fps —— 送 omni 的视频帧率, 与 fps 解耦; omni 已是瓶颈, 不随 tracker 提频涨
       fps: 3
       omni_fps: 1
+    gate:
+      # visual 滞回时长(秒)。visual 最近通过过、距今 <= 此值时,本窗 visual 不通过
+      # 也强制生成 packet 并打 hold 标志,保住 video 路由不被纯音频短路。
+      # 0 = 关闭 hold。过长在画面间歇有变化的场景会持续续命窗口、期间静默窗也被
+      # 拉起跑下游 omni,浪费调用;过短则人短暂静止时 video 路由会切走。
+      hold_duration_sec: 90
     identity:
       # mock | real | deep_sort —— v1.2 主动注册默认 deep_sort,DeepSORT 内置
       # ReID 关联,跟踪更稳;额外暴露 Track.features deque 给陌生人池零额外推理

--- a/backend/miloco/src/miloco/perception/engine/config.py
+++ b/backend/miloco/src/miloco/perception/engine/config.py
@@ -36,7 +36,10 @@ class GateConfig:
     speech_vad_min_speech_chunks: int = 3  # 需 >= 此数的 512 样本帧过阈才判有人声(抗单次咔哒尖峰)
     # visual 滞回时长(秒)。visual 最近通过过、距今 <= 此值时,本窗 visual
     # 不通过也强制生成 packet 并打 hold 标志。0 = 关闭。
-    hold_duration_sec: float = 360.0
+    # 默认 90s:过长(如 6min)在画面间歇有变化的场景会持续刷新 last_visual_pass_ts、
+    # hold 窗反复续命,期间纯静默窗也被拉起跑下游,浪费 omni 调用。运维侧可在
+    # settings.yaml 的 perception.engine.gate.hold_duration_sec 覆盖。
+    hold_duration_sec: float = 90.0
 
 
 @dataclass

--- a/backend/miloco/tests/perception/engine/test_config.py
+++ b/backend/miloco/tests/perception/engine/test_config.py
@@ -4,7 +4,7 @@ from miloco.perception.engine.config import GateConfig
 
 
 def test_gate_config_default_hold_duration_sec():
-    assert GateConfig().hold_duration_sec == 360.0
+    assert GateConfig().hold_duration_sec == 90.0
 
 
 def test_gate_config_hold_duration_sec_zero_allowed():


### PR DESCRIPTION
6min 默认在画面间歇有变化时会反复续命 hold 窗,期间静默窗也被拉起跑下游
omni,浪费调用。压到 90s,并把 gate.hold_duration_sec 列进 settings.yaml, 运维侧无需改代码即可微调。