### PR TITLE
fix: CoreML 临时模型文件泄漏,$TMPDIR 无界堆积改为有界复用缓存

### DIFF
--- a/backend/miloco/src/miloco/perception/engine/identity/tracker/detector.py
+++ b/backend/miloco/src/miloco/perception/engine/identity/tracker/detector.py
@@ -99,6 +99,18 @@ class Detector:
         self.input_height = self.input_shape[2]
         self.input_width = self.input_shape[3]
 
+    def release(self):
+        """释放 ONNX session。
+
+        置 None 让 refcount 归零,触发底层 CoreML Execution 析构链清理其中间
+        模型文件(见 ort_utils);与 HumanReID.release 对齐,给高频重建路径一个
+        确定性的 teardown 入口,避免只靠 GC 时机不定。
+        """
+        self.session = None
+
+    def __del__(self):
+        self.release()
+
     def preprocess(self, image: np.ndarray) -> Tuple[np.ndarray, float, float, float]:
         """
         预处理图像

--- a/backend/miloco/src/miloco/perception/inference/ort_utils.py
+++ b/backend/miloco/src/miloco/perception/inference/ort_utils.py
@@ -37,6 +37,9 @@ _COREML_CACHE_DIRNAME = "coreml_cache"
 
 # 兜底:cache 目录总大小超过 models_dir 下所有 onnx 之和的这个倍数时整目录清空
 # 重建。全清是安全操作(下次 session 重编译一次而已,不会用错模型),故阈值可保守。
+# 真机实测(ort 1.27.0):单模型 CoreML 编译产物约为源 onnx 的 ~2x(det 43MB →
+# cache 89MB),稳态 det+reid 合计 total/base ≈ 1.4x;模型升级一次(旧目录暂留)
+# 约 2.8x 仍 < 3x,连续两次以上升级累积才触发全清 —— 故 3x 余量足、稳态不误触发。
 _CACHE_OVERSIZE_MULTIPLIER = 3
 
 # 总量兜底清理进程内只跑一次(首个 CoreML session 创建前),避免边清边读。
@@ -88,7 +91,6 @@ def _sweep_coreml_cache_if_oversized_once() -> None:
     with _cache_sweep_lock:
         if _cache_sweep_done:
             return
-        _cache_sweep_done = True
         try:
             from miloco.config import get_settings
 
@@ -120,6 +122,11 @@ def _sweep_coreml_cache_if_oversized_once() -> None:
             _LOGGER.warning(
                 "CoreML cache 兜底清理失败(忽略,不影响启动)", exc_info=True
             )
+        finally:
+            # 置位移到清理完成之后:并发 make_session 的其它线程在快速路径见到未置位
+            # 时会进锁阻塞,直到 rmtree 结束才放行,兑现「首个 session 创建前清完」
+            # 屏障、杜绝边清边读;用 finally 保证即便清理体抛异常也只跑一次、不重试。
+            _cache_sweep_done = True
 
 
 def make_session(

--- a/backend/miloco/src/miloco/perception/inference/ort_utils.py
+++ b/backend/miloco/src/miloco/perception/inference/ort_utils.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import platform
+import shutil
+import threading
+from pathlib import Path
 
 import onnxruntime as ort
 
@@ -22,6 +26,23 @@ _IS_APPLE_SILICON = (
     platform.system() == "Darwin" and platform.machine() == "arm64"
 )
 
+# CoreML EP 每建一个 InferenceSession 都会把 ONNX 子图序列化成一个 ~模型等大的
+# 中间 .mlmodel 写进 $TMPDIR,且删除只挂在 C++ Execution 析构链上——进程被
+# SIGKILL / session 对象不及时释放时文件永久遗留,长跑累积可撑爆磁盘(上游
+# microsoft/onnxruntime#26023,至今无修复)。ModelCacheDirectory(>=1.21)把这些
+# 文件从 $TMPDIR 挪到我们指定的持久目录并跨 session/进程复用,把"无界泄漏"收敛
+# 成"每模型一份的有界 footprint"。cache 子目录按模型内容 hash 隔离,规避 ORT 自身
+# cache key 不检测内容变更(原地换模型会复用旧编译产物)的坑。
+_COREML_CACHE_DIRNAME = "coreml_cache"
+
+# 兜底:cache 目录总大小超过 models_dir 下所有 onnx 之和的这个倍数时整目录清空
+# 重建。全清是安全操作(下次 session 重编译一次而已,不会用错模型),故阈值可保守。
+_CACHE_OVERSIZE_MULTIPLIER = 3
+
+# 总量兜底清理进程内只跑一次(首个 CoreML session 创建前),避免边清边读。
+_cache_sweep_lock = threading.Lock()
+_cache_sweep_done = False
+
 
 def _ort_version_ge(major: int, minor: int) -> bool:
     try:
@@ -29,6 +50,76 @@ def _ort_version_ge(major: int, minor: int) -> bool:
         return (int(parts[0]), int(parts[1])) >= (major, minor)
     except (ValueError, IndexError):
         return False
+
+
+def _hash_model_file(model_path: str) -> str:
+    """模型文件内容的 sha256 前 16 位,作 cache 子目录名。
+
+    用内容而非路径:模型换代(原地覆盖同名文件)hash 变→新目录,天然规避复用旧
+    编译产物;同一模型(重启/跨机复制)hash 稳→复用同一目录。
+    """
+    h = hashlib.sha256()
+    with open(model_path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()[:16]
+
+
+def _coreml_cache_root() -> Path:
+    # 惰性 import:config 不反向依赖本模块,函数内 import 既避免任何 import cycle,
+    # 也沿用 detector/human_reid 里 make_session 的惰性风格。
+    from miloco.config import get_settings
+
+    return get_settings().directories.workspace_dir / _COREML_CACHE_DIRNAME
+
+
+def _model_cache_dir(model_path: str) -> Path:
+    """该模型的独立 CoreML cache 目录(coreml_cache/<content-hash>/),已确保存在。"""
+    cache_dir = _coreml_cache_root() / _hash_model_file(model_path)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return cache_dir
+
+
+def _sweep_coreml_cache_if_oversized_once() -> None:
+    """进程内一次:cache 目录总量超阈值则整目录清空重建。失败只告警不阻断启动。"""
+    global _cache_sweep_done
+    if _cache_sweep_done:
+        return
+    with _cache_sweep_lock:
+        if _cache_sweep_done:
+            return
+        _cache_sweep_done = True
+        try:
+            from miloco.config import get_settings
+
+            dirs = get_settings().directories
+            root = dirs.workspace_dir / _COREML_CACHE_DIRNAME
+            if not root.is_dir():
+                return
+            models_dir = dirs.models_dir
+            base = (
+                sum(p.stat().st_size for p in models_dir.glob("*.onnx"))
+                if models_dir.is_dir()
+                else 0
+            )
+            if base <= 0:
+                # 基准算不出(模型目录缺失)时不敢清,避免误删。
+                return
+            total = sum(p.stat().st_size for p in root.rglob("*") if p.is_file())
+            if total > base * _CACHE_OVERSIZE_MULTIPLIER:
+                shutil.rmtree(root, ignore_errors=True)
+                root.mkdir(parents=True, exist_ok=True)
+                _LOGGER.warning(
+                    "CoreML cache %s 膨胀到 %.0fMB > %dx onnx总和(%.0fMB),已整清重建",
+                    root,
+                    total / 1e6,
+                    _CACHE_OVERSIZE_MULTIPLIER,
+                    base / 1e6,
+                )
+        except Exception:
+            _LOGGER.warning(
+                "CoreML cache 兜底清理失败(忽略,不影响启动)", exc_info=True
+            )
 
 
 def make_session(
@@ -58,6 +149,27 @@ def make_session(
     # p95 = 4e-4 — 故未加 provider_options 钉死 MLComputeUnits。
     elif _IS_APPLE_SILICON and "CoreMLExecutionProvider" in available:
         providers = ["CoreMLExecutionProvider", "CPUExecutionProvider"]
+        # ModelCacheDirectory 需 onnxruntime >= 1.21;更低版本(如本地测试用的
+        # 1.19)不认该 option,退回不带 cache 的 plain CoreML(与旧行为一致,
+        # 不 break)。cache 目录准备的任何异常也一律优雅退回——cache 是优化,
+        # 绝不能因它拖垮感知推理。
+        if _ort_version_ge(1, 21):
+            cache_dir = None
+            try:
+                _sweep_coreml_cache_if_oversized_once()
+                cache_dir = _model_cache_dir(model_path)
+            except Exception:
+                _LOGGER.warning(
+                    "CoreML cache 目录准备失败,退回无 cache 模式", exc_info=True
+                )
+            if cache_dir is not None:
+                providers = [
+                    (
+                        "CoreMLExecutionProvider",
+                        {"ModelCacheDirectory": str(cache_dir)},
+                    ),
+                    "CPUExecutionProvider",
+                ]
     elif _IS_APPLE_SILICON:
         # 自构 / 精简版 wheel 可能不带 CoreML EP,此时静默退回 CPU EP 会让本
         # 模块的内存修复彻底失效。WARNING 级别醒目,避免长跑几小时才发现 RSS

--- a/backend/miloco/src/miloco/perception/inference/ort_utils.py
+++ b/backend/miloco/src/miloco/perception/inference/ort_utils.py
@@ -43,8 +43,11 @@ _COREML_CACHE_DIRNAME = "coreml_cache"
 _CACHE_OVERSIZE_MULTIPLIER = 3
 
 # 总量兜底清理进程内只跑一次(首个 CoreML session 创建前),避免边清边读。
+# 用 threading.Event 表达「已清」这一次性标志:is_set / set 线程安全,配合下面的
+# 锁做双检锁;比模块级 bool + global 更贴 once 语义,也让 CodeQL 不再把「本次
+# 调用写、下次调用读」的跨调用持久 flag 按单次数据流误判为 unused global。
 _cache_sweep_lock = threading.Lock()
-_cache_sweep_done = False
+_cache_swept = threading.Event()
 
 
 def _ort_version_ge(major: int, minor: int) -> bool:
@@ -85,11 +88,10 @@ def _model_cache_dir(model_path: str) -> Path:
 
 def _sweep_coreml_cache_if_oversized_once() -> None:
     """进程内一次:cache 目录总量超阈值则整目录清空重建。失败只告警不阻断启动。"""
-    global _cache_sweep_done
-    if _cache_sweep_done:
+    if _cache_swept.is_set():
         return
     with _cache_sweep_lock:
-        if _cache_sweep_done:
+        if _cache_swept.is_set():
             return
         try:
             from miloco.config import get_settings
@@ -126,10 +128,10 @@ def _sweep_coreml_cache_if_oversized_once() -> None:
                 "CoreML cache 兜底清理失败(忽略,不影响启动)", exc_info=True
             )
         finally:
-            # 置位移到清理完成之后:并发 make_session 的其它线程在快速路径见到未置位
+            # set 移到清理完成之后:并发 make_session 的其它线程在快速路径见到未 set
             # 时会进锁阻塞,直到 rmtree 结束才放行,兑现「首个 session 创建前清完」
-            # 屏障、杜绝边清边读;用 finally 保证即便清理体抛异常也只跑一次、不重试。
-            _cache_sweep_done = True
+            # 屏障、杜绝边清边读;用 finally 保证即便清理体抛异常也只 set 一次、不重试。
+            _cache_swept.set()
 
 
 def make_session(

--- a/backend/miloco/src/miloco/perception/inference/ort_utils.py
+++ b/backend/miloco/src/miloco/perception/inference/ort_utils.py
@@ -95,7 +95,10 @@ def _sweep_coreml_cache_if_oversized_once() -> None:
             from miloco.config import get_settings
 
             dirs = get_settings().directories
-            root = dirs.workspace_dir / _COREML_CACHE_DIRNAME
+            # 缓存根与 _model_cache_dir 走同一来源(_coreml_cache_root),避免两处
+            # 拼路径:将来改缓存根布局时只改一处就会让 sweep 与实际缓存目录分叉、
+            # 清错 / 清不到。
+            root = _coreml_cache_root()
             if not root.is_dir():
                 return
             models_dir = dirs.models_dir

--- a/backend/miloco/src/miloco/person/router.py
+++ b/backend/miloco/src/miloco/person/router.py
@@ -4,9 +4,9 @@
 """Person controller — family member CRUD + Tier A 样本登记 + 习惯（v1.2 新增）。"""
 
 import asyncio
-import functools
 import logging
 import re
+import threading
 
 import cv2
 import numpy as np
@@ -969,25 +969,42 @@ class RegisterCommitPayload(BaseModel):
     _norm_role = field_validator("member_role")(_normalize_optional_str)
 
 
-@functools.lru_cache(maxsize=1)
+_detector_lock = threading.Lock()
+_detector_singleton = None
+
+
 def _load_detector():
     # 走 settings.directories.models_dir($MILOCO_HOME/models/)而非 __file__ 相对路径:
     # uv tool install miloco 后 __file__ 落在 site-packages 内, 但 wheel 不打 onnx,
     # 真模型部署到 $MILOCO_HOME/models/。主流程 perception/client.py 走的也是这个口径。
     #
-    # 单例复用:本函数原被 7+ 处注册/分析路径各调一次、每次新建一个 Detector →
-    # 每次多一个 CoreML session(各自在 cache/临时目录留一份中间模型文件)。改为
-    # 进程内复用同一实例:detect() 无共享可变状态、ORT session.run 线程安全,故并发
-    # 注册复用安全。lru_cache 在 settings reset 时由下方 hook 清空(换 workspace/
-    # 测试);生产原地热替换模型需重启进程才生效。
-    from miloco.perception.engine.identity.tracker.detector import Detector
-    det_path = get_settings().directories.models_dir / "det_4C.onnx"
-    return Detector(model_path=str(det_path), conf_threshold=0.4, use_gpu=False)
+    # 显式双检锁做进程内单例:本函数被 7+ 处注册/分析路径调用,且都在
+    # asyncio.to_thread 里跑(真实多线程并发)。用锁把构造串起来 —— 而非依赖
+    # functools.lru_cache(其执行期间不持锁,冷启动并发 miss 会各建一个 Detector、
+    # 只留一个),让「单例」在冷启动瞬间也严格成立、不多建 CoreML session。
+    # detect() 只读 self、ORT session.run 线程安全,故复用同一实例并发安全;生产原地
+    # 热替换模型需重启进程才生效。
+    global _detector_singleton
+    if _detector_singleton is not None:
+        return _detector_singleton
+    with _detector_lock:
+        if _detector_singleton is None:
+            from miloco.perception.engine.identity.tracker.detector import Detector
+            det_path = get_settings().directories.models_dir / "det_4C.onnx"
+            _detector_singleton = Detector(
+                model_path=str(det_path), conf_threshold=0.4, use_gpu=False
+            )
+    return _detector_singleton
 
 
-# settings reset(换 workspace / 测试)后让上面的单例失效,避免返回指向旧 models_dir
-# 的残留 Detector。
-register_reset_hook("person_router_detector", _load_detector.cache_clear)
+def _reset_detector_singleton():
+    # settings reset(换 workspace / 测试)后让单例失效,避免返回指向旧 models_dir
+    # 的残留 Detector。
+    global _detector_singleton
+    _detector_singleton = None
+
+
+register_reset_hook("person_router_detector", _reset_detector_singleton)
 
 
 def _should_use_frontal_seed(

--- a/backend/miloco/src/miloco/person/router.py
+++ b/backend/miloco/src/miloco/person/router.py
@@ -4,6 +4,7 @@
 """Person controller — family member CRUD + Tier A 样本登记 + 习惯（v1.2 新增）。"""
 
 import asyncio
+import functools
 import logging
 import re
 
@@ -13,7 +14,7 @@ from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field, field_validator
 
-from miloco.config import get_settings
+from miloco.config import get_settings, register_reset_hook
 from miloco.database.person_repo import UNSET
 from miloco.manager import get_manager
 from miloco.middleware import verify_token
@@ -968,13 +969,25 @@ class RegisterCommitPayload(BaseModel):
     _norm_role = field_validator("member_role")(_normalize_optional_str)
 
 
+@functools.lru_cache(maxsize=1)
 def _load_detector():
     # 走 settings.directories.models_dir($MILOCO_HOME/models/)而非 __file__ 相对路径:
     # uv tool install miloco 后 __file__ 落在 site-packages 内, 但 wheel 不打 onnx,
     # 真模型部署到 $MILOCO_HOME/models/。主流程 perception/client.py 走的也是这个口径。
+    #
+    # 单例复用:本函数原被 7+ 处注册/分析路径各调一次、每次新建一个 Detector →
+    # 每次多一个 CoreML session(各自在 cache/临时目录留一份中间模型文件)。改为
+    # 进程内复用同一实例:detect() 无共享可变状态、ORT session.run 线程安全,故并发
+    # 注册复用安全。lru_cache 在 settings reset 时由下方 hook 清空(换 workspace/
+    # 测试);生产原地热替换模型需重启进程才生效。
     from miloco.perception.engine.identity.tracker.detector import Detector
     det_path = get_settings().directories.models_dir / "det_4C.onnx"
     return Detector(model_path=str(det_path), conf_threshold=0.4, use_gpu=False)
+
+
+# settings reset(换 workspace / 测试)后让上面的单例失效,避免返回指向旧 models_dir
+# 的残留 Detector。
+register_reset_hook("person_router_detector", _load_detector.cache_clear)
 
 
 def _should_use_frontal_seed(

--- a/backend/miloco/tests/perception/inference/test_ort_utils.py
+++ b/backend/miloco/tests/perception/inference/test_ort_utils.py
@@ -92,7 +92,7 @@ def test_reset_hook_invalidates_detector_singleton(iso_home, monkeypatch):
 
     # stub 掉真 Detector,避免建真实 CoreML session;每次返回不同对象便于判定
     monkeypatch.setattr(detector_mod, "Detector", lambda **kw: object())
-    router._load_detector.cache_clear()
+    router._reset_detector_singleton()
 
     d1 = router._load_detector()
     d2 = router._load_detector()

--- a/backend/miloco/tests/perception/inference/test_ort_utils.py
+++ b/backend/miloco/tests/perception/inference/test_ort_utils.py
@@ -6,6 +6,8 @@ CoreML session(不依赖 CoreML EP / 真实模型推理)。
 """
 from __future__ import annotations
 
