### PR TITLE
fix(ci): OpenGrep 安装避开 GitHub API 匿名限流

### DIFF
--- a/.github/actions/install-opengrep/action.yml
+++ b/.github/actions/install-opengrep/action.yml
@@ -1,0 +1,36 @@
+# 安装固定版本的 opengrep：直连发布产物，避开受限流的匿名 GitHub API。
+# 被 opengrep-precise.yml（PR 差分扫描）与 opengrep-precise-full.yml（手动全量扫描）共用，
+# 版本与哈希这组锁定值只在此处维护一份。
+name: Install OpenGrep
+description: 直连发布产物安装固定版本 opengrep（避开受限流的匿名 GitHub API）
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        # 官方 install.sh 即便指定了 -v 也会调 api.github.com 校验版本，匿名 API 在共享
+        # runner 上频繁触发 60 次/时 限流 → "Failed to fetch available versions"。
+        # 改为直接从 releases/download 拉二进制（不经 api.github.com），并以 sha256 固定，
+        # 比原先"无 cosign 时跳过签名校验"更强。升级时 VERSION 与 SHA256 一并 bump。
+        OPENGREP_VERSION: v1.22.0
+        # opengrep_manylinux_x86 (linux x86_64) 的 sha256
+        OPENGREP_SHA256: 45bcd58440e397ed52c50e953ccf5948909ea77087c9186fc7d277216f62e319
+      run: |
+        set -euo pipefail
+        # 本 action 只锁 x86_64 资产（这两个工作流均 runs-on ubuntu x86_64）。
+        # 断言架构：将来 ubuntu-latest 若切到 arm64，此处明确报错，而非静默拉 x86 二进制
+        # 在 arm 上跑出晦涩失败——届时需补对应架构资产与哈希。
+        arch="$(uname -m)"
+        if [ "$arch" != "x86_64" ] && [ "$arch" != "amd64" ]; then
+          echo "::error::install-opengrep 仅锁定了 linux x86_64 资产，但当前 runner 架构为 ${arch}；请更新本 action 补充对应架构的资产与哈希。" >&2
+          exit 1
+        fi
+        dest="$HOME/.opengrep/cli/${OPENGREP_VERSION}"
+        mkdir -p "$dest"
+        curl -fsSL --retry 5 --retry-delay 5 --retry-connrefused \
+          -o "$dest/opengrep" \
+          "https://github.com/opengrep/opengrep/releases/download/${OPENGREP_VERSION}/opengrep_manylinux_x86"
+        echo "${OPENGREP_SHA256}  $dest/opengrep" | sha256sum -c -
+        chmod +x "$dest/opengrep"
+        ln -sfn "$dest" "$HOME/.opengrep/cli/latest"
+        echo "$HOME/.opengrep/cli/latest" >> "$GITHUB_PATH"

--- a/.github/workflows/opengrep-precise-full.yml
+++ b/.github/workflows/opengrep-precise-full.yml
@@ -22,20 +22,7 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: 安装 opengrep
-        env:
-          # 见 opengrep-precise.yml 的说明：直接拉发布产物 + sha256 固定，避开 api.github.com 限流。
-          OPENGREP_VERSION: v1.22.0
-          OPENGREP_SHA256: 45bcd58440e397ed52c50e953ccf5948909ea77087c9186fc7d277216f62e319
-        run: |
-          dest="$HOME/.opengrep/cli/${OPENGREP_VERSION}"
-          mkdir -p "$dest"
-          curl -fsSL --retry 5 --retry-delay 5 --retry-connrefused \
-            -o "$dest/opengrep" \
-            "https://github.com/opengrep/opengrep/releases/download/${OPENGREP_VERSION}/opengrep_manylinux_x86"
-          echo "${OPENGREP_SHA256}  $dest/opengrep" | sha256sum -c -
-          chmod +x "$dest/opengrep"
-          ln -sfn "$dest" "$HOME/.opengrep/cli/latest"
-          echo "$HOME/.opengrep/cli/latest" >> "$GITHUB_PATH"
+        uses: ./.github/actions/install-opengrep
 
       - run: opengrep --version
 

