### PR TITLE
fix(skills): 身份注册附件路径去框架耦合

### DIFF
--- a/plugins/skills/miloco-miot-identity-register/SKILL.md
+++ b/plugins/skills/miloco-miot-identity-register/SKILL.md
@@ -474,7 +474,7 @@ miloco-cli identity register from-cluster \
 - 单帧的人体特征不足以代表一个人, **样本多样性差** → 后续识别误识率高
 - 后端 `--video` 通路已含完整的多人物追踪 + 跨帧关联 + 单帧选样, agent 端重做无意义
 
-CLI 已加防呆: `--image` 收到视频文件或 `xxx.mp4.png` 衍生帧直接 exit 1。OpenClaw 飞书插件下载视频默认存 `~/.openclaw/media/inbound/<原文件名>.mp4`。
+CLI 已加防呆: `--image` 收到视频文件或 `xxx.mp4.png` 衍生帧直接 exit 1。视频原文件由宿主框架下载到本地, 用框架本轮给出的真实路径直接调 `--video`(落盘目录随框架而异, 见"其他通用规则")。
 
 ### 约束 3 · 同一条消息内 ≥ 2 张图必须单次批量, 禁止拆调
 
@@ -509,7 +509,9 @@ miloco-cli identity register preview \
 
 - **入库前必须用户确认**, 不调 `register from-media`(已在约束 1 强调)
 - **重名后端自动追加同 person**, agent 不需要自己查重
-- **附件下载是 agent 框架职责**, 本 SKILL 假设附件已存到本地路径(飞书默认 `~/.openclaw/media/inbound/`)
+- **附件下载是 agent 框架职责**: 本 SKILL 假设附件已由宿主框架下载到本地, agent 一律使用框架在本轮消息/上下文中给出的**真实本地路径**调 `--image/--video`, **不要凭文件名自行拼目录**——文件名通常是框架生成的随机标识、无法预先推断, 落盘目录也随框架与渠道配置而异。下列各框架的实际落盘位置**仅供理解、不可作为路径来源**:
+    - OpenClaw：附件真实文件在 `~/.openclaw/media/inbound/` 下，本轮消息会给你它的完整路径（`MediaPath` 字段）和一个 `media://` 别名。调 `--image/--video` 用 `MediaPath` 的完整路径，别用 `media://`（不是真实文件，会报错）。
+    - Hermes(NousResearch): 落 `$HERMES_HOME`(默认 `~/.hermes`)下 `cache/images/` / `cache/videos/`(旧版 `image_cache/` / `video_cache/`)
 - **CLI 非零 exit code 时用人话告知用户**, 不直接抛 stack
 
 ## 异常处理

--- a/plugins/skills/miloco-miot-identity-register/SKILL.md
+++ b/plugins/skills/miloco-miot-identity-register/SKILL.md
@@ -510,7 +510,7 @@ miloco-cli identity register preview \
 - **入库前必须用户确认**, 不调 `register from-media`(已在约束 1 强调)
 - **重名后端自动追加同 person**, agent 不需要自己查重
 - **附件下载是 agent 框架职责**: 本 SKILL 假设附件已由宿主框架下载到本地, agent 一律使用框架在本轮消息/上下文中给出的**真实本地路径**调 `--image/--video`, **不要凭文件名自行拼目录**——文件名通常是框架生成的随机标识、无法预先推断, 落盘目录也随框架与渠道配置而异。下列各框架的实际落盘位置**仅供理解、不可作为路径来源**:
-    - OpenClaw：附件真实文件在 `~/.openclaw/media/inbound/` 下，本轮消息会给你它的完整路径（`MediaPath` 字段）和一个 `media://` 别名。调 `--image/--video` 用 `MediaPath` 的完整路径，别用 `media://`（不是真实文件，会报错）。
+    - OpenClaw: 附件真实文件在 `~/.openclaw/media/inbound/` 下, 本轮消息会给你它的完整路径(`MediaPath` 字段)和一个 `media://` 别名。调 `--image/--video` 用 `MediaPath` 的完整路径, 别用 `media://`(不是真实文件, 会报错)。
     - Hermes(NousResearch): 落 `$HERMES_HOME`(默认 `~/.hermes`)下 `cache/images/` / `cache/videos/`(旧版 `image_cache/` / `video_cache/`)
 - **CLI 非零 exit code 时用人话告知用户**, 不直接抛 stack
 


### PR DESCRIPTION
## 概述

身份注册 SKILL 原先把「附件下载后的本地目录」写死成某宿主 agent 框架专属的绝对路径。这是一处可移植性缺陷：SKILL 是与宿主无关的技能格式（可被多种 agent 框架消费），附件下载本就是宿主框架的职责、而非 miloco 的契约（注册 CLI 的 `--image/--video` 接受任意已存在的本地路径，插件不经手下载）；写死宿主路径在换框架时必然失效，还可能诱导 agent 凭文件名自行拼路径导致找不到文件。本 MR 将其改为与框架无关的通用规则，并有意保留已知框架的示例落盘位置作为性能优化。

（术语：**宿主框架** = 承载并调用本 SKILL 的 agent 运行框架；附件由它下载落盘、并把本地路径交给 agent。）

## 1. 附件路径去框架耦合（可移植到任意宿主框架）· fix

**问题**：附件落盘目录被写死为单一宿主框架的绝对路径 —— 非 miloco 契约、换框架失效，且易误导 agent 拼错路径。

**解决方案**：
- **通用规则打底（保正确、可移植）**：附件下载是宿主框架职责；agent 一律使用框架本轮在消息/上下文中给出的**真实本地路径**调用 `--image/--video`，不假设、不拼接任何框架特定目录。
- **已知框架保留示例路径（有意的性能优化）**：对 OpenClaw / Hermes 等已知宿主直接给出实际落盘位置，agent 无需额外探查即可一步定位文件、**减少 tool-call 轮数**；同时标注「仅供辨识、不可作为路径来源」，避免被当默认值写死。二者互补——规则保正确 / 可移植，示例保效率。
- **点明路径来源优先级**：OpenClaw 示例明确「用**真实文件路径**（`MediaPath`）、**不要把 `media://` 引用别名传给 CLI**」（CLI 用路径存在性校验、URI 会在参数解析阶段失败）；并删去原先的落盘文件名模板，避免诱导 agent 照命名规律自拼路径。

## 测试与兼容性

- **改动范围**：仅身份注册 SKILL 正文措辞，不涉及后端 / CLI / 数据，无运行时代码路径变化。
- **验证**：在真实 OpenClaw 部署上端到端验证一次注册 —— 发送视频素材 → `register preview` 出候选拼图 → 用户确认 → `register commit` 入库；后端 preview / commit 请求均返回 200、目标成员成功进入身份库；过程中 agent 正确使用框架提供的真实绝对路径调用 `--video`（未硬编码、未拼错）。
- **兼容 / 回滚**：纯文档措辞改动，向后兼容，回滚无副作用。