+import threading
+
 import pytest
 from miloco.perception.inference import ort_utils
 
@@ -41,7 +43,7 @@ def _cache_root(monkeypatch):
     """取当前 settings 下的 cache 根目录,并把进程级 once-guard 复位以便本次 sweep 生效。"""
     from miloco.config import get_settings
 
-    monkeypatch.setattr(ort_utils, "_cache_sweep_done", False)
+    monkeypatch.setattr(ort_utils, "_cache_swept", threading.Event())
     dirs = get_settings().directories
     return dirs.models_dir, dirs.workspace_dir / ort_utils._COREML_CACHE_DIRNAME
 

--- a/backend/miloco/tests/perception/inference/test_ort_utils.py
+++ b/backend/miloco/tests/perception/inference/test_ort_utils.py
@@ -1,0 +1,103 @@
+"""ort_utils 的 CoreML cache 逻辑单测。
+
+覆盖:内容寻址 hash、总量兜底清理(超标全清 / 阈值内保留 / once-guard 幂等)、
+以及 person router 检测器单例在 settings reset 后失效。均为纯逻辑,不建真实
+CoreML session(不依赖 CoreML EP / 真实模型推理)。
+"""
+from __future__ import annotations
+
+import pytest
+from miloco.perception.inference import ort_utils
+
+
+def test_hash_model_file_is_content_addressed(tmp_path):
+    a = tmp_path / "a.onnx"
+    a.write_bytes(b"model-A-bytes")
+    b = tmp_path / "b.onnx"
+    b.write_bytes(b"model-B-bytes")
+    c = tmp_path / "c.onnx"
+    c.write_bytes(b"model-A-bytes")  # 与 a 同内容、异名
+
+    ha = ort_utils._hash_model_file(str(a))
+    assert len(ha) == 16
+    assert ha == ort_utils._hash_model_file(str(a))  # 同文件稳定
+    assert ha == ort_utils._hash_model_file(str(c))  # 同内容 → 同 hash(与文件名无关)
+    assert ha != ort_utils._hash_model_file(str(b))  # 不同内容 → 不同 hash
+
+
+@pytest.fixture
+def iso_home(tmp_path, monkeypatch):
+    """把 MILOCO_HOME 指到临时目录,workspace_dir / models_dir 随之落在 tmp。"""
+    monkeypatch.setenv("MILOCO_HOME", str(tmp_path))
+    from miloco.config import reset_settings
+
+    reset_settings()
+    (tmp_path / "models").mkdir(exist_ok=True)
+    yield tmp_path
+    reset_settings()
+
+
+def _cache_root(monkeypatch):
+    """取当前 settings 下的 cache 根目录,并把进程级 once-guard 复位以便本次 sweep 生效。"""
+    from miloco.config import get_settings
+
+    monkeypatch.setattr(ort_utils, "_cache_sweep_done", False)
+    dirs = get_settings().directories
+    return dirs.models_dir, dirs.workspace_dir / ort_utils._COREML_CACHE_DIRNAME
+
+
+def test_sweep_clears_oversized_then_idempotent(iso_home, monkeypatch):
+    models_dir, root = _cache_root(monkeypatch)
+    # 基准:models 下 1MB 假 onnx → 阈值 = 3MB
+    (models_dir / "det.onnx").write_bytes(b"x" * 1_000_000)
+    (root / "hashA").mkdir(parents=True)
+    (root / "hashA" / "blob.bin").write_bytes(b"y" * 5_000_000)  # 5MB > 3MB
+
+    ort_utils._sweep_coreml_cache_if_oversized_once()
+    # 超标 → 整目录清空重建(root 仍在但为空)
+    assert root.is_dir()
+    assert not any(p.is_file() for p in root.rglob("*"))
+
+    # once-guard 幂等:再造 oversize,第二次调用不再清
+    (root / "hashB").mkdir(parents=True)
+    (root / "hashB" / "blob.bin").write_bytes(b"z" * 5_000_000)
+    ort_utils._sweep_coreml_cache_if_oversized_once()
+    assert any(p.is_file() for p in root.rglob("*"))
+
+
+def test_sweep_keeps_within_threshold(iso_home, monkeypatch):
+    models_dir, root = _cache_root(monkeypatch)
+    (models_dir / "det.onnx").write_bytes(b"x" * 5_000_000)  # 基准 5MB → 阈值 15MB
+    (root / "hashA").mkdir(parents=True)
+    (root / "hashA" / "blob.bin").write_bytes(b"y" * 6_000_000)  # 6MB < 15MB
+
+    ort_utils._sweep_coreml_cache_if_oversized_once()
+    assert (root / "hashA" / "blob.bin").exists()  # 未超标 → 保留复用
+
+
+def test_sweep_skips_when_base_unknown(iso_home, monkeypatch):
+    """models 无 onnx → 算不出基准 → 不敢清(避免误删),即便 cache 很大。"""
+    _, root = _cache_root(monkeypatch)
+    (root / "hashA").mkdir(parents=True)
+    (root / "hashA" / "blob.bin").write_bytes(b"y" * 9_000_000)
+
+    ort_utils._sweep_coreml_cache_if_oversized_once()
+    assert (root / "hashA" / "blob.bin").exists()
+
+
+def test_reset_hook_invalidates_detector_singleton(iso_home, monkeypatch):
+    import miloco.perception.engine.identity.tracker.detector as detector_mod
+    import miloco.person.router as router
+    from miloco.config import reset_settings
+
+    # stub 掉真 Detector,避免建真实 CoreML session;每次返回不同对象便于判定
+    monkeypatch.setattr(detector_mod, "Detector", lambda **kw: object())
+    router._load_detector.cache_clear()
+
+    d1 = router._load_detector()
+    d2 = router._load_detector()
+    assert d1 is d2  # 单例:进程内复用同一实例
+
+    reset_settings()  # 触发 register_reset_hook 注册的 cache_clear
+    d3 = router._load_detector()
+    assert d3 is not d1  # reset 后单例失效,重新构造


