### PR TITLE
feat(omni): provider adapter + multi-model support

### DIFF
--- a/backend/miloco/src/miloco/config/settings.yaml
+++ b/backend/miloco/src/miloco/config/settings.yaml
@@ -85,6 +85,7 @@ perception:
       #   omni_fps —— 送 omni 的视频帧率, 与 fps 解耦; omni 已是瓶颈, 不随 tracker 提频涨
       fps: 3
       omni_fps: 1
+      video_short_edge: 512   # 视频编码短边像素（保持宽高比缩放）
     gate:
       # visual 滞回时长(秒)。visual 最近通过过、距今 <= 此值时,本窗 visual 不通过
       # 也强制生成 packet 并打 hold 标志,保住 video 路由不被纯音频短路。

--- a/backend/miloco/src/miloco/perception/engine/api.py
+++ b/backend/miloco/src/miloco/perception/engine/api.py
@@ -89,10 +89,12 @@ class PerceptionEngine(BasePerceptionEngine):
 
         self._config = config or PerceptionConfig()
 
+        from miloco.perception.engine.omni.provider import adjust_fps_for_omni
+
         fps = self._config.input.fps
         omni_fps = self._config.input.omni_fps
-        if omni_fps > 0 and fps % omni_fps != 0:
-            new_fps = omni_fps if omni_fps > fps else omni_fps * -(-fps // omni_fps)
+        new_fps = adjust_fps_for_omni(fps, omni_fps)
+        if new_fps != fps:
             logger.info(
                 "fps(%d) %% omni_fps(%d) != 0，自动调整 fps=%d → %d 保证整除",
                 fps, omni_fps, fps, new_fps,

--- a/backend/miloco/src/miloco/perception/engine/api.py
+++ b/backend/miloco/src/miloco/perception/engine/api.py
@@ -89,6 +89,20 @@ class PerceptionEngine(BasePerceptionEngine):
 
         self._config = config or PerceptionConfig()
 
+        fps = self._config.input.fps
+        omni_fps = self._config.input.omni_fps
+        if omni_fps > 0 and fps % omni_fps != 0:
+            new_fps = omni_fps if omni_fps > fps else omni_fps * -(-fps // omni_fps)
+            logger.info(
+                "fps(%d) %% omni_fps(%d) != 0，自动调整 fps=%d → %d 保证整除",
+                fps, omni_fps, fps, new_fps,
+            )
+            from dataclasses import replace
+            self._config = replace(
+                self._config,
+                input=replace(self._config.input, fps=new_fps),
+            )
+
         # ============ tracking_service 构造参数缓存（懒加载 factory 复用）============
         self._tracking_mode = self._config.identity.tracking_service_mode
         # 把 IdentityEngineConfig.sort 转成 sort.py 的 SortConfig（duck typing：字段同名）

--- a/backend/miloco/src/miloco/perception/engine/config.py
+++ b/backend/miloco/src/miloco/perception/engine/config.py
@@ -17,6 +17,7 @@ class InputConfig:
     audio_overlap_ms: int = (
         100  # overlap window to reduce audio truncation at boundaries
     )
+    video_short_edge: int = 512  # 视频编码短边像素（保持宽高比缩放）
 
 
 @dataclass

--- a/backend/miloco/src/miloco/perception/engine/config.py
+++ b/backend/miloco/src/miloco/perception/engine/config.py
@@ -17,7 +17,6 @@ class InputConfig:
     audio_overlap_ms: int = (
         100  # overlap window to reduce audio truncation at boundaries
     )
-    video_short_edge: int = 512  # 视频编码短边像素（保持宽高比缩放）
 
 
 @dataclass

--- a/backend/miloco/src/miloco/perception/engine/omni/omni.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/omni.py
@@ -23,7 +23,6 @@ from miloco.perception.engine.omni.omni_client import (
     extract_usage,
     resolve_api_key,
 )
-from miloco.perception.engine.omni.provider import get_adapter
 from miloco.perception.engine.omni.prompt_builder import (
     FusedPromptConfig,
     build_batch_prompt,
@@ -33,6 +32,7 @@ from miloco.perception.engine.omni.prompt_builder import (
     build_stream_prompt,
     format_person_label,
 )
+from miloco.perception.engine.omni.provider import get_adapter
 from miloco.perception.engine.omni.response_parser import (
     parse_identity_assignments,
     parse_omni_response,

--- a/backend/miloco/src/miloco/perception/engine/omni/omni.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/omni.py
@@ -317,12 +317,10 @@ async def _call_omni_messages(
         # 服务端在 fused 大 payload 下偶发返回非 dict body (~1.5%);此处校验
         # 形态并 dump 截断后的原始响应,便于事后定位服务端返回了什么。
         if not isinstance(raw, dict):
-            logger.error(
-                "[omni-fused] unexpected response shape | status=%d type=%s body=%s",
-                resp.status_code,
-                type(raw).__name__,
-                resp.text[:1000],
-            )
+            detail = f"type={type(raw).__name__} body={str(raw)[:1000]}"
+            if not forced_stream:
+                detail = f"status={resp.status_code} {detail}"
+            logger.error("[omni-fused] unexpected response shape | %s", detail)
             raise OmniError(
                 f"omni response is not a dict (got {type(raw).__name__})"
             )

--- a/backend/miloco/src/miloco/perception/engine/omni/omni.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/omni.py
@@ -317,12 +317,12 @@ async def _call_omni_messages(
         # 服务端在 fused 大 payload 下偶发返回非 dict body (~1.5%);此处校验
         # 形态并 dump 截断后的原始响应,便于事后定位服务端返回了什么。
         if not isinstance(raw, dict):
-            detail = f"type={type(raw).__name__} body={str(raw)[:1000]}"
+            detail = f"type={raw.__class__.__name__} body={str(raw)[:1000]}"
             if not forced_stream:
                 detail = f"status={resp.status_code} {detail}"
             logger.error("[omni-fused] unexpected response shape | %s", detail)
             raise OmniError(
-                f"omni response is not a dict (got {type(raw).__name__})"
+                f"omni response is not a dict (got {raw.__class__.__name__})"
             )
         fire_record(config.model, raw.get("usage", {}), type)
         return raw

--- a/backend/miloco/src/miloco/perception/engine/omni/omni.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/omni.py
@@ -22,6 +22,7 @@ from miloco.perception.engine.omni.omni_client import (
     extract_usage,
     resolve_api_key,
 )
+from miloco.perception.engine.omni.provider import get_adapter
 from miloco.perception.engine.omni.prompt_builder import (
     FusedPromptConfig,
     build_batch_prompt,
@@ -45,6 +46,7 @@ from miloco.perception.types import MatchedRule, Speech, Suggestion
 
 if TYPE_CHECKING:
     from miloco.perception.engine.identity.engine import IdentityEngine
+    from miloco.perception.engine.omni.provider import OmniProviderAdapter
 
 logger = logging.getLogger(__name__)
 
@@ -151,6 +153,7 @@ async def run_omni_fused(
     # deliver_fused_failure，否则 mark_dispatched 已置 inflight=True 的 track
     # 永远不会被 GC（_gc_dead_tracks 跳过 inflight）也不会被重新派发
     # （needs_omni_call 返回 False）。
+    adapter = get_adapter(config.model)
     try:
         payload = build_fused_payload(
             packets=edge_packets,
@@ -159,8 +162,9 @@ async def run_omni_fused(
             gallery_snapshot=gallery_snapshot,
             config=fused_prompt_config,
             label_lookup=name_lookup,
+            adapter=adapter,
         )
-        raw_response = await _call_omni_messages(payload["messages"], config)
+        raw_response = await _call_omni_messages(payload["messages"], config, adapter=adapter)
     except OmniError as e:
         # omni API / 网络错:_call_omni_messages 已在源头打日志(omni API 调用失败),
         # 这里只做 inflight track 清理 + 上抛,不重复打。
@@ -254,7 +258,10 @@ def _get_fused_http_client(timeout: float) -> httpx.AsyncClient:
 
 
 async def _call_omni_messages(
-    messages: list[dict], config: OmniConfig, type: str = "realtime"
+    messages: list[dict],
+    config: OmniConfig,
+    type: str = "realtime",
+    adapter: "OmniProviderAdapter | None" = None,
 ) -> dict[str, Any]:
     """调 omni——直接传 messages（fused 模式专用）。
 
@@ -266,15 +273,16 @@ async def _call_omni_messages(
     if not api_key:
         raise ValueError("MILOCO_MODEL__OMNI__API_KEY is not set; cannot call fused omni")
 
-    body: dict[str, Any] = {
-        "model": config.model,
-        "messages": messages,
-        "max_tokens": config.max_completion_tokens,
-        "temperature": config.temperature,
-        "top_p": config.top_p,
-        "stream": False,
-        "thinking": {"type": "disabled"},
-    }
+    if adapter is None:
+        adapter = get_adapter(config.model)
+    body = adapter.build_request_body(
+        messages,
+        model=config.model,
+        max_tokens=config.max_completion_tokens,
+        temperature=config.temperature,
+        top_p=config.top_p,
+        stream=False,
+    )
 
     client = _get_fused_http_client(config.timeout)
     t0 = time.monotonic()

--- a/backend/miloco/src/miloco/perception/engine/omni/omni.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/omni.py
@@ -17,6 +17,7 @@ from miloco.perception.engine.config import OmniConfig
 from miloco.perception.engine.omni.constants import MILOCO_USER_AGENT
 from miloco.perception.engine.omni.omni_client import (
     OmniError,
+    _collect_stream_response,
     call_omni,
     call_omni_stream,
     extract_usage,
@@ -284,33 +285,35 @@ async def _call_omni_messages(
         stream=False,
     )
 
+    forced_stream = body.get("stream", False)
+
     client = _get_fused_http_client(config.timeout)
     t0 = time.monotonic()
     raw: dict[str, Any] | None = None
     error: dict[str, Any] | None = None
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {api_key}",
+        "User-Agent": MILOCO_USER_AGENT,
+    }
     try:
-        resp = await client.post(
-            f"{config.base_url}/chat/completions",
-            headers={
-                "Content-Type": "application/json",
-                "Authorization": f"Bearer {api_key}",
-                "User-Agent": MILOCO_USER_AGENT,
-            },
-            json=body,
-        )
-        if resp.status_code != 200:
-            logger.error("[omni] omni API 调用失败，错误码=%d | %s", resp.status_code, resp.text[:500])
-            # 400 通常是 multimodal payload 服务端拒收 (corrupted image/video)。
-            # 静态从 traceback 无法定位是哪个块出问题, 这里输出每个多模态块的尺寸
-            # summary (不打 base64 本身, 仅尺寸) 便于事后定位。仅 400 路径打, 不影响
-            # 常态 log 量。
-            if resp.status_code == 400:
-                logger.error(
-                    "[omni] omni 400 payload 摘要 | %s",
-                    _summarize_multimodal_payload(messages),
-                )
-        resp.raise_for_status()
-        raw = resp.json()
+        if not forced_stream:
+            resp = await client.post(
+                f"{config.base_url}/chat/completions",
+                headers=headers,
+                json=body,
+            )
+            if resp.status_code != 200:
+                logger.error("[omni] omni API 调用失败，错误码=%d | %s", resp.status_code, resp.text[:500])
+                if resp.status_code == 400:
+                    logger.error(
+                        "[omni] omni 400 payload 摘要 | %s",
+                        _summarize_multimodal_payload(messages),
+                    )
+            resp.raise_for_status()
+            raw = resp.json()
+        else:
+            raw = await _collect_stream_response(client, config.base_url, headers, body)
         # 服务端在 fused 大 payload 下偶发返回非 dict body (~1.5%);此处校验
         # 形态并 dump 截断后的原始响应,便于事后定位服务端返回了什么。
         if not isinstance(raw, dict):

--- a/backend/miloco/src/miloco/perception/engine/omni/omni_client.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/omni_client.py
@@ -15,6 +15,7 @@ import httpx
 from miloco.database.token_usage_repo import fire_record
 from miloco.perception.engine.config import OmniConfig
 from miloco.perception.engine.omni.constants import MILOCO_USER_AGENT
+from miloco.perception.engine.omni.provider import OmniProviderAdapter, get_adapter
 from miloco.perception.snapshot_context import push_omni_trace
 
 logger = logging.getLogger(__name__)
@@ -144,17 +145,17 @@ async def call_omni(
             f"{_ENV_KEY} is not set. Provide it via config or environment variable."
         )
 
-    messages = _build_messages(payload)
+    adapter = get_adapter(config.model)
+    messages = _build_messages(payload, adapter)
 
-    body: dict[str, Any] = {
-        "model": config.model,
-        "messages": messages,
-        "max_tokens": config.max_completion_tokens,
-        "temperature": config.temperature,
-        "top_p": config.top_p,
-        "stream": False,
-        "thinking": {"type": "disabled"},
-    }
+    body = adapter.build_request_body(
+        messages,
+        model=config.model,
+        max_tokens=config.max_completion_tokens,
+        temperature=config.temperature,
+        top_p=config.top_p,
+        stream=False,
+    )
 
     t0 = time.monotonic()
     raw: dict[str, Any] | None = None
@@ -200,33 +201,17 @@ async def call_omni(
         )
 
 
-def _build_messages(payload: dict) -> list[dict]:
+def _build_messages(payload: dict, adapter: OmniProviderAdapter) -> list[dict]:
     messages: list[dict] = [{"role": "system", "content": payload["system_prompt"]}]
 
     content: list[dict] = [{"type": "text", "text": payload["user_content"]}]
 
-    # Video (frames + audio merged into mp4)；与 audio_base64 互斥（上游 _build_payload 保证）
+    media_info = payload.get("media_info")
+
     if payload.get("video_base64"):
-        content.append(
-            {
-                "type": "video_url",
-                "video_url": {
-                    "url": f"data:video/mp4;base64,{payload['video_base64']}"
-                },
-                "fps": payload.get("video_fps", 3),
-                "media_resolution": "max",
-            }
-        )
-    # Audio-only route：独立 input_audio 块（仅当无 video_base64 时启用）
+        content.append(adapter.build_video_block(payload["video_base64"], media_info))
     elif payload.get("audio_base64"):
-        content.append(
-            {
-                "type": "input_audio",
-                "input_audio": {
-                    "data": f"data:audio/m4a;base64,{payload['audio_base64']}"
-                },
-            }
-        )
+        content.append(adapter.build_audio_block(payload["audio_base64"], media_info))
 
     # Crop images (from tracker)
     for crop in payload.get("crops", []):
@@ -283,18 +268,17 @@ async def call_omni_stream(
             f"{_ENV_KEY} is not set. Provide it via config or environment variable."
         )
 
-    messages = _build_messages(payload)
+    adapter = get_adapter(config.model)
+    messages = _build_messages(payload, adapter)
 
-    body: dict[str, Any] = {
-        "model": config.model,
-        "messages": messages,
-        "max_tokens": config.max_completion_tokens,
-        "temperature": config.temperature,
-        "top_p": config.top_p,
-        "stream": True,
-        "stream_options": {"include_usage": True},
-        "thinking": {"type": "disabled"},
-    }
+    body = adapter.build_request_body(
+        messages,
+        model=config.model,
+        max_tokens=config.max_completion_tokens,
+        temperature=config.temperature,
+        top_p=config.top_p,
+        stream=True,
+    )
     headers = {
         "Content-Type": "application/json",
         "Authorization": f"Bearer {api_key}",

--- a/backend/miloco/src/miloco/perception/engine/omni/omni_client.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/omni_client.py
@@ -225,6 +225,12 @@ async def _collect_stream_response(
         if resp.status_code != 200:
             await resp.aread()
             logger.error("Omni stream error %d: %s", resp.status_code, resp.text[:500])
+            if resp.status_code == 400:
+                from miloco.perception.engine.omni.omni import _summarize_multimodal_payload
+                logger.error(
+                    "[omni] stream 400 payload 摘要 | %s",
+                    _summarize_multimodal_payload(body.get("messages", [])),
+                )
             resp.raise_for_status()
         async for line in resp.aiter_lines():
             line = line.strip()

--- a/backend/miloco/src/miloco/perception/engine/omni/omni_client.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/omni_client.py
@@ -157,30 +157,36 @@ async def call_omni(
         stream=False,
     )
 
+    forced_stream = body.get("stream", False)
+
     t0 = time.monotonic()
     raw: dict[str, Any] | None = None
     error: dict[str, Any] | None = None
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {api_key}",
+        "User-Agent": MILOCO_USER_AGENT,
+    }
     try:
         async with httpx.AsyncClient(timeout=config.timeout) as client:
-            resp = await client.post(
-                f"{config.base_url}/chat/completions",
-                headers={
-                    "Content-Type": "application/json",
-                    "Authorization": f"Bearer {api_key}",
-                    "User-Agent": MILOCO_USER_AGENT,
-                },
-                json=body,
-            )
-            if resp.status_code != 200:
-                logger.error(
-                    "Omni API error %d: %s", resp.status_code, resp.text[:500]
+            if not forced_stream:
+                resp = await client.post(
+                    f"{config.base_url}/chat/completions",
+                    headers=headers,
+                    json=body,
                 )
-            resp.raise_for_status()
-            raw = resp.json()
+                if resp.status_code != 200:
+                    logger.error(
+                        "Omni API error %d: %s", resp.status_code, resp.text[:500]
+                    )
+                resp.raise_for_status()
+                raw = resp.json()
+            else:
+                raw = await _collect_stream_response(client, config.base_url, headers, body)
             fire_record(config.model, raw.get("usage", {}), type)
         return raw
     except OmniError:
-        raise  # 不重复包装
+        raise
     except Exception as e:
         error = {"code": e.__class__.__name__, "msg": str(e)[:512]}
         raise OmniError(
@@ -199,6 +205,50 @@ async def call_omni(
                 "max_tokens": config.max_completion_tokens,
             },
         )
+
+
+async def _collect_stream_response(
+    client: httpx.AsyncClient,
+    base_url: str,
+    headers: dict[str, str],
+    body: dict[str, Any],
+) -> dict[str, Any]:
+    """读取 SSE 流并拼接为等效的非流式响应 dict。
+
+    用于 adapter 强制 stream=True（如 Qwen）但调用方期望同步返回的场景。
+    """
+    content_parts: list[str] = []
+    usage: dict[str, Any] = {}
+    async with client.stream(
+        "POST", f"{base_url}/chat/completions", headers=headers, json=body,
+    ) as resp:
+        if resp.status_code != 200:
+            await resp.aread()
+            logger.error("Omni stream error %d: %s", resp.status_code, resp.text[:500])
+            resp.raise_for_status()
+        async for line in resp.aiter_lines():
+            line = line.strip()
+            if not line or not line.startswith("data: "):
+                continue
+            data = line[6:]
+            if data == "[DONE]":
+                break
+            try:
+                chunk = json.loads(data)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(chunk.get("usage"), dict):
+                usage = chunk["usage"]
+            try:
+                delta = chunk.get("choices", [{}])[0].get("delta", {}).get("content")
+            except (IndexError, KeyError):
+                delta = None
+            if delta:
+                content_parts.append(delta)
+    return {
+        "choices": [{"message": {"content": "".join(content_parts)}}],
+        "usage": usage,
+    }
 
 
 def _build_messages(payload: dict, adapter: OmniProviderAdapter) -> list[dict]:

--- a/backend/miloco/src/miloco/perception/engine/omni/omni_client.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/omni_client.py
@@ -207,6 +207,21 @@ async def call_omni(
         )
 
 
+async def _iter_sse_chunks(resp) -> AsyncGenerator[dict, None]:
+    """从 SSE 响应逐行解析 JSON chunks，跳过空行、非 data 行和畸形 JSON。"""
+    async for line in resp.aiter_lines():
+        line = line.strip()
+        if not line or not line.startswith("data: "):
+            continue
+        data = line[6:]
+        if data == "[DONE]":
+            break
+        try:
+            yield json.loads(data)
+        except json.JSONDecodeError:
+            continue
+
+
 async def _collect_stream_response(
     client: httpx.AsyncClient,
     base_url: str,
@@ -226,23 +241,15 @@ async def _collect_stream_response(
             await resp.aread()
             logger.error("Omni stream error %d: %s", resp.status_code, resp.text[:500])
             if resp.status_code == 400:
-                from miloco.perception.engine.omni.omni import _summarize_multimodal_payload
+                from miloco.perception.engine.omni.omni import (
+                    _summarize_multimodal_payload,
+                )
                 logger.error(
                     "[omni] stream 400 payload 摘要 | %s",
                     _summarize_multimodal_payload(body.get("messages", [])),
                 )
             resp.raise_for_status()
-        async for line in resp.aiter_lines():
-            line = line.strip()
-            if not line or not line.startswith("data: "):
-                continue
-            data = line[6:]
-            if data == "[DONE]":
-                break
-            try:
-                chunk = json.loads(data)
-            except json.JSONDecodeError:
-                continue
+        async for chunk in _iter_sse_chunks(resp):
             if isinstance(chunk.get("usage"), dict):
                 usage = chunk["usage"]
             try:
@@ -363,25 +370,12 @@ async def call_omni_stream(
                         "Omni stream error %d: %s", resp.status_code, resp.text[:500]
                     )
                     resp.raise_for_status()
-                async for line in resp.aiter_lines():
-                    line = line.strip()
-                    if not line or not line.startswith("data: "):
-                        continue
-                    data = line[6:]
-                    if data == "[DONE]":
-                        break
-                    try:
-                        chunk = json.loads(data)
-                    except json.JSONDecodeError:
-                        continue
-
-                    # usage 在最后一个 chunk 的顶层
+                async for chunk in _iter_sse_chunks(resp):
                     if isinstance(chunk.get("usage"), dict):
                         raw_usage_seen = chunk["usage"]
                         if usage_out is not None:
                             usage_out.update(extract_usage({"usage": raw_usage_seen}))
 
-                    # content delta：choices[0].delta.content
                     try:
                         delta = (
                             chunk.get("choices", [{}])[0].get("delta", {}).get("content")

--- a/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
@@ -203,8 +203,9 @@ def build_fused_payload(
     """
     cfg = config or FusedPromptConfig()
     if adapter is None:
+        from miloco.config import get_settings
         from .provider import get_adapter as _get_adapter
-        adapter = _get_adapter("")
+        adapter = _get_adapter(get_settings().model.omni.model)
     if not packets:
         raise ValueError("build_fused_payload: packets 不能为空")
 
@@ -229,11 +230,7 @@ def build_fused_payload(
         if context.room_name:
             user_content.append({"type": "text", "text": f"位置: {context.room_name}"})
         if audio_b64 and len(audio_b64) >= _MIN_AUDIO_B64_LEN:
-            audio_media = LocalMediaInfo(
-                video_width=0, video_height=0, fps=0, frame_count=0,
-                has_audio=True, audio_sample_rate=ep.sample_rate,
-            )
-            user_content.append(adapter.build_audio_block(audio_b64, audio_media))
+            user_content.append(adapter.build_audio_block(audio_b64, _audio_only_media_info(ep.sample_rate)))
         elif audio_b64:
             logger.warning(
                 "event=fused_audio_b64_too_short size=%d (< %d), 跳过 input_audio 块, "
@@ -389,10 +386,7 @@ def _build_payload(
     if route == "audio":
         ep = packets[0]
         base["audio_base64"] = _encode_audio_only_mp4(ep.audio_clip, ep.sample_rate)
-        base["media_info"] = LocalMediaInfo(
-            video_width=0, video_height=0, fps=0, frame_count=0,
-            has_audio=True, audio_sample_rate=ep.sample_rate,
-        )
+        base["media_info"] = _audio_only_media_info(ep.sample_rate)
     else:
         short_edge = _get_video_short_edge()
         video_b64, media_info = _encode_batch_video(packets, short_edge=short_edge)
@@ -1079,6 +1073,13 @@ def _resolve_person_face_jpg(
 # =============================================================================
 
 _VIDEO_SHORT_EDGE = 512  # fallback; prefer InputConfig.video_short_edge
+
+
+def _audio_only_media_info(sample_rate: int) -> LocalMediaInfo:
+    return LocalMediaInfo(
+        video_width=0, video_height=0, fps=0, frame_count=0,
+        has_audio=True, audio_sample_rate=sample_rate,
+    )
 
 
 def _get_video_short_edge() -> int:

--- a/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
@@ -1072,7 +1072,7 @@ def _resolve_person_face_jpg(
 # Video encoding (frames + audio → mp4)
 # =============================================================================
 
-_VIDEO_SHORT_EDGE = 512  # fallback; prefer InputConfig.video_short_edge
+_VIDEO_SHORT_EDGE = 512  # fallback; runtime value from settings.yaml / config.json via _get_video_short_edge()
 
 
 def _audio_only_media_info(sample_rate: int) -> LocalMediaInfo:

--- a/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
@@ -204,6 +204,7 @@ def build_fused_payload(
     cfg = config or FusedPromptConfig()
     if adapter is None:
         from miloco.config import get_settings
+
         from .provider import get_adapter as _get_adapter
         adapter = _get_adapter(get_settings().model.omni.model)
     if not packets:

--- a/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
@@ -107,7 +107,7 @@ def build_prompt(
         label_lookup: person_id (UUID) → 姓名/标签 反查表，渲染 "已识别人物" 段时把
                       UUID 替换为人名。None 时直接渲染 person_id 字段值（与旧行为兼容）。
 
-    Returns dict with keys: system_prompt, user_content, video_base64, video_fps, crops.
+    Returns dict with keys: system_prompt, user_content, video_base64, media_info, crops.
     """
     return _build_payload([identity_packet], context, stream=False, label_lookup=label_lookup)
 
@@ -160,7 +160,6 @@ def build_query_prompt(
         "system_prompt": "\n\n".join(parts),
         "user_content": _build_query_user_content(identity_packets, query, last_caption, label_lookup),
         "video_base64": video_b64,
-        "video_fps": identity_packets[0].frame_info.fps if identity_packets else 1,
         "media_info": media_info,
         "crops": [],
     }
@@ -198,7 +197,6 @@ def build_fused_payload(
     Returns:
         dict，含字段：
           - ``messages``：直接构建好的 OpenAI 兼容 messages 列表（system + user）
-          - ``video_fps``：调用 omni_client 时填进 video block
           - ``candidate_track_ids``：本次 dispatch 候选 track id 列表（debug + 校验用）
     """
     cfg = config or FusedPromptConfig()
@@ -246,11 +244,9 @@ def build_fused_payload(
                 rule_conditions=None,
                 readonly_history=_build_readonly_history(context),
             ),
-            "video_fps": packets[0].frame_info.fps,
             "candidate_track_ids": [],
         }
 
-    fps = packets[0].frame_info.fps
     short_edge = _get_video_short_edge()
     video_b64, media_info = _encode_batch_video(packets, short_edge=short_edge)
 
@@ -269,7 +265,6 @@ def build_fused_payload(
         candidates=candidates,
         gallery_snapshot=gallery_snapshot,
         video_b64=video_b64,
-        video_fps=fps,
         media_info=media_info,
         adapter=adapter,
         cfg=cfg,
@@ -285,7 +280,6 @@ def build_fused_payload(
 
     return {
         "messages": messages,
-        "video_fps": fps,
         "candidate_track_ids": [c.track_id for c in candidates],
     }
 
@@ -392,7 +386,6 @@ def _build_payload(
         short_edge = _get_video_short_edge()
         video_b64, media_info = _encode_batch_video(packets, short_edge=short_edge)
         base["video_base64"] = video_b64
-        base["video_fps"] = packets[0].frame_info.fps
         base["media_info"] = media_info
     return base
 
@@ -568,7 +561,6 @@ def _build_fused_user_content(
     candidates: list["IdentityQueryItem"],
     gallery_snapshot: dict[str, "GallerySamples"],
     video_b64: str | None,
-    video_fps: int,
     media_info: LocalMediaInfo | None,
     adapter: OmniProviderAdapter,
     cfg: FusedPromptConfig,

--- a/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
@@ -53,6 +53,7 @@ from .constants import (
 )
 from .field_registry import SceneDescriptor, render_field_spec, render_schema
 from .home_profile_loader import get_home_profile_prefix
+from .provider import LocalMediaInfo, OmniProviderAdapter
 
 RouteType = Literal["video", "audio"]
 
@@ -153,11 +154,14 @@ def build_query_prompt(
     home_profile = get_home_profile_prefix()
     if home_profile:
         parts.append(home_profile)
+    short_edge = _get_video_short_edge()
+    video_b64, media_info = _encode_batch_video(identity_packets, short_edge=short_edge)
     return {
         "system_prompt": "\n\n".join(parts),
         "user_content": _build_query_user_content(identity_packets, query, last_caption, label_lookup),
-        "video_base64": _encode_batch_video(identity_packets),
+        "video_base64": video_b64,
         "video_fps": identity_packets[0].frame_info.fps if identity_packets else 1,
+        "media_info": media_info,
         "crops": [],
     }
 
@@ -169,6 +173,7 @@ def build_fused_payload(
     gallery_snapshot: dict[str, "GallerySamples"],
     config: FusedPromptConfig | None = None,
     label_lookup: "dict[str, str] | None" = None,
+    adapter: OmniProviderAdapter | None = None,
 ) -> dict:
     """构造 fused 主调用的 payload（身份识别和场景理解合并到同一次 omni 调用）。
 
@@ -197,6 +202,9 @@ def build_fused_payload(
           - ``candidate_track_ids``：本次 dispatch 候选 track id 列表（debug + 校验用）
     """
     cfg = config or FusedPromptConfig()
+    if adapter is None:
+        from .provider import get_adapter as _get_adapter
+        adapter = _get_adapter("")
     if not packets:
         raise ValueError("build_fused_payload: packets 不能为空")
 
@@ -220,12 +228,12 @@ def build_fused_payload(
             user_content.append({"type": "text", "text": f"当前时间: {context.current_time}"})
         if context.room_name:
             user_content.append({"type": "text", "text": f"位置: {context.room_name}"})
-        # 跟 video_b64 / _jpeg_block 同款 size gate, 防极短损坏 b64 入 payload。
         if audio_b64 and len(audio_b64) >= _MIN_AUDIO_B64_LEN:
-            user_content.append({
-                "type": "input_audio",
-                "input_audio": {"data": f"data:audio/m4a;base64,{audio_b64}"},
-            })
+            audio_media = LocalMediaInfo(
+                video_width=0, video_height=0, fps=0, frame_count=0,
+                has_audio=True, audio_sample_rate=ep.sample_rate,
+            )
+            user_content.append(adapter.build_audio_block(audio_b64, audio_media))
         elif audio_b64:
             logger.warning(
                 "event=fused_audio_b64_too_short size=%d (< %d), 跳过 input_audio 块, "
@@ -245,7 +253,8 @@ def build_fused_payload(
         }
 
     fps = packets[0].frame_info.fps
-    video_b64 = _encode_batch_video(packets)
+    short_edge = _get_video_short_edge()
+    video_b64, media_info = _encode_batch_video(packets, short_edge=short_edge)
 
     # has_speech 只由本轮 VAD 决定：本轮真有人声（含 pending 的延续语音）→ VAD 自然过、
     # 保留 speeches、模型把 <pending_speech> 拼成完整句；本轮无人声 → 剥 speeches，挂着的
@@ -263,6 +272,8 @@ def build_fused_payload(
         gallery_snapshot=gallery_snapshot,
         video_b64=video_b64,
         video_fps=fps,
+        media_info=media_info,
+        adapter=adapter,
         cfg=cfg,
         label_lookup=label_lookup,
     )
@@ -378,9 +389,16 @@ def _build_payload(
     if route == "audio":
         ep = packets[0]
         base["audio_base64"] = _encode_audio_only_mp4(ep.audio_clip, ep.sample_rate)
+        base["media_info"] = LocalMediaInfo(
+            video_width=0, video_height=0, fps=0, frame_count=0,
+            has_audio=True, audio_sample_rate=ep.sample_rate,
+        )
     else:
-        base["video_base64"] = _encode_batch_video(packets)
+        short_edge = _get_video_short_edge()
+        video_b64, media_info = _encode_batch_video(packets, short_edge=short_edge)
+        base["video_base64"] = video_b64
         base["video_fps"] = packets[0].frame_info.fps
+        base["media_info"] = media_info
     return base
 
 
@@ -556,6 +574,8 @@ def _build_fused_user_content(
     gallery_snapshot: dict[str, "GallerySamples"],
     video_b64: str | None,
     video_fps: int,
+    media_info: LocalMediaInfo | None,
+    adapter: OmniProviderAdapter,
     cfg: FusedPromptConfig,
     label_lookup: "dict[str, str] | None" = None,
 ) -> list[dict]:
@@ -680,12 +700,7 @@ def _build_fused_user_content(
     # base64 串, 入 payload 会让 omni 服务端 400 Multimodal data is corrupted。
     # 太短 → 跳过 video_url 块, 退化为"无视频窗口"(text + gallery 仍能识别)。
     if video_b64 and len(video_b64) >= _MIN_VIDEO_B64_LEN:
-        content.append({
-            "type": "video_url",
-            "video_url": {"url": f"data:video/mp4;base64,{video_b64}"},
-            "fps": video_fps,
-            "media_resolution": "max",
-        })
+        content.append(adapter.build_video_block(video_b64, media_info))
     elif video_b64:
         logger.warning(
             "event=fused_video_b64_too_short size=%d (< %d), 跳过 video_url 块, "
@@ -1063,7 +1078,15 @@ def _resolve_person_face_jpg(
 # Video encoding (frames + audio → mp4)
 # =============================================================================
 
-_VIDEO_SHORT_EDGE = 512
+_VIDEO_SHORT_EDGE = 512  # fallback; prefer InputConfig.video_short_edge
+
+
+def _get_video_short_edge() -> int:
+    try:
+        from miloco.config import get_settings
+        return get_settings().perception.engine.get("input", {}).get("video_short_edge", _VIDEO_SHORT_EDGE)
+    except Exception:
+        return _VIDEO_SHORT_EDGE
 _CROP_SIZE = (512, 512)
 
 # 多模态 payload sanity check 下限 — 防"非 None 但实际损坏"的 bytes 入 payload
@@ -1119,19 +1142,15 @@ def _batch_video_has_speech(packets: list[IdentityPacket]) -> bool:
     return False
 
 
-def _encode_video(identity_packet: IdentityPacket) -> str | None:
-    """Encode all frames + audio into mp4 video, return base64.
-
-    若 ContextVar `event_artifacts_scope` 在当前 task 中激活,`_encode_video_mp4`
-    会在 resize 后旁路 append 帧给 meaningful_events 截图复用.snapshot 落的就是
-    omni 实际看到的那份 frames.
-    """
+def _encode_video(
+    identity_packet: IdentityPacket,
+    short_edge: int = _VIDEO_SHORT_EDGE,
+) -> tuple[str | None, LocalMediaInfo | None]:
+    """Encode all frames + audio into mp4 video, return ``(base64, media_info)``。"""
     frames = identity_packet.all_frames
     if not frames:
-        return None
+        return None, None
 
-    # audio gate 没通过(audio_active=False)就不把音频喂进 mp4：办公底噪等被持续转写会让
-    # Omni 在低信息音频上幻觉出"看起来像指令"的话。trigger=None(主动查询/旧路径)保持原行为。
     audio = (
         identity_packet.audio_clip
         if _packet_audio_included(identity_packet)
@@ -1142,6 +1161,7 @@ def _encode_video(identity_packet: IdentityPacket) -> str | None:
         audio,
         identity_packet.sample_rate,
         fps=identity_packet.frame_info.fps,
+        short_edge=short_edge,
     )
 
 
@@ -1150,8 +1170,11 @@ def _encode_video_mp4(
     audio_clip: NDArray[np.int16],
     sample_rate: int,
     fps: int,
-) -> str | None:
+    short_edge: int = _VIDEO_SHORT_EDGE,
+) -> tuple[str | None, LocalMediaInfo | None]:
     """Encode BGR frames + PCM audio into mp4 using PyAV.
+
+    Returns ``(base64_str, media_info)``。
 
     Uses a temp file because mp4 container requires seekable output.
 
@@ -1167,7 +1190,7 @@ def _encode_video_mp4(
     from miloco.perception.snapshot_context import push_clip_bytes
 
     if not frames:
-        return None
+        return None, None
 
     with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as tmp:
         tmp_path = tmp.name
@@ -1175,10 +1198,8 @@ def _encode_video_mp4(
     try:
         container = av.open(tmp_path, "w")
 
-        # Video stream — scale to short-edge = _VIDEO_SHORT_EDGE, keep aspect ratio.
-        # h264 requires even dimensions, so round to nearest even number.
         h0, w0 = frames[0].shape[:2]
-        scale = _VIDEO_SHORT_EDGE / min(h0, w0)
+        scale = short_edge / min(h0, w0)
         target_w = int(w0 * scale) // 2 * 2
         target_h = int(h0 * scale) // 2 * 2
         v_stream = container.add_stream("h264", rate=fps)
@@ -1227,9 +1248,16 @@ def _encode_video_mp4(
 
         with open(tmp_path, "rb") as f:
             mp4_bytes = f.read()
-        # 旁路把 omni 看到的字节级 mp4 push 给 meaningful_events 复用(零重编)
         push_clip_bytes(mp4_bytes, "mp4")
-        return base64.b64encode(mp4_bytes).decode()
+        media_info = LocalMediaInfo(
+            video_width=target_w,
+            video_height=target_h,
+            fps=fps,
+            frame_count=len(frames),
+            has_audio=has_audio,
+            audio_sample_rate=sample_rate if has_audio else 0,
+        )
+        return base64.b64encode(mp4_bytes).decode(), media_info
     finally:
         if os.path.exists(tmp_path):
             os.unlink(tmp_path)
@@ -1346,16 +1374,20 @@ def _encode_audio_only_mp4(
             os.unlink(tmp_path)
 
 
-def _encode_batch_video(edge_packets: list[IdentityPacket]) -> str | None:
+def _encode_batch_video(
+    edge_packets: list[IdentityPacket],
+    short_edge: int = _VIDEO_SHORT_EDGE,
+) -> tuple[str | None, LocalMediaInfo | None]:
     """Encode video from the first device that has frames.
 
     audio route 由 _build_payload 短路，不会进入本函数。
+    返回 ``(base64_str, media_info)``。
     """
     for ep in edge_packets:
-        encoded = _encode_video(ep)
-        if encoded is not None:
-            return encoded
-    return None
+        b64, media_info = _encode_video(ep, short_edge=short_edge)
+        if b64 is not None:
+            return b64, media_info
+    return None, None
 
 
 def _encode_batch_crops(edge_packets: list[IdentityPacket]) -> list[dict[str, str]]:

--- a/backend/miloco/src/miloco/perception/engine/omni/provider.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/provider.py
@@ -93,9 +93,65 @@ class MiMoAdapter(OmniProviderAdapter):
         return body
 
 
+class QwenOmniAdapter(OmniProviderAdapter):
+    """Qwen3.5-Omni 系列 API adapter（qwen3.5-omni-plus / qwen3.5-omni-flash）。
+
+    仅支持 Qwen3.5-Omni 系列——fused 模式需要视频+图片+文本组合输入，
+    旧版 qwen3-omni-flash 只支持文本+单一模态，无法满足。
+
+    - video block: ``video_url``（无 fps / media_resolution，API 端固定 2fps 自行抽帧）
+    - audio block: ``input_audio`` + ``format``
+    - request body: 强制 ``stream: true``（Qwen-Omni 非流式会报错）、``modalities: ["text"]``
+    """
+
+    def build_video_block(self, video_base64: str, media: LocalMediaInfo) -> dict[str, Any]:
+        return {
+            "type": "video_url",
+            "video_url": {"url": f"data:;base64,{video_base64}"},
+        }
+
+    def build_audio_block(self, audio_base64: str, media: LocalMediaInfo) -> dict[str, Any]:
+        return {
+            "type": "input_audio",
+            "input_audio": {
+                "data": f"data:;base64,{audio_base64}",
+                "format": "m4a",
+            },
+        }
+
+    def build_request_body(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        model: str,
+        max_tokens: int,
+        temperature: float,
+        top_p: float,
+        stream: bool = False,
+    ) -> dict[str, Any]:
+        return {
+            "model": model,
+            "messages": messages,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "top_p": top_p,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+            "modalities": ["text"],
+        }
+
+
 _DEFAULT_ADAPTER = MiMoAdapter()
+_QWEN_ADAPTER = QwenOmniAdapter()
 
 
 def get_adapter(model: str) -> OmniProviderAdapter:
-    """按 model 字符串返回对应 adapter，默认 MiMo。"""
+    """按 model 字符串返回对应 adapter，默认 MiMo。
+
+    Qwen 侧仅支持 Qwen3.5-Omni 系列（qwen3.5-omni-plus / qwen3.5-omni-flash），
+    旧版 qwen3-omni-flash 不支持多模态组合输入，无法满足 fused 模式需求。
+    """
+    name = model.lower()
+    if "qwen" in name:
+        return _QWEN_ADAPTER
     return _DEFAULT_ADAPTER

--- a/backend/miloco/src/miloco/perception/engine/omni/provider.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/provider.py
@@ -141,6 +141,15 @@ class QwenOmniAdapter(OmniProviderAdapter):
         }
 
 
+def adjust_fps_for_omni(fps: int, omni_fps: int) -> int:
+    """当 fps % omni_fps != 0 时，返回 omni_fps 的最小整数倍 >= fps。"""
+    if omni_fps <= 0 or fps % omni_fps == 0:
+        return fps
+    if omni_fps > fps:
+        return omni_fps
+    return omni_fps * -(-fps // omni_fps)
+
+
 _DEFAULT_ADAPTER = MiMoAdapter()
 _QWEN_ADAPTER = QwenOmniAdapter()
 

--- a/backend/miloco/src/miloco/perception/engine/omni/provider.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/provider.py
@@ -1,0 +1,101 @@
+"""Omni Provider Adapter — 不同模型的 API 请求构建适配层。
+
+两层分离的 Layer 2：根据本地编码后的视频参数，生成让 API 端不二次修改输入的请求参数。
+只管请求构建，不管 response 解析（所有 provider 遵循 OpenAI 兼容协议）。
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class LocalMediaInfo:
+    """本地编码后的视频/音频实际参数。"""
+
+    video_width: int
+    video_height: int
+    fps: int
+    frame_count: int
+    has_audio: bool
+    audio_sample_rate: int
+
+
+class OmniProviderAdapter(ABC):
+
+    @abstractmethod
+    def build_video_block(self, video_base64: str, media: LocalMediaInfo) -> dict[str, Any]:
+        """构建 video content block（进 messages[].content[]）。"""
+
+    @abstractmethod
+    def build_audio_block(self, audio_base64: str, media: LocalMediaInfo) -> dict[str, Any]:
+        """构建 audio-only content block。"""
+
+    @abstractmethod
+    def build_request_body(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        model: str,
+        max_tokens: int,
+        temperature: float,
+        top_p: float,
+        stream: bool = False,
+    ) -> dict[str, Any]:
+        """构建完整 HTTP request body。"""
+
+
+class MiMoAdapter(OmniProviderAdapter):
+    """MiMo-v2.5 API adapter。
+
+    - video block: ``video_url`` + ``fps`` + ``media_resolution: "max"``
+    - audio block: ``input_audio``（m4a AAC）
+    - request body: 含 ``thinking: {"type": "disabled"}``
+    """
+
+    def build_video_block(self, video_base64: str, media: LocalMediaInfo) -> dict[str, Any]:
+        return {
+            "type": "video_url",
+            "video_url": {"url": f"data:video/mp4;base64,{video_base64}"},
+            "fps": media.fps,
+            "media_resolution": "max",
+        }
+
+    def build_audio_block(self, audio_base64: str, media: LocalMediaInfo) -> dict[str, Any]:
+        return {
+            "type": "input_audio",
+            "input_audio": {"data": f"data:audio/m4a;base64,{audio_base64}"},
+        }
+
+    def build_request_body(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        model: str,
+        max_tokens: int,
+        temperature: float,
+        top_p: float,
+        stream: bool = False,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "model": model,
+            "messages": messages,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "top_p": top_p,
+            "stream": stream,
+            "thinking": {"type": "disabled"},
+        }
+        if stream:
+            body["stream_options"] = {"include_usage": True}
+        return body
+
+
+_DEFAULT_ADAPTER = MiMoAdapter()
+
+
+def get_adapter(model: str) -> OmniProviderAdapter:
+    """按 model 字符串返回对应 adapter，默认 MiMo。"""
+    return _DEFAULT_ADAPTER

--- a/backend/miloco/tests/perception/engine/omni/test_collect_stream.py
+++ b/backend/miloco/tests/perception/engine/omni/test_collect_stream.py
@@ -1,11 +1,10 @@
 """Tests for _collect_stream_response SSE parsing."""
 
 import json
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import httpx
 import pytest
-
 from miloco.perception.engine.omni.omni_client import _collect_stream_response
 
 

--- a/backend/miloco/tests/perception/engine/omni/test_collect_stream.py
+++ b/backend/miloco/tests/perception/engine/omni/test_collect_stream.py
@@ -1,0 +1,115 @@
+"""Tests for _collect_stream_response SSE parsing."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from miloco.perception.engine.omni.omni_client import _collect_stream_response
+
+
+def _sse_body(*chunks: dict, done: bool = True) -> str:
+    parts = []
+    for c in chunks:
+        parts.append(f"data: {json.dumps(c)}")
+        parts.append("")
+    if done:
+        parts.append("data: [DONE]")
+        parts.append("")
+    return "\n".join(parts)
+
+
+def _chunk(content: str | None = None, usage: dict | None = None) -> dict:
+    c: dict = {}
+    if content is not None:
+        c["choices"] = [{"delta": {"content": content}}]
+    if usage is not None:
+        c["usage"] = usage
+    return c
+
+
+class _FakeStreamResponse:
+    """Minimal async context manager mimicking httpx streaming response."""
+
+    def __init__(self, status_code: int, body: str):
+        self.status_code = status_code
+        self._body = body
+        self.text = body
+
+    async def aiter_lines(self):
+        for line in self._body.split("\n"):
+            yield line
+
+    async def aread(self):
+        pass
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError(
+                f"{self.status_code}", request=MagicMock(), response=MagicMock(status_code=self.status_code),
+            )
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        pass
+
+
+def _mock_client(status_code: int, body: str):
+    client = MagicMock()
+    client.stream = MagicMock(return_value=_FakeStreamResponse(status_code, body))
+    return client
+
+
+class TestCollectStreamResponse:
+    @pytest.mark.asyncio
+    async def test_basic_content(self):
+        body = _sse_body(_chunk("Hello"), _chunk(" world"))
+        client = _mock_client(200, body)
+        result = await _collect_stream_response(client, "https://test", {}, {"messages": []})
+        assert result["choices"][0]["message"]["content"] == "Hello world"
+
+    @pytest.mark.asyncio
+    async def test_usage_from_last_chunk(self):
+        usage = {"prompt_tokens": 100, "completion_tokens": 20}
+        body = _sse_body(_chunk("Hi"), _chunk(usage=usage))
+        client = _mock_client(200, body)
+        result = await _collect_stream_response(client, "https://test", {}, {"messages": []})
+        assert result["usage"] == usage
+
+    @pytest.mark.asyncio
+    async def test_empty_stream(self):
+        body = "data: [DONE]\n"
+        client = _mock_client(200, body)
+        result = await _collect_stream_response(client, "https://test", {}, {"messages": []})
+        assert result["choices"][0]["message"]["content"] == ""
+        assert result["usage"] == {}
+
+    @pytest.mark.asyncio
+    async def test_skips_malformed_json(self):
+        body = "data: {bad}\n\n" + _sse_body(_chunk("ok"))
+        client = _mock_client(200, body)
+        result = await _collect_stream_response(client, "https://test", {}, {"messages": []})
+        assert result["choices"][0]["message"]["content"] == "ok"
+
+    @pytest.mark.asyncio
+    async def test_skips_empty_and_non_data_lines(self):
+        body = "\n  \nretry: 3000\n" + _sse_body(_chunk("a"))
+        client = _mock_client(200, body)
+        result = await _collect_stream_response(client, "https://test", {}, {"messages": []})
+        assert result["choices"][0]["message"]["content"] == "a"
+
+    @pytest.mark.asyncio
+    async def test_multiple_content_chunks(self):
+        body = _sse_body(_chunk("a"), _chunk("b"), _chunk("c"))
+        client = _mock_client(200, body)
+        result = await _collect_stream_response(client, "https://test", {}, {"messages": []})
+        assert result["choices"][0]["message"]["content"] == "abc"
+
+    @pytest.mark.asyncio
+    async def test_400_raises(self):
+        client = _mock_client(400, '{"error": "bad"}')
+        with pytest.raises(httpx.HTTPStatusError):
+            await _collect_stream_response(client, "https://test", {}, {"messages": []})

--- a/backend/miloco/tests/perception/engine/omni/test_prompt_builder.py
+++ b/backend/miloco/tests/perception/engine/omni/test_prompt_builder.py
@@ -495,10 +495,11 @@ class TestBuildMessagesContentBlocks:
 
     def test_audio_route_emits_input_audio_block(self):
         from miloco.perception.engine.omni.omni_client import _build_messages
+        from miloco.perception.engine.omni.provider import MiMoAdapter
 
         ep = _audio_only_packet()
         payload = build_prompt(ep, OmniContext())
-        messages = _build_messages(payload)
+        messages = _build_messages(payload, MiMoAdapter())
         user_blocks = messages[1]["content"]
         types = [b["type"] for b in user_blocks]
 
@@ -509,10 +510,11 @@ class TestBuildMessagesContentBlocks:
 
     def test_video_route_emits_video_url_block(self):
         from miloco.perception.engine.omni.omni_client import _build_messages
+        from miloco.perception.engine.omni.provider import MiMoAdapter
 
         ep = _video_route_packet()
         payload = build_prompt(ep, OmniContext())
-        messages = _build_messages(payload)
+        messages = _build_messages(payload, MiMoAdapter())
         user_blocks = messages[1]["content"]
         types = [b["type"] for b in user_blocks]
 
@@ -940,12 +942,12 @@ class TestEncodeVideoAudioGating:
     """video 路由按 audio gate 结果决定是否把音频轨编进 mp4（反语音幻觉）。"""
 
     def test_audio_track_included_when_audio_active(self):
-        b64 = _encode_video(_video_packet(audio_active=True))
+        b64, _info = _encode_video(_video_packet(audio_active=True))
         assert b64 is not None
         assert _mp4_has_audio_stream(b64)
 
     def test_audio_track_dropped_when_audio_inactive(self):
-        b64 = _encode_video(_video_packet(audio_active=False))
+        b64, _info = _encode_video(_video_packet(audio_active=False))
         assert b64 is not None
         assert not _mp4_has_audio_stream(b64)
 
@@ -954,7 +956,7 @@ class TestEncodeVideoAudioGating:
         ep = _mock_edge_packet()
         ep.audio_clip = np.zeros(16000, dtype=np.int16)
         assert ep.trigger is None
-        b64 = _encode_video(ep)
+        b64, _info = _encode_video(ep)
         assert b64 is not None
         assert _mp4_has_audio_stream(b64)
 

--- a/backend/miloco/tests/perception/engine/omni/test_prompt_builder.py
+++ b/backend/miloco/tests/perception/engine/omni/test_prompt_builder.py
@@ -81,7 +81,7 @@ class TestBuildPrompt:
         assert "位置: 书房" in payload["user_content"]  # room_name 作场景参考注入 U4
         assert "读书开灯" in payload["user_content"]  # 规则按 rule_name 渲染（# 待判断规则）
         assert payload["video_base64"] is not None
-        assert payload["video_fps"] == ep.frame_info.fps
+        assert payload["media_info"] is not None
 
     def test_rule_rendered_by_name_without_evidence_suffix(self):
         """规则按 rule_name 渲染进「# 待判断规则」，不带已删除的 ｜允许证据= 后缀。"""
@@ -455,20 +455,19 @@ class TestResolveRoute:
 
 class TestAudioRoutePayload:
     def test_audio_payload_shape(self):
-        """audio route：payload 只有 audio_base64，没有 video_base64 / video_fps。"""
+        """audio route：payload 只有 audio_base64，没有 video_base64。"""
         ep = _audio_only_packet()
         payload = build_prompt(ep, OmniContext())
         assert "audio_base64" in payload
-        assert payload["audio_base64"]  # 非空 base64
+        assert payload["audio_base64"]
         assert "video_base64" not in payload
-        assert "video_fps" not in payload
 
     def test_video_route_no_audio_field(self):
-        """video route：payload 含 video_base64 / video_fps，不含 audio_base64。"""
+        """video route：payload 含 video_base64 + media_info，不含 audio_base64。"""
         ep = _video_route_packet()
         payload = build_prompt(ep, OmniContext())
         assert "video_base64" in payload
-        assert "video_fps" in payload
+        assert "media_info" in payload
         assert "audio_base64" not in payload
 
     def test_audio_route_drops_visual_fields(self):

--- a/backend/miloco/tests/perception/engine/omni/test_provider.py
+++ b/backend/miloco/tests/perception/engine/omni/test_provider.py
@@ -1,7 +1,5 @@
 """Tests for Omni Provider Adapter."""
 
-import pytest
-
 from miloco.perception.engine.omni.provider import (
     LocalMediaInfo,
     MiMoAdapter,

--- a/backend/miloco/tests/perception/engine/omni/test_provider.py
+++ b/backend/miloco/tests/perception/engine/omni/test_provider.py
@@ -1,0 +1,112 @@
+"""Tests for Omni Provider Adapter."""
+
+import pytest
+
+from miloco.perception.engine.omni.provider import (
+    LocalMediaInfo,
+    MiMoAdapter,
+    QwenOmniAdapter,
+    get_adapter,
+)
+
+_VIDEO_MEDIA = LocalMediaInfo(
+    video_width=910, video_height=512, fps=1, frame_count=4,
+    has_audio=True, audio_sample_rate=16000,
+)
+_AUDIO_MEDIA = LocalMediaInfo(
+    video_width=0, video_height=0, fps=0, frame_count=0,
+    has_audio=True, audio_sample_rate=16000,
+)
+_MESSAGES = [{"role": "user", "content": "test"}]
+
+
+class TestGetAdapter:
+    def test_mimo_default(self):
+        assert isinstance(get_adapter("xiaomi/mimo-v2.5"), MiMoAdapter)
+
+    def test_mimo_unknown(self):
+        assert isinstance(get_adapter("some-unknown-model"), MiMoAdapter)
+
+    def test_mimo_empty(self):
+        assert isinstance(get_adapter(""), MiMoAdapter)
+
+    def test_qwen_flash(self):
+        assert isinstance(get_adapter("qwen3.5-omni-flash"), QwenOmniAdapter)
+
+    def test_qwen_plus(self):
+        assert isinstance(get_adapter("qwen3.5-omni-plus"), QwenOmniAdapter)
+
+    def test_qwen_case_insensitive(self):
+        assert isinstance(get_adapter("Qwen3.5-Omni-Flash"), QwenOmniAdapter)
+
+    def test_singleton(self):
+        assert get_adapter("xiaomi/mimo-v2.5") is get_adapter("xiaomi/mimo-v2.5")
+        assert get_adapter("qwen3.5-omni-flash") is get_adapter("qwen3.5-omni-plus")
+
+
+class TestMiMoAdapter:
+    adapter = MiMoAdapter()
+
+    def test_video_block_has_fps_and_media_resolution(self):
+        block = self.adapter.build_video_block("AAAA", _VIDEO_MEDIA)
+        assert block["type"] == "video_url"
+        assert block["fps"] == 1
+        assert block["media_resolution"] == "max"
+        assert block["video_url"]["url"].startswith("data:video/mp4;base64,")
+
+    def test_audio_block(self):
+        block = self.adapter.build_audio_block("BBBB", _AUDIO_MEDIA)
+        assert block["type"] == "input_audio"
+        assert block["input_audio"]["data"].startswith("data:audio/m4a;base64,")
+
+    def test_request_body_non_stream(self):
+        body = self.adapter.build_request_body(
+            _MESSAGES, model="xiaomi/mimo-v2.5",
+            max_tokens=512, temperature=0.1, top_p=0.95, stream=False,
+        )
+        assert body["stream"] is False
+        assert body["thinking"] == {"type": "disabled"}
+        assert "stream_options" not in body
+
+    def test_request_body_stream(self):
+        body = self.adapter.build_request_body(
+            _MESSAGES, model="xiaomi/mimo-v2.5",
+            max_tokens=512, temperature=0.1, top_p=0.95, stream=True,
+        )
+        assert body["stream"] is True
+        assert body["stream_options"] == {"include_usage": True}
+        assert body["thinking"] == {"type": "disabled"}
+
+
+class TestQwenOmniAdapter:
+    adapter = QwenOmniAdapter()
+
+    def test_video_block_no_fps_no_media_resolution(self):
+        block = self.adapter.build_video_block("AAAA", _VIDEO_MEDIA)
+        assert block["type"] == "video_url"
+        assert "fps" not in block
+        assert "media_resolution" not in block
+        assert block["video_url"]["url"].startswith("data:;base64,")
+
+    def test_audio_block_has_format(self):
+        block = self.adapter.build_audio_block("BBBB", _AUDIO_MEDIA)
+        assert block["type"] == "input_audio"
+        assert block["input_audio"]["format"] == "m4a"
+        assert block["input_audio"]["data"].startswith("data:;base64,")
+
+    def test_request_body_forces_stream(self):
+        body = self.adapter.build_request_body(
+            _MESSAGES, model="qwen3.5-omni-flash",
+            max_tokens=512, temperature=0.1, top_p=0.95, stream=False,
+        )
+        assert body["stream"] is True
+        assert body["stream_options"] == {"include_usage": True}
+        assert body["modalities"] == ["text"]
+        assert "thinking" not in body
+
+    def test_request_body_no_thinking(self):
+        body = self.adapter.build_request_body(
+            _MESSAGES, model="qwen3.5-omni-flash",
+            max_tokens=512, temperature=0.1, top_p=0.95,
+        )
+        assert "thinking" not in body

--- a/backend/miloco/tests/perception/engine/run_stream_test.py
+++ b/backend/miloco/tests/perception/engine/run_stream_test.py
@@ -358,7 +358,7 @@ async def run_pipeline_with_timing(
     from miloco.perception.engine.omni.prompt_builder import _encode_video
 
     t0 = time.monotonic()
-    _video_b64 = _encode_video(identity_packet)
+    _video_b64, _media_info = _encode_video(identity_packet)
     timer.video_encode_ms = (time.monotonic() - t0) * 1000
 
     t0 = time.monotonic()

--- a/backend/miloco/tests/perception/engine/test_pipeline.py
+++ b/backend/miloco/tests/perception/engine/test_pipeline.py
@@ -845,7 +845,7 @@ async def test_query_pipeline_downsamples_omni_to_omni_fps():
 
     def _capture(*, identity_packets, **kwargs):
         captured["packets"] = identity_packets
-        return {"messages": [], "video_fps": identity_packets[0].frame_info.fps}
+        return {"messages": []}
 
     with patch(
         "miloco.perception.engine.omni.prompt_builder.build_query_prompt",

--- a/cli/src/miloco_cli/config.py
+++ b/cli/src/miloco_cli/config.py
@@ -235,21 +235,6 @@ def _coerce(path: str, raw: str) -> Any:
     return raw  # str
 
 
-def _warn_fps_divisibility(config: dict[str, Any]) -> None:
-    """omni_fps 设置后校验 fps 整除关系，不整除时 warning。"""
-    inp = config.get("perception", {}).get("engine", {}).get("input", {})
-    fps = inp.get("fps", 3)
-    omni_fps = inp.get("omni_fps", 1)
-    if omni_fps <= 0 or fps % omni_fps == 0:
-        return
-    import logging
-    new_fps = omni_fps if omni_fps > fps else omni_fps * -(-fps // omni_fps)  # 与 provider.adjust_fps_for_omni 同逻辑
-    logging.getLogger(__name__).warning(
-        "fps(%d) %% omni_fps(%d) != 0：引擎启动时会自动将 fps 调整为 %d 保证整除",
-        fps, omni_fps, new_fps,
-    )
-
-
 # ─── 环境变量覆盖 ────────────────────────────────────────────────────────────
 
 _ENV_PREFIX = "MILOCO_"
@@ -331,8 +316,6 @@ def set_values(pairs: list[tuple[str, str]]) -> dict[str, Any]:
     for path, value in resolved.items():
         _set_nested(raw_file, path, value)
     atomic_write(config_file(), raw_file)
-    if any(p.startswith("perception.engine.input.") for p in resolved):
-        _warn_fps_divisibility(raw_file)
     return resolved
 
 

--- a/cli/src/miloco_cli/config.py
+++ b/cli/src/miloco_cli/config.py
@@ -243,15 +243,10 @@ def _warn_fps_divisibility(config: dict[str, Any]) -> None:
     if omni_fps <= 0 or fps % omni_fps == 0:
         return
     import logging
-    step = max(1, round(fps / omni_fps))
-    window = config.get("perception", {}).get("collect", {}).get("window_size", 4)
-    actual_frames = len(range(fps * window - 1, -1, -step))
-    eff_fps = max(1, round(fps / step))
+    new_fps = omni_fps if omni_fps > fps else omni_fps * -(-fps // omni_fps)
     logging.getLogger(__name__).warning(
-        "fps(%d) %% omni_fps(%d) != 0：引擎启动时会自动调整 fps 保证整除。"
-        "建议 omni_fps 为 fps 的因数（fps=%d 可选 %s）",
-        fps, omni_fps,
-        fps, ", ".join(str(d) for d in range(1, fps + 1) if fps % d == 0),
+        "fps(%d) %% omni_fps(%d) != 0：引擎启动时会自动将 fps 调整为 %d 保证整除",
+        fps, omni_fps, new_fps,
     )
 
 

--- a/cli/src/miloco_cli/config.py
+++ b/cli/src/miloco_cli/config.py
@@ -243,7 +243,7 @@ def _warn_fps_divisibility(config: dict[str, Any]) -> None:
     if omni_fps <= 0 or fps % omni_fps == 0:
         return
     import logging
-    new_fps = omni_fps if omni_fps > fps else omni_fps * -(-fps // omni_fps)
+    new_fps = omni_fps if omni_fps > fps else omni_fps * -(-fps // omni_fps)  # 与 provider.adjust_fps_for_omni 同逻辑
     logging.getLogger(__name__).warning(
         "fps(%d) %% omni_fps(%d) != 0：引擎启动时会自动将 fps 调整为 %d 保证整除",
         fps, omni_fps, new_fps,

--- a/cli/src/miloco_cli/config.py
+++ b/cli/src/miloco_cli/config.py
@@ -232,32 +232,27 @@ def _coerce(path: str, raw: str) -> Any:
                 f"timezone 需要合法 IANA 时区名（如 Asia/Shanghai、America/Los_Angeles），"
                 f"收到 {raw!r}"
             )
-    if path == "perception.engine.input.omni_fps":
-        omni_fps = int(raw)
-        current = _read_raw()
-        fps = (
-            current.get("perception", {})
-            .get("engine", {})
-            .get("input", {})
-            .get("fps", 3)
-        )
-        if fps % omni_fps != 0:
-            import logging
-            step = max(1, round(fps / omni_fps))
-            window = current.get("perception", {}).get("collect", {}).get("window_size", 4)
-            actual_frames = len(range(fps * window - 1, -1, -step))
-            eff_fps = max(1, round(fps / step))
-            actual_duration = actual_frames / eff_fps if eff_fps else 0
-            logging.getLogger(__name__).warning(
-                "fps(%d) %% omni_fps(%d) != 0：实际 %d 帧 / %dfps = %.1fs"
-                "（期望 %ds * %dfps = %d 帧）。"
-                "建议 omni_fps 为 fps 的因数（fps=%d 可选 %s）",
-                fps, omni_fps,
-                actual_frames, eff_fps, actual_duration,
-                window, omni_fps, window * omni_fps,
-                fps, ", ".join(str(d) for d in range(1, fps + 1) if fps % d == 0),
-            )
     return raw  # str
+
+
+def _warn_fps_divisibility(config: dict[str, Any]) -> None:
+    """omni_fps 设置后校验 fps 整除关系，不整除时 warning。"""
+    inp = config.get("perception", {}).get("engine", {}).get("input", {})
+    fps = inp.get("fps", 3)
+    omni_fps = inp.get("omni_fps", 1)
+    if omni_fps <= 0 or fps % omni_fps == 0:
+        return
+    import logging
+    step = max(1, round(fps / omni_fps))
+    window = config.get("perception", {}).get("collect", {}).get("window_size", 4)
+    actual_frames = len(range(fps * window - 1, -1, -step))
+    eff_fps = max(1, round(fps / step))
+    logging.getLogger(__name__).warning(
+        "fps(%d) %% omni_fps(%d) != 0：引擎启动时会自动调整 fps 保证整除。"
+        "建议 omni_fps 为 fps 的因数（fps=%d 可选 %s）",
+        fps, omni_fps,
+        fps, ", ".join(str(d) for d in range(1, fps + 1) if fps % d == 0),
+    )
 
 
 # ─── 环境变量覆盖 ────────────────────────────────────────────────────────────
@@ -341,6 +336,8 @@ def set_values(pairs: list[tuple[str, str]]) -> dict[str, Any]:
     for path, value in resolved.items():
         _set_nested(raw_file, path, value)
     atomic_write(config_file(), raw_file)
+    if any(p.startswith("perception.engine.input.") for p in resolved):
+        _warn_fps_divisibility(raw_file)
     return resolved
 
 

--- a/cli/src/miloco_cli/config.py
+++ b/cli/src/miloco_cli/config.py
@@ -72,6 +72,21 @@ _SCHEMA_PATHS: dict[str, tuple[type, Any, str]] = {
         "多模态模型服务 Base URL",
     ),
     "model.omni.api_key": (str, "", "多模态模型 API Key"),
+    "perception.engine.input.video_short_edge": (
+        int,
+        512,
+        "视频编码短边像素（保持宽高比缩放），重启生效",
+    ),
+    "perception.engine.input.omni_fps": (
+        int,
+        1,
+        "送给 omni 的视频帧率（应为 fps 的因数），重启生效",
+    ),
+    "perception.collect.window_size": (
+        int,
+        4,
+        "感知窗口时长（秒），重启生效",
+    ),
 }
 
 # ─── 基础读写 ────────────────────────────────────────────────────────────────
@@ -216,6 +231,31 @@ def _coerce(path: str, raw: str) -> Any:
             raise ValueError(
                 f"timezone 需要合法 IANA 时区名（如 Asia/Shanghai、America/Los_Angeles），"
                 f"收到 {raw!r}"
+            )
+    if path == "perception.engine.input.omni_fps":
+        omni_fps = int(raw)
+        current = _read_raw()
+        fps = (
+            current.get("perception", {})
+            .get("engine", {})
+            .get("input", {})
+            .get("fps", 3)
+        )
+        if fps % omni_fps != 0:
+            import logging
+            step = max(1, round(fps / omni_fps))
+            window = current.get("perception", {}).get("collect", {}).get("window_size", 4)
+            actual_frames = len(range(fps * window - 1, -1, -step))
+            eff_fps = max(1, round(fps / step))
+            actual_duration = actual_frames / eff_fps if eff_fps else 0
+            logging.getLogger(__name__).warning(
+                "fps(%d) %% omni_fps(%d) != 0：实际 %d 帧 / %dfps = %.1fs"
+                "（期望 %ds * %dfps = %d 帧）。"
+                "建议 omni_fps 为 fps 的因数（fps=%d 可选 %s）",
+                fps, omni_fps,
+                actual_frames, eff_fps, actual_duration,
+                window, omni_fps, window * omni_fps,
+                fps, ", ".join(str(d) for d in range(1, fps + 1) if fps % d == 0),
             )
     return raw  # str
 


### PR DESCRIPTION
## Summary

多模型适配的两层分离架构：

- **Layer 1 — 本地编码参数可配置**：`video_short_edge`、`omni_fps`、`window_size` 可通过 `config.json` / `miloco-cli config set` 配置
- **Layer 2 — Provider Adapter**：`OmniProviderAdapter` 抽象接口，根据 `config.model` 自动选择 adapter，确保 API 端不二次修改 Miloco 编码的视频

### 支持的模型

| 模型 | Adapter | 验证状态 |
|---|---|---|
| xiaomi/mimo-v2.5 | MiMoAdapter | 部署机实测 ✓ |
| qwen3.5-omni-flash | QwenOmniAdapter | 部署机实测 ✓ |
| qwen3.5-omni-plus | QwenOmniAdapter | 部署机实测 ✓ |

### 改动文件

| 文件 | 改动 |
|---|---|
| `provider.py` | **新增** — adapter 接口 + MiMoAdapter + QwenOmniAdapter + get_adapter + adjust_fps_for_omni |
| `settings.yaml` | 加 `video_short_edge: 512` 默认值 |
| `prompt_builder.py` | 编码链路参数化 + adapter 委托 + `_get_video_short_edge()` + 清理 video_fps dead plumbing |
| `omni_client.py` | `_build_messages` / `call_omni` / `call_omni_stream` 通过 adapter + `_collect_stream_response` + `_iter_sse_chunks` |
| `omni.py` | `run_omni_fused` / `_call_omni_messages` 通过 adapter + forced_stream 支持 |
| `api.py` | `fps % omni_fps != 0` 时自动调整 fps 保证整除 |
| `cli/config.py` | 注册 3 个感知参数到 CLI 白名单 |
| `test_provider.py` | **新增** — 15 个 adapter 单元测试 |
| `test_collect_stream.py` | **新增** — 7 个 SSE 流式解析单元测试 |
| `test_prompt_builder.py` | 适配新签名 + 清理 video_fps 断言 |
| `test_pipeline.py` | 清理 mock 中 video_fps 残留 |
| `run_stream_test.py` | 适配 tuple 返回值 |

### 注意事项

- `fps % omni_fps != 0` 时引擎启动自动上调 fps 到最小整数倍（如 fps=3, omni_fps=2 → fps=4）
- Qwen 强制 `stream=true`，`call_omni` 和 `_call_omni_messages` 自动用 SSE 流式读取拼接
- 模型切换（model/base_url/api_key）热更新无需重启；分辨率/帧率/窗口时长需重启

## Test plan

- [x] `pytest` 全量回归（55 failed / 2112 passed，均为 pre-existing）
- [x] provider adapter 单元测试 15 passed
- [x] `_collect_stream_response` SSE 解析单元测试 7 passed
- [x] 部署机实测 MiMo-v2.5：video_short_edge 512/768，video_tokens 匹配理论值
- [x] 部署机实测 Qwen3.5-Omni-Flash：多组分辨率/帧率组合，全部匹配官方公式
- [x] 部署机实测 Qwen3.5-Omni-Plus：正常工作
- [x] 部署机实测 CLI config set 三个参数 + fps 自动调整
- [x] 部署机实测 window_size=5 + fps=4(auto) + omni_fps=2 + short_edge=768 → video_tokens=2972 ✓