### PR TITLE
fix(web): improve device status and grouping

### DIFF
--- a/web/src/api/real.ts
+++ b/web/src/api/real.ts
@@ -800,8 +800,21 @@ function humanDeviceStatus(
   const cat = mapCategory(d.category);
 
   if (cat === "lock") {
+    const stateProp = Object.entries(d.spec ?? {}).find(([, spec]) => spec.type_name === "door-state");
+    if (stateProp) {
+      const [iid, spec] = stateProp;
+      const value = values.get(iid);
+      const optionName = spec.value_list?.find((item) => item.value === value)?.name;
+      if (optionName?.includes("Unlocked") || optionName?.includes("Ajar") || optionName?.includes("Not Close")) {
+        return s.unlocked;
+      }
+      if (optionName?.includes("Locked") || optionName?.includes("Closed Properly")) {
+        return s.locked;
+      }
+    }
     const v = values.get("prop.2.1");
-    return v ? s.locked : s.unlocked;
+    if (typeof v === "boolean") return v ? s.locked : s.unlocked;
+    return s.connected;
   }
   if (mainOn === undefined) return s.connected;
   if (cat === "aircond") {

--- a/web/src/api/real.ts
+++ b/web/src/api/real.ts
@@ -681,6 +681,7 @@ export async function realListDevices(): Promise<Device[]> {
       room: cleanRoom(d.room),
       online: d.online,
       statusText: humanDeviceStatus(d, mainSwitch?.current, valueByIid),
+      statusKind: deviceStatusKind(d, mainSwitch?.current, valueByIid),
       dangerous,
       mainSwitch,
       props: allProps,
@@ -790,47 +791,65 @@ const STATUS_TEXT: Record<string, StatusText> = {
   },
 };
 
+function lockStatusKind(
+  d: BackendDevice,
+  values: Map<string, unknown>,
+): Device["statusKind"] {
+  const stateProp = Object.entries(d.spec ?? {}).find(([, spec]) => spec.type_name === "door-state");
+  if (stateProp) {
+    const [iid, spec] = stateProp;
+    const value = values.get(iid);
+    const optionName = spec.value_list?.find((item) => item.value === value)?.name;
+    if (optionName?.includes("Unlocked") || optionName?.includes("Ajar") || optionName?.includes("Not Close")) {
+      return "unlocked";
+    }
+    if (optionName?.includes("Locked") || optionName?.includes("Closed Properly")) {
+      return "locked";
+    }
+  }
+  const v = values.get("prop.2.1");
+  if (typeof v === "boolean") return v ? "locked" : "unlocked";
+  return "connected";
+}
+
+function deviceStatusKind(
+  d: BackendDevice,
+  mainOn: boolean | undefined,
+  values: Map<string, unknown>,
+): Device["statusKind"] {
+  if (!d.online) return "offline";
+  if (mapCategory(d.category) === "lock") return lockStatusKind(d, values);
+  if (mainOn === undefined) return "connected";
+  return mainOn ? "on" : "off";
+}
+
 function humanDeviceStatus(
   d: BackendDevice,
   mainOn: boolean | undefined,
   values: Map<string, unknown>,
 ): string {
   const s = STATUS_TEXT[langKey()] ?? STATUS_TEXT.zh;
-  if (!d.online) return s.offline;
-  const cat = mapCategory(d.category);
+  const kind = deviceStatusKind(d, mainOn, values);
+  if (kind === "offline") return s.offline;
+  if (kind === "locked") return s.locked;
+  if (kind === "unlocked") return s.unlocked;
+  if (kind === "connected") return s.connected;
 
-  if (cat === "lock") {
-    const stateProp = Object.entries(d.spec ?? {}).find(([, spec]) => spec.type_name === "door-state");
-    if (stateProp) {
-      const [iid, spec] = stateProp;
-      const value = values.get(iid);
-      const optionName = spec.value_list?.find((item) => item.value === value)?.name;
-      if (optionName?.includes("Unlocked") || optionName?.includes("Ajar") || optionName?.includes("Not Close")) {
-        return s.unlocked;
-      }
-      if (optionName?.includes("Locked") || optionName?.includes("Closed Properly")) {
-        return s.locked;
-      }
-    }
-    const v = values.get("prop.2.1");
-    if (typeof v === "boolean") return v ? s.locked : s.unlocked;
-    return s.connected;
-  }
-  if (mainOn === undefined) return s.connected;
+  const cat = mapCategory(d.category);
   if (cat === "aircond") {
-    if (!mainOn) return s.off;
+    if (kind === "off") return s.off;
     const t = values.get("prop.2.5") ?? values.get("prop.2.4");
     if (typeof t === "number") return `${t}°C`;
     return s.running;
   }
   if (cat === "purifier") {
-    if (!mainOn) return s.off;
+    if (kind === "off") return s.off;
     const mode = values.get("prop.2.4");
     if (mode === 1) return s.sleepMode;
     if (mode === 0) return s.autoMode;
     return s.running;
   }
-  return mainOn ? s.on : s.off;
+  return kind === "on" ? s.on : s.off;
 }
 
 export async function realControlDeviceProp(

--- a/web/src/api/real.ts
+++ b/web/src/api/real.ts
@@ -673,6 +673,7 @@ export async function realListDevices(): Promise<Device[]> {
     const allProps: DeviceProperty[] = Object.entries(d.spec ?? {})
       .filter(([iid]) => iid.startsWith("prop."))
       .map(([iid, spec]) => mapProp(iid, spec, valueByIid.get(iid)));
+    const statusKind = deviceStatusKind(d, mainSwitch?.current, valueByIid);
 
     return {
       did: d.did,
@@ -680,8 +681,8 @@ export async function realListDevices(): Promise<Device[]> {
       category: cat,
       room: cleanRoom(d.room),
       online: d.online,
-      statusText: humanDeviceStatus(d, mainSwitch?.current, valueByIid),
-      statusKind: deviceStatusKind(d, mainSwitch?.current, valueByIid),
+      statusText: humanDeviceStatus(d, valueByIid, statusKind),
+      statusKind,
       dangerous,
       mainSwitch,
       props: allProps,
@@ -825,11 +826,10 @@ function deviceStatusKind(
 
 function humanDeviceStatus(
   d: BackendDevice,
-  mainOn: boolean | undefined,
   values: Map<string, unknown>,
+  kind: Device["statusKind"],
 ): string {
   const s = STATUS_TEXT[langKey()] ?? STATUS_TEXT.zh;
-  const kind = deviceStatusKind(d, mainOn, values);
   if (kind === "offline") return s.offline;
   if (kind === "locked") return s.locked;
   if (kind === "unlocked") return s.unlocked;

--- a/web/src/api/real.ts
+++ b/web/src/api/real.ts
@@ -679,6 +679,7 @@ export async function realListDevices(): Promise<Device[]> {
       did: d.did,
       name: cleanDeviceName(d.name),
       category: cat,
+      rawCategory: d.category,
       room: cleanRoom(d.room),
       online: d.online,
       statusText: humanDeviceStatus(d, valueByIid, statusKind),

--- a/web/src/api/real.ts
+++ b/web/src/api/real.ts
@@ -801,7 +801,7 @@ function lockStatusKind(
   if (stateProp) {
     const [iid, spec] = stateProp;
     const value = values.get(iid);
-    const optionName = spec.value_list?.find((item) => item.value === value)?.name;
+    const optionName = spec.value_list?.find((item) => String(item.value) === String(value))?.name;
     if (optionName?.includes("Unlocked") || optionName?.includes("Ajar") || optionName?.includes("Not Close")) {
       return "unlocked";
     }
@@ -1347,6 +1347,12 @@ const USAGE_TTL_MS = 5000;
 export function _resetUsageStatsCache(): void {
   usageCache.clear();
 }
+
+export function _resetMiotHomeCache(): void {
+  homeCache = null;
+  homeCacheTs = 0;
+}
+
 
 export function realGetUsageStats(
   period: UsagePeriod = "today",

--- a/web/src/components/DevicesByRoom.tsx
+++ b/web/src/components/DevicesByRoom.tsx
@@ -195,7 +195,7 @@ function DeviceRow({ device }: RowProps) {
   const offline = !device.online;
   const ms = device.mainSwitch;
   const isOn = !offline && (ms?.current ?? false);
-  const isUnlocked = !offline && device.category === "lock" && device.statusText === "未锁";
+  const isUnlocked = device.statusKind === "unlocked";
 
   // 状态提示同色表达：在线=绿，离线=灰，需要注意=warning。
   let dotColor = "bg-text-tertiary";

--- a/web/src/components/DevicesByRoom.tsx
+++ b/web/src/components/DevicesByRoom.tsx
@@ -46,6 +46,211 @@ const CATEGORY_ICON: Record<DeviceCategory, ComponentType<SVGProps<SVGSVGElement
   other: IconPlug,
 };
 
+type DeviceGroupCategory =
+  | "cleaning_appliance"
+  | "security"
+  | "sensor"
+  | "entertainment"
+  | "environment_appliance"
+  | "router_gateway"
+  | "lighting"
+  | "plug_switch"
+  | "kitchen_appliance"
+  | "bathroom"
+  | "personal_living"
+  | "pet_plant"
+  | "fitness_health"
+  | "mobility_vehicle"
+  | "office_study"
+  | "other";
+
+const GROUP_ORDER: DeviceGroupCategory[] = [
+  "cleaning_appliance",
+  "security",
+  "sensor",
+  "entertainment",
+  "environment_appliance",
+  "router_gateway",
+  "lighting",
+  "plug_switch",
+  "kitchen_appliance",
+  "bathroom",
+  "personal_living",
+  "pet_plant",
+  "fitness_health",
+  "mobility_vehicle",
+  "office_study",
+  "other",
+];
+
+const GROUP_LABEL_KEY = {
+  cleaning_appliance: "devices.group.cleaningAppliance",
+  security: "devices.group.security",
+  sensor: "devices.group.sensor",
+  entertainment: "devices.group.entertainment",
+  environment_appliance: "devices.group.environmentAppliance",
+  router_gateway: "devices.group.routerGateway",
+  lighting: "devices.group.lighting",
+  plug_switch: "devices.group.plugSwitch",
+  kitchen_appliance: "devices.group.kitchenAppliance",
+  bathroom: "devices.group.bathroom",
+  personal_living: "devices.group.personalLiving",
+  pet_plant: "devices.group.petPlant",
+  fitness_health: "devices.group.fitnessHealth",
+  mobility_vehicle: "devices.group.mobilityVehicle",
+  office_study: "devices.group.officeStudy",
+  other: "devices.group.other",
+} satisfies { [K in DeviceGroupCategory]: string };
+
+const DEVICE_TO_GROUP: { [K in DeviceCategory]: DeviceGroupCategory } = {
+  camera: "security",
+  lock: "security",
+  purifier: "environment_appliance",
+  fan: "environment_appliance",
+  aircond: "environment_appliance",
+  light: "lighting",
+  curtain: "personal_living",
+  tv: "entertainment",
+  other: "other",
+};
+
+const RAW_CATEGORY_TO_GROUP: Record<string, DeviceGroupCategory> = {
+  "扫地机器人": "cleaning_appliance",
+  "擦地机": "cleaning_appliance",
+  "洗衣机": "cleaning_appliance",
+  "干衣机": "cleaning_appliance",
+  "烘干机": "cleaning_appliance",
+  "垃圾桶": "cleaning_appliance",
+  "camera": "security",
+  "lock": "security",
+  "smart-lock": "security",
+  "可视门铃": "security",
+  "摄像头": "security",
+  "摄像机灯": "security",
+  "sensor": "sensor",
+  "temperature-humidity-sensor": "sensor",
+  "motion-sensor": "sensor",
+  "contact-sensor": "sensor",
+  "smoke-sensor": "sensor",
+  "gas-sensor": "sensor",
+  "water-leak-sensor": "sensor",
+  "蓝牙温湿度传感器": "sensor",
+  "温控器": "sensor",
+  "tv": "entertainment",
+  "television": "entertainment",
+  "set-top-box": "entertainment",
+  "projector": "entertainment",
+  "speaker": "entertainment",
+  "电视": "entertainment",
+  "分体电视": "entertainment",
+  "电视盒子": "entertainment",
+  "机顶盒": "entertainment",
+  "投影仪": "entertainment",
+  "air-conditioner": "environment_appliance",
+  "air-purifier": "environment_appliance",
+  "fan": "environment_appliance",
+  "heater": "environment_appliance",
+  "空气净化器": "environment_appliance",
+  "新风机": "environment_appliance",
+  "加湿器": "environment_appliance",
+  "除湿机": "environment_appliance",
+  "电风扇": "environment_appliance",
+  "电暖器/暖风机/电暖风": "environment_appliance",
+  "凉霸": "environment_appliance",
+  "空调": "environment_appliance",
+  "空调伴侣": "environment_appliance",
+  "香薰机": "environment_appliance",
+  "gateway": "router_gateway",
+  "router": "router_gateway",
+  "网关": "router_gateway",
+  "路由器": "router_gateway",
+  "light": "lighting",
+  "ceiling-light": "lighting",
+  "灯": "lighting",
+  "杀菌灯": "lighting",
+  "outlet": "plug_switch",
+  "wall-switch": "plug_switch",
+  "plug": "plug_switch",
+  "单控开关": "plug_switch",
+  "带温湿度查询功能开关": "plug_switch",
+  "电机控制器": "plug_switch",
+  "养生壶": "kitchen_appliance",
+  "压力锅": "kitchen_appliance",
+  "多功能料理锅": "kitchen_appliance",
+  "微波炉": "kitchen_appliance",
+  "果汁机/破壁料理机": "kitchen_appliance",
+  "油烟机": "kitchen_appliance",
+  "电磁炉": "kitchen_appliance",
+  "电饭煲": "kitchen_appliance",
+  "空气炸锅": "kitchen_appliance",
+  "蒸烤箱": "kitchen_appliance",
+  "集成灶": "kitchen_appliance",
+  "热水壶": "kitchen_appliance",
+  "洗碗机": "kitchen_appliance",
+  "冰箱": "kitchen_appliance",
+  "净水器": "bathroom",
+  "饮水机/净饮机": "bathroom",
+  "热水器": "bathroom",
+  "浴霸": "bathroom",
+  "curtain": "personal_living",
+  "smart-curtain": "personal_living",
+  "窗帘": "personal_living",
+  "开窗器": "personal_living",
+  "晾衣架": "personal_living",
+  "智能床": "personal_living",
+  "智能枕": "personal_living",
+  "电热毯": "personal_living",
+  "按摩器": "personal_living",
+  "按摩椅": "personal_living",
+  "艾灸盒": "personal_living",
+  "足浴盆": "personal_living",
+  "灭蚊器": "personal_living",
+  "宠物喂食器": "pet_plant",
+  "宠物饮水机": "pet_plant",
+  "猫砂盆": "pet_plant",
+  "鱼缸": "pet_plant",
+  "花盆": "pet_plant",
+  "跑步机": "fitness_health",
+  "走步机": "fitness_health",
+  "控制面板": "office_study",
+};
+
+function groupRank(group: DeviceGroupCategory): number {
+  const idx = GROUP_ORDER.indexOf(group);
+  return idx === -1 ? GROUP_ORDER.length : idx;
+}
+
+function deviceGroup(device: Device): DeviceGroupCategory {
+  if (device.rawCategory && RAW_CATEGORY_TO_GROUP[device.rawCategory]) {
+    return RAW_CATEGORY_TO_GROUP[device.rawCategory];
+  }
+  return DEVICE_TO_GROUP[device.category] ?? "other";
+}
+
+export function sortDevicesForDisplay(devices: Device[]): Device[] {
+  return [...devices].sort((a, b) => {
+    if (a.online !== b.online) return a.online ? -1 : 1;
+    const groupDiff = groupRank(deviceGroup(a)) - groupRank(deviceGroup(b));
+    if (groupDiff !== 0) return groupDiff;
+    return a.name.localeCompare(b.name, "zh-Hans-CN") || a.did.localeCompare(b.did);
+  });
+}
+
+export function groupDevicesByCategory(devices: Device[]): [DeviceGroupCategory, Device[]][] {
+  const groups = new Map<DeviceGroupCategory, Device[]>();
+  for (const d of sortDevicesForDisplay(devices)) {
+    const group = deviceGroup(d);
+    if (!groups.has(group)) groups.set(group, []);
+    groups.get(group)!.push(d);
+  }
+  return [...groups.entries()].sort(([aGroup, aList], [bGroup, bList]) => {
+    const aOnline = aList.some((d) => d.online);
+    const bOnline = bList.some((d) => d.online);
+    if (aOnline !== bOnline) return aOnline ? -1 : 1;
+    return groupRank(aGroup) - groupRank(bGroup);
+  });
+}
+
 interface Props {
   devices: Device[];
   scenes: Scene[];
@@ -58,7 +263,7 @@ export function DevicesByRoom({ devices, scenes, onChanged }: Props) {
 
   const unassigned = t("devices.unassigned");
 
-  // 按 room 分组,保留原始顺序
+  // 按 room 分组；每个房间内排序为在线优先，并按设备类型聚类。
   const groups = useMemo(() => {
     const m = new Map<string, Device[]>();
     for (const d of devices) {
@@ -66,7 +271,7 @@ export function DevicesByRoom({ devices, scenes, onChanged }: Props) {
       if (!m.has(key)) m.set(key, []);
       m.get(key)!.push(d);
     }
-    return [...m.entries()];
+    return [...m.entries()].map(([room, list]) => [room, sortDevicesForDisplay(list)] as const);
   }, [devices, unassigned]);
 
   // 默认规则:≤3 个房间全展开;>3 个房间只展第一个
@@ -141,8 +346,17 @@ export function DevicesByRoom({ devices, scenes, onChanged }: Props) {
               </button>
               {open && (
                 <div className="pl-5 pb-1 pr-1">
-                  {list.map((d) => (
-                    <DeviceRow key={d.did} device={d} />
+                  {groupDevicesByCategory(list).map(([category, categoryDevices]) => (
+                    <div key={category} className="py-1">
+                      <div className="text-caption-mono text-text-tertiary px-2 pb-1 flex items-center gap-1.5">
+                        <span>{t(GROUP_LABEL_KEY[category])}</span>
+                        <span>·</span>
+                        <span>{t("devices.countUnit", { n: categoryDevices.length })}</span>
+                      </div>
+                      {categoryDevices.map((d) => (
+                        <DeviceRow key={d.did} device={d} />
+                      ))}
+                    </div>
                   ))}
                 </div>
               )}

--- a/web/src/components/DevicesByRoom.tsx
+++ b/web/src/components/DevicesByRoom.tsx
@@ -4,7 +4,7 @@
  * 视觉规格：
  * - 房间标题行用 chevron + 名字 + mono 计数 meta
  * - 设备行：紧凑（44px 高），左侧图标 + 名字 + 状态点+状态文字 + 主开关 + ⋯
- * - 离线设备状态点用 warn 色
+ * - 状态点与状态文案同色：在线绿、离线灰；异常态预留 warning
  * - 场景行底部 hairline 分隔
  */
 
@@ -195,19 +195,20 @@ function DeviceRow({ device }: RowProps) {
   const offline = !device.online;
   const ms = device.mainSwitch;
   const isOn = !offline && (ms?.current ?? false);
+  const isUnlocked = !offline && device.category === "lock" && device.statusText === "未锁";
 
-  // 状态点颜色:离线=warn,开=ok,关=tertiary,危险设备(锁)=info
+  // 状态提示同色表达：在线=绿，离线=灰，需要注意=warning。
   let dotColor = "bg-text-tertiary";
   let dotRing = "var(--color-bg-tertiary)";
-  if (offline) {
+  let statusTextColor = "text-text-tertiary";
+  if (isUnlocked) {
     dotColor = "bg-warning";
     dotRing = "var(--color-warning-bg)";
-  } else if (device.category === "lock") {
-    dotColor = "bg-info";
-    dotRing = "var(--color-info-bg)";
-  } else if (isOn) {
+    statusTextColor = "text-warning";
+  } else if (!offline) {
     dotColor = "bg-success";
     dotRing = "var(--color-success-bg)";
+    statusTextColor = "text-success";
   }
 
   // v5：纯展示，不响应点击。原 DeviceQuickSheet 弹窗已删（控制能力暂未补齐
@@ -246,9 +247,7 @@ function DeviceRow({ device }: RowProps) {
             boxShadow: `0 0 0 3px ${dotRing}`,
           }}
         />
-        <span
-          className={`text-caption-mono ${offline ? "text-warning" : "text-text-secondary"}`}
-        >
+        <span className={`text-caption-mono ${statusTextColor}`}>
           {device.statusText}
         </span>
       </span>

--- a/web/src/components/DevicesByRoom.tsx
+++ b/web/src/components/DevicesByRoom.tsx
@@ -60,7 +60,6 @@ type DeviceGroupCategory =
   | "personal_living"
   | "pet_plant"
   | "fitness_health"
-  | "mobility_vehicle"
   | "office_study"
   | "other";
 
@@ -78,7 +77,6 @@ const GROUP_ORDER: DeviceGroupCategory[] = [
   "personal_living",
   "pet_plant",
   "fitness_health",
-  "mobility_vehicle",
   "office_study",
   "other",
 ];
@@ -97,7 +95,6 @@ const GROUP_LABEL_KEY = {
   personal_living: "devices.group.personalLiving",
   pet_plant: "devices.group.petPlant",
   fitness_health: "devices.group.fitnessHealth",
-  mobility_vehicle: "devices.group.mobilityVehicle",
   office_study: "devices.group.officeStudy",
   other: "devices.group.other",
 } satisfies { [K in DeviceGroupCategory]: string };
@@ -271,7 +268,11 @@ export function DevicesByRoom({ devices, scenes, onChanged }: Props) {
       if (!m.has(key)) m.set(key, []);
       m.get(key)!.push(d);
     }
-    return [...m.entries()].map(([room, list]) => [room, sortDevicesForDisplay(list)] as const);
+    return [...m.entries()].map(([room, list]) => {
+      const categoryGroups = groupDevicesByCategory(list);
+      const sorted = categoryGroups.flatMap(([, categoryDevices]) => categoryDevices);
+      return [room, sorted, categoryGroups] as const;
+    });
   }, [devices, unassigned]);
 
   // 默认规则:≤3 个房间全展开;>3 个房间只展第一个
@@ -304,7 +305,7 @@ export function DevicesByRoom({ devices, scenes, onChanged }: Props) {
       )}
 
       <div className="px-2">
-        {groups.map(([room, list], idx) => {
+        {groups.map(([room, list, categoryGroups], idx) => {
           const onlineCount = list.filter((d) => d.online).length;
           const onCount = list.filter(
             (d) =>
@@ -346,7 +347,7 @@ export function DevicesByRoom({ devices, scenes, onChanged }: Props) {
               </button>
               {open && (
                 <div className="pl-5 pb-1 pr-1">
-                  {groupDevicesByCategory(list).map(([category, categoryDevices]) => (
+                  {categoryGroups.map(([category, categoryDevices]) => (
                     <div key={category} className="py-1">
                       <div className="text-caption-mono text-text-tertiary px-2 pb-1 flex items-center gap-1.5">
                         <span>{t(GROUP_LABEL_KEY[category])}</span>

--- a/web/src/i18n/locales/en/devices.json
+++ b/web/src/i18n/locales/en/devices.json
@@ -27,7 +27,6 @@
       "personalLiving": "Personal care & living",
       "petPlant": "Pets & plants",
       "fitnessHealth": "Fitness & health",
-      "mobilityVehicle": "Mobility & vehicle",
       "officeStudy": "Office & study",
       "other": "Other"
     }

--- a/web/src/i18n/locales/en/devices.json
+++ b/web/src/i18n/locales/en/devices.json
@@ -12,6 +12,24 @@
     "watchCamera": "Watch {{name}}",
     "liveView": "{{name}} live view",
     "loadingStream": "Loading stream…",
-    "close": "Close"
+    "close": "Close",
+    "group": {
+      "cleaningAppliance": "Cleaning appliances",
+      "security": "Security",
+      "sensor": "Sensors",
+      "entertainment": "Entertainment",
+      "environmentAppliance": "Environment appliances",
+      "routerGateway": "Routers & gateways",
+      "lighting": "Lighting",
+      "plugSwitch": "Plugs & switches",
+      "kitchenAppliance": "Kitchen appliances",
+      "bathroom": "Bathroom",
+      "personalLiving": "Personal care & living",
+      "petPlant": "Pets & plants",
+      "fitnessHealth": "Fitness & health",
+      "mobilityVehicle": "Mobility & vehicle",
+      "officeStudy": "Office & study",
+      "other": "Other"
+    }
   }
 }

--- a/web/src/i18n/locales/zh/devices.json
+++ b/web/src/i18n/locales/zh/devices.json
@@ -12,6 +12,24 @@
     "watchCamera": "看 {{name}}",
     "liveView": "{{name}} 实时画面",
     "loadingStream": "拉流中…",
-    "close": "关闭"
+    "close": "关闭",
+    "group": {
+      "cleaningAppliance": "清洁电器",
+      "security": "安防",
+      "sensor": "传感器",
+      "entertainment": "影音娱乐",
+      "environmentAppliance": "环境电器",
+      "routerGateway": "路由网关",
+      "lighting": "照明",
+      "plugSwitch": "插座开关",
+      "kitchenAppliance": "厨房电器",
+      "bathroom": "卫浴",
+      "personalLiving": "个护与起居",
+      "petPlant": "宠物与植物",
+      "fitnessHealth": "运动健康",
+      "mobilityVehicle": "出行车载",
+      "officeStudy": "办公学习",
+      "other": "其他"
+    }
   }
 }

--- a/web/src/i18n/locales/zh/devices.json
+++ b/web/src/i18n/locales/zh/devices.json
@@ -27,7 +27,6 @@
       "personalLiving": "个护与起居",
       "petPlant": "宠物与植物",
       "fitnessHealth": "运动健康",
-      "mobilityVehicle": "出行车载",
       "officeStudy": "办公学习",
       "other": "其他"
     }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -80,6 +80,8 @@ export interface Device {
   online: boolean;
   // 概览状态文本（"开着" / "26°C 制冷" / "睡眠档"）
   statusText: string;
+  // 机器可读状态分类；UI 颜色/逻辑不要依赖本地化文案。
+  statusKind: "offline" | "locked" | "unlocked" | "on" | "off" | "connected";
   // 是否危险设备（门锁/燃气/烟雾），需要二次确认
   dangerous: boolean;
   // 主开关 prop（单按钮直控；为 null 时只能从 sheet 进）

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -76,6 +76,7 @@ export interface Device {
   did: string;
   name: string;
   category: DeviceCategory;
+  rawCategory?: string;
   room: string;
   online: boolean;
   // 概览状态文本（"开着" / "26°C 制冷" / "睡眠档"）

--- a/web/tests/DevicesByRoom.test.ts
+++ b/web/tests/DevicesByRoom.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  groupDevicesByCategory,
+  sortDevicesForDisplay,
+} from "@/components/DevicesByRoom";
+import type { Device } from "@/lib/types";
+
+const dev = (overrides: Partial<Device>): Device => ({
+  did: "d",
+  name: "设备",
+  category: "other",
+  room: "客厅",
+  online: true,
+  statusText: "已连接",
+  statusKind: "connected",
+  dangerous: false,
+  mainSwitch: undefined,
+  props: [],
+  ...overrides,
+});
+
+describe("DevicesByRoom device grouping", () => {
+  it("sorts online devices before offline devices", () => {
+    const out = sortDevicesForDisplay([
+      dev({ did: "offline", online: false }),
+      dev({ did: "online", online: true }),
+    ]);
+
+    expect(out.map((d) => d.did)).toEqual(["online", "offline"]);
+  });
+
+  it("uses rawCategory before falling back to normalized category", () => {
+    const groups = groupDevicesByCategory([
+      dev({ did: "switch", category: "light", rawCategory: "wall-switch" }),
+    ]);
+
+    expect(groups[0][0]).toBe("plug_switch");
+  });
+
+  it("keeps groups with online devices before all-offline groups", () => {
+    const groups = groupDevicesByCategory([
+      dev({ did: "offline-camera", category: "camera", online: false }),
+      dev({ did: "online-light", category: "light", online: true }),
+    ]);
+
+    expect(groups.map(([group]) => group)).toEqual(["lighting", "security"]);
+  });
+
+  it("sorts devices stably by localized name then did inside a group", () => {
+    const out = sortDevicesForDisplay([
+      dev({ did: "b", name: "台灯" }),
+      dev({ did: "a", name: "台灯" }),
+      dev({ did: "c", name: "壁灯" }),
+    ]);
+
+    expect(out.map((d) => d.did)).toEqual(["c", "a", "b"]);
+  });
+});

--- a/web/tests/real.test.ts
+++ b/web/tests/real.test.ts
@@ -21,6 +21,7 @@ import {
   realListOmniModels,
   realTestOmniConfig,
   _resetUsageStatsCache,
+  _resetMiotHomeCache,
 } from "@/api/real";
 
 // 这些用例直接覆写 globalThis.fetch(非 vi.spyOn),vi.restoreAllMocks() 只还原
@@ -33,6 +34,7 @@ afterEach(() => {
   globalThis.fetch = originalFetch;
   i18n.changeLanguage("zh");
   _resetUsageStatsCache(); // 清掉用量请求级缓存，保证用例间隔离
+  _resetMiotHomeCache(); // 清掉 /api/miot/home TTL 缓存，保证设备用例间隔离
 });
 
 /**
@@ -113,6 +115,89 @@ describe("realListDevices — device status contract", () => {
     expect(devices[0]).toMatchObject({
       statusText: "Unlocked",
       statusKind: "unlocked",
+    });
+  });
+
+  it("matches lock door-state enum values even when backend serializes the value as a string", async () => {
+    mockFetchByUrl({
+      "/api/miot/home": {
+        code: 0,
+        message: "ok",
+        data: {
+          devices: [
+            {
+              did: "lock-2",
+              name: "Back Door",
+              online: true,
+              model: "lock.model",
+              room: "Entry",
+              category: "lock",
+              spec: {
+                "prop.2.1": {
+                  format: "uint8",
+                  type_name: "door-state",
+                  value_list: [
+                    { name: "Locked", value: 1 },
+                    { name: "Ajar", value: 2 },
+                  ],
+                },
+              },
+            },
+          ],
+          areas: [],
+          scenes: [],
+          persons: [],
+        },
+      },
+      "/api/miot/devices/lock-2/status": {
+        code: 0,
+        message: "ok",
+        data: { properties: [{ iid: "prop.2.1", value: "2", code: 0 }] },
+      },
+    });
+
+    await i18n.changeLanguage("en");
+    const devices = await realListDevices();
+    expect(devices[0]).toMatchObject({
+      statusText: "Unlocked",
+      statusKind: "unlocked",
+    });
+  });
+
+  it("falls back to legacy lock boolean when door-state spec is unavailable", async () => {
+    mockFetchByUrl({
+      "/api/miot/home": {
+        code: 0,
+        message: "ok",
+        data: {
+          devices: [
+            {
+              did: "lock-3",
+              name: "Side Door",
+              online: true,
+              model: "lock.model",
+              room: "Entry",
+              category: "lock",
+              spec: {},
+            },
+          ],
+          areas: [],
+          scenes: [],
+          persons: [],
+        },
+      },
+      "/api/miot/devices/lock-3/status": {
+        code: 0,
+        message: "ok",
+        data: { properties: [{ iid: "prop.2.1", value: true, code: 0 }] },
+      },
+    });
+
+    await i18n.changeLanguage("en");
+    const devices = await realListDevices();
+    expect(devices[0]).toMatchObject({
+      statusText: "Locked",
+      statusKind: "locked",
     });
   });
 });

--- a/web/tests/real.test.ts
+++ b/web/tests/real.test.ts
@@ -9,8 +9,10 @@
  */
 
 import { describe, it, expect, vi, afterEach } from "vitest";
+import i18n from "@/i18n";
 import {
   realListActivity,
+  realListDevices,
   realGetUsageStats,
   realGetOmniConfig,
   realUpdateOmniConfig,
@@ -29,6 +31,7 @@ const originalFetch = globalThis.fetch;
 afterEach(() => {
   vi.restoreAllMocks();
   globalThis.fetch = originalFetch;
+  i18n.changeLanguage("zh");
   _resetUsageStatsCache(); // 清掉用量请求级缓存，保证用例间隔离
 });
 
@@ -65,6 +68,54 @@ function mockFetch(events: unknown[]) {
     ),
   ) as unknown as typeof fetch;
 }
+
+describe("realListDevices — device status contract", () => {
+  it("maps lock warning state to statusKind independently from localized statusText", async () => {
+    mockFetchByUrl({
+      "/api/miot/home": {
+        code: 0,
+        message: "ok",
+        data: {
+          devices: [
+            {
+              did: "lock-1",
+              name: "Front Door",
+              online: true,
+              model: "lock.model",
+              room: "Entry",
+              category: "lock",
+              spec: {
+                "prop.2.1": {
+                  format: "uint8",
+                  type_name: "door-state",
+                  value_list: [
+                    { name: "Locked", value: 1 },
+                    { name: "Unlocked", value: 2 },
+                  ],
+                },
+              },
+            },
+          ],
+          areas: [],
+          scenes: [],
+          persons: [],
+        },
+      },
+      "/api/miot/devices/lock-1/status": {
+        code: 0,
+        message: "ok",
+        data: { properties: [{ iid: "prop.2.1", value: 2, code: 0 }] },
+      },
+    });
+
+    await i18n.changeLanguage("en");
+    const devices = await realListDevices();
+    expect(devices[0]).toMatchObject({
+      statusText: "Unlocked",
+      statusKind: "unlocked",
+    });
+  });
+});
 
 describe("realListActivity — /api/events 契约", () => {
   it("BackendMeaningfulEvent → ActivityEvent 字段映射", async () => {


### PR DESCRIPTION
## Summary
- clarify device row status colors so online devices use green status text/dot and offline devices use gray status text/dot
- surface unlocked/ajar/not-closed smart locks as warning status text/dot
- resolve lock status from `door-state` spec values before falling back to legacy boolean `prop.2.1`
- group room devices by online state and category, using raw MIoT categories where available

## Verification
- `cd web && npm run build`
- local Dashboard smoke test via production build/static sync on `http://localhost:1810/`