### PR TITLE
fix(camera): 关闭感知/超上限时停止相机 native 拉流，拉流与投喂统一口径

### DIFF
--- a/backend/miloco/src/miloco/miot/client.py
+++ b/backend/miloco/src/miloco/miot/client.py
@@ -672,8 +672,15 @@ class MiotProxy:
                 for camera_did in list(self._camera_img_managers.keys()):
                     # 不在 active 集（账号消失 / 移出家庭 / 被关 / 离线 / 超额）→ 销毁，
                     # 真正 miot_camera_stop + decoder.stop()，停掉 native 会话与解码。
-                    should_destroy = camera_did not in active
-                    if should_destroy:
+                    if camera_did in active:
+                        logger.debug(
+                            "Manager %s kept alive (in_use & in scope)", camera_did
+                        )
+                        continue
+                    # 每台单独兜异常：批量销（切家庭销旧家庭 N 台 / 超额收敛 N-M 台）时，
+                    # 任一台 unregister/destroy 抛错不能拖垮其余——否则剩余 manager 留在
+                    # dict 里继续白拉流，要等下次 refresh 才重试。失败的留在 dict 待重试。
+                    try:
                         await self._miot_client.unregister_lan_device_changed_async(
                             did=camera_did
                         )
@@ -682,9 +689,12 @@ class MiotProxy:
                         logger.warning(
                             "Camera native stream stopped: %s", camera_did
                         )
