### PR TITLE
docs(dev-guide): 时区配置首推宿主系统时区（openclaw / miloco 双域共享宿主回落）

### DIFF
--- a/backend/miloco/src/miloco/utils/time_utils.py
+++ b/backend/miloco/src/miloco/utils/time_utils.py
@@ -93,10 +93,12 @@ def _warn_utc_once() -> None:
     _logger.warning(
         "Resolved deploy timezone is UTC — no household lives in UTC; the server "
         "timezone is likely unconfigured and all user-facing times may be "
-        "mislabeled. Preferred fix (aligns every component incl. the openclaw "
-        "agent, which only reads the host timezone): set the HOST timezone, e.g. "
-        "`sudo timedatectl set-timezone <IANA-name>` or container `TZ` env. If "
-        "the host cannot be changed: miloco-cli config set timezone <IANA-name>."
+        "mislabeled. Preferred fix: set the HOST timezone — the shared fallback for "
+        "both miloco and the openclaw agent (each reads its own config first, then "
+        "falls back to the host), e.g. `sudo timedatectl set-timezone <IANA-name>` "
+        "or container `TZ` env. If the host cannot be changed, set both app-side: "
+        "miloco-cli config set timezone <IANA-name> AND openclaw's "
+        "agents.defaults.userTimezone."
     )
 
 

--- a/backend/miloco/src/miloco/utils/time_utils.py
+++ b/backend/miloco/src/miloco/utils/time_utils.py
@@ -93,8 +93,10 @@ def _warn_utc_once() -> None:
     _logger.warning(
         "Resolved deploy timezone is UTC — no household lives in UTC; the server "
         "timezone is likely unconfigured and all user-facing times may be "
-        "mislabeled. If your home is elsewhere, set it with: "
-        "miloco-cli config set timezone <IANA-name> (e.g. Asia/Shanghai)."
+        "mislabeled. Preferred fix (aligns every component incl. the openclaw "
+        "agent, which only reads the host timezone): set the HOST timezone, e.g. "
+        "`sudo timedatectl set-timezone <IANA-name>` or container `TZ` env. If "
+        "the host cannot be changed: miloco-cli config set timezone <IANA-name>."
     )
 
 

--- a/knowledge/06-dev-guide/dev-guide.md
+++ b/knowledge/06-dev-guide/dev-guide.md
@@ -129,7 +129,7 @@ Miloco 里"部署时区"指**家庭真实所在的时区**，所有 agent 可见
 
 注意事项：
 
-- **openclaw 是独立进程，只读宿主系统时区**（Node `Intl`），不读 `MILOCO_TIMEZONE` / miloco `config.json`——它会在 agent prompt 底部注入自己解析的 `Current time`。只配 miloco 侧而宿主仍是 UTC 时，prompt 内会同时出现两个矛盾时间源（此时只能靠 miloco 时区块的换算指引软性调解）。**这是"首选改宿主"的核心原因**：宿主时区是唯一能同时对齐 miloco 与 openclaw 的信道。
+- **openclaw 运行时是独立进程，只读宿主系统时区**（Node `Intl`），不读 `MILOCO_TIMEZONE` / miloco `config.json`——它在 agent prompt 底部注入的 `Current time` 行只跟宿主时区走。（注意区分信道：**miloco 插件**虽然运行在 openclaw 内，它自己的 `deployTimezone()` 是读 miloco 配置的，注入的「时间与时区」块因此正确；但 openclaw **运行时**那行 `Current time` 不经过插件，miloco 侧配置无法影响它。）只配 miloco 侧而宿主仍是 UTC 时，prompt 内会同时出现两个矛盾时间源（此时只能靠 miloco 时区块的换算指引软性调解）。**这是"首选改宿主"的核心原因**：宿主时区是唯一能同时对齐 miloco 与 openclaw 运行时的信道。
 - **云主机 / Docker 常见坑**：容器里 `/etc/localtime` 往往是普通文件拷贝（非 symlink）且无 `/etc/timezone`，系统反查靠内容比对兜住；但云主机默认时区多为 `Etc/UTC`——解析结果是 UTC 时 backend 启动会打红旗 warning（没有家庭真住在 UTC），此时应优先给宿主 / 容器设置正确时区；确实无法修改宿主时再用 miloco 侧 `timezone` 配置（注意 openclaw 不受其影响）。
 - `miloco-cli service start` 生成 supervisord.conf 时会把解析出的时区以 `TZ` + `MILOCO_TIMEZONE` 注入 backend 子进程环境（改配置后重启生效）。
 

