### PR TITLE
fix(lan): skip down interfaces instead of aborting socket init

### DIFF
--- a/backend/miot/src/miot/lan.py
+++ b/backend/miot/src/miot/lan.py
@@ -379,7 +379,7 @@ class MIoTLan:
         self.__deinit_socket()
         for if_name in self._net_ifs:
             if if_name not in self._available_net_ifs:
-                return
+                continue
             self.__create_socket(if_name=if_name)
 
     def __on_network_info_change(self, data: _MIoTLanNetworkUpdateData) -> None:

--- a/backend/miot/src/miot/network.py
+++ b/backend/miot/src/miot/network.py
@@ -272,10 +272,15 @@ class MIoTNetwork:
 
     def __get_network_info(self) -> dict[str, NetworkInfo]:
         interfaces = psutil.net_if_addrs()
+        if_stats = psutil.net_if_stats()
         results: dict[str, NetworkInfo] = {}
         for name, addresses in interfaces.items():
             # Skip hassio and docker* interface
             if name == "hassio" or name.startswith("docker"):
+                continue
+            # Skip interfaces that are administratively down or have no carrier
+            if_stat = if_stats.get(name)
+            if if_stat and not if_stat.isup:
                 continue
             for address in addresses:
                 if (

--- a/backend/miot/tests/test_lan.py
+++ b/backend/miot/tests/test_lan.py
@@ -8,6 +8,7 @@ MIoT Lan Test.
 import asyncio
 import logging
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 from miot.lan import MIoTLan
@@ -60,3 +61,25 @@ async def test_network_monitor_loop_async():
 
     await miot_lan.deinit_async()
     await miot_net.deinit_async()
+
+
+@pytest.mark.asyncio
+async def test_init_socket_skips_unavailable_iface():
+    """回归：_net_ifs 中不可用的网卡排在有效网卡之前时，有效网卡仍必须建 socket。
+
+    旧代码在 __init_socket 里用 return 而非 continue，遇到第一个不可用网卡就跳出
+    整个循环，导致排在其后的有效网卡一律建不了 socket（且无任何错误日志）。
+    """
+    miot_net = MIoTNetwork()
+    miot_lan = MIoTLan(net_ifs=["ghost", "eth0"], network=miot_net)
+    # 用 list 固定迭代顺序，把不可用网卡 ghost 稳定排在有效网卡 eth0 之前，
+    # 复现旧 return 的触发场景（set 迭代无序，无法稳定复现该 bug）。
+    miot_lan._net_ifs = ["ghost", "eth0"]
+    miot_lan._available_net_ifs = {"eth0"}
+
+    with patch.object(miot_lan, "_MIoTLan__create_socket") as mock_create:
+        miot_lan._MIoTLan__init_socket()
+
+    created = [call.kwargs.get("if_name") for call in mock_create.call_args_list]
+    assert "eth0" in created
+    assert "ghost" not in created

--- a/backend/miot/tests/test_network.py
+++ b/backend/miot/tests/test_network.py
@@ -7,11 +7,18 @@ Unit test for miot_network.py.
 
 import asyncio
 import logging
+import socket
+from collections import namedtuple
+from unittest.mock import patch
 
 import pytest
 from miot.network import InterfaceStatus, MIoTNetwork, NetworkInfo
 
 _LOGGER = logging.getLogger(__name__)
+
+# psutil 命名元组的最小替身，字段名与 snicaddr / snicstats 对齐。
+_Addr = namedtuple("Addr", "family address netmask broadcast ptp")
+_Stats = namedtuple("Stats", "isup duplex speed mtu flags")
 
 
 @pytest.mark.asyncio
@@ -39,3 +46,38 @@ async def test_network_monitor_loop_async():
     _LOGGER.info("net status: %s", miot_net.network_status)
     _LOGGER.info("net info: %s", miot_net.network_info)
     await miot_net.deinit_async()
+
+
+@pytest.mark.asyncio
+async def test_get_network_info_skips_down_iface():
+    """管理状态 DOWN（isup=False，如无载波的 virbr0）的网卡不应进入 network_info。"""
+    miot_net = MIoTNetwork()
+    addrs = {
+        "eth0": [_Addr(socket.AF_INET, "192.168.1.10", "255.255.255.0", None, None)],
+        "virbr0": [_Addr(socket.AF_INET, "192.168.122.1", "255.255.255.0", None, None)],
+    }
+    stats = {
+        "eth0": _Stats(True, 2, 1000, 1500, "up,broadcast,running"),
+        "virbr0": _Stats(False, 0, 0, 1500, "up,broadcast"),
+    }
+    with (
+        patch("miot.network.psutil.net_if_addrs", return_value=addrs),
+        patch("miot.network.psutil.net_if_stats", return_value=stats),
+    ):
+        info = miot_net._MIoTNetwork__get_network_info()
+    assert set(info.keys()) == {"eth0"}
+
+
+@pytest.mark.asyncio
+async def test_get_network_info_keeps_iface_missing_from_stats():
+    """net_if_addrs / net_if_stats 两次调用之间的竞态：stats 缺该 key 时保守保留接口。"""
+    miot_net = MIoTNetwork()
+    addrs = {
+        "eth0": [_Addr(socket.AF_INET, "192.168.1.10", "255.255.255.0", None, None)],
+    }
+    with (
+        patch("miot.network.psutil.net_if_addrs", return_value=addrs),
+        patch("miot.network.psutil.net_if_stats", return_value={}),
+    ):
+        info = miot_net._MIoTNetwork__get_network_info()
+    assert set(info.keys()) == {"eth0"}


### PR DESCRIPTION
## Summary

修复两个导致路由器重启后 LAN 探测静默失败的 bug。

## 根因

两个 bug 组合导致宿主/路由器重启后摄像头列表显示 is_online: false（LAN 通但 Miloco 不识别为在线）：

### Bug 1: __init_socket 用 return 替代 continue（lan.py:381）

net_ifs 是 set（无序迭代），当第一个不可用的网卡（如 virbr0 NO-CARRIER）排在有效网卡（如 kvmbr0）前面时，return 会直接跳出循环，跳过所有后续网卡。结果：零 socket 创建，LAN 模块哑火，且无任何错误日志。

### Bug 2: __get_network_info 没有过滤 DOWN 状态的接口（network.py:273-298）

psutil.net_if_addrs() 返回所有接口（包括 virbr0、br-* 等未启动的虚拟网桥），这些接口的地址信息被纳入 net_ifs，为 Bug 1 的触发提供了条件。

## 修复

- lan.py:382: return -> continue — 跳过不可用网卡而非终止循环
- network.py:275-284: 新增 psutil.net_if_stats().isup 过滤 — 跳过管理状态为 DOWN 的接口

## 验证

- [x] 语法检查通过
- [x] 现有测试 tests/test_lan.py / tests/test_network.py 无退化