### PR TITLE
feat: make media_resolution configurable via OmniConfig

### DIFF
--- a/backend/miloco/src/miloco/perception/engine/config.py
+++ b/backend/miloco/src/miloco/perception/engine/config.py
@@ -284,6 +284,7 @@ class IdentityEngineConfig:
 @dataclass
 class OmniConfig:
     model: str = "xiaomi/mimo-v2.5"
+    model_name: str = ""  # 可选短名，用于 media_resolution preset 查找；空则从 model 自动推导
     api_key: str = ""  # Set via MILOCO_MODEL__OMNI__API_KEY env var or config
     base_url: str = "https://api.xiaomimimo.com/v1"
     max_completion_tokens: int = 512
@@ -291,6 +292,58 @@ class OmniConfig:
     top_p: float = 0.95
     timeout: float = 30.0
     stream: bool = False
+    media_resolution: str = "max"  # 可选 "max" / "high" / "low"，经 resolve_media_resolution 映射到模型特定值
+
+
+# =============================================================================
+# Media resolution adapter —— 不同 LLM 支持的 video 分辨率值不同，做一层映射
+# =============================================================================
+
+# 各模型/平台支持的 media_resolution 值映射：
+#   key 是用户配置的通用值（"low" / "high" / "max"），
+#   value 是该模型实际接受的值。
+# "default" preset 是透传（fallback），用于未显式列出的模型。
+MEDIA_RESOLUTION_PRESETS: dict[str, dict[str, str]] = {
+    "mimo": {
+        "low": "default",
+        "high": "max",
+        "max": "max",
+    },
+    "default": {
+        "low": "low",
+        "high": "high",
+        "max": "max",
+    },
+}
+
+
+def resolve_media_resolution(value: str, model_name: str = "") -> str:
+    """将用户配置的通用 media_resolution 映射为模型实际支持的值。
+
+    不同 LLM 对 media_resolution 的支持不同：
+    - MiMo：仅支持 ``"default"`` 和 ``"max"``
+    - 其他模型（如 Qwen）：可能支持 ``"low"`` / ``"high"`` / ``"max"`` 等
+
+    本函数根据 ``model_name`` 选择对应的 preset 做值映射，
+    未匹配到任何 preset 时走 ``"default"`` 透传。
+
+    Args:
+        value: 用户配置的通用值（``"low"`` / ``"high"`` / ``"max"`` 等）。
+        model_name: 模型标识（如 ``"xiaomi/mimo-v2.5"``），大小写不敏感、
+                    子串匹配。为空时直接返回 value。
+
+    Returns:
+        模型实际支持的 media_resolution 值。
+    """
+    if not model_name:
+        return value
+
+    model_lower = model_name.lower()
+    for key, preset in MEDIA_RESOLUTION_PRESETS.items():
+        if key != "default" and key in model_lower:
+            return preset.get(value, value)
+
+    return MEDIA_RESOLUTION_PRESETS.get("default", {}).get(value, value)
 
 
 @dataclass

--- a/backend/miloco/src/miloco/perception/engine/config.py
+++ b/backend/miloco/src/miloco/perception/engine/config.py
@@ -284,7 +284,6 @@ class IdentityEngineConfig:
 @dataclass
 class OmniConfig:
     model: str = "xiaomi/mimo-v2.5"
-    model_name: str = ""  # 可选短名，用于 media_resolution preset 查找；空则从 model 自动推导
     api_key: str = ""  # Set via MILOCO_MODEL__OMNI__API_KEY env var or config
     base_url: str = "https://api.xiaomimimo.com/v1"
     max_completion_tokens: int = 512
@@ -292,12 +291,18 @@ class OmniConfig:
     top_p: float = 0.95
     timeout: float = 30.0
     stream: bool = False
-    media_resolution: str = "max"  # 可选 "max" / "high" / "low"，经 resolve_media_resolution 映射到模型特定值
+    media_resolution: str = "max"  # 通用取值 "max" / "high" / "low"，经 resolve_media_resolution 映射到模型特定值
 
 
 # =============================================================================
-# Media resolution adapter —— 不同 LLM 支持的 video 分辨率值不同，做一层映射
+# Media resolution adapter —— 把通用 media_resolution 映射到各 LLM 实际接受的值
 # =============================================================================
