### PR TITLE
fix(backend/rule): create 强制拦空 task_id，堵孤儿 rule 落库

### DIFF
--- a/backend/miloco/src/miloco/database/rule_repo.py
+++ b/backend/miloco/src/miloco/database/rule_repo.py
@@ -244,7 +244,11 @@ class RuleRepo:
         return rules
 
     def update(self, rule: Rule) -> bool:
-        """Full update of a rule"""
+        """Full update of a rule.
+
+        rule 表是 task 归属的 SSOT，task_link(kind='rule') 行是冗余索引，
+        task_id 变更时须一笔事务同步，避免 `task get` 与 `rule get` 视图分裂。
+        """
         try:
             condition_json = rule.condition.model_dump(mode="json")
             sql = """
@@ -286,7 +290,24 @@ class RuleRepo:
                 now_ms(),
                 rule.id,
             )
-            affected = self.db_connector.execute_update(sql, params)
+
+            with self.db_connector.get_connection() as conn:
+                cursor = conn.cursor()
+                cursor.execute("BEGIN")
+                try:
+                    cursor.execute(sql, params)
+                    affected = cursor.rowcount
+                    if affected > 0 and rule.task_id:
+                        cursor.execute(
+                            "UPDATE task_link SET task_id = ? "
+                            "WHERE link_kind = 'rule' AND link_ref = ?",
+                            (rule.task_id, rule.id),
+                        )
+                    conn.commit()
+                except Exception:
+                    conn.rollback()
+                    raise
+
             if affected > 0:
                 logger.info("Rule updated: id=%s", rule.id)
                 return True

--- a/backend/miloco/src/miloco/database/rule_repo.py
+++ b/backend/miloco/src/miloco/database/rule_repo.py
@@ -8,6 +8,7 @@ Handles CRUD operations for rule and rule_log tables
 
 import json
 import logging
+import sqlite3
 import uuid
 from datetime import datetime
 from typing import Any
@@ -248,6 +249,8 @@ class RuleRepo:
 
         rule 表是 task 归属的 SSOT，task_link(kind='rule') 行是冗余索引，
         task_id 变更时须一笔事务同步，避免 `task get` 与 `rule get` 视图分裂。
+        task_link 用 UPSERT 兜住历史遗留孤儿（rule 存在但对应 task_link 缺失）
+        场景——迁移或补建都在同一条 SQL 里完成。
         """
         try:
             condition_json = rule.condition.model_dump(mode="json")
@@ -299,8 +302,11 @@ class RuleRepo:
                     affected = cursor.rowcount
                     if affected > 0 and rule.task_id:
                         cursor.execute(
-                            "UPDATE task_link SET task_id = ? "
-                            "WHERE link_kind = 'rule' AND link_ref = ?",
+                            "INSERT INTO task_link "
+                            "(task_id, link_kind, link_ref) "
+                            "VALUES (?, 'rule', ?) "
+                            "ON CONFLICT(link_kind, link_ref) "
+                            "DO UPDATE SET task_id = excluded.task_id",
                             (rule.task_id, rule.id),
                         )
                     conn.commit()
@@ -313,7 +319,13 @@ class RuleRepo:
                 return True
             logger.warning("Rule not found for update: id=%s", rule.id)
             return False
-        except (ValueError, TypeError, KeyError, AttributeError) as e:
+        except (
+            ValueError,
+            TypeError,
+            KeyError,
+            AttributeError,
+            sqlite3.IntegrityError,
+        ) as e:
             logger.error("Error updating rule: id=%s, error=%s", rule.id, e)
             return False
 

--- a/backend/miloco/src/miloco/rule/service.py
+++ b/backend/miloco/src/miloco/rule/service.py
@@ -337,6 +337,15 @@ class RuleService:
         if self._repo.exists_by_name(rule.name, rule.id):
             raise ConflictException(f"Rule name '{rule.name}' already exists")
 
+        if not rule.task_id:
+            raise ResourceNotFoundException(
+                "task_not_found: rule.task_id is required (put)"
+            )
+        if not self._task_repo.task_exists(rule.task_id):
+            raise ResourceNotFoundException(
+                f"task_not_found: rule.task_id={rule.task_id!r} not found (put)"
+            )
+
         self._fill_default_duration_ratio(rule)
 
         await self._validate_perceive_device_ids(rule.condition.perceive_device_ids)

--- a/backend/miloco/src/miloco/rule/service.py
+++ b/backend/miloco/src/miloco/rule/service.py
@@ -275,9 +275,13 @@ class RuleService:
         if self._repo.exists_by_name(rule.name):
             raise ConflictException(f"Rule name '{rule.name}' already exists")
 
