### PR TITLE
docs: add status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 <p align="center">English | <a href="README.zh.md">简体中文</a></p>
 
+<p align="center">
+  <a href="https://github.com/XiaoMi/xiaomi-miloco/releases/latest"><img src="https://img.shields.io/github/v/release/XiaoMi/xiaomi-miloco?label=release" alt="Latest release" /></a>
+  <a href="LICENSE.md"><img src="https://img.shields.io/badge/license-Xiaomi%20Miloco-blue" alt="License" /></a>
+  <a href="https://github.com/XiaoMi/xiaomi-miloco/releases"><img src="https://img.shields.io/github/downloads/XiaoMi/xiaomi-miloco/total" alt="Downloads" /></a>
+  <a href="https://github.com/XiaoMi/xiaomi-miloco/stargazers"><img src="https://img.shields.io/github/stars/XiaoMi/xiaomi-miloco" alt="Stars" /></a>
+</p>
+
 Xiaomi's open-source AI solution for the future of whole-home intelligence. It uses the video and audio from Mi Home cameras as a full-modal perception gateway, the in-house MiMo large model as its intelligent brain, and runs as an Agent plugin on top of [OpenClaw](https://openclaw.ai) to orchestrate whole-home devices for a proactive, intelligent experience.
 
 Miloco 2.0 perceives what happens at home, makes proactive decisions and controls devices based on common sense, breaks down "vague and long-term" goals into trackable household tasks, recognizes family members, and—drawing on home memory—delivers personalized service to each member: querying and controlling devices, tuning the home to each member's comfort, or offering useful reminders at the right moment.

--- a/README.zh.md
+++ b/README.zh.md
@@ -2,6 +2,13 @@
 
 <p align="center"><a href="README.md">English</a> | 简体中文</p>
 
+<p align="center">
+  <a href="https://github.com/XiaoMi/xiaomi-miloco/releases/latest"><img src="https://img.shields.io/github/v/release/XiaoMi/xiaomi-miloco?label=release" alt="最新版本" /></a>
+  <a href="LICENSE.md"><img src="https://img.shields.io/badge/license-Xiaomi%20Miloco-blue" alt="许可协议" /></a>
+  <a href="https://github.com/XiaoMi/xiaomi-miloco/releases"><img src="https://img.shields.io/github/downloads/XiaoMi/xiaomi-miloco/total" alt="下载量" /></a>
+  <a href="https://github.com/XiaoMi/xiaomi-miloco/stargazers"><img src="https://img.shields.io/github/stars/XiaoMi/xiaomi-miloco" alt="Star 数" /></a>
+</p>
+
 小米面向未来的全屋智能 AI 开源方案，以米家摄像头的画面与声音为全模态感知入口，以自研 MiMo 大模型为智能大脑，以 Agent 插件形式运行在 [OpenClaw](https://openclaw.ai) 之上，联动全屋设备带来主动智能体验。
 
 Miloco 2.0 能感知家中发生的事件，能基于常识主动判断并操控设备，能将"模糊又长期"的目标拆解成可追踪的家庭任务，能识别家庭成员、依托家庭记忆为每位成员提供个性化服务——查询和控制设备、把家调到成员舒适的状态，或在合适的时机给出有用的提醒。


### PR DESCRIPTION
在 README 顶部（中英文两个版本）新增一行徽章，方便访客一眼看到项目状态。

## 改动内容

在语言切换行下方，居中新增以下徽章：

| 徽章 | 说明 | 链接 |
|---|---|---|
| **Release** | 最新发布版本（当前 `v2026.7.3`） | releases/latest |
| **License** | 静态徽章 `Xiaomi Miloco` | LICENSE.md |
| **Downloads** | GitHub release 总下载量 | releases |
| **Stars** | 仓库 Star 数 | stargazers |

## 说明

- License 采用静态徽章而非 shields 的 `github/license`，因为本仓库使用的是自定义《Xiaomi Miloco License Agreement》，GitHub 无法识别为标准 SPDX 协议（自动徽章会显示 "not identifiable"）。
- Downloads 统计的是 release 附件下载量，若某些 release 未附带二进制文件，计数可能为 0。
- 同步修改了 `README.md` 与 `README.zh.md` 两个版本。

<img width="867" height="386" alt="图片" src="https://github.com/user-attachments/assets/76ab9ac9-15af-43e0-845f-da40008ec503" />