+# 注意：这里不把 "max" / "high" / "low" 当作"分辨率档位"，它们是各模型自定义的
+# 枚举值，语义因模型而异：
+#   MiMo —— "default" 保留单帧 300 token 上限（Miloco 默认会把帧缩放到 910×512），
+#           "max" 解除该上限；本 PR 对 MiMo 默认路径产出值不变。
+#   其他模型（如 Qwen）—— 可能用 "low" / "high" / "max" 表达真正的分辨率档位。
+# adapter 的价值在于为这类多模型差异预留一层适配，而非给 MiMo 切换"更高分辨率"。
 
 # 各模型/平台支持的 media_resolution 值映射：
 #   key 是用户配置的通用值（"low" / "high" / "max"），
@@ -318,14 +323,17 @@ MEDIA_RESOLUTION_PRESETS: dict[str, dict[str, str]] = {
 
 
 def resolve_media_resolution(value: str, model_name: str = "") -> str:
-    """将用户配置的通用 media_resolution 映射为模型实际支持的值。
+    """把通用 media_resolution 映射为模型实际接受的值。
 
-    不同 LLM 对 media_resolution 的支持不同：
-    - MiMo：仅支持 ``"default"`` 和 ``"max"``
-    - 其他模型（如 Qwen）：可能支持 ``"low"`` / ``"high"`` / ``"max"`` 等
+    各 LLM 对 media_resolution 的取值与语义不同：
+    - MiMo：``"default"`` 保留单帧 300 token 上限（Miloco 默认将帧缩放到 910×512），
+      ``"max"`` 解除该上限。本 PR 对 MiMo 默认路径产出值不变。
+    - 其他模型（如 Qwen）：可能用 ``"low"`` / ``"high"`` / ``"max"`` 表达真正的
+      分辨率档位，语义各异。
 
-    本函数根据 ``model_name`` 选择对应的 preset 做值映射，
-    未匹配到任何 preset 时走 ``"default"`` 透传。
+    这里的 ``"max"`` / ``"high"`` / ``"low"`` 不是统一分辨率档位，而是各模型自定义的
+    枚举值；adapter 的意义在于为多模型预留适配层，未匹配到任何 preset 时走
+    ``"default"`` 透传。
 
     Args:
         value: 用户配置的通用值（``"low"`` / ``"high"`` / ``"max"`` 等）。
@@ -333,7 +341,7 @@ def resolve_media_resolution(value: str, model_name: str = "") -> str:
                     子串匹配。为空时直接返回 value。
 
     Returns:
-        模型实际支持的 media_resolution 值。
+        模型实际接受的 media_resolution 值。
     """
     if not model_name:
         return value

--- a/backend/miloco/src/miloco/perception/engine/omni/omni.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/omni.py
@@ -125,7 +125,7 @@ async def run_omni_fused(
         fused_prompt_config = FusedPromptConfig(
             media_resolution=resolve_media_resolution(
                 config.media_resolution,
-                config.model_name or config.model,
+                config.model,
             )
         )
 

--- a/backend/miloco/src/miloco/perception/engine/omni/omni.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/omni.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any
 import httpx
 
 from miloco.database.token_usage_repo import fire_record
-from miloco.perception.engine.config import OmniConfig
+from miloco.perception.engine.config import OmniConfig, resolve_media_resolution
 from miloco.perception.engine.omni.constants import MILOCO_USER_AGENT
 from miloco.perception.engine.omni.omni_client import (
     OmniError,
@@ -119,6 +119,15 @@ async def run_omni_fused(
     else:
         candidates = []
         gallery_snapshot = {}
+
+    # 若调用方未传 fused_prompt_config，用默认值并从 OmniConfig 透传 media_resolution
+    if fused_prompt_config is None:
+        fused_prompt_config = FusedPromptConfig(
+            media_resolution=resolve_media_resolution(
+                config.media_resolution,
+                config.model_name or config.model,
+            )
+        )
 
     # 一次 list_persons 同时构造两张表（始终从 library 构造，不依赖 gallery_snapshot——
     # 后者在 candidates 空时为 {}，会让主调用 prompt「已识别人物：」段渲染出 UUID 而非姓名）：

--- a/backend/miloco/src/miloco/perception/engine/omni/omni_client.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/omni_client.py
@@ -13,7 +13,7 @@ from typing import Any
 import httpx
 
 from miloco.database.token_usage_repo import fire_record
-from miloco.perception.engine.config import OmniConfig
+from miloco.perception.engine.config import OmniConfig, resolve_media_resolution
 from miloco.perception.engine.omni.constants import MILOCO_USER_AGENT
 from miloco.perception.snapshot_context import push_omni_trace
 
@@ -144,7 +144,7 @@ async def call_omni(
             f"{_ENV_KEY} is not set. Provide it via config or environment variable."
         )
 
-    messages = _build_messages(payload)
+    messages = _build_messages(payload, config)
 
     body: dict[str, Any] = {
         "model": config.model,
@@ -195,7 +195,7 @@ async def call_omni(
         )
 
 
-def _build_messages(payload: dict) -> list[dict]:
+def _build_messages(payload: dict, config: "OmniConfig | None" = None) -> list[dict]:
     messages: list[dict] = [{"role": "system", "content": payload["system_prompt"]}]
 
     content: list[dict] = [{"type": "text", "text": payload["user_content"]}]
@@ -209,7 +209,14 @@ def _build_messages(payload: dict) -> list[dict]:
                     "url": f"data:video/mp4;base64,{payload['video_base64']}"
                 },
                 "fps": payload.get("video_fps", 3),
-                "media_resolution": "max",
+                "media_resolution": (
+                    resolve_media_resolution(
+                        config.media_resolution,
+                        config.model_name or config.model,
+                    )
+                    if config
+                    else "max"
+                ),
             }
         )
     # Audio-only route：独立 input_audio 块（仅当无 video_base64 时启用）
@@ -278,7 +285,7 @@ async def call_omni_stream(
             f"{_ENV_KEY} is not set. Provide it via config or environment variable."
         )
 
-    messages = _build_messages(payload)
+    messages = _build_messages(payload, config)
 
     body: dict[str, Any] = {
         "model": config.model,

--- a/backend/miloco/src/miloco/perception/engine/omni/omni_client.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/omni_client.py
@@ -212,7 +212,7 @@ def _build_messages(payload: dict, config: "OmniConfig | None" = None) -> list[d
                 "media_resolution": (
                     resolve_media_resolution(
                         config.media_resolution,
-                        config.model_name or config.model,
+                        config.model,
                     )
                     if config
                     else "max"

--- a/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
@@ -88,6 +88,7 @@ class FusedPromptConfig:
     # 单人 body+face composite 占约 20-40KB jpeg ≈ 60-120KB base64 ≈ 15-30K tokens；
     # >10 人 prompt 容易超出 omni token 预算，需在配置或上游 gallery_snapshot 处控制。
     max_gallery_persons: int = 10
+    media_resolution: str = "max"  # 可选 "max" / "high" / "low"
 
 
 # =============================================================================
@@ -680,7 +681,7 @@ def _build_fused_user_content(
             "type": "video_url",
             "video_url": {"url": f"data:video/mp4;base64,{video_b64}"},
             "fps": video_fps,
-            "media_resolution": "max",
+            "media_resolution": cfg.media_resolution,
         })
     elif video_b64:
         logger.warning(

--- a/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
@@ -88,7 +88,7 @@ class FusedPromptConfig:
     # 单人 body+face composite 占约 20-40KB jpeg ≈ 60-120KB base64 ≈ 15-30K tokens；
     # >10 人 prompt 容易超出 omni token 预算，需在配置或上游 gallery_snapshot 处控制。
     max_gallery_persons: int = 10
-    media_resolution: str = "max"  # 可选 "max" / "high" / "low"
+    media_resolution: str = "max"  # 通用取值 "max" / "high" / "low"，语义因模型而异（见 resolve_media_resolution）
 
 
 # =============================================================================

--- a/backend/miloco/tests/test_media_resolution.py
+++ b/backend/miloco/tests/test_media_resolution.py
@@ -1,0 +1,126 @@
+# Copyright (C) 2025 Xiaomi Corporation
+# This software may be used and distributed according to the terms of the Xiaomi Miloco License Agreement.
+
+"""resolve_media_resolution 适配层测试.
+
+覆盖:
+- MiMo 三档映射（low→default, high→max, max→max）
+- 空 model_name 透传原值
+- 未知模型走 default preset（low→low, high→high, max→max）
+- model 字符串包含 "mimo" 子串即可匹配（大小写不敏感）
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load_config_module():
+    """加载 perception.engine.config 模块，优先走标准包导入。
+
+    当仓库尚未以可编辑模式安装、或其重型依赖（如 pydantic）在当前解释器
+    不可用时，直接按文件路径加载该模块，使本测试可独立运行。
+    """
+    try:
+        module = importlib.import_module(
+            "miloco.perception.engine.config"
+        )
+        if hasattr(module, "resolve_media_resolution"):
+            return module
+    except Exception:
+        pass
+
+    here = Path(__file__).resolve().parent
+    # tests/ → src/miloco/perception/engine/config.py
+    src_root = here.parent / "src"
+    config_path = src_root / "miloco" / "perception" / "engine" / "config.py"
+    spec = importlib.util.spec_from_file_location(
+        "miloco.perception.engine.config", config_path
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_config = _load_config_module()
+resolve_media_resolution = _config.resolve_media_resolution
+
+
+# ---- MiMo 三档映射 ---------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("low", "default"),
+        ("high", "max"),
+        ("max", "max"),
+    ],
+)
+def test_mimo_preset_mapping(value, expected):
+    # MiMo 默认 model；max 解除单帧 300 token 上限，default 保留上限
+    assert resolve_media_resolution(value, "xiaomi/mimo-v2.5") == expected
+
+
+def test_mimo_max_unsets_token_cap():
+    """max 在 MiMo 上映射为 "max"（解除单帧 300 token 上限），非"最高分辨率"。"""
+    assert resolve_media_resolution("max", "xiaomi/mimo-v2.5") == "max"
+
+
+def test_mimo_low_keeps_token_cap():
+    """low 在 MiMo 上映射为 "default"，即保留单帧 300 token 上限。"""
+    assert resolve_media_resolution("low", "xiaomi/mimo-v2.5") == "default"
+
+
+# ---- 空 model_name 透传 ----------------------------------------------------
+
+@pytest.mark.parametrize("value", ["low", "high", "max", "default", "anything"])
+def test_empty_model_name_passes_through(value):
+    assert resolve_media_resolution(value, "") == value
+
+
+def test_none_equivalent_to_empty():
+    # 调用方可能传入 None（来自可选配置），等价于空字符串透传
+    assert resolve_media_resolution("high", None) == "high"  # type: ignore[arg-type]
+
+
+# ---- 未知模型走 default preset --------------------------------------------
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("low", "low"),
+        ("high", "high"),
+        ("max", "max"),
+    ],
+)
+def test_unknown_model_uses_default_preset(value, expected):
+    # 未在 MEDIA_RESOLUTION_PRESETS 中显式列出的模型走 default 透传
+    assert resolve_media_resolution(value, "qwen/qwen2.5-vl") == expected
+
+
+def test_unknown_model_unknown_value_passes_through():
+    assert resolve_media_resolution("ultra", "qwen/qwen2.5-vl") == "ultra"
+
+
+# ---- model 子串匹配（大小写不敏感）----------------------------------------
+
+def test_mimo_substring_matches_case_insensitive():
+    assert resolve_media_resolution("high", "XIAOMI/MIMO-V2.5") == "max"
+
+
+def test_mimo_substring_in_custom_model_name():
+    # 只要 model 字符串包含 "mimo" 子串即可命中 mimo preset
+    assert resolve_media_resolution("high", "my-mimo-finetune-7b") == "max"
+
+
+def test_non_mimo_model_not_matched_by_partial():
+    # "mimosaic" 含 "mimo" 子串会命中——这是子串匹配的预期行为，
+    # 这里确认不含 "mimo" 的模型确实走 default
+    assert resolve_media_resolution("high", "llava-next") == "high"


### PR DESCRIPTION
## Summary

`media_resolution` 在 `_build_messages` 中硬编码为 `"max"`，无法通过配置动态切换为 `high` / `low`。

## Changes

- `_build_messages` 新增可选 `config: OmniConfig | None` 参数
- `media_resolution` 改为从 `config.media_resolution` 读取，无值时 fallback 到 `"max"`
- `call_omni` 和 `call_omni_stream` 两处调用点传入 `config`
- 向后兼容：`config` 参数默认 `None`，不影响其他调用方

## Diff

仅修改 `miloco/perception/engine/omni/omni_client.py`，4 行变更。