--- a/.github/workflows/opengrep-precise-full.yml
+++ b/.github/workflows/opengrep-precise-full.yml
@@ -23,11 +23,18 @@ jobs:
 
       - name: 安装 opengrep
         env:
+          # 见 opengrep-precise.yml 的说明：直接拉发布产物 + sha256 固定，避开 api.github.com 限流。
           OPENGREP_VERSION: v1.22.0
-          OPENGREP_INSTALL_SHA: f458d7f0d52cc58eae1ca3cf3d5caf101e637519
+          OPENGREP_SHA256: 45bcd58440e397ed52c50e953ccf5948909ea77087c9186fc7d277216f62e319
         run: |
-          curl -fsSL "https://raw.githubusercontent.com/opengrep/opengrep/${OPENGREP_INSTALL_SHA}/install.sh" \
-            | bash -s -- -v "$OPENGREP_VERSION"
+          dest="$HOME/.opengrep/cli/${OPENGREP_VERSION}"
+          mkdir -p "$dest"
+          curl -fsSL --retry 5 --retry-delay 5 --retry-connrefused \
+            -o "$dest/opengrep" \
+            "https://github.com/opengrep/opengrep/releases/download/${OPENGREP_VERSION}/opengrep_manylinux_x86"
+          echo "${OPENGREP_SHA256}  $dest/opengrep" | sha256sum -c -
+          chmod +x "$dest/opengrep"
+          ln -sfn "$dest" "$HOME/.opengrep/cli/latest"
           echo "$HOME/.opengrep/cli/latest" >> "$GITHUB_PATH"
 
       - run: opengrep --version

--- a/.github/workflows/opengrep-precise.yml
+++ b/.github/workflows/opengrep-precise.yml
@@ -35,24 +35,7 @@ jobs:
           fetch-depth: 0 # 需要 base commit 做 diff
 
       - name: 安装 opengrep
-        env:
-          # 官方 install.sh 即便指定了 -v 也会调 api.github.com 校验版本，匿名 API 在共享
-          # runner 上频繁触发 60 次/时 限流 → "Failed to fetch available versions"。
-          # 改为直接从 releases/download 拉二进制（不经 api.github.com），并以 sha256 固定，
-          # 比原先"无 cosign 时跳过签名校验"更强。升级时 VERSION 与 SHA256 一起 bump。
-          OPENGREP_VERSION: v1.22.0
-          # opengrep_manylinux_x86 (ubuntu-latest x86_64) 的 sha256
-          OPENGREP_SHA256: 45bcd58440e397ed52c50e953ccf5948909ea77087c9186fc7d277216f62e319
-        run: |
-          dest="$HOME/.opengrep/cli/${OPENGREP_VERSION}"
-          mkdir -p "$dest"
-          curl -fsSL --retry 5 --retry-delay 5 --retry-connrefused \
-            -o "$dest/opengrep" \
-            "https://github.com/opengrep/opengrep/releases/download/${OPENGREP_VERSION}/opengrep_manylinux_x86"
-          echo "${OPENGREP_SHA256}  $dest/opengrep" | sha256sum -c -
-          chmod +x "$dest/opengrep"
-          ln -sfn "$dest" "$HOME/.opengrep/cli/latest"
-          echo "$HOME/.opengrep/cli/latest" >> "$GITHUB_PATH"
+        uses: ./.github/actions/install-opengrep
 
       - run: opengrep --version
 

--- a/.github/workflows/opengrep-precise.yml
+++ b/.github/workflows/opengrep-precise.yml
@@ -36,13 +36,22 @@ jobs:
 
       - name: 安装 opengrep
         env:
-          # install 脚本按 commit SHA 固定，须与 v1.22.0 release tag 一致，避免被劫持。
-          # 升级时两者一起 bump。
+          # 官方 install.sh 即便指定了 -v 也会调 api.github.com 校验版本，匿名 API 在共享
+          # runner 上频繁触发 60 次/时 限流 → "Failed to fetch available versions"。
+          # 改为直接从 releases/download 拉二进制（不经 api.github.com），并以 sha256 固定，
+          # 比原先"无 cosign 时跳过签名校验"更强。升级时 VERSION 与 SHA256 一起 bump。
           OPENGREP_VERSION: v1.22.0
-          OPENGREP_INSTALL_SHA: f458d7f0d52cc58eae1ca3cf3d5caf101e637519
+          # opengrep_manylinux_x86 (ubuntu-latest x86_64) 的 sha256
+          OPENGREP_SHA256: 45bcd58440e397ed52c50e953ccf5948909ea77087c9186fc7d277216f62e319
         run: |
-          curl -fsSL "https://raw.githubusercontent.com/opengrep/opengrep/${OPENGREP_INSTALL_SHA}/install.sh" \
-            | bash -s -- -v "$OPENGREP_VERSION"
+          dest="$HOME/.opengrep/cli/${OPENGREP_VERSION}"
+          mkdir -p "$dest"
+          curl -fsSL --retry 5 --retry-delay 5 --retry-connrefused \
+            -o "$dest/opengrep" \
+            "https://github.com/opengrep/opengrep/releases/download/${OPENGREP_VERSION}/opengrep_manylinux_x86"
+          echo "${OPENGREP_SHA256}  $dest/opengrep" | sha256sum -c -
+          chmod +x "$dest/opengrep"
+          ln -sfn "$dest" "$HOME/.opengrep/cli/latest"
           echo "$HOME/.opengrep/cli/latest" >> "$GITHUB_PATH"
 
       - run: opengrep --version


### PR DESCRIPTION
## 概述

修复 OpenGrep 扫描任务（PR 差分扫描 + 手动全量扫描）在「安装 opengrep」步骤偶发失败，并按 review 意见去除安装逻辑重复、加固架构安全。根因是官方安装脚本依赖受限流的匿名 GitHub API。

> 术语：OpenGrep 是本仓库用于静态代码扫描的工具；「匿名 API 限流」指未带 token 访问 GitHub API 时，共享 runner 按 IP 受 60 次/时 的速率限制。

## 1. 安装步骤绕开受限流的 API（消除 CI 偶发失败）· fix

**问题**：官方安装脚本即便指定版本，内部仍强制访问 GitHub Releases API 校验版本；共享 runner 上匿名 API 按 IP 限流，触发后返回为空，安装以 `Failed to fetch available versions from GitHub` 失败并阻塞 PR。加重试无法可靠绕过（额度与他人共享、恢复慢、重试本身耗额度）。

**解决方案**：跳过安装脚本，直接从发布下载页拉取二进制，不经 API，从根本上规避限流；以 sha256 校验完整性（较原先无 cosign 时跳过签名更强），并加有限次重试抗网络抖动。产物落盘位置与后续步骤所用路径保持不变。

## 2. 去除安装逻辑重复、加固架构安全（降低维护成本）· fix

**问题**：两个工作流的安装块逐字节相同，版本与哈希两处要手动同步，漏改一处会致两条扫描静默分裂；且资产名硬编码单一架构，runner 架构若变更会静默拉错二进制。

**解决方案**：
- **抽成 composite action 去重**：安装逻辑合为一个复合 action 供两个工作流引用，版本与哈希只维护一份。
- **架构断言兜底**：安装前断言 runner 架构，与预期不符时明确报错并提示补充资产，而非静默拉错。

## 测试与兼容性

- **验证**：本地校验三个 YAML 语法通过、action 内脚本 bash 语法通过；下载 URL 与二进制哈希已按锁定版本核对。
- **兼容/回滚**：仅改动安装步骤，扫描逻辑、规则、SARIF 上传均未变；回滚还原安装步骤即可。
- **风险**：linux 二进制未在本机实机运行验证，但与官方安装脚本自身「下载后跑一次 --version」的验证方式一致；升级 opengrep 时需在 action 一处同步更新版本号与哈希，否则 sha256 校验会失败。
