### PR TITLE
docs: 添加了miloco推理管线onnx需要本地推理的说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ Miloco 2.0 perceives what happens at home, makes proactive decisions and control
 - **Multimodal large model API key** — [Xiaomi MiMo](https://platform.xiaomimimo.com) is recommended: MiMo-v2.5 for perception, MiMo-v2.5-pro for the Agent (configured in OpenClaw).
 
 > [!CAUTION]
-> **Cost note**: Miloco 2.0's perception and Agent rely primarily on cloud-based large models and will incur ongoing API usage costs—keep an eye on your usage. You can review token consumption on the "Models" page of the home dashboard.
+> **Local ONNX inference required.** Miloco's perception pipeline runs person detection and re-identification models locally via ONNX Runtime — it is not purely cloud-based.
+>
+> **API cost note**: Perception and Agent use cloud large models and will incur ongoing API usage costs — keep an eye on your usage. Token consumption is visible on the "Models" page of the home dashboard.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Miloco 2.0 perceives what happens at home, makes proactive decisions and control
 - **Multimodal large model API key** — [Xiaomi MiMo](https://platform.xiaomimimo.com) is recommended: MiMo-v2.5 for perception, MiMo-v2.5-pro for the Agent (configured in OpenClaw).
 
 > [!CAUTION]
-> **API cost note**: Perception and Agent rely primarily use cloud large models and will incur ongoing API usage costs — keep an eye on your usage. Token consumption is visible on the "Models" page of the home dashboard.
+> **API cost note**: Perception and Agent rely primarily on cloud large models and will incur ongoing API usage costs — keep an eye on your usage. Token consumption is visible on the "Models" page of the home dashboard.
 >
 > **Local ONNX inference required.** Miloco's perception pipeline runs person detection and re-identification models locally via ONNX Runtime — it is not purely cloud-based.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Miloco 2.0 perceives what happens at home, makes proactive decisions and control
 - **Multimodal large model API key** — [Xiaomi MiMo](https://platform.xiaomimimo.com) is recommended: MiMo-v2.5 for perception, MiMo-v2.5-pro for the Agent (configured in OpenClaw).
 
 > [!CAUTION]
-> **API cost note**: Perception and Agent use cloud large models and will incur ongoing API usage costs — keep an eye on your usage. Token consumption is visible on the "Models" page of the home dashboard.
+> **API cost note**: Perception and Agent rely primarily use cloud large models and will incur ongoing API usage costs — keep an eye on your usage. Token consumption is visible on the "Models" page of the home dashboard.
 >
 > **Local ONNX inference required.** Miloco's perception pipeline runs person detection and re-identification models locally via ONNX Runtime — it is not purely cloud-based.
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ Miloco 2.0 perceives what happens at home, makes proactive decisions and control
 - **Multimodal large model API key** — [Xiaomi MiMo](https://platform.xiaomimimo.com) is recommended: MiMo-v2.5 for perception, MiMo-v2.5-pro for the Agent (configured in OpenClaw).
 
 > [!CAUTION]
-> **Local ONNX inference required.** Miloco's perception pipeline runs person detection and re-identification models locally via ONNX Runtime — it is not purely cloud-based.
->
 > **API cost note**: Perception and Agent use cloud large models and will incur ongoing API usage costs — keep an eye on your usage. Token consumption is visible on the "Models" page of the home dashboard.
+>
+> **Local ONNX inference required.** Miloco's perception pipeline runs person detection and re-identification models locally via ONNX Runtime — it is not purely cloud-based.
 
 ## Install
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -33,7 +33,7 @@ Miloco 2.0 能感知家中发生的事件，能基于常识主动判断并操控
 - **多模态大模型 API Key** — 推荐使用[小米 MiMo](https://platform.xiaomimimo.com)：感知用 MiMo-v2.5，Agent 用 MiMo-v2.5-pro（在 OpenClaw 中配置）
 
 > [!CAUTION]
-> **费用提示**：感知与 Agent 调用依赖云端大模型，会持续产生 API 费用，请关注用量。可在家庭面板「模型」页查看 token 消耗。
+> **费用提示**：感知与 Agent 调用主要依赖云端大模型，会持续产生 API 费用，请关注用量。可在家庭面板「模型」页查看 token 消耗。
 >
 > **需本地 ONNX 推理。** Miloco 的感知管线通过 ONNX Runtime 在本地运行人体检测和重识别模型，并非全部依赖云端。
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -33,9 +33,9 @@ Miloco 2.0 能感知家中发生的事件，能基于常识主动判断并操控
 - **多模态大模型 API Key** — 推荐使用[小米 MiMo](https://platform.xiaomimimo.com)：感知用 MiMo-v2.5，Agent 用 MiMo-v2.5-pro（在 OpenClaw 中配置）
 
 > [!CAUTION]
-> **需本地 ONNX 推理。** Miloco 的感知管线通过 ONNX Runtime 在本地运行人体检测和重识别模型，并非全部依赖云端。
->
 > **费用提示**：感知与 Agent 调用依赖云端大模型，会持续产生 API 费用，请关注用量。可在家庭面板「模型」页查看 token 消耗。
+>
+> **需本地 ONNX 推理。** Miloco 的感知管线通过 ONNX Runtime 在本地运行人体检测和重识别模型，并非全部依赖云端。
 
 ## 安装
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -33,7 +33,9 @@ Miloco 2.0 能感知家中发生的事件，能基于常识主动判断并操控
 - **多模态大模型 API Key** — 推荐使用[小米 MiMo](https://platform.xiaomimimo.com)：感知用 MiMo-v2.5，Agent 用 MiMo-v2.5-pro（在 OpenClaw 中配置）
 
 > [!CAUTION]
-> **成本提示**：Miloco 2.0 的感知与 Agent 主要依赖云端大模型，会持续产生 API 调用费用，请关注用量。可在家庭面板「模型」页查看 token 消耗。
+> **需本地 ONNX 推理。** Miloco 的感知管线通过 ONNX Runtime 在本地运行人体检测和重识别模型，并非全部依赖云端。
+>
+> **费用提示**：感知与 Agent 调用依赖云端大模型，会持续产生 API 费用，请关注用量。可在家庭面板「模型」页查看 token 消耗。
 
 ## 安装
 


### PR DESCRIPTION
- README (EN/ZH): update caution block to clarify local ONNX inference is required, not purely cloud-based