### PR TITLE
fix(perception): 新增“非人误检”(no_person)判定，误检物体不再被当作人

### DIFF
--- a/backend/miloco/src/miloco/perception/engine/config.py
+++ b/backend/miloco/src/miloco/perception/engine/config.py
@@ -237,6 +237,35 @@ class DriftCheckConfigDC:
 
 
 @dataclass
+class NoPersonConfigDC:
+    """无人误检（no_person）抑制参数。
+
+    检测模型偶尔把静态杂物 / 家具误报成人体框 → 形成 track → 注入 omni → caption 据框
+    脑补"陌生人在做某事"。omni 在 identities 里把"框内确无人"判为 ``no_person``（区别于
+    ``unknown``=有人但不认识，见 ``field_registry``），本配置控制引擎侧如何消费该判定：
+    连续 ``vote_threshold`` 次 no_person 才落定 ``no_person`` 状态（停派发 omni、身份不导出、
+    不进陌生人池）；该 track 一旦相对落定时的锚点 bbox 明显移动（疑似被路过的真人 ID-switch
+    带走）即回到 pending 重新走识别——确保不会把真人长期误压成无人。
+
+    召回保护：偏"少误判无人"——需连续多票 + 任何明显移动立即解除。
+    """
+
+    enabled: bool = True
+    # 连续命中 no_person 多少次才落定状态（防单次误判把背对 / 遮挡的真人误当无人）
+    vote_threshold: int = 2
+    # 落定后"明显移动"判据：中心位移 ≥ min_abs_px **且** ≥ ratio×bbox 对角线，两者同时满足才算移动
+    motion_clear_displacement_ratio: float = 0.15
+    motion_clear_min_abs_px: float = 30.0
+
+    # reject_region（P3，默认关）：把 no_person 的屏幕区域登记为"禁新建 track 区"，
+    # 直到真人 track 与之明显重叠或区域 TTL 到期才失效。默认关闭——需现场验证后再开
+    # （误开会挡住门口 / 座位等真人常现位置的新 track）。
+    reject_region_enabled: bool = False
+    reject_region_ttl_sec: float = 300.0      # 区域登记后多久自动过期失效
+    reject_region_clear_iou: float = 0.3      # 真人 track 与禁区 IoU ≥ 此值即解除该禁区
+
+
+@dataclass
 class IdentityEngineConfig:
     """omni 身份识别系统总配置。"""
 
@@ -258,6 +287,7 @@ class IdentityEngineConfig:
     stranger: StrangerConfigDC = field(default_factory=StrangerConfigDC)
     tierc_clear: TierCClearConfig = field(default_factory=TierCClearConfig)
     drift_check: DriftCheckConfigDC = field(default_factory=DriftCheckConfigDC)
+    no_person: NoPersonConfigDC = field(default_factory=NoPersonConfigDC)   # 无人误检抑制
 
     # crop / 累积
     body_crop_padding_ratio: float = 0.05
@@ -329,6 +359,7 @@ def identity_engine_config_from_dict(d: dict | None) -> IdentityEngineConfig:
         "stranger": StrangerConfigDC,
         "tierc_clear": TierCClearConfig,
         "drift_check": DriftCheckConfigDC,
+        "no_person": NoPersonConfigDC,
     }
     kwargs: dict = {}
 

--- a/backend/miloco/src/miloco/perception/engine/config.py
+++ b/backend/miloco/src/miloco/perception/engine/config.py
@@ -244,10 +244,16 @@ class NoPersonConfigDC:
     脑补"陌生人在做某事"。omni 在 identities 里把"框内确无人"判为 ``no_person``（区别于
     ``unknown``=有人但不认识，见 ``field_registry``），本配置控制引擎侧如何消费该判定：
     连续 ``vote_threshold`` 次 no_person 才落定 ``no_person`` 状态（停派发 omni、身份不导出、
-    不进陌生人池）；该 track 一旦相对落定时的锚点 bbox 明显移动（疑似被路过的真人 ID-switch
-    带走）即回到 pending 重新走识别——确保不会把真人长期误压成无人。
+    不进陌生人池）。
 
