### PR TITLE
fix(cli): 修正 admin/config 命令说明并对齐子命令展示顺序

### DIFF
--- a/cli/src/miloco_cli/commands/_ordered_group.py
+++ b/cli/src/miloco_cli/commands/_ordered_group.py
@@ -1,0 +1,15 @@
+"""按命令定义顺序（而非字母序）展示子命令的 click.Group。
+
+Click 默认 ``Group.list_commands`` 返回 ``sorted``（字母序），导致 ``--help`` 的
+Commands 区顺序与命令组 docstring 里人工编排的顺序对不上。本子类改为按注册
+（即源码中 ``@group.command()`` 的定义）顺序展示，使两者一致——把命令按希望展示
+的顺序定义即可，无需再维护一份独立的顺序列表。
+"""
+
+import click
+
+
+class OrderedGroup(click.Group):
+    def list_commands(self, ctx: click.Context) -> list[str]:
+        # self.commands 是 dict，Python 3.7+ 保留插入顺序 = 定义顺序
+        return list(self.commands)

--- a/cli/src/miloco_cli/commands/admin.py
+++ b/cli/src/miloco_cli/commands/admin.py
@@ -5,12 +5,13 @@ import sys
 
 import click
 
+from miloco_cli.commands._ordered_group import OrderedGroup
 from miloco_cli.output import print_result
 
 
-@click.group("admin")
+@click.group("admin", cls=OrderedGroup)
 def admin_group():
-    """系统管理：状态 / 缓存 / 模型管理 / 成本。"""
+    """系统管理：状态 / 家庭信息 / 成本。"""
 
 
 @admin_group.command("status")
@@ -26,7 +27,7 @@ def admin_status(pretty):
 @admin_group.command("home-info")
 @click.option("--pretty", is_flag=True)
 def admin_home_info(pretty):
-    """从后端拉取 home_info 并展示摘要。"""
+    """展示家庭信息摘要：设备 / 区域 / 场景 / 成员数量。"""
     from miloco_cli.home_info import get_home_info
 
     info = get_home_info()

--- a/cli/src/miloco_cli/commands/config.py
+++ b/cli/src/miloco_cli/commands/config.py
@@ -42,7 +42,7 @@ def _mask(data: dict) -> dict:
 
 @click.group("config", cls=OrderedGroup)
 def config_group():
-    """配置管理（服务端 / 模型 / Agent）：查看 / 取值 / 设置。"""
+    """配置管理（服务端 / 模型 / Agent）：查看 / 取值 / 设置 / 列出路径。"""
 
 
 @config_group.command("show")

--- a/cli/src/miloco_cli/commands/config.py
+++ b/cli/src/miloco_cli/commands/config.py
@@ -1,8 +1,9 @@
-"""``miloco-cli config`` 子命令：show / get / set。
+"""``miloco-cli config`` 子命令：show / get / set / list-paths。
 
 - ``config show`` 输出合并后（默认 + ``$MILOCO_HOME/config.json`` + env）的完整配置。
 - ``config get <path>`` 按点号路径取值。
 - ``config set <path> <value>`` schema 校验后原子写入 ``config.json``。
+- ``config list-paths`` 列出全部合法配置路径与说明。
 
 ``config set`` 默认行为：写入后若后端正在运行则调用 ``service restart`` 使新配置
 生效；传 ``--no-restart`` 显式跳过。
@@ -15,6 +16,7 @@ import sys
 
 import click
 