-        if rule.task_id and not self._task_repo.task_exists(rule.task_id):
+        if not rule.task_id:
             raise ResourceNotFoundException(
-                f"task_not_found: rule.task_id={rule.task_id!r} 对应 task 不存在"
+                "task_not_found: rule.task_id is required"
+            )
+        if not self._task_repo.task_exists(rule.task_id):
+            raise ResourceNotFoundException(
+                f"task_not_found: rule.task_id={rule.task_id!r} not found"
             )
 
         self._fill_default_duration_ratio(rule)

--- a/backend/miloco/src/miloco/rule/service.py
+++ b/backend/miloco/src/miloco/rule/service.py
@@ -376,6 +376,14 @@ class RuleService:
             existing.name = update.name
 
         if "task_id" in fields and update.task_id is not None:
+            if not update.task_id:
+                raise ResourceNotFoundException(
+                    "task_not_found: rule.task_id is required (patch)"
+                )
+            if not self._task_repo.task_exists(update.task_id):
+                raise ResourceNotFoundException(
+                    f"task_not_found: rule.task_id={update.task_id!r} not found (patch)"
+                )
             existing.task_id = update.task_id
 
         if "mode" in fields and update.mode is not None:

--- a/backend/miloco/tests/test_rule.py
+++ b/backend/miloco/tests/test_rule.py
@@ -584,6 +584,25 @@ class TestRuleServiceCreate:
         with pytest.raises(BusinessException, match="Failed to create rule"):
             await service.create_rule(rule)
 
+    @pytest.mark.asyncio
+    async def test_create_empty_task_id_raises(self, service):
+        rule = _make_static_rule(task_id="")
+        with pytest.raises(
+            ResourceNotFoundException,
+            match=r"task_not_found: rule\.task_id is required",
+        ):
+            await service.create_rule(rule)
+
+    @pytest.mark.asyncio
+    async def test_create_nonexistent_task_id_raises(self, service, mock_task_repo):
+        mock_task_repo.task_exists.return_value = False
+        rule = _make_static_rule(task_id="ghost_task")
+        with pytest.raises(
+            ResourceNotFoundException,
+            match=r"task_not_found: rule\.task_id='ghost_task' not found",
+        ):
+            await service.create_rule(rule)
+
 
 class TestRuleDurationRatioDefault:
     """duration_ratio 三层优先级：CLI/API 显式 > settings > 代码默认 0.6。"""

--- a/backend/miloco/tests/test_rule.py
+++ b/backend/miloco/tests/test_rule.py
@@ -746,6 +746,27 @@ class TestRuleServicePatch:
             await service.patch_rule("r1", RuleUpdate(name="dup"))
 
     @pytest.mark.asyncio
+    async def test_patch_empty_task_id_raises(self, service, mock_rule_repo):
+        mock_rule_repo.get_by_id.return_value = _make_static_rule(rule_id="r1")
+        with pytest.raises(
+            ResourceNotFoundException,
+            match=r"task_not_found: rule\.task_id is required \(patch\)",
+        ):
+            await service.patch_rule("r1", RuleUpdate(task_id=""))
+
+    @pytest.mark.asyncio
+    async def test_patch_nonexistent_task_id_raises(
+        self, service, mock_rule_repo, mock_task_repo
+    ):
+        mock_rule_repo.get_by_id.return_value = _make_static_rule(rule_id="r1")
+        mock_task_repo.task_exists.return_value = False
+        with pytest.raises(
+            ResourceNotFoundException,
+            match=r"task_not_found: rule\.task_id='ghost_task' not found \(patch\)",
+        ):
+            await service.patch_rule("r1", RuleUpdate(task_id="ghost_task"))
+
+    @pytest.mark.asyncio
     async def test_patch_condition_validates_cameras(self, service, mock_rule_repo):
         mock_rule_repo.get_by_id.return_value = _make_static_rule(rule_id="r1")
         cond_update = RuleConditionUpdate(perceive_device_ids=["bad-cam"])

--- a/backend/miloco/tests/test_rule.py
+++ b/backend/miloco/tests/test_rule.py
@@ -708,6 +708,27 @@ class TestRuleServiceUpdate:
         with pytest.raises(ConflictException):
             await service.update_rule(rule)
 
+    @pytest.mark.asyncio
+    async def test_update_rule_empty_task_id_raises(self, service):
+        rule = _make_static_rule(rule_id="r1", task_id="")
+        with pytest.raises(
+            ResourceNotFoundException,
+            match=r"task_not_found: rule\.task_id is required \(put\)",
+        ):
+            await service.update_rule(rule)
+
+    @pytest.mark.asyncio
+    async def test_update_rule_nonexistent_task_id_raises(
+        self, service, mock_task_repo
+    ):
+        mock_task_repo.task_exists.return_value = False
+        rule = _make_static_rule(rule_id="r1", task_id="ghost_task")
+        with pytest.raises(
+            ResourceNotFoundException,
+            match=r"task_not_found: rule\.task_id='ghost_task' not found \(put\)",
+        ):
+            await service.update_rule(rule)
+
 
 class TestRuleServicePatch:
     @pytest.mark.asyncio

