### PR TITLE
fix: consolidated duplicate httpx.AsyncClient implementations

### DIFF
--- a/backend/miloco/src/miloco/perception/engine/omni/omni.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/omni.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import re
 import time

--- a/backend/miloco/src/miloco/perception/engine/omni/omni.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/omni.py
@@ -9,6 +9,8 @@ from collections import Counter
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
+import httpx
+
 from miloco.database.token_usage_repo import fire_record
 from miloco.perception.engine.config import OmniConfig
 from miloco.perception.engine.omni.constants import MILOCO_USER_AGENT
@@ -256,6 +258,7 @@ async def _call_omni_messages(
                 "User-Agent": MILOCO_USER_AGENT,
             },
             json=body,
+            timeout=httpx.Timeout(config.timeout, connect=10.0),
         )
         if resp.status_code != 200:
             logger.error("[omni] omni API 调用失败，错误码=%d | %s", resp.status_code, resp.text[:500])

--- a/backend/miloco/src/miloco/perception/engine/omni/omni.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/omni.py
@@ -10,13 +10,12 @@ from collections import Counter
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
-import httpx
-
 from miloco.database.token_usage_repo import fire_record
 from miloco.perception.engine.config import OmniConfig
 from miloco.perception.engine.omni.constants import MILOCO_USER_AGENT
 from miloco.perception.engine.omni.omni_client import (
     OmniError,
+    _get_http_client,
     call_omni,
     call_omni_stream,
     extract_usage,
@@ -222,37 +221,6 @@ async def run_omni_fused(
             await identity_engine.deliver_fused_failure("run_omni_fused parse/deliver incomplete")
 
 
-# fused 模式共享 httpx.AsyncClient（连接池 + keepalive），避免每窗口一次 TLS 握手
-# （省 ~50-100ms 连接延迟）。
-#
-# AsyncClient 绑定到创建时所在的 event loop；当那个 loop 被关闭（测试用例
-# asyncio.run、CLI 一次性运行、FastAPI 重启等），cached client 后续使用会抛
-# "Event loop is closed"。所以这里按 loop 缓存：每个 loop 一个 client，loop
-# 不匹配（前一个 loop 已关闭）时重建。生产长跑场景下 loop 是稳定的同一个，
-# 与单 client 等价，没有性能损失。
-# 客户端不显式关闭（进程退出由 OS 回收）。
-# omni_client.py 的 non-fused 路径暂不复用（改动面更大），后续可统一。
-_fused_http_client: "httpx.AsyncClient | None" = None
-_fused_http_client_loop: "asyncio.AbstractEventLoop | None" = None
-
-
-def _get_fused_http_client(timeout: float) -> httpx.AsyncClient:
-    global _fused_http_client, _fused_http_client_loop
-    loop = asyncio.get_running_loop()
-    if (
-        _fused_http_client is None
-        or _fused_http_client_loop is not loop
-        or _fused_http_client.is_closed
-    ):
-        # 旧 client 绑定的 loop 已不可用——丢弃（GC 自然回收），新 loop 重建。
-        _fused_http_client = httpx.AsyncClient(
-            timeout=httpx.Timeout(timeout, connect=10.0),
-            limits=httpx.Limits(max_keepalive_connections=4, max_connections=8),
-        )
-        _fused_http_client_loop = loop
-    return _fused_http_client
-
-
 async def _call_omni_messages(
     messages: list[dict], config: OmniConfig, type: str = "realtime"
 ) -> dict[str, Any]:
@@ -276,7 +244,7 @@ async def _call_omni_messages(
         "thinking": {"type": "disabled"},
     }
 
-    client = _get_fused_http_client(config.timeout)
+    client = _get_http_client(config.timeout)
     t0 = time.monotonic()
     raw: dict[str, Any] | None = None
     error: dict[str, Any] | None = None

--- a/backend/miloco/src/miloco/perception/engine/omni/omni_client.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/omni_client.py
@@ -26,26 +26,23 @@ _ENV_KEY = "MILOCO_MODEL__OMNI__API_KEY"
 # 统一 omni_client.py 与 omni.py 中原本独立的两套客户端实现为一个共享
 # httpx.AsyncClient（池化 + keepalive），消除三个调用路径的重复代码与行为差异。
 # AsyncClient 绑定到创建时所在的 event loop；感知每窗 asyncio.run() 起新 loop，client 每窗重建。
-# 客户端不显式关闭（进程退出由 OS 回收）。
+# 三条路径均不做 per-call aclose（与原 fused 行为一致）：每窗临时 loop 关闭时回收其连接。
 _http_client: "httpx.AsyncClient | None" = None
-# _http_client_loop: CodeQL "is unused" alert is a false positive.
-# This is the sole trigger for rebuilding the client when the event loop
-# changes — removing it reuses a client bound to a dead loop and causes
-# "Event loop is closed". Do not delete.
+# 记录 client 绑定的 loop；loop 变更时用它触发重建（见 _get_http_client）。
 _http_client_loop: "asyncio.AbstractEventLoop | None" = None
 
 
 def _get_http_client(timeout: float) -> httpx.AsyncClient:
     global _http_client, _http_client_loop
     loop = asyncio.get_running_loop()
-    if (
-        _http_client is None
-        or _http_client_loop is not loop
-        or _http_client.is_closed
-    ):
+    # 无条件读 _http_client_loop（不藏在短路后），避免 CodeQL 把该读误判为 unused
+    loop_changed = _http_client_loop is not loop
+    if _http_client is None or loop_changed or _http_client.is_closed:
         _http_client = httpx.AsyncClient(
             timeout=httpx.Timeout(timeout, connect=10.0),
-            limits=httpx.Limits(max_keepalive_connections=4, max_connections=8),  # matches max camera count per window (≤1 omni call per camera via room batches)
+            # 假设单窗并发 omni（room×device 全 gather）≤ 相机数；若某部署相机 >8，
+            # 超出的请求会在连接池上排队至 request timeout。
+            limits=httpx.Limits(max_keepalive_connections=4, max_connections=8),
         )
         _http_client_loop = loop
     return _http_client
@@ -198,6 +195,7 @@ async def call_omni(
                 "User-Agent": MILOCO_USER_AGENT,
             },
             json=body,
+            timeout=httpx.Timeout(config.timeout, connect=10.0),
         )
         if resp.status_code != 200:
             logger.error(
@@ -343,6 +341,7 @@ async def call_omni_stream(
             f"{config.base_url}/chat/completions",
             headers=headers,
             json=body,
+            timeout=httpx.Timeout(config.timeout, connect=10.0),
         ) as resp:
             if resp.status_code != 200:
                 await resp.aread()

--- a/backend/miloco/src/miloco/perception/engine/omni/omni_client.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/omni_client.py
@@ -23,11 +23,15 @@ logger = logging.getLogger(__name__)
 _ENV_KEY = "MILOCO_MODEL__OMNI__API_KEY"
 
 # ── shared httpx.AsyncClient ──────────────────────────────────────────────
-# 复用连接池 + keepalive，避免每窗口一次 TCP+TLS 握手（省 ~50-100ms 延迟）。
+# 统一 omni_client.py 与 omni.py 中原本独立的两套客户端实现为一个共享
+# httpx.AsyncClient（池化 + keepalive），消除三个调用路径的重复代码与行为差异。
 # AsyncClient 绑定到创建时所在的 event loop；loop 关闭后重建（测试/重启场景）。
-# 同时被 omni_client 的 call_omni / call_omni_stream 和 omni.py 的 fused 路径共用。
 # 客户端不显式关闭（进程退出由 OS 回收）。
 _http_client: "httpx.AsyncClient | None" = None
+# _http_client_loop: CodeQL "is unused" alert is a false positive.
+# This is the sole trigger for rebuilding the client when the event loop
+# changes — removing it reuses a client bound to a dead loop and causes
+# "Event loop is closed". Do not delete.
 _http_client_loop: "asyncio.AbstractEventLoop | None" = None
 
 
@@ -41,7 +45,7 @@ def _get_http_client(timeout: float) -> httpx.AsyncClient:
     ):
         _http_client = httpx.AsyncClient(
             timeout=httpx.Timeout(timeout, connect=10.0),
-            limits=httpx.Limits(max_keepalive_connections=4, max_connections=8),
+            limits=httpx.Limits(max_keepalive_connections=4, max_connections=8),  # matches max camera count: realtime makes ≤1 omni call per camera per window via room batches; on_demand runs on separate loop with own pool — don't change without re-evaluating
         )
         _http_client_loop = loop
     return _http_client

--- a/backend/miloco/src/miloco/perception/engine/omni/omni_client.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/omni_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
@@ -20,6 +21,30 @@ from miloco.perception.snapshot_context import push_omni_trace
 logger = logging.getLogger(__name__)
 
 _ENV_KEY = "MILOCO_MODEL__OMNI__API_KEY"
+
+# ── shared httpx.AsyncClient ──────────────────────────────────────────────
+# 复用连接池 + keepalive，避免每窗口一次 TCP+TLS 握手（省 ~50-100ms 延迟）。
+# AsyncClient 绑定到创建时所在的 event loop；loop 关闭后重建（测试/重启场景）。
+# 同时被 omni_client 的 call_omni / call_omni_stream 和 omni.py 的 fused 路径共用。
+# 客户端不显式关闭（进程退出由 OS 回收）。
+_http_client: "httpx.AsyncClient | None" = None
+_http_client_loop: "asyncio.AbstractEventLoop | None" = None
+
+
+def _get_http_client(timeout: float) -> httpx.AsyncClient:
+    global _http_client, _http_client_loop
+    loop = asyncio.get_running_loop()
+    if (
+        _http_client is None
+        or _http_client_loop is not loop
+        or _http_client.is_closed
+    ):
+        _http_client = httpx.AsyncClient(
+            timeout=httpx.Timeout(timeout, connect=10.0),
+            limits=httpx.Limits(max_keepalive_connections=4, max_connections=8),
+        )
+        _http_client_loop = loop
+    return _http_client
 
 
 class OmniError(Exception):
@@ -160,23 +185,23 @@ async def call_omni(
     raw: dict[str, Any] | None = None
     error: dict[str, Any] | None = None
     try:
-        async with httpx.AsyncClient(timeout=config.timeout) as client:
-            resp = await client.post(
-                f"{config.base_url}/chat/completions",
-                headers={
-                    "Content-Type": "application/json",
-                    "Authorization": f"Bearer {api_key}",
-                    "User-Agent": MILOCO_USER_AGENT,
-                },
-                json=body,
+        client = _get_http_client(config.timeout)
+        resp = await client.post(
+            f"{config.base_url}/chat/completions",
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {api_key}",
+                "User-Agent": MILOCO_USER_AGENT,
+            },
+            json=body,
+        )
+        if resp.status_code != 200:
+            logger.error(
+                "Omni API error %d: %s", resp.status_code, resp.text[:500]
             )
-            if resp.status_code != 200:
-                logger.error(
-                    "Omni API error %d: %s", resp.status_code, resp.text[:500]
-                )
-            resp.raise_for_status()
-            raw = resp.json()
-            fire_record(config.model, raw.get("usage", {}), type)
+        resp.raise_for_status()
+        raw = resp.json()
+        fire_record(config.model, raw.get("usage", {}), type)
         return raw
     except OmniError:
         raise  # 不重复包装
@@ -308,49 +333,47 @@ async def call_omni_stream(
     error: dict[str, Any] | None = None
     t0 = time.monotonic()
     try:
-        async with httpx.AsyncClient(
-            timeout=httpx.Timeout(config.timeout, connect=10.0)
-        ) as client:
-            async with client.stream(
-                "POST",
-                f"{config.base_url}/chat/completions",
-                headers=headers,
-                json=body,
-            ) as resp:
-                if resp.status_code != 200:
-                    await resp.aread()
-                    logger.error(
-                        "Omni stream error %d: %s", resp.status_code, resp.text[:500]
+        client = _get_http_client(config.timeout)
+        async with client.stream(
+            "POST",
+            f"{config.base_url}/chat/completions",
+            headers=headers,
+            json=body,
+        ) as resp:
+            if resp.status_code != 200:
+                await resp.aread()
+                logger.error(
+                    "Omni stream error %d: %s", resp.status_code, resp.text[:500]
+                )
+                resp.raise_for_status()
+            async for line in resp.aiter_lines():
+                line = line.strip()
+                if not line or not line.startswith("data: "):
+                    continue
+                data = line[6:]
+                if data == "[DONE]":
+                    break
+                try:
+                    chunk = json.loads(data)
+                except json.JSONDecodeError:
+                    continue
+
+                # usage 在最后一个 chunk 的顶层
+                if isinstance(chunk.get("usage"), dict):
+                    raw_usage_seen = chunk["usage"]
+                    if usage_out is not None:
+                        usage_out.update(extract_usage({"usage": raw_usage_seen}))
+
+                # content delta：choices[0].delta.content
+                try:
+                    delta = (
+                        chunk.get("choices", [{}])[0].get("delta", {}).get("content")
                     )
-                    resp.raise_for_status()
-                async for line in resp.aiter_lines():
-                    line = line.strip()
-                    if not line or not line.startswith("data: "):
-                        continue
-                    data = line[6:]
-                    if data == "[DONE]":
-                        break
-                    try:
-                        chunk = json.loads(data)
-                    except json.JSONDecodeError:
-                        continue
-
-                    # usage 在最后一个 chunk 的顶层
-                    if isinstance(chunk.get("usage"), dict):
-                        raw_usage_seen = chunk["usage"]
-                        if usage_out is not None:
-                            usage_out.update(extract_usage({"usage": raw_usage_seen}))
-
-                    # content delta：choices[0].delta.content
-                    try:
-                        delta = (
-                            chunk.get("choices", [{}])[0].get("delta", {}).get("content")
-                        )
-                    except (IndexError, KeyError):
-                        delta = None
-                    if delta:
-                        response_chunks.append(delta)
-                        yield delta
+                except (IndexError, KeyError):
+                    delta = None
+                if delta:
+                    response_chunks.append(delta)
+                    yield delta
     except OmniError:
         raise  # 不重复包装
     except Exception as e:

--- a/backend/miloco/src/miloco/perception/engine/omni/omni_client.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/omni_client.py
@@ -25,7 +25,7 @@ _ENV_KEY = "MILOCO_MODEL__OMNI__API_KEY"
 # ── shared httpx.AsyncClient ──────────────────────────────────────────────
 # 统一 omni_client.py 与 omni.py 中原本独立的两套客户端实现为一个共享
 # httpx.AsyncClient（池化 + keepalive），消除三个调用路径的重复代码与行为差异。
-# AsyncClient 绑定到创建时所在的 event loop；loop 关闭后重建（测试/重启场景）。
+# AsyncClient 绑定到创建时所在的 event loop；感知每窗 asyncio.run() 起新 loop，client 每窗重建。
 # 客户端不显式关闭（进程退出由 OS 回收）。
 _http_client: "httpx.AsyncClient | None" = None
 # _http_client_loop: CodeQL "is unused" alert is a false positive.
@@ -45,7 +45,7 @@ def _get_http_client(timeout: float) -> httpx.AsyncClient:
     ):
         _http_client = httpx.AsyncClient(
             timeout=httpx.Timeout(timeout, connect=10.0),
-            limits=httpx.Limits(max_keepalive_connections=4, max_connections=8),  # matches max camera count: realtime makes ≤1 omni call per camera per window via room batches; on_demand runs on separate loop with own pool — don't change without re-evaluating
+            limits=httpx.Limits(max_keepalive_connections=4, max_connections=8),  # matches max camera count per window (≤1 omni call per camera via room batches)
         )
         _http_client_loop = loop
     return _http_client


### PR DESCRIPTION
问题：
omni_client.py和omni.py各自维护了独立的httpx.AsyncClient实现——call_omni /callomni_stream每次新建client，run_omni_fused有自己的一套_get_fused_http_client。两条路径的代码重复、行为不一致（一边复用连接、一边每次建连）。
修法:
把共享AsyncClient逻辑统一到omni_client.py的_get_http.client，删掉omni.py里的_get_fused_http_client和对应的asyncio import。三条路径共用一个per-loop缓存的client,保持一致的连接池和keepalive 行为。