-                    else:
-                        logger.debug(
-                            "Manager %s kept alive (in_use & in scope)", camera_did
+                    except Exception as e:  # noqa: BLE001
+                        logger.error(
+                            "Failed to destroy camera manager %s, "
+                            "leaving in dict for retry: %s",
+                            camera_did,
+                            e,
                         )
                 await self._sync_camera_state_subscriptions()
                 return cameras

--- a/backend/miloco/src/miloco/miot/client.py
+++ b/backend/miloco/src/miloco/miot/client.py
@@ -36,7 +36,7 @@ from pydantic_core import to_jsonable_python
 from miloco.config import get_settings
 from miloco.database.kv_repo import AuthConfigKeys, DeviceInfoKeys, KVRepo
 from miloco.miot.camera_handler import CameraVisionHandler
-from miloco.miot.filter import is_home_allowed
+from miloco.miot.filter import denied_camera_dids, is_home_allowed
 from miloco.miot.mips_listeners import (
     BindEventListener,
     CameraStateEventListener,
@@ -550,9 +550,8 @@ class MiotProxy:
         self,
         camera_info: MIoTCameraInfo,
     ) -> CameraVisionHandler | None:
-        # scope 不影响 manager 的建立——watch 视频流需要 camera instance 无论 inUse 状态。
-        # toggle_scope 只改 KV,不触发 refresh_cameras,所以这里只在启动/摄像头首次发现时调用,
-        # 此时 start_async 是正常的初始化,不会干扰已有连接。
+        # 纯建原语:不含 scope gate(黑名单/home 白名单的判断在调用方 refresh_cameras)。
+        # start_async 起 native PPCS 会话+解码;只对通过 refresh gate 的相机调用。
         camera_instance = await self._get_camera_instance(camera_info)
         if camera_instance is not None:
             await camera_instance.start_async(enable_reconnect=True, enable_audio=True)
@@ -637,10 +636,16 @@ class MiotProxy:
                 cameras = copy.deepcopy(cameras)
                 # Publish before registering so callbacks resolve against the new dict.
                 self._camera_info_dict = cameras
+                # manager(native PPCS 会话+解码线程)生命周期跟随 scope：home 未启用
+                # 或相机被关(in_use=false → 进黑名单)的相机不建、已建的销，关了就停拉流。
+                denied = denied_camera_dids(self._kv_repo)
                 for camera_did in cameras.keys():
                     if camera_did not in self._camera_img_managers:
-                        if not is_home_allowed(
-                            self._kv_repo, cameras[camera_did].home_id
+                        if (
+                            not is_home_allowed(
+                                self._kv_repo, cameras[camera_did].home_id
+                            )
+                            or camera_did in denied
                         ):
                             continue
                         manager = await self._create_camera_img_manager(
@@ -659,17 +664,22 @@ class MiotProxy:
 
                 for camera_did in list(self._camera_img_managers.keys()):
                     cam = cameras.get(camera_did)
-                    # scope=false 时不 destroy,只有摄像头真正从账号消失才 destroy。
-                    if cam is None:
+                    # 三种情况销毁 manager：相机从账号消失 / 移出当前家庭 / 被关闭。
+                    # 销毁即真正 miot_camera_stop + decoder.stop()，停掉 native 会话与解码。
+                    should_destroy = (
+                        cam is None
+                        or not is_home_allowed(self._kv_repo, cam.home_id)
+                        or camera_did in denied
+                    )
+                    if should_destroy:
                         await self._miot_client.unregister_lan_device_changed_async(
                             did=camera_did
                         )
                         await self._camera_img_managers[camera_did].destroy()
                         del self._camera_img_managers[camera_did]
                     else:
-                        # cam 仍在账号里,manager 保活(无论 scope 状态)。
                         logger.debug(
-                            "Manager %s kept alive for watch stream", camera_did
+                            "Manager %s kept alive (in_use & in scope)", camera_did
                         )
                 await self._sync_camera_state_subscriptions()
                 return cameras

--- a/backend/miloco/src/miloco/miot/client.py
+++ b/backend/miloco/src/miloco/miot/client.py
@@ -36,7 +36,7 @@ from pydantic_core import to_jsonable_python
 from miloco.config import get_settings
 from miloco.database.kv_repo import AuthConfigKeys, DeviceInfoKeys, KVRepo
 from miloco.miot.camera_handler import CameraVisionHandler
-from miloco.miot.filter import denied_camera_dids, is_home_allowed
+from miloco.miot.filter import is_home_allowed, select_active_camera_dids
 from miloco.miot.mips_listeners import (
     BindEventListener,
     CameraStateEventListener,
@@ -636,17 +636,19 @@ class MiotProxy:
                 cameras = copy.deepcopy(cameras)
                 # Publish before registering so callbacks resolve against the new dict.
                 self._camera_info_dict = cameras
-                # manager(native PPCS 会话+解码线程)生命周期跟随 scope：home 未启用
-                # 或相机被关(in_use=false → 进黑名单)的相机不建、已建的销，关了就停拉流。
-                denied = denied_camera_dids(self._kv_repo)
+                # manager(native PPCS 会话+解码线程)的建/销与感知投喂**共用同一口径**
+                # (select_active_camera_dids)：在启用家庭 + 未拉黑 + 在线、按 did 截到上限。
+                # 拉流集 = 投喂集，单一来源不漂移；关掉/移出家庭/离线/超额的相机都不在
+                # active 里 → 不建/已建则销，真正停掉 native 会话与解码（含 over-cap 收敛）。
+                active = set(select_active_camera_dids(self._kv_repo, cameras))
+                logger.debug(
+                    "Camera streaming set: active=%s managers=%s",
+                    sorted(active),
+                    sorted(self._camera_img_managers),
+                )
                 for camera_did in cameras.keys():
                     if camera_did not in self._camera_img_managers:
-                        if (
-                            not is_home_allowed(
-                                self._kv_repo, cameras[camera_did].home_id
-                            )
-                            or camera_did in denied
-                        ):
+                        if camera_did not in active:
                             continue
                         manager = await self._create_camera_img_manager(
                             cameras[camera_did]
@@ -657,26 +659,29 @@ class MiotProxy:
                             await self._miot_client.register_lan_device_changed_async(
                                 did=camera_did, callback=self._on_lan_device_changed
                             )
+                            # 起停相机 native 会话直接影响相机有限的并发流名额，
+                            # 用 WARNING 便于运维一眼追踪拉流生命周期。
+                            logger.warning(
+                                "Camera native stream started: %s", camera_did
+                            )
                     else:
                         await self._camera_img_managers[camera_did].update_camera_info(
                             cameras[camera_did]
                         )
 
                 for camera_did in list(self._camera_img_managers.keys()):
-                    cam = cameras.get(camera_did)
-                    # 三种情况销毁 manager：相机从账号消失 / 移出当前家庭 / 被关闭。
-                    # 销毁即真正 miot_camera_stop + decoder.stop()，停掉 native 会话与解码。
-                    should_destroy = (
-                        cam is None
-                        or not is_home_allowed(self._kv_repo, cam.home_id)
-                        or camera_did in denied
-                    )
+                    # 不在 active 集（账号消失 / 移出家庭 / 被关 / 离线 / 超额）→ 销毁，
+                    # 真正 miot_camera_stop + decoder.stop()，停掉 native 会话与解码。
+                    should_destroy = camera_did not in active
                     if should_destroy:
                         await self._miot_client.unregister_lan_device_changed_async(
                             did=camera_did
                         )
                         await self._camera_img_managers[camera_did].destroy()
                         del self._camera_img_managers[camera_did]
+                        logger.warning(
+                            "Camera native stream stopped: %s", camera_did
+                        )
                     else:
                         logger.debug(
                             "Manager %s kept alive (in_use & in scope)", camera_did

--- a/backend/miloco/src/miloco/miot/filter.py
+++ b/backend/miloco/src/miloco/miot/filter.py
@@ -74,6 +74,45 @@ def is_home_allowed(kv_repo: KVRepo, home_id: str | None) -> bool:
     return home_id is not None and home_id in allow
 
 
+def select_active_camera_dids(
+    kv_repo: KVRepo,
+    cameras: dict[str, T],
+    *,
+    online_only: bool = True,
+    require_lan: bool = True,
+    cap: bool = True,
+) -> list[str]:
+    """决定「哪些相机该投喂/拉流」的**单一口径**——感知投喂(camera_adapter)与 native
+    会话建销(refresh_cameras)共用此函数，避免两套判定漂移。
+
+    过滤：在启用家庭内 + 未拉黑 +（``online_only`` 时）在线。``require_lan=True`` 看
+    ``online and lan_online``；``False`` 只看云端 ``online``（放过 lan_online 陈旧的卡死态
+    相机）。``cap=True`` 时按 did 升序确定性截断到 ``MAX_ENABLED_CAMERAS``——投喂/拉流
+    上限的唯一兜底，与 ``service.toggle_camera`` 的主动 enable 校验互补；不写 KV、不碰
+    黑名单。``cap=False`` 用于「列全集」语义（如 rule target 校验）。
+
+    返回 did 列表：未截断为输入顺序，截断为 did 升序前 N。``cameras`` 的 value 需带
+    ``home_id`` / ``online`` / ``lan_online`` 属性。
+    """
+    denied = denied_camera_dids(kv_repo)
+    result: list[str] = []
+    for did, info in cameras.items():
+        if did in denied:
+            continue
+        if not is_home_allowed(kv_repo, getattr(info, "home_id", None)):
+            continue
+        online = bool(getattr(info, "online", False))
+        lan = bool(getattr(info, "lan_online", False))
+        connectable = (online and lan) if require_lan else online
+        if online_only and not connectable:
+            continue
+        result.append(did)
+    if not cap or len(result) <= MAX_ENABLED_CAMERAS:
+        return result
+    # 超限：按 did 升序确定性截断（同一账号每轮选同一批）。
+    return sorted(result)[:MAX_ENABLED_CAMERAS]
+
+
 def filter_by_home(kv_repo: KVRepo, items: dict[str, T]) -> dict[str, T]:
     """按 ``home_id`` 过滤 dict（value 需带 ``home_id`` 属性）。空启用集表示未选择家庭。"""
     allow = allowed_home_ids(kv_repo)

--- a/backend/miloco/src/miloco/miot/service.py
+++ b/backend/miloco/src/miloco/miot/service.py
@@ -1027,9 +1027,11 @@ class MiotService:
             _, c = set_cameras_in_use(self._kv_repo, enable_dids, True)
             changed = changed or c
         if changed:
-            # KV 写入后热同步感知订阅(不触发 refresh_cameras,不重建 camera manager,
-            # 不扰动 watch 视频流)。_sync_camera_adapter → sync_devices 只影响
-            # camera_adapter 里的 perception decode 订阅,与 watch WS 完全独立。
+            # 先 refresh_cameras：按新 KV(黑名单)建/销 camera manager——关掉的相机
+            # 销毁 manager，停掉 native PPCS 会话+解码线程，不再拉流。
+            # 再 _sync_camera_adapter：perception 按新 manager 集连/断订阅。顺序不可换,
+            # 否则 sync 先连上随后 manager 被销,会留 stale reg_id。
+            await self._miot_proxy.refresh_cameras()
             await self._sync_camera_adapter()
         # 返回受影响的相机，结构与 list_cameras_with_state 一致
         all_cameras = await self.list_cameras_with_state()

--- a/backend/miloco/src/miloco/perception/collect/camera_adapter.py
+++ b/backend/miloco/src/miloco/perception/collect/camera_adapter.py
@@ -131,49 +131,31 @@ class CameraDeviceAdapter(BaseDeviceAdapter):
         的相机；口径与 toggle_camera 自洽（同样只数通过 home filter + 未拉黑的相机）。
         ``cap=False`` 用于「列全集」语义（如 rule target 校验），不受投喂上限影响。
         """
-        from miloco.miot.filter import (
-            MAX_ENABLED_CAMERAS,
-            denied_camera_dids,
-            is_home_allowed,
-        )
+        from miloco.miot.filter import select_active_camera_dids
 
         kv = self._miot_proxy._kv_repo
-        denied = denied_camera_dids(kv)
+        # 选择口径与 refresh_cameras 的 manager 建销共用同一函数，避免投喂集与拉流集
+        # 漂移：在启用家庭 + 未拉黑 + 在线、按 did 截到 MAX_ENABLED_CAMERAS。
+        cams = {
+            did: info
+            for did, info in all_devices.items()
+            if isinstance(info, MIoTCameraInfo)
+        }
+        active = select_active_camera_dids(
+            kv, cams, online_only=online_only, require_lan=require_lan, cap=cap
+        )
         result: dict[str, PerceptionDevice] = {}
-        for did, info in all_devices.items():
-            if not isinstance(info, MIoTCameraInfo):
-                continue
-
-            if did in denied:
-                continue
-
-            if not is_home_allowed(kv, getattr(info, "home_id", None)):
-                continue
-
-            camera_info = CameraInfo.model_validate(info.model_dump())
-
-            device_online = camera_info.online and camera_info.lan_online
-            # require_lan=False 时只看云端 online：放过 lan_online 陈旧成 false 的
-            # 卡死态相机（云端 online=True，refresh 能救活），但排除云端就离线
-            # （拔电/断网）的相机——给「应连数」判据用，避免离线相机致 refresh 空转。
-            connectable = device_online if require_lan else camera_info.online
-            if online_only and not connectable:
-                continue
-
+        for did in active:
+            camera_info = CameraInfo.model_validate(cams[did].model_dump())
             result[did] = PerceptionDevice(
                 did=did,
                 name=camera_info.name,
                 device_type="camera",
                 room_id=camera_info.room_name,
                 room_name=camera_info.room_name,
-                online=device_online,
+                online=camera_info.online and camera_info.lan_online,
             )
-
-        if not cap or len(result) <= MAX_ENABLED_CAMERAS:
-            return result
-        # 超限：按 did 升序保留前 N 路，确定性截断（同一账号每轮 discover 选同一批）。
-        kept = sorted(result)[:MAX_ENABLED_CAMERAS]
-        return {did: result[did] for did in kept}
+        return result
 
     async def sync_devices(self, all_devices: dict | None = None) -> None:
         """周期 sync 入口：先做「按需补建」，再走基类热插拔同步。

--- a/backend/miloco/tests/test_miot_filter_and_cameras.py
+++ b/backend/miloco/tests/test_miot_filter_and_cameras.py
@@ -943,6 +943,44 @@ async def test_refresh_cameras_destroys_overcap_existing_manager(_scope_proxy_en
 
 
 @pytest.mark.asyncio
+async def test_refresh_cameras_destroy_failure_isolated(_scope_proxy_env):
+    """批量销时某台 destroy 抛错不拖垮其余：失败的留在 dict 待重试，其余照常销。
+
+    Phase 1 把 destroy 触发条件扩到关/移出家庭/离线/超额 → 切家庭等场景一次销 N 台。
+    防回归钉：若移除 per-iteration try/except，c1 抛错会 break 整个循环，c2 不会被销。
+    """
+    proxy, kv, miot_client = _scope_proxy_env
+    # 两台都移出 scope（白名单只含 H2，二者都在 H1）→ 都该销
+    kv.set(ScopeConfigKeys.HOME_WHITE_LIST_KEY, json.dumps(["H2"]))
+
+    h1 = MagicMock()
+    h1.destroy = AsyncMock(side_effect=RuntimeError("destroy boom"))
+    h1.update_camera_info = AsyncMock()
+    h2 = MagicMock()
+    h2.destroy = AsyncMock()
+    h2.update_camera_info = AsyncMock()
+    proxy._camera_img_managers["c1"] = h1
+    proxy._camera_img_managers["c2"] = h2
+    miot_client.get_cameras_async = AsyncMock(
+        return_value={
+            "c1": _camera("c1", home_id="H1"),
+            "c2": _camera("c2", home_id="H1"),
+        }
+    )
+
+    # 不应抛出（refresh 整体仍成功返回）
+    result = await proxy.refresh_cameras()
+    assert result is not None
+
+    # c1 destroy 抛错 → 留在 dict 待下次 refresh 重试
+    h1.destroy.assert_awaited_once()
+    assert "c1" in proxy._camera_img_managers
+    # c2 不受 c1 失败影响，照常销毁
+    h2.destroy.assert_awaited_once()
+    assert "c2" not in proxy._camera_img_managers
+
+
+@pytest.mark.asyncio
 async def test_refresh_cameras_offline_not_built(_scope_proxy_env):
     """离线相机不在投喂/拉流集 → 不建 manager（Phase 1：拉流=投喂，离线不建）。"""
     proxy, kv, miot_client = _scope_proxy_env

--- a/backend/miloco/tests/test_miot_filter_and_cameras.py
+++ b/backend/miloco/tests/test_miot_filter_and_cameras.py
@@ -611,10 +611,11 @@ def _scope_proxy_env(tmp_path, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_create_camera_img_manager_denied_by_disabled(_scope_proxy_env):
-    """命中相机停用集 → 仍然建 manager(watch 视频流需要 camera instance)。
+    """`_create_camera_img_manager` 是纯建原语,本身不含 scope gate。
 
-    设计变更:scope_denied 不再阻止 manager 建立。watch 视频流与感知 scope 解耦,
-    inUse=false 只影响感知分析订阅,camera manager 须始终存在以支持 watch WS。
+    scope gate(黑名单 / home 白名单)在调用方 refresh_cameras 层。直调 _create
+    时即使相机在停用集也会尝试建(确保 gate 没误下沉到这一层);此处 instance
+    返回 None 故 manager 不写入 dict。
     """
     proxy, kv, miot_client = _scope_proxy_env
     kv.set(ScopeConfigKeys.CAMERA_BLACK_LIST_KEY, json.dumps(["c1"]))
@@ -631,7 +632,7 @@ async def test_create_camera_img_manager_denied_by_disabled(_scope_proxy_env):
 
 @pytest.mark.asyncio
 async def test_create_camera_img_manager_denied_by_home_filter(_scope_proxy_env):
-    """home_id 不在启用集 → 同上：仍然尝试建 manager(不 gate scope)。"""
+    """home_id 不在启用集 → 同上：_create 不 gate(gate 在 refresh 层)，仍尝试建。"""
     proxy, kv, miot_client = _scope_proxy_env
     kv.set(ScopeConfigKeys.HOME_WHITE_LIST_KEY, json.dumps(["H1"]))
 
@@ -646,10 +647,10 @@ async def test_create_camera_img_manager_denied_by_home_filter(_scope_proxy_env)
 
 @pytest.mark.asyncio
 async def test_create_camera_img_manager_denied_but_valid_instance_builds_manager(_scope_proxy_env):
-    """scope_denied + 有效 instance → manager 仍然被建立(核心路径断言)。
+    """denied + 有效 instance → _create 仍建 manager（_create 是 gate-free 原语）。
 
-    这是新设计的防回归钉:若有人把 scope gate 恢复,create_camera_instance_async
-    不会被调用,handler 不会建立,_camera_img_managers 不会有该 did,测试立刻失败。
+    钉住分层契约:scope gate 只在 refresh_cameras,_create_camera_img_manager
+    本身不查黑名单/白名单。若有人把 gate 误下沉到 _create,该测试会失败。
     """
     proxy, kv, miot_client = _scope_proxy_env
     kv.set(ScopeConfigKeys.CAMERA_BLACK_LIST_KEY, json.dumps(["c1"]))
@@ -674,7 +675,7 @@ async def test_create_camera_img_manager_denied_but_valid_instance_builds_manage
 
 @pytest.mark.asyncio
 async def test_create_camera_img_manager_denied_by_home_filter_valid_instance_builds_manager(_scope_proxy_env):
-    """home_id 不在启用集 + 有效 instance → manager 仍然被建立(home filter 变体防回归钉)。"""
+    """home filter 变体：home 不在启用集 + 有效 instance → _create 仍建(gate 在 refresh 层)。"""
     proxy, kv, miot_client = _scope_proxy_env
     kv.set(ScopeConfigKeys.HOME_WHITE_LIST_KEY, json.dumps(["H1"]))
 
@@ -694,12 +695,11 @@ async def test_create_camera_img_manager_denied_by_home_filter_valid_instance_bu
 
 
 @pytest.mark.asyncio
-async def test_refresh_cameras_keeps_scope_denied_existing_manager(_scope_proxy_env):
-    """先有 manager + 后写停用集 + refresh → 历史 manager 保活(不销毁)。
+async def test_refresh_cameras_destroys_scope_denied_existing_manager(_scope_proxy_env):
+    """先有 manager + 后写停用集 + refresh → manager 被销毁（关就停）。
 
-    设计变更:scope_denied 时不再 destroy manager,只 log。watch 视频流依赖
-    camera instance 存活,销毁会让已有的 watch WS 帧停止。只有摄像头真正从
-    账号消失(cam is None)时才 destroy。
+    设计:相机被关(in_use=false → 进黑名单)时 refresh 销毁其 manager,真正停掉
+    native PPCS 会话+解码线程,不再拉流。destroy + unregister + dict 删除三件配对。
     """
     proxy, kv, miot_client = _scope_proxy_env
 
@@ -713,18 +713,70 @@ async def test_refresh_cameras_keeps_scope_denied_existing_manager(_scope_proxy_
     kv.set(ScopeConfigKeys.CAMERA_BLACK_LIST_KEY, json.dumps(["c1"]))
     await proxy.refresh_cameras()
 
-    # scope_denied 时不销毁,manager 保活;走 else 分支 update_camera_info
-    handler.destroy.assert_not_awaited()
-    miot_client.unregister_lan_device_changed_async.assert_not_awaited()
-    assert "c1" in proxy._camera_img_managers
-    handler.update_camera_info.assert_awaited_once()
+    handler.destroy.assert_awaited_once()
+    miot_client.unregister_lan_device_changed_async.assert_awaited_once_with(did="c1")
+    assert "c1" not in proxy._camera_img_managers
+
+
+@pytest.mark.asyncio
+async def test_refresh_cameras_destroys_scope_out_of_home_manager(_scope_proxy_env):
+    """切换家庭后旧家庭相机移出 scope → manager 被销毁；scope 内的保活。
+
+    模拟 switch_home 切到 H2：H1 的 c1 home 不在白名单 → 销毁；H2 的 c2 → 保活。
+    """
+    proxy, kv, miot_client = _scope_proxy_env
+
+    h1 = MagicMock()
+    h1.destroy = AsyncMock()
+    h1.update_camera_info = AsyncMock()
+    h2 = MagicMock()
+    h2.destroy = AsyncMock()
+    h2.update_camera_info = AsyncMock()
+    proxy._camera_img_managers["c1"] = h1
+    proxy._camera_img_managers["c2"] = h2
+    miot_client.get_cameras_async = AsyncMock(
+        return_value={"c1": _camera("c1", home_id="H1"), "c2": _camera("c2", home_id="H2")}
+    )
+
+    # 已切到 H2：H1 相机移出 scope
+    kv.set(ScopeConfigKeys.HOME_WHITE_LIST_KEY, json.dumps(["H2"]))
+    await proxy.refresh_cameras()
+
+    h1.destroy.assert_awaited_once()
+    assert "c1" not in proxy._camera_img_managers
+    h2.destroy.assert_not_awaited()
+    assert "c2" in proxy._camera_img_managers
+    h2.update_camera_info.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_refresh_cameras_skips_manager_for_denied_camera(_scope_proxy_env):
+    """refresh_cameras 新建分支：相机在停用集(黑名单)时 continue，不建 manager。
+
+    防回归钉：若有人移除黑名单 gate，create_camera_instance_async 调用次数
+    会从 1 变为 2，测试立即失败。
+    """
+    proxy, kv, miot_client = _scope_proxy_env
+    kv.set(ScopeConfigKeys.HOME_WHITE_LIST_KEY, json.dumps(["H1"]))
+    kv.set(ScopeConfigKeys.CAMERA_BLACK_LIST_KEY, json.dumps(["c2"]))
+
+    miot_client.get_cameras_async = AsyncMock(
+        return_value={"c1": _camera("c1", home_id="H1"), "c2": _camera("c2", home_id="H1")}
+    )
+    miot_client.create_camera_instance_async = AsyncMock(return_value=None)
+
+    await proxy.refresh_cameras()
+
+    # c1 未拉黑 → 尝试建；c2 在黑名单 → continue 跳过
+    assert miot_client.create_camera_instance_async.call_count == 1
+    assert "c2" not in proxy._camera_img_managers
 
 
 @pytest.mark.asyncio
 async def test_refresh_cameras_destroys_when_camera_removed_from_account(_scope_proxy_env):
     """摄像头从账号消失(cam is None) → destroy + unregister + dict 删除三件配对。
 
-    这是唯一剩余的 destroy 触发路径。scope_denied 时不再 destroy,只有这条路走 destroy。
+    destroy 触发路径之一(另两条:移出当前家庭 / 被关闭,见上面两个测试)。
     """
     proxy, kv, miot_client = _scope_proxy_env
 
@@ -795,24 +847,32 @@ async def test_refresh_cameras_skips_manager_for_disallowed_home(_scope_proxy_en
 
 
 @pytest.mark.asyncio
-async def test_toggle_camera_triggers_sync_camera_adapter_when_changed():
-    """toggle_camera 写完 KV 后调 _sync_camera_adapter → 感知订阅热同步。
+async def test_toggle_camera_triggers_refresh_then_sync_when_changed():
+    """toggle_camera 写完 KV(changed=True) → 先 refresh_cameras 后 _sync_camera_adapter。
 
-    设计变更:toggle_camera 不再触发 refresh_cameras(避免重建 camera manager
-    扰动 watch 视频流),改调 _sync_camera_adapter 只同步感知订阅。
-    KV 改变(changed=True)时触发;不变(同操作重复)时跳过。
+    refresh_cameras 按新黑名单建/销 camera manager(关掉的相机停 native 会话+解码),
+    _sync_camera_adapter 再让 perception 按新 manager 集连/断。顺序不可换。
+    KV 不变(同操作重复)时两者都跳过。
     """
     kv = _FakeKV()
     svc = _make_service(cameras={"c1": _camera("c1")}, kv=kv)
 
-    # 追踪 _sync_camera_adapter 调用
-    svc._sync_camera_adapter = AsyncMock()
+    call_order: list[str] = []
+    svc._miot_proxy.refresh_cameras = AsyncMock(
+        side_effect=lambda *a, **k: call_order.append("refresh")
+    )
+    svc._sync_camera_adapter = AsyncMock(
+        side_effect=lambda *a, **k: call_order.append("sync")
+    )
 
     await svc.toggle_camera([{"did": "c1", "in_use": False}])
+    assert svc._miot_proxy.refresh_cameras.await_count == 1
     assert svc._sync_camera_adapter.await_count == 1
+    assert call_order == ["refresh", "sync"]
 
-    # 第二次相同操作 → KV 已含 c1，changed=False → 不再 sync
+    # 第二次相同操作 → KV 已含 c1，changed=False → 两者都不再调
     await svc.toggle_camera([{"did": "c1", "in_use": False}])
+    assert svc._miot_proxy.refresh_cameras.await_count == 1
     assert svc._sync_camera_adapter.await_count == 1
 
 

--- a/backend/miloco/tests/test_miot_filter_and_cameras.py
+++ b/backend/miloco/tests/test_miot_filter_and_cameras.py
@@ -115,6 +115,55 @@ def test_filter_by_home_drops_disallowed():
     assert set(miot_filter.filter_by_home(kv, items).keys()) == {"a"}
 
 
+# ─── filter.py: select_active_camera_dids（投喂/拉流共用口径）───────────────────
+
+
+def test_select_active_filters_home_denied_offline():
+    kv = _FakeKV(
+        {
+            ScopeConfigKeys.HOME_WHITE_LIST_KEY: json.dumps(["H1"]),
+            ScopeConfigKeys.CAMERA_BLACK_LIST_KEY: json.dumps(["c2"]),
+        }
+    )
+    cameras = {
+        "c1": _camera("c1", home_id="H1"),  # 通过
+        "c2": _camera("c2", home_id="H1"),  # 被拉黑 → 排除
+        "c3": _camera("c3", home_id="H2"),  # 家庭未启用 → 排除
+        "c4": _camera("c4", home_id="H1", online=False, lan_online=False),  # 离线 → 排除
+    }
+    assert miot_filter.select_active_camera_dids(kv, cameras) == ["c1"]
+
+
+def test_select_active_require_lan_false_keeps_lan_stale():
+    kv = _FakeKV({ScopeConfigKeys.HOME_WHITE_LIST_KEY: json.dumps(["H1"])})
+    # 云端 online=True 但 lan_online=False（卡死态）
+    cameras = {"c1": _camera("c1", home_id="H1", online=True, lan_online=False)}
+    # require_lan=True（默认连接口径）→ 排除
+    assert miot_filter.select_active_camera_dids(kv, cameras) == []
+    # require_lan=False（应连数口径）→ 放过
+    assert miot_filter.select_active_camera_dids(
+        kv, cameras, require_lan=False
+    ) == ["c1"]
+
+
+def test_select_active_caps_by_did(monkeypatch):
+    monkeypatch.setattr("miloco.miot.filter.MAX_ENABLED_CAMERAS", 2)
+    kv = _FakeKV({ScopeConfigKeys.HOME_WHITE_LIST_KEY: json.dumps(["H1"])})
+    cameras = {
+        "c3": _camera("c3", home_id="H1"),
+        "c1": _camera("c1", home_id="H1"),
+        "c2": _camera("c2", home_id="H1"),
+    }
+    # 超额 → 按 did 升序保留前 2
+    assert miot_filter.select_active_camera_dids(kv, cameras) == ["c1", "c2"]
+    # cap=False → 全集（输入顺序，列全集语义）
+    assert set(miot_filter.select_active_camera_dids(kv, cameras, cap=False)) == {
+        "c1",
+        "c2",
+        "c3",
+    }
+
+
 # ─── filter.py: write helpers ────────────────────────────────────────────────
 
 
@@ -840,6 +889,76 @@ async def test_refresh_cameras_skips_manager_for_disallowed_home(_scope_proxy_en
 
     # c1 的 home 在白名单，尝试建 manager；c2 的 home 不在，continue 跳过
     assert miot_client.create_camera_instance_async.call_count == 1
+    assert "c2" not in proxy._camera_img_managers
+
+
+@pytest.mark.asyncio
+async def test_refresh_cameras_caps_managers_to_max(_scope_proxy_env, monkeypatch):
+    """在线相机超过上限 → 只为前 N(按 did)建 manager，超额的不建（拉流=投喂口径）。"""
+    monkeypatch.setattr("miloco.miot.filter.MAX_ENABLED_CAMERAS", 2)
+    proxy, kv, miot_client = _scope_proxy_env
+    kv.set(ScopeConfigKeys.HOME_WHITE_LIST_KEY, json.dumps(["H1"]))
+
+    miot_client.get_cameras_async = AsyncMock(
+        return_value={
+            "c1": _camera("c1", home_id="H1"),
+            "c2": _camera("c2", home_id="H1"),
+            "c3": _camera("c3", home_id="H1"),  # 第 3 台在线 → 超额，不建
+        }
+    )
+    miot_client.create_camera_instance_async = AsyncMock(return_value=None)
+
+    await proxy.refresh_cameras()
+
+    # 只为 c1/c2 建，c3 超额跳过
+    assert miot_client.create_camera_instance_async.call_count == 2
+    assert "c3" not in proxy._camera_img_managers
+
+
+@pytest.mark.asyncio
+async def test_refresh_cameras_destroys_overcap_existing_manager(_scope_proxy_env, monkeypatch):
+    """已建 >MAX 个 manager（存量超额）→ refresh 收敛到 MAX，多的销毁。"""
+    monkeypatch.setattr("miloco.miot.filter.MAX_ENABLED_CAMERAS", 2)
+    proxy, kv, miot_client = _scope_proxy_env
+    kv.set(ScopeConfigKeys.HOME_WHITE_LIST_KEY, json.dumps(["H1"]))
+
+    handlers = {}
+    for did in ("c1", "c2", "c3"):
+        h = MagicMock()
+        h.destroy = AsyncMock()
+        h.update_camera_info = AsyncMock()
+        handlers[did] = h
+        proxy._camera_img_managers[did] = h
+    miot_client.get_cameras_async = AsyncMock(
+        return_value={did: _camera(did, home_id="H1") for did in ("c1", "c2", "c3")}
+    )
+
+    await proxy.refresh_cameras()
+
+    # 按 did 保留 c1/c2，c3 超额被销
+    handlers["c3"].destroy.assert_awaited_once()
+    assert "c3" not in proxy._camera_img_managers
+    assert "c1" in proxy._camera_img_managers
+    assert "c2" in proxy._camera_img_managers
+
+
+@pytest.mark.asyncio
+async def test_refresh_cameras_offline_not_built(_scope_proxy_env):
+    """离线相机不在投喂/拉流集 → 不建 manager（Phase 1：拉流=投喂，离线不建）。"""
+    proxy, kv, miot_client = _scope_proxy_env
+    kv.set(ScopeConfigKeys.HOME_WHITE_LIST_KEY, json.dumps(["H1"]))
+
+    miot_client.get_cameras_async = AsyncMock(
+        return_value={
+            "c1": _camera("c1", home_id="H1"),  # 在线
+            "c2": _camera("c2", home_id="H1", online=False, lan_online=False),  # 离线
+        }
+    )
+    miot_client.create_camera_instance_async = AsyncMock(return_value=None)
+
+    await proxy.refresh_cameras()
+
+    assert miot_client.create_camera_instance_async.call_count == 1  # 只为在线的 c1
     assert "c2" not in proxy._camera_img_managers
 
 


### PR DESCRIPTION
## 背景
此前相机的 native 会话（`CameraVisionHandler`，持有 PPCS 会话 + 解码线程）**只要相机还在账号里就一直保活**：
- 在 web 关闭某相机的感知开关、或切换家庭把它移出范围后，**native 会话与解码仍在跑**——白占相机有限的并发流名额、带宽和解码 CPU。
- 启用家庭内相机数超过上限（`MAX_ENABLED_CAMERAS`）时，**超出的相机也都建了会话拉流**，但感知只投喂前 N 个；多出来的纯属白拉。

根因：**“建 native 会话（拉流）”和“感知投喂”是两套各自的判定**，容易不一致；且会话生命周期没跟随 scope/上限。

## 改动
1. **关就停**：native 会话（manager）生命周期跟随 scope——相机被关闭（in_use=false）或移出当前家庭时销毁 manager（真正 `miot_camera_stop` + 解码线程 stop），停止拉流；重新启用/移入时重建。

2. **拉流 = 投喂，单一口径**：新增 `filter.select_active_camera_dids`（启用家庭 ∩ 未拉黑 ∩ 在线 ∩ 按 did 升序截到 `MAX_ENABLED_CAMERAS`），`refresh_cameras` 的会话建/销与 `camera_adapter` 的感知投喂发现**共用同一函数**。拉流集 = 投喂集，单一来源不漂移；超出上限的相机不建会话（over-cap 自动收敛）。

3. **可观测性**：native 会话起/停打 WARNING 日志（`Camera native stream started/stopped: <did>`）便于排查拉流生命周期。

不改动 `in_use`/黑名单语义（opt-out 模型保持不变）。

## 验证
- **单测**（`tests/test_miot_filter_and_cameras.py`，全绿）：`select_active_camera_dids` 的家庭/黑名单/在线过滤、require_lan、按 did 截断；`refresh_cameras` 在关闭/移出家庭/账号消失/超上限/离线各情形下的建/销。
- **真机（macOS arm64 主机）**：
  - 关闭某相机感知开关 → 日志出现 `Camera native stream stopped: <did>`，其解码停止；重新启用 → `started` 且恢复投喂。
  - 切换家庭 → 旧家庭相机会话全停。
  - 启用家庭内 >上限 台在线相机时 → 仅前 N 台（按 did）建会话投喂，其余不拉流。

## 已知局限（后续单独处理）
- 本次把 native 会话的建/销绑定到 lan_online，lan_online 抖动的相机会触发会话重建（PPCS 重连 + 解码重注册）。后续让会话建销由本地全局 LAN 扫描事件驱动、加去抖来收敛。
- 超额/离线相机的开关仍显示为开（in_use=true）但无实时画面（connected=false），属前端展示项，本次不涉及。

🤖 Generated with [Claude Code](https://claude.com/claude-code)