--- a/knowledge/06-dev-guide/dev-guide.md
+++ b/knowledge/06-dev-guide/dev-guide.md
@@ -129,8 +129,10 @@ Miloco 里"部署时区"指**家庭真实所在的时区**，所有 agent 可见
 
 注意事项：
 
-- **openclaw 运行时是独立进程，只读宿主系统时区**（Node `Intl`），不读 `MILOCO_TIMEZONE` / miloco `config.json`——它在 agent prompt 底部注入的 `Current time` 行只跟宿主时区走。（注意区分信道：**miloco 插件**虽然运行在 openclaw 内，它自己的 `deployTimezone()` 是读 miloco 配置的，注入的「时间与时区」块因此正确；但 openclaw **运行时**那行 `Current time` 不经过插件，miloco 侧配置无法影响它。）只配 miloco 侧而宿主仍是 UTC 时，prompt 内会同时出现两个矛盾时间源（此时只能靠 miloco 时区块的换算指引软性调解）。**这是"首选改宿主"的核心原因**：宿主时区是唯一能同时对齐 miloco 与 openclaw 运行时的信道。
-- **云主机 / Docker 常见坑**：容器里 `/etc/localtime` 往往是普通文件拷贝（非 symlink）且无 `/etc/timezone`，系统反查靠内容比对兜住；但云主机默认时区多为 `Etc/UTC`——解析结果是 UTC 时 backend 启动会打红旗 warning（没有家庭真住在 UTC），此时应优先给宿主 / 容器设置正确时区；确实无法修改宿主时再用 miloco 侧 `timezone` 配置（注意 openclaw 不受其影响）。
+- **两个独立的时区配置域，共享宿主作为回落**：miloco（backend + 插件）按上表顺序读 `MILOCO_TIMEZONE` / `config.json`；**openclaw 运行时**——即在 agent prompt 底部注入 `Current time` 行的那一方——读它自己的 `openclaw.json` → `agents.defaults.userTimezone`（openclaw `resolveUserTimezone`：配了且合法就用它，否则回落 `Intl` 宿主时区，再否则 `UTC`）。两个域互不读对方的配置，但**各自的显式配置为空时都回落到宿主系统时区**。（注意区分信道：**miloco 插件**虽运行在 openclaw 内，它自己的 `deployTimezone()` 读 miloco 配置，注入的「时间与时区」块因此正确；而 openclaw **运行时**那行 `Current time` 不经过插件、也不读 miloco 配置，由 `userTimezone` / 宿主决定。）
+- **为何首选改宿主**：宿主时区是这两个域**唯一共享的回落信道**——设好宿主、两边显式配置都留空，openclaw 与 miloco 便一起对齐，只需动一处。若偏好显式配置，须**同时**设 openclaw 的 `agents.defaults.userTimezone` 与 miloco 的 `config.json` `timezone`；只设一边会让另一边停在回落上。
+- **openclaw 侧没有"中国兜底"，这是历史 bug 的根源**：miloco 域在彻底无法解析时兜底 `Asia/Shanghai`，而 openclaw 域回落只到宿主时区（云主机通常 `Etc/UTC`）、无额外兜底。故 `userTimezone` 未设 + 宿主 UTC 时，openclaw 的 `Current time` 会显示 UTC——「上午 10 点被叙述成凌晨」正源于此。修法：设 `openclaw.json` 的 `userTimezone`（openclaw 原生机制），或设对宿主时区。
+- **云主机 / Docker 常见坑**：容器里 `/etc/localtime` 往往是普通文件拷贝（非 symlink）且无 `/etc/timezone`，系统反查靠内容比对兜住；但云主机默认时区多为 `Etc/UTC`——解析结果是 UTC 时 backend 启动会打红旗 warning（没有家庭真住在 UTC），此时应优先给宿主 / 容器设置正确时区；确实无法修改宿主时再用 miloco 侧 `timezone` 配置（openclaw 侧的 `Current time` 另由其 `userTimezone` / 宿主回落决定，见上）。
 - `miloco-cli service start` 生成 supervisord.conf 时会把解析出的时区以 `TZ` + `MILOCO_TIMEZONE` 注入 backend 子进程环境（改配置后重启生效）。
 
 ### 配置修改后是否需要重启