+from miloco_cli.commands._ordered_group import OrderedGroup
 from miloco_cli.config import (
     describe,
     get_value,
@@ -38,9 +40,9 @@ def _mask(data: dict) -> dict:
     return masked
 
 
-@click.group("config")
+@click.group("config", cls=OrderedGroup)
 def config_group():
-    """配置管理：show / get / set。"""
+    """配置管理（服务端 / 模型 / Agent）：查看 / 取值 / 设置。"""
 
 
 @config_group.command("show")
@@ -73,14 +75,6 @@ def config_get(path: str, pretty: bool, value_only: bool):
         print("" if value is None else value)
         return
     print_result({"path": path, "value": value}, pretty)
-
-
-@config_group.command("list-paths")
-@click.option("--pretty", is_flag=True)
-def config_list_paths(pretty: bool):
-    """列出全部合法的配置路径与中文说明。"""
-    items = [{"path": p, "description": describe(p)} for p in known_paths()]
-    print_result(items, pretty)
 
 
 @config_group.command("set")
@@ -173,3 +167,11 @@ def _restart_if_running(pretty: bool) -> dict | None:
         return {"triggered": True, "failed": True, "exit_code": exc.code}
     except Exception as exc:  # pragma: no cover - defensive
         return {"triggered": True, "failed": True, "error": str(exc)}
+
+
+@config_group.command("list-paths")
+@click.option("--pretty", is_flag=True)
+def config_list_paths(pretty: bool):
+    """列出全部合法的配置路径与中文说明。"""
+    items = [{"path": p, "description": describe(p)} for p in known_paths()]
+    print_result(items, pretty)


### PR DESCRIPTION
## 概述

修正 admin、config 两个命令组的用法说明，使其与实际子命令一致、表述具体、风格统一；并让 `--help` 的 Commands 区不再按字母序排列，而是与组说明里人工编排的顺序保持一致。
<img width="652" height="231" alt="img_v3_0212v_8e61afb1-1b1d-4784-8f9d-01465b51b78g" src="https://github.com/user-attachments/assets/f48af7e3-d61f-46b3-9a97-86210d3321db" />
<img width="732" height="362" alt="img_v3_0212v_aaa8f987-1570-4e7a-873b-2b516e71a15g" src="https://github.com/user-attachments/assets/e533e115-343b-4686-8a28-cd8273b5aeb4" />


## 1. 命令组用法说明与实现对齐 · fix

**问题**：用法说明与实现对不上——admin 列了并不存在的「缓存 / 模型管理」、漏了「家庭信息」；home-info 的说明是「拉取 home_info 并展示摘要」这类循环定义，没说清输出什么；config 组说明只罗列英文子命令名、未点明所管配置域，且漏列了实际存在的「列出可配置项」命令，与其余命令组风格不统一。

**解决方案**：
- **admin 组说明对齐子命令**：去掉「缓存 / 模型管理」、补回「家庭信息」，与实际可用子命令一一对应。
- **home-info 说清实际输出**：改为明确列出摘要内容（设备 / 区域 / 场景 / 成员数量），不再循环引用命令名。
- **config 组说明改用功能词并标注配置域**：用中文功能词（查看 / 取值 / 设置）描述并标注主要配置域（服务端 / 模型 / Agent），与其余命令组风格统一。
- **config 模块说明补全**：补回漏列的「列出可配置项」命令，使概览与实际子命令集合一致。

## 2. 子命令按定义顺序展示 · fix

**问题**：Click 默认把 `--help` 的 Commands 区按字母序排列，与命令组说明里人工编排的逻辑顺序对不上，读起来割裂。

**解决方案**：
- **新增按定义顺序展示的命令组基类**：覆盖默认子命令列举逻辑，改为按命令注册（源码定义）顺序返回，无需额外维护一份顺序列表。
- **admin / config 改用该基类**：两个命令组切换到该基类，使各自 Commands 区顺序与组说明一致；config 内「列出可配置项」命令的定义位置随之移到末尾以匹配展示顺序。

## 测试与兼容性

- **验证**：本地 `cd cli && uv run pytest` 全部通过（384 passed；本 PR 未改动测试文件）。
- **兼容性**：纯文案与展示顺序调整，不改变任何命令的行为、参数或输出结构；「列出可配置项」命令的能力与签名未变，仅源码定义位置随展示顺序调整。`--help` 的 Commands 区由字母序改为定义序，属可见展示变化。
- **回滚**：去掉基类引用、还原说明文案即可，无数据或配置层面影响。
- **风险**：低。仅当外部脚本依赖 `--help` 输出的字母序来解析子命令列表时，展示顺序变化才可能影响其结果（一般无此类依赖）。