### PR TITLE
fix: 感知「休息」开关持久化，重启/重新授权不再静默复位

### DIFF
--- a/backend/miloco/src/miloco/database/kv_repo.py
+++ b/backend/miloco/src/miloco/database/kv_repo.py
@@ -205,6 +205,7 @@ class AuthConfigKeys:
 
 class SystemConfigKeys:
     DEVICE_UUID_KEY = "DEVICE_UUID_KEY"
+    PERCEPTION_ENABLED_KEY = "PERCEPTION_ENABLED_KEY"  # 用户「感知开关」意图（缺省=开）
 
 
 class DeviceInfoKeys:

--- a/backend/miloco/src/miloco/manager.py
+++ b/backend/miloco/src/miloco/manager.py
@@ -99,7 +99,9 @@ class Manager:
 
         # Initialize perception module
         async with mon.track_async(NodeName.PERCEPTION_SERVICE, "init"):
-            self._perception_service = await init_perception_module(self._miot_proxy)
+            self._perception_service = await init_perception_module(
+                self._miot_proxy, self._kv_repo
+            )
 
         self._task_service = TaskService()
 

--- a/backend/miloco/src/miloco/miot/service.py
+++ b/backend/miloco/src/miloco/miot/service.py
@@ -209,12 +209,18 @@ class MiotService:
         """Restart perception engine after auth to pick up newly available cameras."""
         try:
             from miloco.manager import get_manager
+            from miloco.perception.engine_state import is_perception_enabled
 
             perception_service = get_manager().perception_service
             logger.info("Restarting perception engine after auth callback")
-            await perception_service.stop_engine()
-            await perception_service.start_engine()
-            logger.info("Perception engine restarted successfully")
+            await perception_service.stop_engine()  # 未运行时是安全 no-op
+            # 尊重用户「休息」意图：被手动暂停时重新授权不自动拉起引擎，
+            # 否则重新授权会绕开开机门控、无视暂停继续烧 token。
+            if is_perception_enabled(self._kv_repo):
+                await perception_service.start_engine()
+                logger.info("Perception engine restarted successfully")
+            else:
+                logger.info("感知被用户手动休息，重新授权后不自动拉起引擎")
         except Exception as e:
             # 有意不 re-raise：感知引擎重启失败不应导致授权本身失败，
             # token 已持久化，用户可手动重启服务恢复摄像头。

--- a/backend/miloco/src/miloco/perception/__init__.py
+++ b/backend/miloco/src/miloco/perception/__init__.py
@@ -3,6 +3,7 @@ Perception module — multimodal smart home perception engine.
 """
 
 import asyncio
+import logging
 
 from miloco.database.perception_repo import PerceptionLogRepo
 from miloco.perception.client import PerceptionEngineProxy
@@ -10,11 +11,14 @@ from miloco.perception.collect.camera_adapter import CameraDeviceAdapter
 from miloco.perception.collect.collector import MultimodalCollector
 from miloco.perception.processor import PipelineProcessor
 
+logger = logging.getLogger(__name__)
 
-async def init_perception_module(miot_proxy):
+
+async def init_perception_module(miot_proxy, kv_repo):
     """
     初始化感知模块所有组件
     :param miot_proxy: 外部传入的 miot 代理实例
