### PR TITLE
feat: reset miloco agent sessions on home switch

### DIFF
--- a/backend/miloco/src/miloco/dispatch/__init__.py
+++ b/backend/miloco/src/miloco/dispatch/__init__.py
@@ -4,6 +4,7 @@
 """Agent turn 调度包：按会话单飞 + 同类批量合并，收口 producer → agent 投递。"""
 
 from miloco.dispatch.dispatcher import (
+    MILOCO_SESSION_KEYS,
     AgentDispatcher,
     EventType,
     dispatch_event,
@@ -13,6 +14,7 @@ from miloco.dispatch.dispatcher import (
 )
 
 __all__ = [
+    "MILOCO_SESSION_KEYS",
     "AgentDispatcher",
     "EventType",
     "dispatch_event",

--- a/backend/miloco/src/miloco/dispatch/dispatcher.py
+++ b/backend/miloco/src/miloco/dispatch/dispatcher.py
@@ -45,6 +45,12 @@ _ROUTE: dict[EventType, tuple[str, str, int]] = {
     "onboarding": ("agent:main:miloco", "miloco-interactive", 30),
 }
 
+# 去重后的 miloco session 全集（保持插入序），供切换家庭时批量 reset 用——
+# 以 _ROUTE 为唯一事实源，避免在别处手抄 sessionKey 造成漂移。
+MILOCO_SESSION_KEYS: list[str] = list(
+    dict.fromkeys(session_key for session_key, _lane, _prio in _ROUTE.values())
+)
+
 # 仅这三类（== AgentRunSource）写 agent_runs；bind / onboarding 不统计。
 _TRACKED: frozenset[EventType] = frozenset({"interaction", "rule", "suggestion"})
 

--- a/backend/miloco/src/miloco/miot/service.py
+++ b/backend/miloco/src/miloco/miot/service.py
@@ -963,6 +963,22 @@ class MiotService:
         _background_tasks.add(task)
         task.add_done_callback(_background_tasks.discard)
 
+        # 切换家庭后重置 openclaw 里的 miloco session，清掉旧家庭遗留的上下文
+        # （设备 / 房间 / 习惯），避免串入新家庭。best-effort 后台执行：openclaw
+        # 不可达 / 删除失败只 WARN，绝不阻塞或打断切换本身。
+        async def _reset_agent_sessions_bg():
+            from miloco.dispatch.dispatcher import MILOCO_SESSION_KEYS
+            from miloco.utils.agent_client import reset_agent_sessions
+
+            try:
+                await reset_agent_sessions(MILOCO_SESSION_KEYS)
+            except Exception as e:
+                logger.warning("switch_home reset agent sessions failed: %s", e)
+
+        reset_task = asyncio.create_task(_reset_agent_sessions_bg())
+        _background_tasks.add(reset_task)
+        reset_task.add_done_callback(_background_tasks.discard)
+
         # KV 已写入，本地更新 in_use 标记后立即返回，不等待 refresh 完成。
         allow = allowed_home_ids(self._kv_repo)
         for h in homes:

--- a/backend/miloco/src/miloco/miot/service.py
+++ b/backend/miloco/src/miloco/miot/service.py
@@ -916,10 +916,34 @@ class MiotService:
             logger.info("启用集与可见家庭无交集，自动启用首个家庭 %s（兜底）", first)
             for h in seen.values():
                 h["in_use"] = h["home_id"] in allow
+            # 兜底自动切换同样换掉了启用家庭 → 重置会话，消除旧家庭上下文泄漏
+            # （与显式 switch_home 同一 bug class）。
+            self._schedule_agent_session_reset()
 
         # 按 home_id 字典序排序——米家 SDK 返回顺序受设备活跃度等影响不稳定，
         # 不排 HomeSwitcher 列表会在两次 reload 之间跳。
         return sorted(seen.values(), key=lambda h: h["home_id"])
+
+    def _schedule_agent_session_reset(self) -> None:
+        """切换家庭后后台 best-effort 重置 openclaw 里的 miloco session，清掉旧家庭
+        遗留的上下文（设备 / 房间 / 习惯），避免串入新家庭。
+
+        显式 `switch_home` 与 `list_homes` 兜底自动切换共用此入口。fire-and-forget：
+        openclaw 不可达 / 删除失败只 WARN、不上抛，绝不阻塞或打断切换本身。
+        """
+        async def _bg():
+            from miloco.dispatch.dispatcher import MILOCO_SESSION_KEYS
+            from miloco.utils.agent_client import reset_agent_sessions
+
+            try:
+                await reset_agent_sessions(MILOCO_SESSION_KEYS)
+            except Exception as e:
+                logger.warning("reset agent sessions failed: %s", e)
+
+        reset_task = asyncio.create_task(_bg())
+        # 防御性持有引用，避免 task 在 await 挂起期间被 GC 回收。
+        _background_tasks.add(reset_task)
+        reset_task.add_done_callback(_background_tasks.discard)
 
     async def switch_home(self, home_id: str) -> list[dict]:
         """切换到指定家庭（唯一启用），其余自动停用。
@@ -934,6 +958,9 @@ class MiotService:
             raise ValidationException(
                 f"Unknown home_id {home_id!r}; valid: {sorted(known)}"
             )
+        # 切换前后的启用集：只有真的变了才 reset——切到"已是当前唯一启用"的家庭
+        # （重复点选 / 重复提交同一 home_id）不该白删仍然有效的热上下文。
+        prev_allow = allowed_home_ids(self._kv_repo)
         # 先把目标加进在用集合,再把其余移出。
         target_list, _ = set_homes_in_use(self._kv_repo, [home_id], True)
         others = [h for h in target_list if h != home_id]
@@ -963,24 +990,11 @@ class MiotService:
         _background_tasks.add(task)
         task.add_done_callback(_background_tasks.discard)
 
-        # 切换家庭后重置 openclaw 里的 miloco session，清掉旧家庭遗留的上下文
-        # （设备 / 房间 / 习惯），避免串入新家庭。best-effort 后台执行：openclaw
-        # 不可达 / 删除失败只 WARN，绝不阻塞或打断切换本身。
-        async def _reset_agent_sessions_bg():
-            from miloco.dispatch.dispatcher import MILOCO_SESSION_KEYS
-            from miloco.utils.agent_client import reset_agent_sessions
-
-            try:
-                await reset_agent_sessions(MILOCO_SESSION_KEYS)
-            except Exception as e:
-                logger.warning("switch_home reset agent sessions failed: %s", e)
-
-        reset_task = asyncio.create_task(_reset_agent_sessions_bg())
-        _background_tasks.add(reset_task)
-        reset_task.add_done_callback(_background_tasks.discard)
-
         # KV 已写入，本地更新 in_use 标记后立即返回，不等待 refresh 完成。
         allow = allowed_home_ids(self._kv_repo)
+        # 启用集真的变化了才重置会话（避免切到当前家庭白丢热上下文）。
+        if allow != prev_allow:
+            self._schedule_agent_session_reset()
         for h in homes:
             h["in_use"] = h["home_id"] in allow
         return homes

--- a/backend/miloco/src/miloco/utils/agent_client.py
+++ b/backend/miloco/src/miloco/utils/agent_client.py
@@ -87,6 +87,32 @@ async def call_agent_webhook(
     return result.get("data")
 
 
+async def reset_agent_sessions(
+    session_keys: list[str],
+    *,
+    delete_transcript: bool = True,
+    timeout: float = 10.0,
+) -> Any:
+    """批量重置（删除）指定 agent session：调插件 ``reset_sessions`` webhook。
+
+    用于切换家庭时清掉旧家庭遗留的 miloco 会话上下文。``session_keys`` 空则直接短路
+    （不发请求）。传输 / 结构化失败沿用 :func:`call_agent_webhook` 抛
+    :class:`AgentWebhookException`——本函数不兜底，由调用方（switch_home 的后台任务）
+    捕获并降级为 WARN，绝不影响切换本身。返回 webhook 的 ``data``
+    （``{"reset": [...], "failed": [...]}``）。
+    """
+    if not session_keys:
+        return None
+    return await call_agent_webhook(
+        "reset_sessions",
+        {
+            "sessionKeys": list(session_keys),
+            "deleteTranscript": delete_transcript,
+        },
+        timeout=timeout,
+    )
+
+
 async def run_agent_turn(
     text: str,
     *,

--- a/backend/miloco/tests/dispatch/test_dispatcher.py
+++ b/backend/miloco/tests/dispatch/test_dispatcher.py
@@ -748,3 +748,18 @@ async def test_delivered_false_on_no_channel_status(patched, monkeypatch):
 
     assert fut.result() is False
     assert calls == 1  # 正常 HTTP 返回，不走传输重试
+
+
+def test_miloco_session_keys_derived_from_route():
+    """MILOCO_SESSION_KEYS = _ROUTE 去重后的 sessionKey 全集（供切换家庭批量 reset）。
+    以 _ROUTE 为唯一事实源，别处手抄会漂移。"""
+    from miloco.dispatch.dispatcher import MILOCO_SESSION_KEYS
+
+    assert MILOCO_SESSION_KEYS == [
+        "agent:main:miloco",
+        "agent:main:miloco-rule",
+        "agent:main:miloco-suggest",
+    ]
+    # 无重复，且是 _ROUTE 里 sessionKey 的去重集合。
+    assert len(MILOCO_SESSION_KEYS) == len(set(MILOCO_SESSION_KEYS))
+    assert set(MILOCO_SESSION_KEYS) == {sk for sk, _, _ in disp_mod._ROUTE.values()}

--- a/backend/miloco/tests/test_miot_filter_and_cameras.py
+++ b/backend/miloco/tests/test_miot_filter_and_cameras.py
@@ -284,6 +284,49 @@ async def test_switch_home_persists_through_kv():
     assert json.loads(kv.get(ScopeConfigKeys.HOME_WHITE_LIST_KEY)) == ["H2"]
 
 
+async def _drain_reset(mock, timeout: float = 1.0) -> None:
+    """switch_home 的 reset 走 fire-and-forget 后台任务，轮询等它跑完（或超时）。"""
+    import time as _t
+
+    deadline = _t.monotonic() + timeout
+    while _t.monotonic() < deadline:
+        if mock.await_count:
+            return
+        await asyncio.sleep(0.01)
+
+
+@pytest.mark.asyncio
+async def test_switch_home_resets_agent_sessions():
+    """切换家庭后后台批量 reset miloco session，传入 MILOCO_SESSION_KEYS 全集。"""
+    from unittest.mock import patch
+
+    from miloco.dispatch import MILOCO_SESSION_KEYS
+
+    svc = _make_service(devices={"d1": _home("H1"), "d2": _home("H2")}, kv=_FakeKV())
+    reset = AsyncMock(return_value={"reset": MILOCO_SESSION_KEYS, "failed": []})
+    with patch("miloco.utils.agent_client.reset_agent_sessions", new=reset):
+        res = await svc.switch_home("H2")
+        await _drain_reset(reset)
+
+    assert {h["home_id"]: h["in_use"] for h in res}["H2"] is True
+    reset.assert_awaited_once_with(MILOCO_SESSION_KEYS)
+
+
+@pytest.mark.asyncio
+async def test_switch_home_reset_failure_is_swallowed():
+    """reset 失败（openclaw 不可达）只 WARN，绝不打断切换本身。"""
+    from unittest.mock import patch
+
+    svc = _make_service(devices={"d1": _home("H1"), "d2": _home("H2")}, kv=_FakeKV())
+    reset = AsyncMock(side_effect=RuntimeError("openclaw down"))
+    with patch("miloco.utils.agent_client.reset_agent_sessions", new=reset):
+        res = await svc.switch_home("H2")  # 不抛异常
+        await _drain_reset(reset)
+
+    assert {h["home_id"]: h["in_use"] for h in res}["H2"] is True
+    reset.assert_awaited_once()
+
+
 @pytest.mark.asyncio
 async def test_switch_home_rejects_unknown():
     svc = _make_service(devices={"d1": _home("H1")})

--- a/backend/miloco/tests/test_miot_filter_and_cameras.py
+++ b/backend/miloco/tests/test_miot_filter_and_cameras.py
@@ -295,14 +295,22 @@ async def _drain_reset(mock, timeout: float = 1.0) -> None:
         await asyncio.sleep(0.01)
 
 
+def _kv_with_home(home_id: str) -> "_FakeKV":
+    """预置某家庭为启用，避免 list_homes 兜底自动选家干扰 reset 计数。"""
+    return _FakeKV({ScopeConfigKeys.HOME_WHITE_LIST_KEY: json.dumps([home_id])})
+
+
 @pytest.mark.asyncio
 async def test_switch_home_resets_agent_sessions():
-    """切换家庭后后台批量 reset miloco session，传入 MILOCO_SESSION_KEYS 全集。"""
+    """启用家庭真的变化时，后台批量 reset miloco session，传入 MILOCO_SESSION_KEYS 全集。"""
     from unittest.mock import patch
 
     from miloco.dispatch import MILOCO_SESSION_KEYS
 
-    svc = _make_service(devices={"d1": _home("H1"), "d2": _home("H2")}, kv=_FakeKV())
+    # 预置 H1 启用 → list_homes 不会兜底自动切；switch 到 H2 才是唯一一次启用集变化。
+    svc = _make_service(
+        devices={"d1": _home("H1"), "d2": _home("H2")}, kv=_kv_with_home("H1")
+    )
     reset = AsyncMock(return_value={"reset": MILOCO_SESSION_KEYS, "failed": []})
     with patch("miloco.utils.agent_client.reset_agent_sessions", new=reset):
         res = await svc.switch_home("H2")
@@ -313,17 +321,54 @@ async def test_switch_home_resets_agent_sessions():
 
 
 @pytest.mark.asyncio
+async def test_switch_home_noop_when_already_active_skips_reset():
+    """切到"已是当前唯一启用"的家庭 → 启用集没变 → 不 reset，保住热上下文。"""
+    from unittest.mock import patch
+
+    svc = _make_service(
+        devices={"d1": _home("H1"), "d2": _home("H2")}, kv=_kv_with_home("H2")
+    )
+    reset = AsyncMock()
+    with patch("miloco.utils.agent_client.reset_agent_sessions", new=reset):
+        res = await svc.switch_home("H2")  # 目标已启用
+        await _drain_reset(reset, timeout=0.2)
+
+    assert {h["home_id"]: h["in_use"] for h in res}["H2"] is True
+    reset.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_switch_home_reset_failure_is_swallowed():
     """reset 失败（openclaw 不可达）只 WARN，绝不打断切换本身。"""
     from unittest.mock import patch
 
-    svc = _make_service(devices={"d1": _home("H1"), "d2": _home("H2")}, kv=_FakeKV())
+    svc = _make_service(
+        devices={"d1": _home("H1"), "d2": _home("H2")}, kv=_kv_with_home("H1")
+    )
     reset = AsyncMock(side_effect=RuntimeError("openclaw down"))
     with patch("miloco.utils.agent_client.reset_agent_sessions", new=reset):
         res = await svc.switch_home("H2")  # 不抛异常
         await _drain_reset(reset)
 
     assert {h["home_id"]: h["in_use"] for h in res}["H2"] is True
+    reset.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_list_homes_fallback_auto_switch_resets_sessions():
+    """list_homes 兜底自动切换（选中家失效）也触发 reset——与显式切换同一 bug class。"""
+    from unittest.mock import patch
+
+    # 启用集 = {H_gone}（已从账号消失），可见家庭只有 H1/H2 → 无交集 → 兜底选 H1。
+    svc = _make_service(
+        devices={"d1": _home("H1"), "d2": _home("H2")}, kv=_kv_with_home("H_gone")
+    )
+    reset = AsyncMock()
+    with patch("miloco.utils.agent_client.reset_agent_sessions", new=reset):
+        homes = await svc.list_homes()
+        await _drain_reset(reset)
+
+    assert {h["home_id"]: h["in_use"] for h in homes}["H1"] is True
     reset.assert_awaited_once()
 
 

--- a/backend/miloco/tests/utils/test_agent_client.py
+++ b/backend/miloco/tests/utils/test_agent_client.py
@@ -19,7 +19,11 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from miloco.middleware.exceptions import AgentWebhookException
-from miloco.utils.agent_client import _HTTP_BUFFER_S, run_agent_turn
+from miloco.utils.agent_client import (
+    _HTTP_BUFFER_S,
+    reset_agent_sessions,
+    run_agent_turn,
+)
 
 _WAIT_MS = 30_000
 
@@ -137,3 +141,34 @@ async def test_run_agent_turn_passes_no_channel_status_through():
         )
     assert run_id is None
     assert status == "no-channel"
+
+
+async def test_reset_agent_sessions_builds_payload():
+    # session_keys / deleteTranscript 原样组包成 reset_sessions webhook payload。
+    mock = AsyncMock(return_value={"reset": ["a", "b"], "failed": []})
+    keys = ["agent:main:miloco", "agent:main:miloco-rule"]
+    with patch("miloco.utils.agent_client.call_agent_webhook", new=mock):
+        data = await reset_agent_sessions(keys)
+    assert data == {"reset": ["a", "b"], "failed": []}
+    action, payload = mock.await_args.args[0], mock.await_args.args[1]
+    assert action == "reset_sessions"
+    assert payload["sessionKeys"] == keys
+    assert payload["deleteTranscript"] is True
+
+
+async def test_reset_agent_sessions_short_circuits_on_empty():
+    # 空列表直接短路：不发 webhook。
+    mock = AsyncMock()
+    with patch("miloco.utils.agent_client.call_agent_webhook", new=mock):
+        assert await reset_agent_sessions([]) is None
+    mock.assert_not_awaited()
+
+
+async def test_reset_agent_sessions_propagates_webhook_exception():
+    # 传输/结构化失败不吞：交由调用方（switch_home 后台任务）兜底降级。
+    with patch(
+        "miloco.utils.agent_client.call_agent_webhook",
+        new=AsyncMock(side_effect=AgentWebhookException("boom")),
+    ):
+        with pytest.raises(AgentWebhookException):
+            await reset_agent_sessions(["agent:main:miloco"])

--- a/plugins/openclaw/src/webhooks/index.ts
+++ b/plugins/openclaw/src/webhooks/index.ts
@@ -4,6 +4,7 @@ import { getPluginConfig, type MilocoPluginConfig } from "../config.js";
 import { logger } from "../utils/logger.js";
 import { kAgentWebhook } from "./agent.js";
 import { kGetTraceWebhook } from "./get_trace.js";
+import { kResetSessionsWebhook } from "./reset_sessions.js";
 
 // 已处理标记
 export const ALREADY_HANDLED = "ALREADY_HANDLED";
@@ -11,6 +12,7 @@ export const ALREADY_HANDLED = "ALREADY_HANDLED";
 const kWebhooks = [
   kAgentWebhook, // 向 Agent 发消息
   kGetTraceWebhook, // backend 反向取 agent turn 元数据
+  kResetSessionsWebhook, // 切换家庭时批量重置 miloco session
 ].reduce(
   (acc, e) => {
     acc[e.name] = e.action;

--- a/plugins/openclaw/src/webhooks/reset_sessions.ts
+++ b/plugins/openclaw/src/webhooks/reset_sessions.ts
@@ -1,0 +1,52 @@
+import { logger } from "../utils/logger.js";
+import type { WebhookEntry } from "./index.js";
+
+interface IRequestBody {
+  // 待重置（删除）的 session key 列表。由调用方（backend）传入，插件不硬编码业务 key。
+  sessionKeys: string[];
+  // 是否连 transcript 落盘文件一起删。默认 true = 彻底清空，符合"切换家庭防上下文干扰"语义。
+  deleteTranscript?: boolean;
+}
+
+interface ResetResult {
+  reset: string[];
+  failed: { sessionKey: string; error: string }[];
+}
+
+// 批量 reset 指定 session：逐个 deleteSession，单个失败不影响其余（session 不存在按幂等成功
+// 处理，deleteSession 通常对不存在的 key 也不抛错）。返回删除成功 / 失败清单供后端观测。
+export const kResetSessionsWebhook: WebhookEntry<IRequestBody> = {
+  name: "reset_sessions",
+  action: async ({ api, payload }) => {
+    const { sessionKeys, deleteTranscript = true } = payload ?? {};
+    if (!Array.isArray(sessionKeys) || sessionKeys.length === 0) {
+      return { status: "error", message: "sessionKeys must be a non-empty array" };
+    }
+
+    const result: ResetResult = { reset: [], failed: [] };
+    for (const sessionKey of sessionKeys) {
+      if (typeof sessionKey !== "string" || !sessionKey) {
+        result.failed.push({
+          sessionKey: String(sessionKey),
+          error: "invalid sessionKey",
+        });
+        continue;
+      }
+      try {
+        await api.runtime.subagent.deleteSession({ sessionKey, deleteTranscript });
+        result.reset.push(sessionKey);
+      } catch (err) {
+        const error = err instanceof Error ? err.message : String(err);
+        logger.warn(
+          `[reset-sessions] deleteSession failed session=${sessionKey}: ${error}`,
+        );
+        result.failed.push({ sessionKey, error });
+      }
+    }
+
+    logger.info(
+      `[reset-sessions] reset=${result.reset.length} failed=${result.failed.length} deleteTranscript=${deleteTranscript}`,
+    );
+    return result;
+  },
+};

--- a/plugins/openclaw/src/webhooks/reset_sessions.ts
+++ b/plugins/openclaw/src/webhooks/reset_sessions.ts
@@ -20,7 +20,9 @@ export const kResetSessionsWebhook: WebhookEntry<IRequestBody> = {
   action: async ({ api, payload }) => {
     const { sessionKeys, deleteTranscript = true } = payload ?? {};
     if (!Array.isArray(sessionKeys) || sessionKeys.length === 0) {
-      return { status: "error", message: "sessionKeys must be a non-empty array" };
+      // 入参校验失败走和其它 action 一致的错误通道：抛错 → index.ts catch →
+      // fail(3000) 返 code!=0，避免被外层 ok() 包成 code:0「成功」误导调用方。
+      throw new Error("sessionKeys must be a non-empty array");
     }
 
     const result: ResetResult = { reset: [], failed: [] };

--- a/plugins/openclaw/tests/reset-sessions.test.ts
+++ b/plugins/openclaw/tests/reset-sessions.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/utils/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { kResetSessionsWebhook } from "../src/webhooks/reset_sessions.js";
+
+const KEYS = [
+  "agent:main:miloco",
+  "agent:main:miloco-rule",
+  "agent:main:miloco-suggest",
+];
+
+function makeApi(deleteSession?: ReturnType<typeof vi.fn>) {
+  const del = deleteSession ?? vi.fn(async () => {});
+  const api = { runtime: { subagent: { deleteSession: del } } } as never;
+  return { api, del };
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: test payload shape
+function invoke(api: unknown, payload: any) {
+  // biome-ignore lint/suspicious/noExplicitAny: webhook returns any
+  return kResetSessionsWebhook.action({ api, payload } as any) as Promise<any>;
+}
+
+afterEach(() => vi.clearAllMocks());
+
+describe("kResetSessionsWebhook 批量重置 session", () => {
+  it("全部删除成功 → 每个 key 各 deleteSession 一次，返回 reset 全集", async () => {
+    const { api, del } = makeApi();
+    const res = await invoke(api, { sessionKeys: KEYS });
+
+    expect(del).toHaveBeenCalledTimes(3);
+    for (const sessionKey of KEYS) {
+      expect(del).toHaveBeenCalledWith({ sessionKey, deleteTranscript: true });
+    }
+    expect(res.reset).toEqual(KEYS);
+    expect(res.failed).toEqual([]);
+  });
+
+  it("deleteTranscript 透传（false）", async () => {
+    const { api, del } = makeApi();
+    await invoke(api, {
+      sessionKeys: ["agent:main:miloco"],
+      deleteTranscript: false,
+    });
+    expect(del).toHaveBeenCalledWith({
+      sessionKey: "agent:main:miloco",
+      deleteTranscript: false,
+    });
+  });
+
+  it("单个 key 删除失败 → 其余继续，failed 记录该 key", async () => {
+    const del = vi.fn(async ({ sessionKey }: { sessionKey: string }) => {
+      if (sessionKey === "agent:main:miloco-rule") throw new Error("boom");
+    });
+    const { api } = makeApi(del);
+    const res = await invoke(api, { sessionKeys: KEYS });
+
+    expect(del).toHaveBeenCalledTimes(3);
+    expect(res.reset).toEqual(["agent:main:miloco", "agent:main:miloco-suggest"]);
+    expect(res.failed).toEqual([
+      { sessionKey: "agent:main:miloco-rule", error: "boom" },
+    ]);
+  });
+
+  it("空 / 非数组 sessionKeys → 结构化错误，不触发 deleteSession", async () => {
+    const { api, del } = makeApi();
+    const empty = await invoke(api, { sessionKeys: [] });
+    expect(empty.status).toBe("error");
+    const missing = await invoke(api, {});
+    expect(missing.status).toBe("error");
+    expect(del).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/openclaw/tests/reset-sessions.test.ts
+++ b/plugins/openclaw/tests/reset-sessions.test.ts
@@ -65,12 +65,15 @@ describe("kResetSessionsWebhook 批量重置 session", () => {
     ]);
   });
 
-  it("空 / 非数组 sessionKeys → 结构化错误，不触发 deleteSession", async () => {
+  it("空 / 非数组 sessionKeys → 抛错（交 index.ts 包成 code!=0），不触发 deleteSession", async () => {
     const { api, del } = makeApi();
-    const empty = await invoke(api, { sessionKeys: [] });
-    expect(empty.status).toBe("error");
-    const missing = await invoke(api, {});
-    expect(missing.status).toBe("error");
+    // 抛错而非返回结构化 error：与其它 action 校验失败的错误通道一致。
+    await expect(invoke(api, { sessionKeys: [] })).rejects.toThrow(
+      "sessionKeys must be a non-empty array",
+    );
+    await expect(invoke(api, {})).rejects.toThrow(
+      "sessionKeys must be a non-empty array",
+    );
     expect(del).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## 背景

在 miloco 网页 / CLI **切换家庭**时，openclaw 里 miloco 相关的 agent session 仍保留着上一个家庭的上下文（设备、房间、习惯等），会串入新家庭、造成上下文干扰。本 PR 让切换家庭时把这些 session 批量重置（delete）。

## 改动

**插件（openclaw）**
- 新增 `reset_sessions` webhook（`src/webhooks/reset_sessions.ts`）：接收 `{ sessionKeys[], deleteTranscript? }`，逐个 `deleteSession`，**单个失败不影响其余**，返回 `{ reset, failed }` 便于后端观测。做成通用的"reset 指定 session"接口，session 列表由后端传入，插件不硬编码业务 key。
- 在 `webhooks/index.ts` 注册该 action。

**后端（miloco）**
- `dispatch/dispatcher.py`：从 `_ROUTE` 派生去重的 `MILOCO_SESSION_KEYS`（`agent:main:miloco` / `-rule` / `-suggest`），以 `_ROUTE` 为**唯一事实源**，避免别处手抄漂移。
- `utils/agent_client.py`：新增 `reset_agent_sessions()` 封装 `reset_sessions` webhook 调用；空列表短路。
- `miot/service.py::switch_home()`（网页 `PUT /api/miot/scope/homes` 与 CLI `scope home switch` 的共同收口点）在 KV 写入后**后台 best-effort** 触发 reset：openclaw 不可达 / 删除失败只 WARN，**绝不阻塞或打断切换本身**（对齐现有 `_background_refresh` 模式）。

## 设计取舍

- **后台而非同步 await**：`switch_home` 现有设计刻意把云端刷新丢后台以免拖慢 HTTP，reset 同理。代价是切换后到 reset 完成间有极短窗口，若正好落进一条旧家庭感知 turn 会用到旧 session——概率极低且无害（下一 turn 即空会话）。
- **`deleteTranscript=true`**：彻底清空，最符合"防上下文干扰"语义；删的是后台 agent 会话（非车主 IM 会话），安全，无溢出自愈里"误删用户 IM 历史"的顾虑。

## 测试

- 插件 `tests/reset-sessions.test.ts`：全删成功 / `deleteTranscript` 透传 / 单 key 失败其余继续 / 空数组结构化错误。
- 后端 `test_agent_client.py`：组包 payload / 空列表短路 / 异常上抛。
- 后端 `test_miot_filter_and_cameras.py`：`switch_home` 触发 reset 传入 `MILOCO_SESSION_KEYS`；reset 失败被吞不影响切换。
- 后端 `test_dispatcher.py`：`MILOCO_SESSION_KEYS` 与 `_ROUTE` 派生一致。

本地验证：后端 `pytest`（108 passed）、插件 `vitest`（128 passed）、`tsc --noEmit`、`ruff` 与 `biome check`（改动文件）均通过。