--- a/knowledge/06-dev-guide/dev-guide.md
+++ b/knowledge/06-dev-guide/dev-guide.md
@@ -112,15 +112,25 @@ Miloco 里"部署时区"指**家庭真实所在的时区**，所有 agent 可见
 3. 系统时区反查：`TZ` env → `/etc/timezone` → `/etc/localtime`（symlink 目标；普通文件则按字节内容反查 zoneinfo 数据库）
 4. 最后兜底 `Asia/Shanghai` + 一次性 warning（宿主完全不暴露 IANA 身份时；面向国内主流用户的保守选择，非国内部署请显式配置时区）
 
-配置方式：
+配置方式（按推荐顺序）：
 
-```bash
-miloco-cli config set timezone Asia/Shanghai   # IANA 名，非法名会被拦
-```
+1. **首选：设置宿主系统时区**——一次对齐所有组件（miloco backend / 插件、openclaw、日志时间戳、系统 cron 以及未来任何依赖）：
+
+   ```bash
+   sudo timedatectl set-timezone Asia/Shanghai   # 裸机 / 云主机
+   docker run -e TZ=Asia/Shanghai ...            # 容器
+   ```
+
+2. **Fallback：miloco 侧配置**（无法修改宿主时区、或临时测试时）：
+
+   ```bash
+   miloco-cli config set timezone Asia/Shanghai   # IANA 名，非法名会被拦
+   ```
 
 注意事项：
 
-- **云主机 / Docker 常见坑**：容器里 `/etc/localtime` 往往是普通文件拷贝（非 symlink）且无 `/etc/timezone`，系统反查靠内容比对兜住；但云主机默认时区多为 `Etc/UTC`——解析结果是 UTC 时 backend 启动会打红旗 warning（没有家庭真住在 UTC），此时应显式配置 `timezone` 或给容器设 `TZ` 环境变量。
+- **openclaw 是独立进程，只读宿主系统时区**（Node `Intl`），不读 `MILOCO_TIMEZONE` / miloco `config.json`——它会在 agent prompt 底部注入自己解析的 `Current time`。只配 miloco 侧而宿主仍是 UTC 时，prompt 内会同时出现两个矛盾时间源（此时只能靠 miloco 时区块的换算指引软性调解）。**这是"首选改宿主"的核心原因**：宿主时区是唯一能同时对齐 miloco 与 openclaw 的信道。
+- **云主机 / Docker 常见坑**：容器里 `/etc/localtime` 往往是普通文件拷贝（非 symlink）且无 `/etc/timezone`，系统反查靠内容比对兜住；但云主机默认时区多为 `Etc/UTC`——解析结果是 UTC 时 backend 启动会打红旗 warning（没有家庭真住在 UTC），此时应优先给宿主 / 容器设置正确时区；确实无法修改宿主时再用 miloco 侧 `timezone` 配置（注意 openclaw 不受其影响）。
 - `miloco-cli service start` 生成 supervisord.conf 时会把解析出的时区以 `TZ` + `MILOCO_TIMEZONE` 注入 backend 子进程环境（改配置后重启生效）。
 
 ### 配置修改后是否需要重启


### PR DESCRIPTION
## Summary

#383 合并后 @Zirconi 的架构观察与 @Ada-xia 的意见的落地（纯文档 + 一行告警文案，不动逻辑）：

**openclaw 是独立进程，不读 miloco 侧配置**（`MILOCO_TIMEZONE` / miloco `config.json`）。它注入在 agent prompt 底部的 `Current time` 按 `agents.defaults.userTimezone`（openclaw.json）→ 宿主系统时区（Node `Intl`）→ UTC 解析，**无中国兜底**。当 `userTimezone` 未配且宿主是 UTC 时（云主机 / Docker 默认，正是原始事故现场），只配 miloco 侧会让 prompt 内同时出现两个矛盾时间源，只能靠 miloco 时区块的换算指引软性调解。

**宿主时区是唯一能同时对齐 miloco 与 openclaw 的信道**。因此把 dev-guide 时区章节的推荐顺序改为：

1. 首选 `sudo timedatectl set-timezone` / 容器 `-e TZ=`（一次对齐 miloco backend/plugin、openclaw、日志、系统 cron）；
2. `miloco-cli config set timezone` 降级为无法修改宿主时区时的 fallback / 测试用。

同步改动：UTC 红旗告警文案的建议指向同步为"优先改宿主时区"（`time_utils.py` 一行）；注意事项新增 openclaw 独立性的显式说明。

## 测试

时区相关套件 25 passed（告警文案断言的关键子串在新文案中均保留）；`ruff` 全绿。

## 关联

- #383（本 PR 是其合并后讨论的 follow-up）
- @Zirconi 的跨系统边界分析、@Ada-xia 的"后续与系统保持一致"方向

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UoQdo1uiv3aecQVJ9RVVT

