### PR TITLE
fix(cli): treat only negative MIoT result codes as device failure

### DIFF
--- a/cli/src/miloco_cli/commands/device.py
+++ b/cli/src/miloco_cli/commands/device.py
@@ -83,7 +83,10 @@ def _annotate_result_codes(data: dict) -> None:
     for it in items:
         total += 1
         code = it.get("code")
-        if isinstance(code, int) and code not in _MIOT_OK_CODES:
+        # 负值才是失败：米家 spec 错误码全为大负数（见 _MIOT_SPEC_CODES）。正数 / 0
+        # 代表指令已下发并执行（实测部分开关返回 code:1 仍生效），绝不能误判为失败——
+        # 否则上层 agent 见"失败"会盲目重试（甚至换 toggle 反复翻转开关）、并谎报失败。
+        if isinstance(code, int) and code < 0 and code not in _MIOT_OK_CODES:
             msg = _MIOT_SPEC_CODES.get(
                 code, "设备侧执行失败（未知错误码，详见米家 spec 错误码表）"
             )

--- a/cli/tests/test_commands.py
+++ b/cli/tests/test_commands.py
@@ -544,6 +544,29 @@ def test_device_control_annotates_unknown_error_code(runner, fake_home_info):
     assert data["code"] == -999999999
 
 
+def test_device_control_positive_code_is_success(runner, fake_home_info):
+    """设备侧正数码（如 code:1，指令已执行生效）不可误判为失败——对齐"负值即失败"。
+
+    回归：某些开关 set_property 成功后仍返回 code:1。旧逻辑（非白名单即失败）把它
+    打成"失败：设备侧执行失败"，上层 agent 据此盲目重试 / 谎报失败。修复后正数码
+    不补失败释义、外层信封保持成功。
+    """
+    with patch("miloco_cli.client.api_post") as mock:
+        mock.return_value = {
+            "code": 0,
+            "message": "executed successfully",
+            "data": {"results": [{"code": 1}]},
+        }
+        result = runner.invoke(
+            cli, ["device", "control", "lamp_001", "prop.2.1", "true"]
+        )
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert "code_msg" not in data["data"]["results"][0]
+    assert data["code"] == 0
+    assert "失败" not in data["message"]
+
+
 def test_device_control_partial_failure_envelope(runner, fake_home_info):
     """多设备部分失败 → 外层 message 标"部分失败（n/total）"。"""
     with patch("miloco_cli.client.api_post") as mock:


### PR DESCRIPTION
## Summary

修复设备控制结果码的误判：`_annotate_result_codes` 目前用白名单判断（`code not in _MIOT_OK_CODES` 即失败），但实测部分设备**执行成功**仍返回正数结果码（如某双开开关返回 `code:1`，灯已实际点亮）——被误标为「设备侧执行失败」。

**真实事故链**（我家部署实测复现）：用户语音开灯 → 执行成功但 CLI 报「失败」→ agent 信以为真开始重试（`on` → `toggle` → `on`……）→ **灯反复关开关开震荡**，最后 agent 还向用户谎报「开不了」。一次成功的操作被上报层演成了持续骚扰 + 错误结论。

## 修复

米家 spec 的错误码全部为大负数（见 `_MIOT_SPEC_CODES`），与代码中既有的「负值即失败」注释一致。改为仅当 `code < 0` 且不在 OK 白名单时才判失败：

```python
if isinstance(code, int) and code < 0 and code not in _MIOT_OK_CODES:
```

正数 / 0 表示指令已下发并执行，不再误判。新增回归测试 `test_device_control_positive_code_is_success`（mock `code:1` 结果 → 断言无 `code_msg`、外层 code 0、无「失败」字样）。

## 关联

与 #380 是同一事故的两半：#380 恢复语音链路（默认开启），本 PR 保证语音触发的设备控制**结果上报诚实**——语音链路放开后，这个误判的暴露面会显著增大（每次语音控制遇到正数结果码的设备都会触发重试风暴），建议一并合入。

CLI 全套 502 passed。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UoQdo1uiv3aecQVJ9RVVT