### PR DESCRIPTION
## 概述

修复 macOS(Apple Silicon)上 CoreML 执行后端(ONNX Runtime 的 CoreML EP)的临时模型文件泄漏:每建一个推理 session(InferenceSession),CoreML EP 都会把 ONNX 子图序列化成一份与模型等大的中间文件写进系统临时目录,而删除只挂在底层 C++ 对象的析构链上——进程被强杀 / session 不及时释放即永久遗留(上游行为,至今无修复);感知侧高频重建 session 将其放大到百 GB 级、几乎撑爆部署机磁盘。本 PR 从「持久复用缓存 + 总量兜底清理 + 降低重建频次」三处收敛。

## 1. 中间文件迁到有界复用缓存(根治磁盘泄漏)· fix

**问题**:CoreML EP 每建 session 产一份中间文件写系统临时目录,仅靠析构删除,强杀 / 不及时释放即遗留;检测模型含多个分区,单次建 session 实产多份,高频重建放大到百 GB。

**解决方案**:
- **挂持久缓存目录**:给 CoreML provider 设缓存目录,中间文件与编译产物落到该目录并跨 session / 进程复用,不再进系统临时目录(需 runtime ≥1.21,更低版本自动退回原行为)。
- **按模型内容 hash 隔离**:缓存子目录以模型文件内容 hash 命名,规避上游缓存键不检测模型变更、原地换模型复用旧编译产物的正确性坑;模型换代自动换目录。
- **全程 fail-safe**:缓存目录准备的任何异常一律退回无缓存的 plain CoreML,不让优化拖垮推理。