+    :param kv_repo: 持久化 KV 仓库，用于读取用户「感知开关」意图
     """
     from miloco.perception.runner import PerceptionRunner
     from miloco.perception.service import PerceptionService
@@ -59,7 +63,13 @@ async def init_perception_module(miot_proxy):
         log_repo=perception_log_repo,
     )
 
-    # 8. 启动引擎
-    await perception_runner.start()
+    # 8. 启动引擎 —— 尊重用户「休息」意图：上次被手动暂停则不自动拉起，
+    #    否则后台每次重启都会无视暂停、继续烧 token。
+    from miloco.perception.engine_state import is_perception_enabled
+
+    if is_perception_enabled(kv_repo):
+        await perception_runner.start()
+    else:
+        logger.info("[perception] 上次被用户手动休息，跳过开机自动启动")
 
     return perception_service

--- a/backend/miloco/src/miloco/perception/engine_state.py
+++ b/backend/miloco/src/miloco/perception/engine_state.py
@@ -1,0 +1,34 @@
+"""感知引擎「用户开关」的持久化状态。
+
+用户在 Web 上「让它休息 / 唤醒」= 暂停 / 恢复感知。该意图必须落盘，
+否则后台一旦重启就无条件把引擎拉起、继续烧 token。
+
+约定与 miot/filter.py 一致：free function 首参 kv_repo、值用 json 序列化。
+key 缺省视为「开启」——老部署与新装维持既有行为，只有用户主动暂停才写 false。
+"""
+
+import json
+import logging
+
+from miloco.database.kv_repo import KVRepo, SystemConfigKeys
+
+logger = logging.getLogger(__name__)
+
+
+def is_perception_enabled(kv_repo: KVRepo) -> bool:
+    raw = kv_repo.get(SystemConfigKeys.PERCEPTION_ENABLED_KEY)
+    if raw is None:
+        return True  # 从未设置 → 默认开启（保持既有行为）
+    try:
+        return bool(json.loads(raw))
+    except (json.JSONDecodeError, TypeError):
+        logger.warning(
+            "KV %s 值非法(%r)，按默认开启处理",
+            SystemConfigKeys.PERCEPTION_ENABLED_KEY,
+            raw,
+        )
+        return True
+
+
+def set_perception_enabled(kv_repo: KVRepo, enabled: bool) -> None:
+    kv_repo.set(SystemConfigKeys.PERCEPTION_ENABLED_KEY, json.dumps(enabled))

--- a/backend/miloco/src/miloco/perception/engine_state.py
+++ b/backend/miloco/src/miloco/perception/engine_state.py
@@ -30,5 +30,16 @@ def is_perception_enabled(kv_repo: KVRepo) -> bool:
         return True
 
 
-def set_perception_enabled(kv_repo: KVRepo, enabled: bool) -> None:
-    kv_repo.set(SystemConfigKeys.PERCEPTION_ENABLED_KEY, json.dumps(enabled))
+def set_perception_enabled(kv_repo: KVRepo, enabled: bool) -> bool:
+    """落盘用户「感知开关」意图，返回是否写入成功。
+
+    KVRepo.set 内部吞掉 sqlite 异常、失败仅返回 False。这里透传该结果并记 error：
+    「暂停/唤醒」若没真正落盘，重启后门控会读到旧值 → 本模块要根治的静默复位在边缘
+    路径复现，故调用方（用户 endpoint）应据此 fail loud，而非假装写成功。
+    """
+    ok = kv_repo.set(SystemConfigKeys.PERCEPTION_ENABLED_KEY, json.dumps(enabled))
+    if not ok:
+        logger.error(
+            "持久化感知开关意图失败 (enabled=%s)，重启后可能复位", enabled
+        )
+    return ok

--- a/backend/miloco/src/miloco/perception/router.py
+++ b/backend/miloco/src/miloco/perception/router.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, Depends, Query
 from miloco.manager import get_manager
 from miloco.middleware import verify_token
 from miloco.middleware.exceptions import HTTPException
+from miloco.perception.engine_state import set_perception_enabled
 from miloco.perception.schema import OnDemandPerceptionRequest
 from miloco.schema.common_schema import NormalResponse
 
@@ -49,6 +50,9 @@ async def get_engine_status():
     dependencies=[Depends(verify_token)],
 )
 async def start_engine():
+    # 用户主动「唤醒」：先落盘意图=开再启动。持久化只挂在这条用户动作上，
+    # 系统路径(开机/重新授权)不走本端点，故不会误翻此 flag。
+    set_perception_enabled(manager.kv_repo, True)
     await manager.perception_service.start_engine()
     return NormalResponse(code=0, message="Perception engine started")
 
@@ -59,6 +63,8 @@ async def start_engine():
     dependencies=[Depends(verify_token)],
 )
 async def stop_engine():
+    # 用户主动「让它休息」：落盘意图=关，重启后开机门控据此跳过自动启动。
+    set_perception_enabled(manager.kv_repo, False)
     await manager.perception_service.stop_engine()
     return NormalResponse(code=0, message="Perception engine stopped")
 

--- a/backend/miloco/src/miloco/perception/router.py
+++ b/backend/miloco/src/miloco/perception/router.py
@@ -52,7 +52,12 @@ async def get_engine_status():
 async def start_engine():
     # 用户主动「唤醒」：先落盘意图=开再启动。持久化只挂在这条用户动作上，
     # 系统路径(开机/重新授权)不走本端点，故不会误翻此 flag。
-    set_perception_enabled(manager.kv_repo, True)
+    # 落盘失败则 fail loud、不继续，避免用户以为已保存而实际重启后复位。
+    if not set_perception_enabled(manager.kv_repo, True):
+        raise HTTPException(
+            message="failed to persist perception resume intent",
+            status_code=500,
+        )
     await manager.perception_service.start_engine()
     return NormalResponse(code=0, message="Perception engine started")
 
@@ -63,8 +68,13 @@ async def start_engine():
     dependencies=[Depends(verify_token)],
 )
 async def stop_engine():
-    # 用户主动「让它休息」：落盘意图=关，重启后开机门控据此跳过自动启动。
-    set_perception_enabled(manager.kv_repo, False)
+    # 用户主动「让它休息」：先落盘意图=关（重启后开机门控据此跳过自动启动）。
+    # 落盘失败则 fail loud、不继续 —— 否则用户以为已暂停，重启后引擎仍被拉起继续烧 token。
+    if not set_perception_enabled(manager.kv_repo, False):
+        raise HTTPException(
+            message="failed to persist perception pause intent",
+            status_code=500,
+        )
     await manager.perception_service.stop_engine()
     return NormalResponse(code=0, message="Perception engine stopped")
 

--- a/backend/miloco/tests/perception/test_perception_pause_persistence.py
+++ b/backend/miloco/tests/perception/test_perception_pause_persistence.py
@@ -223,3 +223,35 @@ async def test_start_endpoint_persists_enabled_intent(real_db):
 
     fm.perception_service.start_engine.assert_awaited_once()
     assert is_perception_enabled(KVRepo()) is True
+
+
+async def test_stop_endpoint_fails_loud_when_persist_fails():
+    """/engine/stop：落盘失败(KVRepo.set→False) → 抛 HTTPException、不执行 stop（不静默 200）。"""
+    from miloco.middleware.exceptions import HTTPException
+    from miloco.perception import router as perception_router
+
+    fm = MagicMock()
+    fm.kv_repo.set.return_value = False  # 模拟 sqlite 写失败被 KVRepo 吞成 False
+    fm.perception_service.stop_engine = AsyncMock()
+
+    with patch.object(perception_router, "manager", fm):
+        with pytest.raises(HTTPException):
+            await perception_router.stop_engine()
+
+    fm.perception_service.stop_engine.assert_not_awaited()
+
+
+async def test_start_endpoint_fails_loud_when_persist_fails():
+    """/engine/start：落盘失败 → 抛 HTTPException、不执行 start。"""
+    from miloco.middleware.exceptions import HTTPException
+    from miloco.perception import router as perception_router
+
+    fm = MagicMock()
+    fm.kv_repo.set.return_value = False
+    fm.perception_service.start_engine = AsyncMock()
+
+    with patch.object(perception_router, "manager", fm):
+        with pytest.raises(HTTPException):
+            await perception_router.start_engine()
+
+    fm.perception_service.start_engine.assert_not_awaited()

--- a/backend/miloco/tests/perception/test_perception_pause_persistence.py
+++ b/backend/miloco/tests/perception/test_perception_pause_persistence.py
@@ -1,0 +1,225 @@
+# Copyright (C) 2025 Xiaomi Corporation
+# This software may be used and distributed according to the terms of the Xiaomi Miloco License Agreement.
+
+"""感知「休息」开关持久化 —— 覆盖三处：持久化往返 + 开机门控 + 重新授权门控。
+
+背景：用户在 Web 上「让它休息」（暂停感知）后，后台一旦重启，感知又被无条件拉起、
+继续烧云端多模态 token。修复把「用户是否要开启感知」这个意图落盘（缺省=开），所有
+系统自动拉起处启动前先查它。本文件锁住三条关键行为：
+
+1. **持久化往返**：写 false 后新建 KVRepo(重读同一库 = 模拟重启)仍为 false；缺省=开。
+2. **开机门控**：init_perception_module 在 flag=false 时**不** await PerceptionRunner.start，
+   缺省/true 时**已** await。
+3. **重新授权门控**：_restart_perception_engine 在 flag=false 时 stop 后**不** start，true 时 start。
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class _FakeKV:
+    """最小 KV 桩：只实现 is_perception_enabled 需要的 get()，raw 直控门控取值。"""
+
+    def __init__(self, raw: str | None):
+        self._raw = raw
+
+    def get(self, key: str, default_value: str | None = None) -> str | None:
+        return self._raw
+
+
+# ─── 1. 持久化往返（真 SQLite，模拟重启）────────────────────────────────────
+
+
+@pytest.fixture
+def real_db(tmp_path, monkeypatch):
+    """Each test case gets a fresh SQLite DB.（复用 test_perception_repo_sqlite 的做法）"""
+    db_file = tmp_path / "test.db"
+    monkeypatch.setenv("MILOCO_DATABASE__PATH", str(db_file))
+
+    from miloco.config import reset_settings
+
+    reset_settings()
+
+    import miloco.database.connector as connector_module
+
+    monkeypatch.setattr(connector_module, "db_connector", None)
+    connector_module.init_database()
+
+    yield db_file
+
+    reset_settings()
+
+
+def test_persist_roundtrip_survives_restart(real_db):
+    """写入的暂停意图跨 KVRepo 实例（= 跨进程重启）保持；key 缺省时默认开启。"""
+    from miloco.database.kv_repo import KVRepo
+    from miloco.perception.engine_state import (
+        is_perception_enabled,
+        set_perception_enabled,
+    )
+
+    # 从未设置 → 默认开启（老部署 / 新装维持既有行为）
+    assert is_perception_enabled(KVRepo()) is True
+
+    # 用户「让它休息」→ 落盘 false
+    set_perception_enabled(KVRepo(), False)
+    # 新建 KVRepo 重读同一临时库（缓存不复用）= 模拟后台重启后仍为 false
+    assert is_perception_enabled(KVRepo()) is False
+
+    # 用户「唤醒」→ 落盘 true，重启后仍为 true
+    set_perception_enabled(KVRepo(), True)
+    assert is_perception_enabled(KVRepo()) is True
+
+
+# ─── 2. 开机门控（init_perception_module）───────────────────────────────────
+
+
+@contextmanager
+def _patched_init_deps():
+    """patch init_perception_module 的重构造依赖，只留门控 + PerceptionRunner.start 可观测。
+
+    模块级依赖在 miloco.perception 命名空间；PerceptionRunner / PerceptionService 是函数内
+    import，patch 其原模块路径。start 设 AsyncMock 以便 assert_awaited / assert_not_awaited。
+    """
+    runner_cls = MagicMock()
+    runner_cls.return_value.start = AsyncMock()
+    with patch("miloco.perception.PerceptionLogRepo"), patch(
+        "miloco.perception.PerceptionEngineProxy"
+    ), patch("miloco.perception.CameraDeviceAdapter"), patch(
+        "miloco.perception.MultimodalCollector"
+    ), patch("miloco.perception.PipelineProcessor"), patch(
+        "miloco.perception.runner.PerceptionRunner", runner_cls
+    ), patch("miloco.perception.service.PerceptionService"):
+        yield runner_cls
+
+
+async def test_boot_gate_skips_start_when_paused():
+    """flag=false：开机不 await PerceptionRunner.start（尊重上次休息意图）。"""
+    from miloco.perception import init_perception_module
+
+    with _patched_init_deps() as runner_cls:
+        await init_perception_module(MagicMock(), _FakeKV(json.dumps(False)))
+
+    runner_cls.return_value.start.assert_not_awaited()
+
+
+async def test_boot_gate_starts_when_enabled():
+    """flag=true：开机 await 一次 PerceptionRunner.start。"""
+    from miloco.perception import init_perception_module
+
+    with _patched_init_deps() as runner_cls:
+        await init_perception_module(MagicMock(), _FakeKV(json.dumps(True)))
+
+    runner_cls.return_value.start.assert_awaited_once()
+
+
+async def test_boot_gate_starts_by_default_when_unset():
+    """key 缺省（从未暂停）：开机照常 await start，老部署行为不变。"""
+    from miloco.perception import init_perception_module
+
+    with _patched_init_deps() as runner_cls:
+        await init_perception_module(MagicMock(), _FakeKV(None))
+
+    runner_cls.return_value.start.assert_awaited_once()
+
+
+# ─── 3. 重新授权门控（MiotService._restart_perception_engine）────────────────
+
+
+def _make_service(kv_raw: str | None):
+    """绕过 __init__ 构造 MiotService，只挂 _restart_perception_engine 用到的 _kv_repo（经 _miot_proxy）。"""
+    from miloco.miot.service import MiotService
+
+    svc = MiotService.__new__(MiotService)
+    svc._miot_proxy = MagicMock()
+    svc._miot_proxy._kv_repo = _FakeKV(kv_raw)
+    return svc
+
+
+def _mock_perception_service():
+    ps = MagicMock()
+    ps.start_engine = AsyncMock()
+    ps.stop_engine = AsyncMock()
+    return ps
+
+
+async def test_reauth_gate_skips_start_when_paused():
+    """flag=false：重新授权 stop 后不 start（stop 必被 await，证明是门控挡下而非异常早退）。"""
+    svc = _make_service(json.dumps(False))
+    ps = _mock_perception_service()
+    fake_manager = MagicMock()
+    fake_manager.perception_service = ps
+
+    with patch("miloco.manager.get_manager", return_value=fake_manager):
+        await svc._restart_perception_engine()
+
+    ps.stop_engine.assert_awaited_once()
+    ps.start_engine.assert_not_awaited()
+
+
+async def test_reauth_gate_starts_when_enabled():
+    """flag=true：重新授权 stop 后照常 start。"""
+    svc = _make_service(json.dumps(True))
+    ps = _mock_perception_service()
+    fake_manager = MagicMock()
+    fake_manager.perception_service = ps
+
+    with patch("miloco.manager.get_manager", return_value=fake_manager):
+        await svc._restart_perception_engine()
+
+    ps.stop_engine.assert_awaited_once()
+    ps.start_engine.assert_awaited_once()
+
+
+# ─── 4. 写路径（HTTP 端点确实落盘意图）──────────────────────────────────────
+#
+# 上面三组只测「读」侧（助手往返 + 两处门控喂入 _FakeKV）。写侧——即唯一真正落盘意图的
+# 两个用户端点——若被重构写反布尔或漏掉落盘调用，本修复要治的 bug 就会静默复现，而上面
+# 的测试照样全绿。这里直接驱动路由函数、用新建 KVRepo 重读磁盘，锁死「停=落 false / 起=落 true」。
+
+
+def _patched_router_manager(kv):
+    """patch router 模块级 manager：kv_repo 用真库，perception_service 启停用 AsyncMock。"""
+    fake_manager = MagicMock()
+    fake_manager.kv_repo = kv
+    fake_manager.perception_service.start_engine = AsyncMock()
+    fake_manager.perception_service.stop_engine = AsyncMock()
+    return fake_manager
+
+
+async def test_stop_endpoint_persists_paused_intent(real_db):
+    """/engine/stop：落盘 false（新建 KVRepo 重读磁盘确认，防写反 / 漏写）。"""
+    from miloco.database.kv_repo import KVRepo
+    from miloco.perception import router as perception_router
+    from miloco.perception.engine_state import is_perception_enabled
+
+    fm = _patched_router_manager(KVRepo())
+    with patch.object(perception_router, "manager", fm):
+        await perception_router.stop_engine()
+
+    fm.perception_service.stop_engine.assert_awaited_once()
+    assert is_perception_enabled(KVRepo()) is False
+
+
+async def test_start_endpoint_persists_enabled_intent(real_db):
+    """/engine/start：把已暂停(false)翻回 true（证明确实由端点写入，而非默认值）。"""
+    from miloco.database.kv_repo import KVRepo
+    from miloco.perception import router as perception_router
+    from miloco.perception.engine_state import (
+        is_perception_enabled,
+        set_perception_enabled,
+    )
+
+    # 先落 false 模拟「已休息」，再验唤醒端点确实翻回 true
+    set_perception_enabled(KVRepo(), False)
+    fm = _patched_router_manager(KVRepo())
+    with patch.object(perception_router, "manager", fm):
+        await perception_router.start_engine()
+
+    fm.perception_service.start_engine.assert_awaited_once()
+    assert is_perception_enabled(KVRepo()) is True