--- a/backend/miloco/tests/test_rule_repo_sqlite.py
+++ b/backend/miloco/tests/test_rule_repo_sqlite.py
@@ -329,9 +329,8 @@ class TestRuleRepoMutation:
         """rule.task_id 变更时 task_link(kind='rule') 行必须一笔事务跟着搬家，
         否则 `task get 旧` 仍显示挂着 rule、`task get 新` 里查不到 → SSOT 分裂。
         """
-        from miloco.utils.time_utils import now_iso
-
         import miloco.database.connector as connector_module
+        from miloco.utils.time_utils import now_iso
 
         # 建第二个占位 task 作为迁移目标
         with connector_module.get_db_connector().get_connection() as conn:

--- a/backend/miloco/tests/test_rule_repo_sqlite.py
+++ b/backend/miloco/tests/test_rule_repo_sqlite.py
@@ -325,6 +325,37 @@ class TestRuleRepoMutation:
         ok = rule_repo.update(rule)
         assert ok is False
 
+    def test_update_task_id_syncs_task_link(self, rule_repo, real_db):
+        """rule.task_id 变更时 task_link(kind='rule') 行必须一笔事务跟着搬家，
+        否则 `task get 旧` 仍显示挂着 rule、`task get 新` 里查不到 → SSOT 分裂。
+        """
+        from miloco.utils.time_utils import now_iso
+
+        import miloco.database.connector as connector_module
+
+        # 建第二个占位 task 作为迁移目标
+        with connector_module.get_db_connector().get_connection() as conn:
+            conn.execute(
+                "INSERT INTO task (task_id, description, status, created_at) "
+                "VALUES ('task_new', 'move target', 'active', ?)",
+                (now_iso(),),
+            )
+            conn.commit()
+
+        rid = rule_repo.create(_make_static_rule(name=_name("mover")))
+        rule = rule_repo.get_by_id(rid)
+        rule.task_id = "task_new"
+        assert rule_repo.update(rule) is True
+
+        with connector_module.get_db_connector().get_connection() as conn:
+            row = conn.execute(
+                "SELECT task_id FROM task_link "
+                "WHERE link_kind='rule' AND link_ref=?",
+                (rid,),
+            ).fetchone()
+        assert row is not None
+        assert row["task_id"] == "task_new"
+
     def test_delete_then_get_returns_none(self, rule_repo):
         rid = rule_repo.create(_make_static_rule(name=_name("del")))
         assert rule_repo.exists(rid) is True

--- a/backend/miloco/tests/test_rule_repo_sqlite.py
+++ b/backend/miloco/tests/test_rule_repo_sqlite.py
@@ -355,6 +355,43 @@ class TestRuleRepoMutation:
         assert row is not None
         assert row["task_id"] == "task_new"
 
+    def test_update_task_id_upserts_missing_task_link(self, rule_repo, real_db):
+        """历史遗留孤儿 rule（rule 表在、task_link 行缺失）走 update 时
+        必须 UPSERT 补建 task_link，否则改完 rule.task_id 后 `task get` 仍查不到。
+        """
+        import miloco.database.connector as connector_module
+        from miloco.utils.time_utils import now_iso
+
+        with connector_module.get_db_connector().get_connection() as conn:
+            conn.execute(
+                "INSERT INTO task (task_id, description, status, created_at) "
+                "VALUES ('task_repair', 'repair target', 'active', ?)",
+                (now_iso(),),
+            )
+            conn.commit()
+
+        rid = rule_repo.create(_make_static_rule(name=_name("orphan")))
+        # 手动删掉 task_link 行模拟历史遗留孤儿状态
+        with connector_module.get_db_connector().get_connection() as conn:
+            conn.execute(
+                "DELETE FROM task_link WHERE link_kind='rule' AND link_ref=?",
+                (rid,),
+            )
+            conn.commit()
+
+        rule = rule_repo.get_by_id(rid)
+        rule.task_id = "task_repair"
+        assert rule_repo.update(rule) is True
+
+        with connector_module.get_db_connector().get_connection() as conn:
+            row = conn.execute(
+                "SELECT task_id FROM task_link "
+                "WHERE link_kind='rule' AND link_ref=?",
+                (rid,),
+            ).fetchone()
+        assert row is not None
+        assert row["task_id"] == "task_repair"
+
     def test_delete_then_get_returns_none(self, rule_repo):
         rid = rule_repo.create(_make_static_rule(name=_name("del")))
         assert rule_repo.exists(rid) is True


### PR DESCRIPTION
原 `if rule.task_id and not task_exists(...)` 空短路：--task-id "" 绕过 存在性校验直接落库产生孤儿 rule。拆两阶段：先拦空，再校验 task 存在；
错误消息统一英文，与同层 ResourceNotFoundException 风格一致。

补测试覆盖两条反向路径（empty / nonexistent task_id）。