## 2. 缓存总量兜底清理(防累积)· fix

**问题**:内容 hash 隔离会随模型换代累积旧目录,上游缓存无自动淘汰。

**解决方案**:
- **进程内一次的总量清理**:首个 session 创建前查一次,缓存总量超过模型总和设定倍数即整目录清空重建;只清自家独占的缓存目录、不碰共享临时目录,失败只告警、不阻断启动。

## 3. 降低 session 重建频次(兼治内存 / 句柄)· refactor

**问题**:注册 / 分析路径每次调用新建检测器,除磁盘外还累积 native 内存与句柄。

**解决方案**:
- **检测器进程内单例**:复用同一实例(配套在配置重置时失效);检测无共享可变状态、推理线程安全,复用安全。
- **补确定性释放**:给检测器加显式释放 + 析构入口,给高频重建路径确定的 teardown。

## 测试与兼容性

- **真机 + 本地实测 + 单测**:与部署同版本(runtime 1.27.0)+ Apple Silicon 环境实测,建 session 后系统临时目录零增长、中间文件落内容 hash 缓存、第二次复用显著加速;并补纯逻辑单测覆盖内容 hash、兜底清理(超标全清 / 阈值内保留 / 基准缺失不清 / 幂等)、单例 reset 失效;相关回归单测全绿。
- **兼容 / 回滚**:runtime <1.21 或非 Apple Silicon 自动走原路径;缓存异常自动退回原行为;纯运行时产物,可安全回滚。
- **风险提醒**:缓存落在运行时工作目录下(与截图 / 数据库同级),若部署流程清空工作目录会连带清缓存(无害,自动重建);模型热替换需重启进程(单例与内容 hash 均以进程 / 文件为界)。