### PR DESCRIPTION
## 概述

用户在 Web 上「让它休息」（暂停摄像头感知）后，后台一旦重启就把感知无条件拉起、
继续调用云端 multimodal 模型烧 token，包年额度会被静默耗光。根因是暂停状态只存在
内存、不落盘，且开机链路无条件 start、不读「上次是否被暂停」。

本 PR 把「用户是否要开启感知」这个 intent 持久化到 KV，所有系统自动拉起处在 start
前先查它；缺省视为开启，老部署 / 新装行为不变。纯后端改动，前端零改动（开关本就是
后端运行态的投影）。

术语：
- **KV**：后端 SQLite `kv` 表的持久化 key-value store。
- **系统自动拉起**：非用户主动触发的 engine start —— 开机 init、崩溃后 supervisord
  autorestart、米家重新授权后的 restart 等。

## 1. 落盘用户「感知开关」意图，只挂在用户动作上 · fix

**问题**：暂停 / 恢复感知只翻一个内存 bool，不落盘；任何后台重启都读不到用户上次的暂停意图。

**解决方案**：
- **新增持久化 intent key**：在 KV 加一个「感知开关」key，缺省（从未设置）视为开启。
- **leaf helper 提供读/写**：独立无依赖的小模块暴露读 / 写两个 free-function，值走 json
  序列化、对齐既有 KV 读写约定，供多处共用且无 import cycle。
