### PR TITLE
fix: review-pr --ci 模板拆两步独立 Bash 调用，避开 dontAsk compound 限制

### DIFF
--- a/.agents/commands/review-pr.md
+++ b/.agents/commands/review-pr.md
@@ -380,31 +380,19 @@ PR 上始终只保留 1 条 review-pr-ci comment——多次跑 `--ci` 不累积
 
 把 **Step 8 完整输出**（不要复制模板，直接复用上面已经生成的内容）前缀上一行 `<!-- review-pr-ci -->` 作为 body。heredoc 用 `'EOF'` 引号防止 shell 解释 review body 里的反引号 / `$`。
 
-**单次 bash 调用完成「查找 → 决策 → PATCH/POST」**——把分支判断压在同一个 shell 进程内（避免跨 Bash 工具调用时变量丢失）：
+**分两步独立 Bash 调用**——每一步都干净地以 `gh api` 或 `jq` 开头，确保权限规则精准命中：
 
+1. 查找已有 review-pr-ci comment 的 ID（无结果时输出空串）：
 ```bash
-COMMENT_ID=$(gh api \
-  "/repos/XiaoMi/xiaomi-miloco/issues/$PR_ID/comments" --paginate \
-  | jq -rs 'add | [.[] | select((.body // "") | startswith("<!-- review-pr-ci -->")) | .id] | .[0] // ""')
-
-if [ -n "$COMMENT_ID" ]; then
-    gh api -X PATCH \
-      "/repos/XiaoMi/xiaomi-miloco/issues/comments/$COMMENT_ID" \
-      -f body="$(cat <<'EOF'
-<!-- review-pr-ci -->
-<这里粘贴 Step 8 的完整输出，不要重写一遍>
-EOF
-)" | jq -r '"https://github.com/XiaoMi/xiaomi-miloco/pull/'"$PR_ID"'#issuecomment-\(.id)"'
-else
-    gh api -X POST \
-      "/repos/XiaoMi/xiaomi-miloco/issues/$PR_ID/comments" \
-      -f body="$(cat <<'EOF'
-<!-- review-pr-ci -->
-<这里粘贴 Step 8 的完整输出，不要重写一遍>
-EOF
-)" | jq -r '"https://github.com/XiaoMi/xiaomi-miloco/pull/'"$PR_ID"'#issuecomment-\(.id)"'
-fi
+gh api "/repos/XiaoMi/xiaomi-miloco/issues/$PR_ID/comments" --paginate | jq -rs 'add | [.[] | select((.body // "") | startswith("<!-- review-pr-ci -->")) | .id] | .[0] // ""'
 ```
+
+2. 根据第 1 步输出选一条执行（**只跑匹配的那条，不要两条都跑**）。heredoc 用 `'INNEREOF'` 避免与外层 `'EOF'` 冲突：
+
+| 第 1 步输出 | 执行 |
+|---|---|
+| 数字 id（如 `1234567890`） | `gh api -X PATCH "/repos/XiaoMi/xiaomi-miloco/issues/comments/<id>" -f body="$(cat <<'INNEREOF'\n<!-- review-pr-ci -->\n<这里粘贴 Step 8 的完整输出，不要重写一遍>\nINNEREOF\n)"` |
+| 空串 | `gh api -X POST "/repos/XiaoMi/xiaomi-miloco/issues/$PR_ID/comments" -f body="$(cat <<'INNEREOF'\n<!-- review-pr-ci -->\n<这里粘贴 Step 8 的完整输出，不要重写一遍>\nINNEREOF\n)"` |
 
 ### Step 10 — Cleanup（主动执行，仅默认 / `--post` 模式）
 

--- a/.ci/pr-review-gate.sh
+++ b/.ci/pr-review-gate.sh
@@ -35,7 +35,7 @@ git show "origin/main:.agents/commands/review-pr.md" \
 # dontAsk 模式下只有 permissions.allow 名单内的命令能执行，其余自拒；
 # 与 --tools "Bash,Read,Glob,Grep" 工具白名单形成纵深防御。
 cat > .claude/settings.json <<'SETEOF'
-{"permissions": {"allow": ["Bash(gh *)", "Bash(git *)", "Bash(md5sum *)", "Bash(diff *)"]}}
+{"permissions": {"allow": ["Bash(jq *)", "Bash(gh *)", "Bash(git *)", "Bash(md5sum *)", "Bash(diff *)"]}}
 SETEOF
 
 # 跑审查：主模型失败时降级到备用模型/endpoint 重试一次。


### PR DESCRIPTION
## 问题

review-pr --ci 在 dontAsk 模式下，发布 PR comment 的 Bash 调用被拒绝：
`Permission to use Bash has been denied because Claude Code is running in don't ask mode.`

## 根因

dontAsk 对复合命令要求**每个子命令都必须有匹配的 allow 规则**。原始 `--ci` 模板用单次 Bash 调用：
```bash
COMMENT_ID=$(gh api ... | jq ...)
if [ -n "$COMMENT_ID" ]; then gh api -X PATCH ...; else gh api -X POST ...; fi
```
`splitCommand`(newline/`;` 等分隔) 拆出的 `COMMENT_ID=$(`, `if`, `else`, `fi` 子命令无法匹配任何 allow 规则。

## 修改

1. `review-pr.md` — `--ci` 模板拆为两步独立 Bash 调用：
   - Step 1: `gh api ... | jq ...` 查已有 comment ID
   - Step 2: `gh api -X PATCH` 或 `gh api -X POST` 发评论
   每步干净以 `gh api` 或 `jq` 开头，`Bash(gh *)` + `Bash(jq *)` 精准命中

2. `pr-review-gate.sh` — 权限白名单补充 `Bash(jq *)` 覆盖 pipe 链里的 jq 子命令

## 验证

HCl8 fork 完整回归测试通过（PATCH 更新已有 comment ✅，POST 新建 comment ✅）

🤖 Generated with [Claude Code](https://claude.com/claude-code)