### PR TITLE
docs: add OpenClaw version prerequisite to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Miloco 2.0 perceives what happens at home, makes proactive decisions and control
 
 - **Hardware**: ≥ 4GB RAM and ≥ 256GB storage recommended, running 24/7. A Mac mini is recommended.
 - **Operating System**: macOS / Linux (run under WSL on Windows).
+- **OpenClaw** — Miloco runs as a plugin on top of it, so [install it](https://openclaw.ai) first with version ≥ 2026.5.2.
 - **Xiaomi account** + devices already added to Mi Home.
 - **Multimodal large model API key** — [Xiaomi MiMo](https://platform.xiaomimimo.com) is recommended: MiMo-v2.5 for perception, MiMo-v2.5-pro for the Agent (configured in OpenClaw).
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -29,6 +29,7 @@ Miloco 2.0 能感知家中发生的事件，能基于常识主动判断并操控
 
 - **硬件**：建议内存 ≥ 4GB，存储 ≥ 256GB，7×24 常驻运行，推荐 Mac mini
 - **操作系统**：macOS / Linux（Windows 请在 WSL 中运行）
+- **OpenClaw** — Miloco 以插件形式运行其上，需先[安装](https://openclaw.ai)且版本 ≥ 2026.5.2
 - **小米账号** + 已接入米家的设备
 - **多模态大模型 API Key** — 推荐使用[小米 MiMo](https://platform.xiaomimimo.com)：感知用 MiMo-v2.5，Agent 用 MiMo-v2.5-pro（在 OpenClaw 中配置）
 


### PR DESCRIPTION
在中英文 README 的「前置条件 / Prerequisites」中新增 OpenClaw 说明：Miloco 以插件形式运行在 OpenClaw 之上，需先安装且版本 ≥ 2026.5.2。

版本号取自 `plugins/openclaw/package.json` 的 peerDependencies、`scripts/install-guide.md` 以及安装脚本版本校验文案（三处一致）。