- **只在用户动作上落盘**：仅「唤醒」/「让它休息」两个用户可达 endpoint 在启停前写 intent
  （开 / 关）；已核实无任何模块内部调用这两个 endpoint，系统路径不会误翻此意图。
- **落盘失败 fail loud**：底层 KV 写失败（返回 False、不抛异常）时 endpoint 抛 500、
  不继续启停，避免用户以为已保存而重启后复位。

## 2. 系统自动拉起处按意图门控 · fix

**问题**：开机 init 无条件 start 且不读暂停意图；米家重新授权后的 restart 同样无视暂停，
是绕开开机门控的第二条复位路径。

**解决方案**：
- **开机 init 加 gate**：start engine 前先查 intent，被暂停则跳过并记 log；为此给 init 补传 KV 入参。
- **重新授权 restart 加 gate**：stop 后仅在未被暂停时 start（stop 对未运行 engine 是安全 no-op）。
- **机制层保持不变**：engine 启停底层方法、软停（模型增删）、优雅关停、切家等一律不碰
  —— 显式「唤醒」仍必然 start，不会被自己挡住。

## 测试与兼容性

- **测试**（新增一组 pause 持久化测试，10 例全绿）：
  - intent 跨 KV 实例（= 模拟进程重启）往返保持，缺省为开；
  - 开机 gate 在暂停时不 start、缺省 / 唤醒时 start；
  - 重新授权 gate 同理；
  - 两个用户 endpoint 确实落盘（停 → false / 起 → true），防重构写反或漏写让原 bug 静默复现；
  - 两个用户 endpoint 在落盘失败时 fail loud（抛 500、不触发启停）。
- **兼容性 / 回滚**：缺省=开，老部署 / 新装 / 从未动过开关的用户行为完全不变，无需数据迁移；
  回滚只需还原本 PR，KV 里的残留 key 不影响旧逻辑。
- **风险提醒**：unit test 覆盖三条关键逻辑，但端到端（起后台 → 暂停 → 重启应保持 stopped
  → 唤醒 → 重启应保持 running → 暂停下走一次重新授权应不拉起）需在带米家 auth 的真实环境
  验证，建议 merge 前在真机走一遍。