-    召回保护：偏"少误判无人"——需连续多票 + 任何明显移动立即解除。
+    召回保护偏"少误判无人"——落定后有三重解除通道，确保任何 track 都不会被永久静音：
+      1) 落定需连续 ``vote_threshold`` 票（防单次误判掉背对 / 遮挡的真人）；
+      2) 框相对落定锚点明显移动 → 立即回 pending（会动的真人即时自愈，走
+         ``clear_no_person_on_motion``）；
+      3) 每 ``no_person_recheck_sec`` 放行一次慢重审，重审判到人即回 pending（走
+         ``clear_no_person_to_pending``）。这条是最后兜底的"不永久卡死"自愈不变式，非主恢复
+         通道：只为极少数"未注册真人一动不动、被连判两票误压、又不触发移动解除"的残留兜底。
+         注意急性摔倒 / 倒地动作由上游动作 / 事件检测捕获、不依赖本状态，故此周期可放得很长。
     """
 
     enabled: bool = True
@@ -256,6 +262,10 @@ class NoPersonConfigDC:
     # 落定后"明显移动"判据：中心位移 ≥ min_abs_px **且** ≥ ratio×bbox 对角线，两者同时满足才算移动
     motion_clear_displacement_ratio: float = 0.15
     motion_clear_min_abs_px: float = 30.0
+    # 慢重审自愈周期（秒）：落定后每此秒数放行一次 omni 重审，判到人即回 pending。这是"任何状态
+    # 都不会被永久卡死"的最后兜底（主恢复靠上面的移动解除 + 上游动作检测），故可放长；
+    # needs_omni_call 入口按 engine_fps 换算成帧。默认 1200s(20min)，现场想更懒可调 1800/3600。
+    no_person_recheck_sec: float = 1200.0
 
     # reject_region（P3，默认关）：把 no_person 的屏幕区域登记为"禁新建 track 区"，
     # 直到真人 track 与之明显重叠或区域 TTL 到期才失效。默认关闭——需现场验证后再开

--- a/backend/miloco/src/miloco/perception/engine/identity/default_config.yaml
+++ b/backend/miloco/src/miloco/perception/engine/identity/default_config.yaml
@@ -121,6 +121,21 @@ drift_check:
   consecutive_windows: 2       # 累计 M 个低窗才入嫌疑集(无数据窗不计不清)
   min_track_emb: 3             # track 质心要求最少 emb 数
 
+# 无人误检(no_person)抑制: 检测模型把静态杂物/家具误报成人体框 → 注入 omni → caption 脑补"陌生人"。
+# omni 在 identities 把"框内确无人"判为 no_person(区别于 unknown=有人但认不出); 引擎连续 N 票才落定
+# no_person 状态(停派发 omni / 身份不导出 / 不进陌生人池); 该 track 一旦明显移动(被路过真人 ID-switch
+# 带走)即回 pending 重新识别。偏召回: 多票 + 任何明显移动立即解除, 不把真人长期误压成无人。
+no_person:
+  enabled: true
+  vote_threshold: 2                      # 连续命中 no_person 多少次才落定(防单次误判误掉真人)
+  motion_clear_displacement_ratio: 0.15  # "明显移动": 中心位移 ≥ ratio×对角线
+  motion_clear_min_abs_px: 30.0          # 且 ≥ 此绝对像素(两者同时满足)
+  # reject_region(默认关): 把 no_person 屏幕区域登记为"禁新建 track 区", 直到真人覆盖或 TTL 到期失效。
+  # 需现场验证后再开(误开会挡门口/座位等真人常现位置的新 track)。
+  reject_region_enabled: false
+  reject_region_ttl_sec: 300.0
+  reject_region_clear_iou: 0.3
+
 body_crop_padding_ratio: 0.05  # bbox 紧贴；过多 padding 降低 omni 分辨率利用率
 tier_c_accumulate_on_commit: true
 tier_c_verify_enabled: true           # 写 tier_c 前 omni 同人校验(E7), 挡非本人误判落库; 默认开; 也是 C3 回喂的前提

--- a/backend/miloco/src/miloco/perception/engine/identity/default_config.yaml
+++ b/backend/miloco/src/miloco/perception/engine/identity/default_config.yaml
@@ -130,6 +130,9 @@ no_person:
   vote_threshold: 2                      # 连续命中 no_person 多少次才落定(防单次误判误掉真人)
   motion_clear_displacement_ratio: 0.15  # "明显移动": 中心位移 ≥ ratio×对角线
   motion_clear_min_abs_px: 30.0          # 且 ≥ 此绝对像素(两者同时满足)
+  # 慢重审自愈周期(秒): 落定后每此秒数放行一次 omni 重审, 判到人即回 pending。这是"任何状态都不会被
+  # 永久卡死"的最后兜底(主恢复靠上面的移动解除 + 上游动作检测), 故放得很长。默认 1200s(20min)。
+  no_person_recheck_sec: 1200.0
   # reject_region(默认关): 把 no_person 屏幕区域登记为"禁新建 track 区", 直到真人覆盖或 TTL 到期失效。
   # 需现场验证后再开(误开会挡门口/座位等真人常现位置的新 track)。
   reject_region_enabled: false

--- a/backend/miloco/src/miloco/perception/engine/identity/dispatcher.py
+++ b/backend/miloco/src/miloco/perception/engine/identity/dispatcher.py
@@ -84,6 +84,9 @@ class OmniIdentityResult:
     # 仅在 omni 明确返回了该 track 的 assignment 时才透传真值；omni 漏报该 track 或
     # 整体调用失败时保持 None（非否定，按弃权处理）。
     face_visible: Optional[bool] = None
+    # omni 在 identities 把该框判为 "no_person"（框内确无人 / 非人误检），区别于 unknown
+    # （有人但认不出）。上层 _on_result 据此累计 no_person 票、落定后停派发 + 身份不导出。
+    no_person: bool = False
 
 
 # =============================================================================
@@ -247,6 +250,7 @@ class FusedDispatcher:
                     pid = None
                 conf = float(a.get("confidence", 0.0))
                 reason = str(a.get("reason", ""))
+                is_no_person = bool(a.get("no_person", False))
             except (TypeError, ValueError) as e:
                 logger.warning("fused response 解析单条 assignment 失败 a=%s err=%s", a, e)
                 continue
@@ -273,6 +277,7 @@ class FusedDispatcher:
                     batch_size=batch_size,
                     dup_id=dup_id,
                     face_visible=face_visible_by_tid.get(tid),
+                    no_person=is_no_person,
                 ))
             except Exception:  # noqa: BLE001
                 # 单条 on_result 抛出不连累整批,也不向上传播(否则 run_omni_fused 的 finally

--- a/backend/miloco/src/miloco/perception/engine/identity/dispatcher.py
+++ b/backend/miloco/src/miloco/perception/engine/identity/dispatcher.py
@@ -87,6 +87,11 @@ class OmniIdentityResult:
     # omni 在 identities 把该框判为 "no_person"（框内确无人 / 非人误检），区别于 unknown
     # （有人但认不出）。上层 _on_result 据此累计 no_person 票、落定后停派发 + 身份不导出。
     no_person: bool = False
+    # omni 是否对该 track 真正给出了判定。True = 本条来自 omni response 的实际 assignment
+    # （成员 / unknown / no_person 都算"答了"）；False = 合成的"非答复"——omni 漏报该 track 或
+    # 整体调用失败时兜底补投（person_id=None、no_person=False，但并非"判到人"）。上层据此避免把
+    # "没答/失败"误当"判到人"（尤其别拿它把已落定的 no_person 解除、复发 caption 陌生人幻觉）。
+    omni_answered: bool = True
 
 
 # =============================================================================
@@ -294,6 +299,7 @@ class FusedDispatcher:
                         confidence=0.0,
                         reason="fused_response_missing_track",
                         batch_size=batch_size,
+                        omni_answered=False,   # 漏报 = 未判定，非"判到人"
                     ))
                 except Exception:  # noqa: BLE001
                     logger.warning("fused on_result(missing) 异常 track_id=%d", cand.track_id, exc_info=True)
@@ -315,6 +321,7 @@ class FusedDispatcher:
                     confidence=0.0,
                     reason=f"fused_main_call_failed: {reason}",
                     batch_size=batch_size,
+                    omni_answered=False,   # 整体失败 = 未判定，非"判到人"
                 ))
             except Exception:  # noqa: BLE001
                 logger.warning("fused on_result(failure) 异常 track_id=%d", cand.track_id, exc_info=True)

--- a/backend/miloco/src/miloco/perception/engine/identity/engine.py
+++ b/backend/miloco/src/miloco/perception/engine/identity/engine.py
@@ -51,10 +51,12 @@ from miloco.perception.engine.identity.state import (
     TrackIdentityState,
     apply_recheck_result,
     check_pending_timeout,
+    clear_no_person_on_motion,
     get_face_id_value,
     mark_dispatched,
     needs_omni_call,
     promote_to_pending,
+    record_no_person,
     update_evidence,
 )
 
@@ -150,6 +152,21 @@ def _max_overlap_ratio(
         if ratio > best:
             best = ratio
     return best
+
+
+def _bbox_iou(a: tuple[int, int, int, int], b: tuple[int, int, int, int]) -> float:
+    """两框 IoU（交集 / 并集）。退化框返 0.0。reject_region 覆盖判定用。"""
+    ax1, ay1, ax2, ay2 = a
+    bx1, by1, bx2, by2 = b
+    iw = min(ax2, bx2) - max(ax1, bx1)
+    ih = min(ay2, by2) - max(ay1, by1)
+    if iw <= 0 or ih <= 0:
+        return 0.0
+    inter = iw * ih
+    area_a = max(0, ax2 - ax1) * max(0, ay2 - ay1)
+    area_b = max(0, bx2 - bx1) * max(0, by2 - by1)
+    union = area_a + area_b - inter
+    return inter / union if union > 0 else 0.0
 
 
 def _normalize_bbox_to_1000(
@@ -349,6 +366,9 @@ class IdentityEngine:
         # True ⟺ 本窗该 track 人体框被他人框遮挡 ≥ _TIER_C_MAX_BODY_OVERLAP_RATIO。
         # 消费点: _enqueue_tier_c_candidate 与 E5 人脸门同级早退 (不入库、不走 omni)。
         self._overlap_other_person: dict[int, bool] = {}
+        # reject_region（默认关）：no_person 落定时登记的屏幕区域 (bbox_xyxy, 过期墙钟 ts)，
+        # 区域内全新静止 track 直接预标 no_person、被 confirmed 真人覆盖或 TTL 到期解除。
+        self._no_person_regions: list[tuple[tuple[int, int, int, int], float]] = []
 
         # 身份库变化监听：每窗口对比 library 的 person 快照，发现差异（成员新增/删除、
         # 或某成员 tier_a 样本指纹变化）时把所有 track 的身份字段清空回 pending，
@@ -505,6 +525,16 @@ class IdentityEngine:
             ):
                 state.write_eligible_count = 0
 
+            # no_person track 相对锚点明显移动 → 回 pending 重新识别（疑似被路过真人 ID-switch 带走）。
+            # 静态误检框不动则维持 no_person（停派发、不导出），稳态下持续存活、不重注入 omni。
+            if state.status == "no_person" and self.config.no_person.enabled:
+                clear_no_person_on_motion(
+                    state,
+                    self._latest_bbox.get(tid),
+                    self.config.no_person.motion_clear_displacement_ratio,
+                    self.config.no_person.motion_clear_min_abs_px,
+                )
+
             # SortTracker 给出该 track，本帧首次见 → promote 到 pending
             promote_to_pending(state, now_ts)
 
@@ -566,6 +596,10 @@ class IdentityEngine:
         # enforce 撤回的 track 本窗即作去先验 candidate 一并重判(与 library 变化重置同款
         # "重置→本窗重派"语义)。mode=off 时 O(1) 早退。
         self._run_drift_check(active_track_ids, now_ts, name_lookup)
+
+        # reject_region（默认关）：区域级记忆，压同位置反复误检的 omni 重问。放在收集 candidate
+        # 之前，使预标的 no_person track 本窗即不进派发。
+        self._apply_reject_regions(active_track_ids, now_ts)
 
         candidates: list[IdentityQueryItem] = []
         for tid in active_track_ids:
@@ -982,6 +1016,61 @@ class IdentityEngine:
         self._next_unknown_index += 1
         return idx
 
+    def _apply_reject_regions(self, active_track_ids: set[int], now_ts: float) -> None:
+        """reject_region（默认关）维护。
+
+        no_person 落定时登记屏幕区域（见 ``_on_result``）。本步：
+          ① TTL 过期清理；
+          ② 被 confirmed 真人覆盖（IoU ≥ clear_iou）的区域解除（真人确在那）；
+          ③ 区域内"全新（从未派发）且本帧检测到的 pending track"直接预标 no_person，
+             跳过 omni 重问——压住同位置反复误检的调用。
+        预标的 track 仍受移动解除保护（真人移动即回 pending 重识别）。
+        ``reject_region_enabled=false``（默认）时整体跳过，零行为影响。
+        """
+        np_cfg = self.config.no_person
+        if not (np_cfg.enabled and np_cfg.reject_region_enabled):
+            return
+        if not self._no_person_regions:
+            return
+        # ① TTL 过期
+        self._no_person_regions = [
+            (b, exp) for (b, exp) in self._no_person_regions if exp > now_ts
+        ]
+        # ② 被 confirmed 真人覆盖的区域解除
+        confirmed_boxes = [
+            self._latest_bbox[t] for t in active_track_ids
+            if self._states[t].status == "confirmed"
+            and self._detected_this_frame.get(t, False)
+            and t in self._latest_bbox
+        ]
+        if confirmed_boxes:
+            self._no_person_regions = [
+                (b, exp) for (b, exp) in self._no_person_regions
+                if max((_bbox_iou(b, cb) for cb in confirmed_boxes), default=0.0)
+                < np_cfg.reject_region_clear_iou
+            ]
+        # ③ 区域内全新 track 预标 no_person（跳过 omni）
+        for tid in active_track_ids:
+            st = self._states[tid]
+            if not (
+                st.status == "pending"
+                and st.last_omni_call_frame == 0      # 全新、从未派发过
+                and st.no_person_vote_count == 0
+                and self._detected_this_frame.get(tid, False)
+            ):
+                continue
+            box = self._latest_bbox.get(tid)
+            if box is not None and any(
+                _bbox_iou(box, rb) >= np_cfg.reject_region_clear_iou
+                for rb, _ in self._no_person_regions
+            ):
+                st.status = "no_person"
+                st.no_person_anchor_bbox = box
+                logger.info(
+                    "[Identity] cam=%s track_id=%d 落在 no_person reject_region → 预标 no_person（跳过 omni）",
+                    self.cam_id, tid,
+                )
+
     def _gc_dead_tracks(self, active_ids: set[int], frame_index: int) -> None:
         """清理 SortTracker 已不再返回、且超过 grace 帧未再现的 track state。
 
