### PR TITLE
fix(web): 展开事件后允许复制文字

### DIFF
--- a/web/src/components/ActivityFeed.tsx
+++ b/web/src/components/ActivityFeed.tsx
@@ -540,7 +540,7 @@ function ActivityRow({
 
   return (
     <li
-      onClick={() => setExpanded((x) => !x)}
+      onClick={() => { if (!window.getSelection()?.toString()) setExpanded((x) => !x); }}
       aria-expanded={expanded}
       className="px-5 py-2.5 hover:bg-bg-tertiary transition-colors cursor-pointer"
     >


### PR DESCRIPTION
## Summary

- 修复日志页面展开事件后无法复制文字的 bug
- 用户拖选文字时 `mouseup` 触发 `<li>` 的 `onClick`，导致行折叠、选中文字消失
- 改为在 `onClick` 中检查 `window.getSelection()?.toString()`，有选中文字时跳过折叠/展开

## Test plan

- [x] 部署验证：展开事件后可正常拖选复制文字
- [x] 部署验证：点击（无选中文字）仍正常折叠/展开
- [x] 子元素交互不受影响（clip 播放器、反馈按钮均有 stopPropagation）
- [x] TypeScript 类型检查通过