@@ -1078,8 +1167,9 @@ class IdentityEngine:
             state = self._states.get(tid)
             if state is None:
                 continue
-            # 已 confirmed 的 track 不进池——它们走 tier_c 累积路径
-            if state.status == "confirmed":
+            # 已 confirmed 的 track 不进池——它们走 tier_c 累积路径。
+            # no_person（非人误检）也不进池——杂物 crop 进陌生人池会污染聚类。
+            if state.status in ("confirmed", "no_person"):
                 continue
             tr = tr_by_id.get(tid)
             if tr is None:
@@ -1130,6 +1220,35 @@ class IdentityEngine:
                 logger.warning("on_result 收到 unknown track_id=%d 的结果（state 已 GC）",
                                result.track_id)
                 return
+
+            # no_person：omni 判该框内确无人（非人误检）。累计票数，连续达阈值落定 no_person
+            # （停派发 / 身份不导出 / 不进陌生人池）；confirmed 成员不被翻（见 record_no_person）。
+            # 非 no_person 结果到达时清票，保证"连续"语义。confirmed 成员永不被 no_person 干扰。
+            if self.config.no_person.enabled and result.no_person:
+                committed = record_no_person(
+                    state,
+                    anchor_bbox=self._latest_bbox.get(result.track_id),
+                    vote_threshold=self.config.no_person.vote_threshold,
+                )
+                if committed:
+                    logger.info(
+                        "[Identity] cam=%s track_id=%d 落定 no_person（非人误检，停派发 / 身份不导出）",
+                        self.cam_id, result.track_id,
+                    )
+                    # reject_region（默认关）：登记该屏幕区域，抑制同位置反复误检的 omni 重问
+                    np_cfg = self.config.no_person
+                    anchor = self._latest_bbox.get(result.track_id)
+                    if np_cfg.reject_region_enabled and anchor is not None:
+                        self._no_person_regions.append(
+                            (anchor, now_ts + np_cfg.reject_region_ttl_sec)
+                        )
+                        # 软上限防无限增长（TTL 过期已每窗清理，此处兜底极端多误检场景）
+                        if len(self._no_person_regions) > 64:
+                            self._no_person_regions = self._no_person_regions[-64:]
+                return
+            if state.no_person_vote_count:
+                # omni 本窗看到人了 → no_person 连续性中断，清票
+                state.no_person_vote_count = 0
 
             # D · 跨身份冲突兜底：dispatcher 检测出"omni 把已锁定身份挂到了
             # 另一个 candidate"——同一身份只能对应一个 track，物理上不可能两个

--- a/backend/miloco/src/miloco/perception/engine/identity/engine.py
+++ b/backend/miloco/src/miloco/perception/engine/identity/engine.py
@@ -52,6 +52,7 @@ from miloco.perception.engine.identity.state import (
     apply_recheck_result,
     check_pending_timeout,
     clear_no_person_on_motion,
+    clear_no_person_to_pending,
     get_face_id_value,
     mark_dispatched,
     needs_omni_call,
@@ -609,6 +610,7 @@ class IdentityEngine:
                 self.config.dispatch.min_interval_sec,
                 self.config.stability,
                 self._engine_fps,
+                self.config.no_person.no_person_recheck_sec,
             ):
                 continue
             # coasting（人离开/跟丢后纯 Kalman 预测残留）的 track 当窗口不进 omni
@@ -1225,6 +1227,11 @@ class IdentityEngine:
             # （停派发 / 身份不导出 / 不进陌生人池）；confirmed 成员不被翻（见 record_no_person）。
             # 非 no_person 结果到达时清票，保证"连续"语义。confirmed 成员永不被 no_person 干扰。
             if self.config.no_person.enabled and result.no_person:
+                if state.status == "confirmed":
+                    # confirmed 成员不被 no_person 翻（record_no_person 视为弃权），但这一窗仍是
+                    # "没认到本人" → 按弃权口径打断 tier_c 写库连续段（与 coasting / 看脸否定同口径），
+                    # 不放松"连续 N 次一致才写库"的不变式。
+                    state.write_eligible_count = 0
                 committed = record_no_person(
                     state,
                     anchor_bbox=self._latest_bbox.get(result.track_id),
@@ -1246,9 +1253,19 @@ class IdentityEngine:
                         if len(self._no_person_regions) > 64:
                             self._no_person_regions = self._no_person_regions[-64:]
                 return
+            # 走到这里 = 本窗 omni 判"有人"（非 no_person）。
             if state.no_person_vote_count:
-                # omni 本窗看到人了 → no_person 连续性中断，清票
+                # no_person 连续性中断，清累计票
                 state.no_person_vote_count = 0
+            if self.config.no_person.enabled and state.status == "no_person":
+                # 已落定 no_person 却被慢重审判到人 → 第二条解除通道：回 pending 重新识别（随后
+                # needs_omni_call 对 pending "下窗即派"，几秒内 commit 出去）。真静止误检物体每次
+                # 重审仍判 no_person、走不到这里，不会复发"陌生人"幻觉。兜"未注册真人一动不动被误压"。
+                logger.info(
+                    "[Identity] cam=%s track_id=%d no_person 慢重审判到人 → 回 pending 重识别",
+                    self.cam_id, result.track_id,
+                )
+                clear_no_person_to_pending(state, now_ts)
 
             # D · 跨身份冲突兜底：dispatcher 检测出"omni 把已锁定身份挂到了
             # 另一个 candidate"——同一身份只能对应一个 track，物理上不可能两个

--- a/backend/miloco/src/miloco/perception/engine/identity/engine.py
+++ b/backend/miloco/src/miloco/perception/engine/identity/engine.py
@@ -1253,14 +1253,26 @@ class IdentityEngine:
                         if len(self._no_person_regions) > 64:
                             self._no_person_regions = self._no_person_regions[-64:]
                 return
-            # 走到这里 = 本窗 omni 判"有人"（非 no_person）。
+            # 走到这里 = 本窗结果非 no_person（omni 判到人 / unknown，或"漏报 / 失败"的合成非答复）。
             if state.no_person_vote_count:
                 # no_person 连续性中断，清累计票
                 state.no_person_vote_count = 0
             if self.config.no_person.enabled and state.status == "no_person":
-                # 已落定 no_person 却被慢重审判到人 → 第二条解除通道：回 pending 重新识别（随后
-                # needs_omni_call 对 pending "下窗即派"，几秒内 commit 出去）。真静止误检物体每次
-                # 重审仍判 no_person、走不到这里，不会复发"陌生人"幻觉。兜"未注册真人一动不动被误压"。
+                if not result.omni_answered:
+                    # omni 本窗漏报该 track / 整体调用失败（合成的"非答复"，person_id=None 但并非
+                    # "判到人"）→ 按弃权维持 no_person：不解除抑制。否则一次 omni 漏报 / 失败就会把
+                    # 静止误检框打回 pending → caption 复发"陌生人"，整体失败更会一次掀翻全场 no_person。
+                    # 只清 inflight，让下一个周期能再慢重审（inflight 残留会永久堵死重审）。
+                    state.inflight = False
+                    return
+                # omni 确实判到"有人"（成员或 unknown）→ 第二条解除通道：回 pending 重新识别。
+                # 与上面 no_person=True 分支不同，这里**刻意不 return**：本窗这条真判定紧接着落到下面的
+                # update_evidence，作为 pending 的第一票**立即消费**——用满这条真证据加速恢复（高置信
+                # 成员本窗即可 commit-to-confirmed 单窗恢复；unknown 记第一票，后续 pending "下窗即派"
+                # 继续累积）。一票远低于 commit 阈值，即便是 omni 偶发抖动也不会误 commit 成某身份。
+                # 真静止误检物体每次重审仍判 no_person、走不到这里，不复发"陌生人"幻觉。兜"未注册真人
+                # 一动不动被误压"。（no_person=True 分支的 return 是对的：那条被 record_no_person 消费完
+                # 即无后续；这条是"有人"判定，要它既解除又顺带播种重识别，故不 return。）
                 logger.info(
                     "[Identity] cam=%s track_id=%d no_person 慢重审判到人 → 回 pending 重识别",
                     self.cam_id, result.track_id,

--- a/backend/miloco/src/miloco/perception/engine/identity/state.py
+++ b/backend/miloco/src/miloco/perception/engine/identity/state.py
@@ -17,7 +17,7 @@ import time
 from dataclasses import dataclass
 from typing import Literal
 
-TrackStatus = Literal["none", "pending", "confirmed", "unknown"]
+TrackStatus = Literal["none", "pending", "confirmed", "unknown", "no_person"]
 
 
 # =============================================================================
@@ -92,6 +92,12 @@ class TrackIdentityState:
     # 退回后经过的重审窗数; 达 flip_sticky_max_recheck 仍未 commit → engine 放手(置上面 False)。
     flip_recheck_count: int = 0
 
+    # ----- no_person（非人误检抑制）-----
+    # 连续命中 omni "no_person"（框内确无人）的票数; 达 vote_threshold 落定 status=no_person。
+    no_person_vote_count: int = 0
+    # 落定 no_person 时该 track 的锚点 bbox(xyxy); 后续帧据此判"明显移动"→回 pending 重新识别。
+    no_person_anchor_bbox: tuple[int, int, int, int] | None = None
+
 
 # =============================================================================
 # 状态机操作（纯函数）
@@ -135,6 +141,77 @@ def promote_to_pending(state: TrackIdentityState, now_ts: float | None = None) -
         return
     state.status = "pending"
     state.pending_started_ts = now_ts if now_ts is not None else time.time()
+
+
+def record_no_person(
+    state: TrackIdentityState,
+    *,
+    anchor_bbox: tuple[int, int, int, int] | None,
+    vote_threshold: int,
+) -> bool:
+    """omni 判该框"无人"（no_person）时累计票数；连续达 ``vote_threshold`` 则落定 no_person 状态。
+
+    仅对**未确认成员**的 track 生效（none / pending / unknown）：confirmed 成员不因 no_person
+    票翻转（视为弃权，防把背对 / 遮挡的真本人误掉），返回 False 不计票。已是 no_person 的
+    track 不重复落定。落定时清空身份字段（candidate / committed / unknown_index）并记锚点 bbox。
+
+    Returns:
+        True 仅当本次调用使状态落定到 ``no_person``。
+    """
+    state.inflight = False  # 任务回流，清 inflight
+    if state.status in ("confirmed", "no_person"):
+        return False
+    state.no_person_vote_count += 1
+    if state.no_person_vote_count < vote_threshold:
+        return False
+    state.status = "no_person"
+    state.no_person_anchor_bbox = anchor_bbox
+    state.candidate_person_id = None
+    state.committed_person_id = None
+    state.unknown_index = None
+    state.stability_count = 0
+    state.best_conf = 0.0
+    return True
+
+
+def _bbox_moved(
+    anchor: tuple[int, int, int, int],
+    cur: tuple[int, int, int, int],
+    displacement_ratio: float,
+    min_abs_px: float,
+) -> bool:
+    """中心位移同时满足"≥ min_abs_px"且"≥ ratio×锚点对角线"才算明显移动。"""
+    ax1, ay1, ax2, ay2 = anchor
+    cx1, cy1, cx2, cy2 = cur
+    disp = (((ax1 + ax2) - (cx1 + cx2)) ** 2 + ((ay1 + ay2) - (cy1 + cy2)) ** 2) ** 0.5 / 2.0
+    diag = ((ax2 - ax1) ** 2 + (ay2 - ay1) ** 2) ** 0.5
+    return disp >= min_abs_px and disp >= displacement_ratio * diag
+
+
+def clear_no_person_on_motion(
+    state: TrackIdentityState,
+    current_bbox: tuple[int, int, int, int] | None,
+    displacement_ratio: float,
+    min_abs_px: float,
+) -> bool:
+    """no_person track 相对锚点 bbox 明显移动 → 回 pending 重新识别。
+
+    处理"误检框被路过的真人 ID-switch 带走"：静态误检框不动、维持 no_person；一旦框开始
+    随真人移动，立即解除抑制、重新走识别。返回 True 表示本次解除。
+    """
+    if (
+        state.status != "no_person"
+        or state.no_person_anchor_bbox is None
+        or current_bbox is None
+    ):
+        return False
+    if not _bbox_moved(state.no_person_anchor_bbox, current_bbox, displacement_ratio, min_abs_px):
+        return False
+    state.status = "pending"
+    state.no_person_vote_count = 0
+    state.no_person_anchor_bbox = None
+    state.pending_started_ts = time.time()
+    return True
 
 
 def update_evidence(
@@ -374,6 +451,9 @@ def needs_omni_call(
     if state.status == "none":
         # 还没 promote 到 pending；等 SortTracker 把它 confirmed 上来才会 call promote_to_pending
         return False
+    if state.status == "no_person":
+        # 已落定非人误检：不再派发 omni（停止对幻影框的重复识别）。移动解除走 engine 侧 motion check。
+        return False
     if state.inflight:
         return False
     if state.status == "pending":
@@ -445,6 +525,9 @@ def get_face_id_value(
         - "unknown"                                       unknown + distinguish=false
     """
     if state.status == "none":
+        return "none"
+    if state.status == "no_person":
+        # 非人误检：身份不导出（不进名册、不当待识别人物），等同"此处没人"。
         return "none"
     if state.status == "pending":
         # 翻转黏旧名: 由 confirmed 退回的 pending 显示保持旧成员名, 翻转期不闪 unknown。

--- a/backend/miloco/src/miloco/perception/engine/identity/state.py
+++ b/backend/miloco/src/miloco/perception/engine/identity/state.py
@@ -214,6 +214,20 @@ def clear_no_person_on_motion(
     return True
 
 
+def clear_no_person_to_pending(state: TrackIdentityState, now_ts: float | None = None) -> None:
+    """no_person track 被慢重审判到"人"（收到非 no_person 的 omni 结果）→ 回 pending 重新识别。
+
+    与 ``clear_no_person_on_motion`` 并列的第二条解除通道：那条靠"框移动"（会动的真人），这条
+    靠"重审真看到人"（一动不动、只能靠 ``needs_omni_call`` 慢周期重审兜底的真人）。转 pending 后
+    needs_omni_call 对 pending 走"下窗即派"，几秒内即可重新 commit 出去；真静止误检物体每次重审
+    仍判 no_person、走不到这里，故不会因此复发"陌生人"幻觉。
+    """
+    state.status = "pending"
+    state.no_person_vote_count = 0
+    state.no_person_anchor_bbox = None
+    state.pending_started_ts = now_ts if now_ts is not None else time.time()
+
+
 def update_evidence(
     state: TrackIdentityState,
     candidate_person_id: str | None,
@@ -429,6 +443,7 @@ def needs_omni_call(
     min_dispatch_interval_sec: float,
     config: StabilityConfig,
     engine_fps: float,
+    no_person_recheck_sec: float = 1200.0,
 ) -> bool:
     """判断该 track 是否需要派发新的 omni 识别任务。
 
@@ -452,8 +467,19 @@ def needs_omni_call(
         # 还没 promote 到 pending；等 SortTracker 把它 confirmed 上来才会 call promote_to_pending
         return False
     if state.status == "no_person":
-        # 已落定非人误检：不再派发 omni（停止对幻影框的重复识别）。移动解除走 engine 侧 motion check。
-        return False
+        # 已落定非人误检：默认停派发（不重复问 omni 幻影框）。但每 no_person_recheck_sec 放行一次
+        # 慢重审——"任何状态都不会被永久卡死"的最后兜底，兜极少数"未注册真人一动不动被连判两票
+        # 误压、又不触发移动解除"的残留（会动的人由 engine 侧 motion check 即时解除；急性摔倒 /
+        # 倒地动作由上游事件检测捕获、不依赖此状态，故周期放得很长）。重审判到人即回 pending
+        # （见 _on_result → clear_no_person_to_pending）。
+        if state.inflight:
+            return False
+        if state.last_omni_call_frame == 0:
+            # reject_region 预标的 track（从未真正派过 omni）不参与时间重审：其解除靠移动 /
+            # 真人覆盖 / 区域 TTL；否则流跑久后 now_frame 一上来就 ≥ 周期而立即误派。
+            return False
+        interval = max(1, round(no_person_recheck_sec * engine_fps))
+        return (now_frame - state.last_omni_call_frame) >= interval
     if state.inflight:
         return False
     if state.status == "pending":

--- a/backend/miloco/src/miloco/perception/engine/omni/field_registry.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/field_registry.py
@@ -50,9 +50,9 @@ class FieldSpec:
 
 IDENTITY = FieldSpec(
     name="identities",
-    schema_literal='"identities":[{"track_id":<int>,"name":"<姓名|unknown>","confidence":0-1,"reason":"≤20字"}]',
+    schema_literal='"identities":[{"track_id":<int>,"name":"<姓名|unknown|no_person>","confidence":0-1,"reason":"≤20字"}]',
     spec_md="""## identities
-- 覆盖"待识别 track"所有 track_id，不遗漏不新增；匹配上 <gallery> 成员填其 name，否则填 "unknown"
+- 覆盖"待识别 track"所有 track_id，不遗漏不新增。name 三选一：对上 <gallery> 成员→填其 name；确有人但认不出→填 "unknown"；框内根本不是人（非人物体被误检成人）→填 "no_person"
 - 先定 name 与 confidence，再用 reason（≤20字）简述所靠特征（面部/发型/体型）；reason 是对已定结论的事后交代，不得先编"吻合"叙事把自己说服进匹配
 
 - 待识别 track（无论首次出现还是系统重核）一律只凭 <gallery> 独立判断、不沿用任何旧结论
@@ -69,7 +69,7 @@ IDENTITY = FieldSpec(
 
 - 按「区分度」判置信，不按「有无脸」硬归类——决定 confidence 的不是「看不看得到脸」，而是「能否在 <gallery> 其他成员里把这人独一无二地认出来」：高(≥0.85)=清晰人脸明显吻合，或独特外观组合(身型+发型)吻合『且不与库中其他成员混淆』；中(0.65–0.85)=多项外观线索倾向该成员，但人脸不清晰、『无法完全排除其他相似成员』；低(<0.65)=仅泛化相似（同性别/同发色/相近体型等，库中其他成员也可能符合）→ 倾向 unknown
 - confidence = 对本次判断的把握，判成员或判 unknown 都按"有多确定"打分，与 name 取值无关
-- 退化框兜底：框内明显无人 / 严重模糊不可分辨 → unknown（宁可漏认不可错认）""",
+- no_person vs unknown：框内没有真实人体、只是家中非人物体被误框（如 3D 打印机、落地扇、衣帽架或搭挂/晾晒的衣物、落地绿植、纸箱行李堆 等外形易被误当成人的物体）→ "no_person"，纵使轮廓像人；确有人体（哪怕背影/侧身/局部/遮挡/模糊）→ "unknown"；分不清是人还是物时才倾向 unknown（别把真人误判成没人）""",
     requires_video=True,
     requires_identity=True,
 )
@@ -80,6 +80,7 @@ CAPTION = FieldSpec(
     spec_md="""## caption
 - 如实描述本轮画面所见，优先动态部分：①人、宠物的状态和正在做的事（含手持物）②物品移动（从哪移到哪）③设备运行（电视播放、风扇运转等）④环境异常（冒烟、起火、漏水、液体外溢等）
 - ≤100 字；不用规则措辞、不因规则夸大
+- 待识别 track 若 identities 判为 no_person（框内确无人）→ caption 不据该框描述任何人物或动作，当作此处没人；仅 identities 判 unknown 才写"陌生人 / 某人"；名册里的"陌生人"若本轮画面没真正看到，也别写进 caption（仅限陌生人，成员不受限）
 - 涉及人物只用本轮 identities 判出的姓名；identities 没识别出该人（判 unknown / 没给出）→ 写"陌生人 / 某人"，不写"一人"这类泛称，不要从 gallery 或家庭档案里取成员名安到没被识别出的人身上
 - 物体类别拿不准时退到上位概念（"细长物体" / "手中持有物体" / "桌面有物品"），不对不确定物体硬落具体类别（"水杯" / "手机" / "食物"）——宁可粗不可错""",
     requires_video=True,

--- a/backend/miloco/src/miloco/perception/engine/omni/response_parser.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/response_parser.py
@@ -53,7 +53,7 @@ def parse_identity_assignments(
     """fused 主调用 response 中 ``identity_assignments`` 字段的抽取 + 校验。
 
     fused 模式下 omni 主调用 response JSON 多一个 ``identity_assignments`` 字段：
-        [{"track_id":<int>, "name":"<姓名|unknown>", "confidence":0~1, "reason":"..."}]
+        [{"track_id":<int>, "name":"<姓名|unknown|no_person>", "confidence":0~1, "reason":"..."}]
 
     Args:
         raw:               omni 完整响应（dict）或累积的 streaming text（str）
@@ -137,12 +137,15 @@ def _parse_identity_assignments(
         # （match: unknown / unknown_<digit/track_id> / unknown_xxx / unknown-<scope>-<n>）
         lower = raw_name_str.lower()
         is_unknown_n = lower.startswith("unknown_") or lower.startswith("unknown-")
+        # no_person：omni 判该框内确无人（非人误检），区别于 unknown（有人但认不出）。
+        # 不走 gallery 反查、不打"不在 gallery"warning；person_id 记 None，下游靠 no_person 标志分流。
+        is_no_person = lower == "no_person"
         if is_unknown_n and not distinguish:
             logger.info("distinguish=false 但收到 %r，规范化为 'unknown'", raw_name_str)
             raw_name_str = "unknown"
 
-        # unknown / Unknown / UNKNOWN / unknown_<n> 等 → person_id=None
-        if raw_name_str.lower() == "unknown" or is_unknown_n:
+        # no_person / unknown / unknown_<n> 等 → person_id=None
+        if is_no_person or raw_name_str.lower() == "unknown" or is_unknown_n:
             person_id: str | None = None
         else:
             # 反查
@@ -182,6 +185,7 @@ def _parse_identity_assignments(
             "confidence": conf,
             "reason": reason,
             "raw_name": raw_name_str,
+            "no_person": is_no_person,
         })
     return out
 

--- a/backend/miloco/src/miloco/perception/engine/omni/response_parser.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/response_parser.py
@@ -139,7 +139,11 @@ def _parse_identity_assignments(
         is_unknown_n = lower.startswith("unknown_") or lower.startswith("unknown-")
         # no_person：omni 判该框内确无人（非人误检），区别于 unknown（有人但认不出）。
         # 不走 gallery 反查、不打"不在 gallery"warning；person_id 记 None，下游靠 no_person 标志分流。
-        is_no_person = lower == "no_person"
+        # 与 unknown 同口径放宽匹配：容忍附注 / 大小写 / 空格 / 连字符变体（omni 有回显完整标签的
+        # 习惯，如 "no_person（3D打印机）" / "no person"），避免格式抖动时静默退化成 unknown，
+        # 把本该抑制的误检框又当"陌生人"描述（即 no_person 要修的老 bug 回归）。
+        normalized = re.sub(r"[\s\-]+", "_", lower).strip("_")
+        is_no_person = normalized.startswith("no_person")
         if is_unknown_n and not distinguish:
             logger.info("distinguish=false 但收到 %r，规范化为 'unknown'", raw_name_str)
             raw_name_str = "unknown"

--- a/backend/miloco/tests/perception/engine/identity/test_no_person.py
+++ b/backend/miloco/tests/perception/engine/identity/test_no_person.py
@@ -1,0 +1,209 @@
+"""no_person（非人误检抑制）单测。
+
+覆盖三层：
+  - 解析层：``parse_identity_assignments`` 把 omni name="no_person" 标成 no_person=True，
+    区别于 unknown（有人但认不出）。
+  - 状态机：``record_no_person`` 连续 2 票才落定、confirmed 成员不被翻；落定后
+    ``needs_omni_call``→False、``get_face_id_value``→"none"。
+  - 移动解除：``clear_no_person_on_motion`` 静止维持、明显移动回 pending。
+"""
+
+from __future__ import annotations
+
+import json
+
+from miloco.perception.engine.config import IdentityEngineConfig, StabilityConfigDC
+from miloco.perception.engine.identity.engine import IdentityEngine, _bbox_iou
+from miloco.perception.engine.identity.state import (
+    TrackIdentityState,
+    clear_no_person_on_motion,
+    get_face_id_value,
+    needs_omni_call,
+    record_no_person,
+)
+from miloco.perception.engine.omni.response_parser import parse_identity_assignments
+
+
+def _resp(identities: list[dict]) -> str:
+    return json.dumps({"identities": identities})
+
+
+class TestParseNoPerson:
+    def test_no_person_flagged_and_not_a_person(self):
+        out = parse_identity_assignments(
+            _resp([{"track_id": 7, "name": "no_person", "confidence": 0.9, "reason": "空框"}]),
+            prompt_track_ids={7},
+        )
+        assert len(out) == 1
+        assert out[0]["no_person"] is True
+        # no_person 不是身份 → person_id 归 "unknown"（下游靠 no_person 标志分流，不当成员）
+        assert out[0]["person_id"] == "unknown"
+
+    def test_unknown_is_not_no_person(self):
+        out = parse_identity_assignments(
+            _resp([{"track_id": 7, "name": "unknown", "confidence": 0.9}]),
+            prompt_track_ids={7},
+        )
+        assert out[0]["no_person"] is False
+        assert out[0]["person_id"] == "unknown"
+
+    def test_named_member_is_not_no_person(self):
+        out = parse_identity_assignments(
+            _resp([{"track_id": 7, "name": "张三", "confidence": 0.95}]),
+            name_to_pid={"张三": "pid-zhang"},
+            prompt_track_ids={7},
+        )
+        assert out[0]["no_person"] is False
+        assert out[0]["person_id"] == "pid-zhang"
+
+
+class TestRecordNoPerson:
+    def test_two_votes_to_commit(self):
+        state = TrackIdentityState(track_id=1, status="pending")
+        assert record_no_person(state, anchor_bbox=(10, 10, 50, 90), vote_threshold=2) is False
+        assert state.status == "pending"
+        assert state.no_person_vote_count == 1
+        committed = record_no_person(state, anchor_bbox=(10, 10, 50, 90), vote_threshold=2)
+        assert committed is True
+        assert state.status == "no_person"
+        assert state.no_person_anchor_bbox == (10, 10, 50, 90)
+
+    def test_confirmed_member_not_flipped(self):
+        state = TrackIdentityState(
+            track_id=1, status="confirmed", committed_person_id="pid-x",
+        )
+        for _ in range(3):
+            assert record_no_person(state, anchor_bbox=(0, 0, 1, 1), vote_threshold=2) is False
+        assert state.status == "confirmed"
+        assert state.committed_person_id == "pid-x"
+        assert state.no_person_vote_count == 0
+
+    def test_commit_clears_identity_fields(self):
+        state = TrackIdentityState(
+            track_id=1, status="unknown", unknown_index=3,
+            candidate_person_id="pid-y", committed_person_id="pid-y",
+        )
+        record_no_person(state, anchor_bbox=(5, 5, 25, 65), vote_threshold=1)
+        assert state.status == "no_person"
+        assert state.unknown_index is None
+        assert state.candidate_person_id is None
+        assert state.committed_person_id is None
+
+
+class TestNoPersonGates:
+    def test_needs_omni_call_false(self):
+        state = TrackIdentityState(track_id=1, status="no_person")
+        assert needs_omni_call(
+            state, now_frame=100, now_ts=100.0, min_dispatch_interval_sec=5.0,
+            config=StabilityConfigDC(), engine_fps=3,
+        ) is False
+
+    def test_face_id_value_none(self):
+        state = TrackIdentityState(track_id=1, status="no_person")
+        assert get_face_id_value(state, distinguish=False) == "none"
+
+
+class TestClearNoPersonOnMotion:
+    def test_static_keeps_no_person(self):
+        state = TrackIdentityState(
+            track_id=1, status="no_person", no_person_anchor_bbox=(100, 100, 200, 300),
+        )
+        # 抖动级位移（几像素）→ 不解除
+        moved = clear_no_person_on_motion(
+            state, (102, 101, 202, 301), displacement_ratio=0.15, min_abs_px=30.0,
+        )
+        assert moved is False
+        assert state.status == "no_person"
+
+    def test_clear_motion_back_to_pending(self):
+        state = TrackIdentityState(
+            track_id=1, status="no_person", no_person_anchor_bbox=(100, 100, 200, 300),
+        )
+        # 整框平移到远处（中心位移远超阈值）→ 解除回 pending 重新识别
+        moved = clear_no_person_on_motion(
+            state, (500, 500, 600, 700), displacement_ratio=0.15, min_abs_px=30.0,
+        )
+        assert moved is True
+        assert state.status == "pending"
+        assert state.no_person_vote_count == 0
+        assert state.no_person_anchor_bbox is None
+
+
+def _reject_engine(*, reject_enabled: bool = True, clear_iou: float = 0.3) -> IdentityEngine:
+    """构造仅含 _apply_reject_regions 所需属性的轻量 engine（绕过 __init__）。"""
+    eng = IdentityEngine.__new__(IdentityEngine)
+    cfg = IdentityEngineConfig()
+    cfg.no_person.enabled = True
+    cfg.no_person.reject_region_enabled = reject_enabled
+    cfg.no_person.reject_region_clear_iou = clear_iou
+    eng.config = cfg
+    eng.cam_id = "camA"
+    eng._states = {}
+    eng._latest_bbox = {}
+    eng._detected_this_frame = {}
+    eng._no_person_regions = []
+    return eng
+
+
+_FAR_FUTURE = 9_999_999_999.0  # 远未来 expiry，确保 TTL 不在测试中过期
+
+
+class TestBboxIou:
+    def test_identical(self):
+        assert _bbox_iou((0, 0, 10, 10), (0, 0, 10, 10)) == 1.0
+
+    def test_disjoint(self):
+        assert _bbox_iou((0, 0, 10, 10), (100, 100, 110, 110)) == 0.0
+
+    def test_half_overlap(self):
+        # inter = 5×10 = 50; union = 100 + 100 − 50 = 150
+        assert abs(_bbox_iou((0, 0, 10, 10), (5, 0, 15, 10)) - 50 / 150) < 1e-9
+
+
+class TestRejectRegion:
+    def test_premark_new_track_in_region(self):
+        eng = _reject_engine()
+        eng._no_person_regions = [((100, 100, 200, 300), _FAR_FUTURE)]
+        st = TrackIdentityState(track_id=5, status="pending")  # 全新: last_omni_call_frame=0, vote=0
+        eng._states[5] = st
+        eng._latest_bbox[5] = (100, 100, 200, 300)
+        eng._detected_this_frame[5] = True
+        eng._apply_reject_regions({5}, now_ts=1000.0)
+        assert st.status == "no_person"
+        assert st.no_person_anchor_bbox == (100, 100, 200, 300)
+
+    def test_disabled_skips_premark(self):
+        eng = _reject_engine(reject_enabled=False)
+        eng._no_person_regions = [((100, 100, 200, 300), _FAR_FUTURE)]
+        st = TrackIdentityState(track_id=5, status="pending")
+        eng._states[5] = st
+        eng._latest_bbox[5] = (100, 100, 200, 300)
+        eng._detected_this_frame[5] = True
+        eng._apply_reject_regions({5}, now_ts=1000.0)
+        assert st.status == "pending"
+
+    def test_already_dispatched_track_not_premarked(self):
+        eng = _reject_engine()
+        eng._no_person_regions = [((100, 100, 200, 300), _FAR_FUTURE)]
+        st = TrackIdentityState(track_id=5, status="pending", last_omni_call_frame=42)
+        eng._states[5] = st
+        eng._latest_bbox[5] = (100, 100, 200, 300)
+        eng._detected_this_frame[5] = True
+        eng._apply_reject_regions({5}, now_ts=1000.0)
+        assert st.status == "pending"  # 非全新 → 不预标
+
+    def test_confirmed_track_disarms_region(self):
+        eng = _reject_engine()
+        eng._no_person_regions = [((100, 100, 200, 300), _FAR_FUTURE)]
+        st = TrackIdentityState(track_id=9, status="confirmed", committed_person_id="pid")
+        eng._states[9] = st
+        eng._latest_bbox[9] = (100, 100, 200, 300)
+        eng._detected_this_frame[9] = True
+        eng._apply_reject_regions({9}, now_ts=1000.0)
+        assert eng._no_person_regions == []  # 真人覆盖 → 区域解除
+
+    def test_ttl_expiry_drops_region(self):
+        eng = _reject_engine()
+        eng._no_person_regions = [((100, 100, 200, 300), 500.0)]  # 已过期(< now 1000)
+        eng._apply_reject_regions(set(), now_ts=1000.0)
+        assert eng._no_person_regions == []

--- a/backend/miloco/tests/perception/engine/identity/test_no_person.py
+++ b/backend/miloco/tests/perception/engine/identity/test_no_person.py
@@ -1,22 +1,27 @@
 """no_person（非人误检抑制）单测。
 
-覆盖三层：
+覆盖：
   - 解析层：``parse_identity_assignments`` 把 omni name="no_person" 标成 no_person=True，
-    区别于 unknown（有人但认不出）。
+    区别于 unknown（有人但认不出）；且与 unknown 同口径放宽匹配（附注 / 空格 / 连字符变体）。
   - 状态机：``record_no_person`` 连续 2 票才落定、confirmed 成员不被翻；落定后
-    ``needs_omni_call``→False、``get_face_id_value``→"none"。
-  - 移动解除：``clear_no_person_on_motion`` 静止维持、明显移动回 pending。
+    ``get_face_id_value``→"none"。
+  - 三重解除通道：① 多票；② ``clear_no_person_on_motion`` 明显移动回 pending；
+    ③ ``needs_omni_call`` 慢周期重审 + ``clear_no_person_to_pending`` 判到人回 pending。
+  - 编排层：``_make_on_result`` 的投票清零 / confirmed 早退不误伤 / 慢重审回 pending。
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
 
 from miloco.perception.engine.config import IdentityEngineConfig, StabilityConfigDC
+from miloco.perception.engine.identity.dispatcher import OmniIdentityResult
 from miloco.perception.engine.identity.engine import IdentityEngine, _bbox_iou
 from miloco.perception.engine.identity.state import (
     TrackIdentityState,
     clear_no_person_on_motion,
+    clear_no_person_to_pending,
     get_face_id_value,
     needs_omni_call,
     record_no_person,
@@ -56,6 +61,15 @@ class TestParseNoPerson:
         assert out[0]["no_person"] is False
         assert out[0]["person_id"] == "pid-zhang"
 
+    def test_no_person_variants_still_flagged(self):
+        """omni 回显变体（附注 / 空格 / 连字符 / 大小写）仍判 no_person，不静默退化成 unknown。"""
+        for name in ("no_person（3D打印机）", "No Person", "no-person", "NO_PERSON."):
+            out = parse_identity_assignments(
+                _resp([{"track_id": 7, "name": name, "confidence": 0.9}]),
+                prompt_track_ids={7},
+            )
+            assert out[0]["no_person"] is True, name
+
 
 class TestRecordNoPerson:
     def test_two_votes_to_commit(self):
@@ -91,12 +105,28 @@ class TestRecordNoPerson:
 
 
 class TestNoPersonGates:
-    def test_needs_omni_call_false(self):
-        state = TrackIdentityState(track_id=1, status="no_person")
+    def test_premarked_never_rechecks(self):
+        """reject_region 预标（从未派过 omni，last_omni_call_frame==0）→ 永不时间重审，
+        即便 now_frame 已很大（避免流跑久后一上来就 ≥ 周期而立即误派）。"""
+        state = TrackIdentityState(track_id=1, status="no_person")  # last_omni_call_frame=0
         assert needs_omni_call(
-            state, now_frame=100, now_ts=100.0, min_dispatch_interval_sec=5.0,
-            config=StabilityConfigDC(), engine_fps=3,
+            state, now_frame=10_000, now_ts=0.0, min_dispatch_interval_sec=5.0,
+            config=StabilityConfigDC(), engine_fps=3, no_person_recheck_sec=10.0,
         ) is False
+
+    def test_recheck_fires_after_period(self):
+        """落定 no_person（曾派发，last_omni_call_frame>0）→ 距上次派发满周期才放行慢重审。"""
+        state = TrackIdentityState(track_id=1, status="no_person", last_omni_call_frame=100)
+        # no_person_recheck_sec=10s × fps=3 → interval=30 帧
+        assert needs_omni_call(state, 100 + 29, 0.0, 5.0, StabilityConfigDC(), 3, 10.0) is False
+        assert needs_omni_call(state, 100 + 30, 0.0, 5.0, StabilityConfigDC(), 3, 10.0) is True
+
+    def test_inflight_blocks_recheck(self):
+        """重审在途（inflight）→ 即便已过周期也不重复派。"""
+        state = TrackIdentityState(
+            track_id=1, status="no_person", last_omni_call_frame=100, inflight=True,
+        )
+        assert needs_omni_call(state, 100 + 999, 0.0, 5.0, StabilityConfigDC(), 3, 10.0) is False
 
     def test_face_id_value_none(self):
         state = TrackIdentityState(track_id=1, status="no_person")
@@ -207,3 +237,84 @@ class TestRejectRegion:
         eng._no_person_regions = [((100, 100, 200, 300), 500.0)]  # 已过期(< now 1000)
         eng._apply_reject_regions(set(), now_ts=1000.0)
         assert eng._no_person_regions == []
+
+
+class TestClearNoPersonToPending:
+    def test_recheck_saw_person_back_to_pending(self):
+        """慢重审判到人 → 回 pending、清票 / 锚点、重置 pending 起始时间。"""
+        state = TrackIdentityState(
+            track_id=1, status="no_person",
+            no_person_vote_count=2, no_person_anchor_bbox=(10, 10, 50, 90),
+        )
+        clear_no_person_to_pending(state, now_ts=1234.0)
+        assert state.status == "pending"
+        assert state.no_person_vote_count == 0
+        assert state.no_person_anchor_bbox is None
+        assert state.pending_started_ts == 1234.0
+
+
+def _on_result_engine() -> IdentityEngine:
+    """构造仅含 _make_on_result 所需属性的轻量 engine（绕过 __init__）。"""
+    eng = IdentityEngine.__new__(IdentityEngine)
+    cfg = IdentityEngineConfig()
+    cfg.no_person.enabled = True
+    eng.config = cfg
+    eng.cam_id = "camA"
+    eng._states = {}
+    eng._latest_bbox = {}
+    eng.tier_u_pool = None
+    return eng
+
+
+def _run_on_result(
+    eng: IdentityEngine, result: OmniIdentityResult, *, now_ts: float = 1000.0,
+) -> None:
+    asyncio.run(eng._make_on_result(now_ts=now_ts)(result))
+
+
+class TestOnResultOrchestration:
+    """驱动 _make_on_result 闭包，回归"投票清零 / confirmed 早退 / 慢重审回 pending"的编排。"""
+
+    def test_non_no_person_result_clears_vote(self):
+        """投一票 no_person 后来一次"有人"结果 → 票清 0（连续性中断），仍 pending。"""
+        eng = _on_result_engine()
+        st = TrackIdentityState(track_id=1, status="pending", no_person_vote_count=1)
+        eng._states[1] = st
+        _run_on_result(eng, OmniIdentityResult(
+            track_id=1, person_id=None, confidence=0.6, no_person=False,
+        ))
+        assert st.no_person_vote_count == 0
+        assert st.status == "pending"
+
+    def test_confirmed_member_no_person_early_return(self):
+        """confirmed 成员连投 3 次 no_person → 仍 confirmed、committed 不变、写库连续计数清 0。"""
+        eng = _on_result_engine()
+        st = TrackIdentityState(
+            track_id=1, status="confirmed", committed_person_id="pid-x",
+            write_eligible_count=5,
+        )
+        eng._states[1] = st
+        for _ in range(3):
+            _run_on_result(eng, OmniIdentityResult(
+                track_id=1, person_id=None, confidence=0.9, no_person=True,
+            ))
+        assert st.status == "confirmed"
+        assert st.committed_person_id == "pid-x"
+        assert st.write_eligible_count == 0      # 🔵-2：弃权口径打断 tier_c 写库连续段
+        assert st.no_person_vote_count == 0      # confirmed 不计 no_person 票
+
+    def test_committed_no_person_recovers_on_person(self):
+        """落定 no_person 的 track 被慢重审判到人 → 回 pending（自愈通道 ③，端到端走 _on_result）。"""
+        eng = _on_result_engine()
+        st = TrackIdentityState(
+            track_id=1, status="no_person",
+            no_person_vote_count=2, no_person_anchor_bbox=(10, 10, 50, 90),
+            last_omni_call_frame=100,
+        )
+        eng._states[1] = st
+        _run_on_result(eng, OmniIdentityResult(
+            track_id=1, person_id=None, confidence=0.6, no_person=False,
+        ))
+        assert st.status == "pending"
+        assert st.no_person_anchor_bbox is None
+        assert st.no_person_vote_count == 0

--- a/backend/miloco/tests/perception/engine/identity/test_no_person.py
+++ b/backend/miloco/tests/perception/engine/identity/test_no_person.py
@@ -16,7 +16,11 @@ import asyncio
 import json
 
 from miloco.perception.engine.config import IdentityEngineConfig, StabilityConfigDC
-from miloco.perception.engine.identity.dispatcher import OmniIdentityResult
+from miloco.perception.engine.identity.dispatcher import (
+    FusedDispatcher,
+    IdentityQueryItem,
+    OmniIdentityResult,
+)
 from miloco.perception.engine.identity.engine import IdentityEngine, _bbox_iou
 from miloco.perception.engine.identity.state import (
     TrackIdentityState,
@@ -304,7 +308,8 @@ class TestOnResultOrchestration:
         assert st.no_person_vote_count == 0      # confirmed 不计 no_person 票
 
     def test_committed_no_person_recovers_on_person(self):
-        """落定 no_person 的 track 被慢重审判到人 → 回 pending（自愈通道 ③，端到端走 _on_result）。"""
+        """落定 no_person 被慢重审"真判到人"（omni_answered=True 的 unknown）→ 回 pending
+        （自愈通道 ③，端到端走 _on_result）。person_id=None 也算——真·未注册人正是要恢复的场景。"""
         eng = _on_result_engine()
         st = TrackIdentityState(
             track_id=1, status="no_person",
@@ -313,8 +318,80 @@ class TestOnResultOrchestration:
         )
         eng._states[1] = st
         _run_on_result(eng, OmniIdentityResult(
-            track_id=1, person_id=None, confidence=0.6, no_person=False,
+            track_id=1, person_id=None, confidence=0.6, no_person=False,  # omni_answered 默认 True
         ))
         assert st.status == "pending"
         assert st.no_person_anchor_bbox is None
         assert st.no_person_vote_count == 0
+        # 本窗这条真判定被当作 pending 第一票**立即消费**（刻意不 return）——锁定该有意行为
+        assert st.stability_count == 1
+
+    def test_committed_no_person_high_conf_member_single_window_recover(self):
+        """落定 no_person 被慢重审"高置信认出成员"→ 本窗即 commit-to-confirmed（证第一票被消费、单窗恢复）。"""
+        eng = _on_result_engine()
+        st = TrackIdentityState(
+            track_id=1, status="no_person",
+            no_person_anchor_bbox=(10, 10, 50, 90), last_omni_call_frame=100,
+        )
+        eng._states[1] = st
+        _run_on_result(eng, OmniIdentityResult(
+            track_id=1, person_id="pid-x", confidence=0.95, no_person=False,
+        ))
+        assert st.status == "confirmed"
+        assert st.committed_person_id == "pid-x"
+
+    def test_committed_no_person_holds_on_omni_nonanswer(self):
+        """慢重审窗 omni 漏报 / 整体失败（omni_answered=False，合成非答复）→ 维持 no_person、
+        不被误当"判到人"解除；只清 inflight 让下周期可再重审。防"一次 omni 抖动掀翻抑制"。"""
+        eng = _on_result_engine()
+        st = TrackIdentityState(
+            track_id=1, status="no_person",
+            no_person_anchor_bbox=(10, 10, 50, 90), last_omni_call_frame=100, inflight=True,
+        )
+        eng._states[1] = st
+        _run_on_result(eng, OmniIdentityResult(
+            track_id=1, person_id=None, confidence=0.0,
+            reason="fused_response_missing_track", omni_answered=False,
+        ))
+        assert st.status == "no_person"                    # 未被误解除
+        assert st.no_person_anchor_bbox == (10, 10, 50, 90)
+        assert st.inflight is False                        # 清 inflight，下周期可再慢重审
+
+
+class TestDispatcherNonAnswerFlag:
+    """锁定契约：omni 漏报 / 整体失败合成的结果 omni_answered=False；真实 assignment 为 True。
+    no_person 慢重审恢复通道据此区分"判到人"与"没答/失败"，避免一次抖动掀翻抑制。"""
+
+    @staticmethod
+    def _drive(deliver) -> list[OmniIdentityResult]:
+        captured: list[OmniIdentityResult] = []
+
+        async def _cap(r: OmniIdentityResult) -> None:
+            captured.append(r)
+
+        async def _run() -> None:
+            disp = FusedDispatcher()
+            await disp.dispatch([IdentityQueryItem(track_id=1)], {}, _cap)
+            await deliver(disp)
+
+        asyncio.run(_run())
+        return captured
+
+    def test_missing_track_marked_not_answered(self):
+        # response 里没有 track 1 → 漏报兜底
+        out = self._drive(lambda d: d.deliver_response([]))
+        assert len(out) == 1
+        assert out[0].omni_answered is False
+        assert out[0].no_person is False
+
+    def test_failure_marked_not_answered(self):
+        out = self._drive(lambda d: d.deliver_failure("boom"))
+        assert len(out) == 1
+        assert out[0].omni_answered is False
+
+    def test_real_assignment_is_answered(self):
+        out = self._drive(lambda d: d.deliver_response(
+            [{"track_id": 1, "person_id": None, "confidence": 0.7, "reason": "x"}]
+        ))
+        assert len(out) == 1
+        assert out[0].omni_answered is True


### PR DESCRIPTION
## 背景

现场无人时，人体检测偶发把静态物体/家具（如 3D 打印机、落地扇、衣帽架、搭挂的衣物、
落地绿植、纸箱行李堆等外形易被误当成人的物体）误检成人体框，形成 track 后注入多模态识别。
此时“画面描述”会据此脑补出“一名陌生人背对镜头站在……”之类的人物与动作，并随事件提醒
推送给用户，造成“现场无人却报告有人”的体验，用户反馈“恐怖”。

## 根因

人形误检是检测模型固有的一类问题、难以在源头彻底根除，因此关键不在于消灭误检，而在于
下游要有兜底；而当前这一路恰恰缺少兜底，误检框会一路走到多模态识别并被当作真人来描述：

- 画面描述字段缺少空框护栏：框内不认识的目标会被直接描述成“陌生人在做某事”。
- `unknown` 把“有人但认不出”与“根本没有人”混为一类，识别层没有表达“这个框不是人”的出口。

## 改动

- **识别输出区分“非人误检”与“有人认不出”**：新增独立于 `unknown` 的 `no_person`
  判定（框内确无真实人体、只是物体被误框；字段说明列举常见易误检物并提示“轮廓像人也算物”），
  同时约束“分不清是人还是物时一律按 unknown 处理”以保护召回；画面描述与人物名册对判为
  非人的框不再描述任何人物。
- **状态机消费该判定**：新增对应状态（`TrackStatus` 新增 `no_person` 状态），连续多票才
  落定（防单次误判掉真人）；落定后停止重复识别、身份不对外导出、不进陌生人聚类；该目标一旦
  相对锚点明显移动（疑似被路过真人顶替）即重新进入识别，避免把真人长期误压成无人。
- **补一条画面描述护栏**：人物名册中已列的“陌生人”若本轮画面未真正看到，不凭名册写进描述
  （仅限陌生人，不影响已识别成员）。
- **误检位置区域抑制（默认关闭）**：可选地把反复误检的屏幕区域登记为“禁新建跟踪区”，被真人
  覆盖或超时即失效；落在引擎侧、不改动 tracker，`reject_region_enabled` 默认关闭，需现场
  验证后再启用。

## 测试与验证

- 补充该能力专项单测；既有识别 / 多模态用例全部通过。
- 在身份识别测试集（约 743 例）上做了回归，主链路无性能退化；逐窗召回与误识还观察到小幅
  改善（非本次目标，附带说明）。
- 真实片段人工 A/B 复核：空场景中最易误检的物体（含 3D 打印机）能被判为非人、画面描述不再
  脑补人物；真人硬样本（背对、摔倒、躺下、低置信）以及真人正站在误检物体前的场景，均未被
  误判为无人（不会因物体所在位置而压制真人）。

## 兼容性与回滚

- 默认仅开启识别层区分 + 状态机消费；区域抑制默认关闭，可按需灰度。
- 对身份识别主链路无破坏，回滚只需还原本 PR 即可。