### PR TITLE
fix(camera): 帧流佐证 #403 的 awake——纠正 camera-control:on 假阴性导致在拍相机被踢出活跃集

### DIFF
--- a/backend/miloco/src/miloco/miot/router.py
+++ b/backend/miloco/src/miloco/miot/router.py
@@ -94,11 +94,15 @@ async def _first_frame_watchdog(
     # 而是需要住户去米家唤醒；其余（True/未知）仍按连不上处理。
     reason, message = "camera_unreachable", "连不上摄像头(可能不在同一局域网,或摄像头离线)"
     try:
-        awake = (
+        raw_awake = (
             await manager.miot_service._miot_proxy.read_cameras_awake(
                 [camera_id], cache_only=True
             )
         ).get(camera_id)
+        # 与 list 路径同口径：帧流佐证 awake，纠正 camera-control:on 的假阴性。watch WS 拿不到
+        # 首帧不代表镜头关——感知 decode 可能仍在出帧（属性假阴性 / 直播 relay 单独故障）。
+        # 帧在流则相机是醒的，不该把住户指去唤醒，回落 unreachable。
+        awake = manager.miot_service.corroborated_awake(camera_id, raw_awake)
         if awake is False:
             reason, message = (
                 "camera_sleeping",

--- a/backend/miloco/src/miloco/miot/router.py
+++ b/backend/miloco/src/miloco/miot/router.py
@@ -89,20 +89,31 @@ async def _first_frame_watchdog(
     await asyncio.sleep(_FIRST_FRAME_TIMEOUT_S)
     if miot_video_stream_manager.has_emitted_frame(camera_id, channel):
         return
+    # 分流「休眠」vs「连不上」：无首帧有两种截然不同的原因，给住户的行动指引也不同。
+    # 读镜头开关（camera-control:on）缓存——明确为 False（镜头关/休眠）时不是"连不上"，
+    # 而是需要住户去米家唤醒；其余（True/未知）仍按连不上处理。
+    reason, message = "camera_unreachable", "连不上摄像头(可能不在同一局域网,或摄像头离线)"
+    try:
+        awake = (
+            await manager.miot_service._miot_proxy.read_cameras_awake(
+                [camera_id], cache_only=True
+            )
+        ).get(camera_id)
+        if awake is False:
+            reason, message = (
+                "camera_sleeping",
+                "摄像头处于休眠状态(在米家 app 或面板中唤醒后即可观看)",
+            )
+    except Exception as err:  # noqa: BLE001 — 分流失败退回默认 unreachable，不阻断
+        logger.info("watchdog awake lookup skipped, %s.%d: %s", camera_id, channel, err)
     logger.warning(
-        "First-frame watchdog fired, %s.%d — no frame in %.0fs, camera likely "
-        "unreachable (cross-LAN / offline / PPCS relay not established)",
-        camera_id, channel, _FIRST_FRAME_TIMEOUT_S,
+        "First-frame watchdog fired, %s.%d — no frame in %.0fs, reason=%s",
+        camera_id, channel, _FIRST_FRAME_TIMEOUT_S, reason,
     )
     try:
-        # reason 是给将来按机器码分流预留的字段;前端 watch.html 当前只展示 message,
-        # 不读 reason。两个都发,前端按需取。
+        # 前端 watch.html 当前只展示 message,不读 reason。两个都发,前端按需取。
         await websocket.send_text(
-            json.dumps({
-                "type": "error",
-                "reason": "camera_unreachable",
-                "message": "连不上摄像头(可能不在同一局域网,或摄像头离线)",
-            })
+            json.dumps({"type": "error", "reason": reason, "message": message})
         )
     except Exception as err:
         # send 失败基本意味着连接已被对端关掉——再 close 也是白搭,还会再抛一条
@@ -113,9 +124,7 @@ async def _first_frame_watchdog(
         return
     try:
         # 1011 + 短 reason(已被 _truncate_ws_reason 口径约束在 control frame 上限内)
-        await websocket.close(
-            code=1011, reason=_truncate_ws_reason("camera_unreachable")
-        )
+        await websocket.close(code=1011, reason=_truncate_ws_reason(reason))
     except Exception as err:
         logger.info("watchdog close failed, %s.%d: %s", camera_id, channel, err)
 

--- a/backend/miloco/src/miloco/miot/service.py
+++ b/backend/miloco/src/miloco/miot/service.py
@@ -54,8 +54,34 @@ from miloco.miot.schema import (
 
 logger = logging.getLogger(__name__)
 
+# 帧流「还活着」的判定窗口：距最近一帧 ≤ 此毫秒数视为在出帧。用于给 awake 属性
+# 佐证——camera-control:on 有假阴性（真机实测：正在出帧的机位属性仍读到 on=False），
+# 帧在流可一票否决属性说关的误读。30s 覆盖感知采样间隔的抖动，不至于把短暂断流误判为醒。
+_FRAME_ALIVE_MS = 30_000
+
 # 持有后台 task 引用，避免 CPython GC 回收 fire-and-forget task。
 _background_tasks: set[asyncio.Task] = set()
+
+
+def _corroborate_awake(
+    raw_awake: bool | None, frames_flowing: bool | None
+) -> bool | None:
+    """用帧流佐证镜头开关（awake）属性，纠正其假阴性。
+
+    ``camera-control:on`` 属性存在假阴性——真机实测：正在出帧的机位属性仍读到
+    ``on=False``（云端缓存陈旧 / 型号语义差异）。若单凭属性把它判成「镜头关」，
+    #403 的 ``select_active`` 会据此把一台**明明在拍**的相机踢出活跃集、丢掉感知。
+
+    佐证规则（只纠正 False→True 这一种假阴性，不反向覆盖）：
+      - 属性说醒（True）/ 未知（None）：原样返回，帧流不改写（醒着就是醒着）。
+      - 属性说关（False）但帧在流（True）：属性不可信，纠正为 True。
+      - 属性说关（False）且帧流已死 / 无佐证（False/None）：维持 False（确认镜头关）。
+    """
+    if raw_awake is not False:
+        return raw_awake
+    if frames_flowing:
+        return True
+    return False
 
 
 def _parse_prop_iid(iid: str) -> tuple[int, int]:
@@ -1034,10 +1060,18 @@ class MiotService:
         devices = await self._miot_proxy.get_devices()
         cameras = {did: info for did, info in cameras.items() if did in devices}
         # awake：只读缓存（云读收在 refresh_camera_online_status，前端列表前必调）。
-        awake_map = await self._miot_proxy.read_cameras_awake(
+        raw_awake = await self._miot_proxy.read_cameras_awake(
             list(cameras.keys()), cache_only=True
         )
+        # 帧流佐证：camera-control:on 有假阴性——正在出帧的机位属性仍可能读到 on=False。
+        # 若不纠正，select_active 会把明明在拍的相机当「镜头关」踢出活跃集、丢掉感知。
+        # 用帧龄一票否决属性说关的误读（只纠正 False→True，不反向覆盖）。
+        awake_map = {
+            did: _corroborate_awake(raw_awake.get(did), self.camera_frames_flowing(did))
+            for did in cameras
+        }
         # in_use = 活跃集：与拉流/投喂同一口径（select_active：未拉黑 + home + 三态 + 上限）。
+        # 喂佐证后的 awake_map，醒着的相机不再因属性假阴性被误踢。
         active = set(
             select_active_camera_dids(self._kv_repo, cameras, awake_map=awake_map)
         )
@@ -1217,6 +1251,24 @@ class MiotService:
     def _connected_camera_dids(self) -> set[str]:
         adapter = self._camera_adapter()
         return set(adapter.get_connected_devices().keys()) if adapter else set()
+
+    def camera_frames_flowing(self, did: str) -> bool | None:
+        """该机位当前是否在出帧。True/False；适配器不可用或从未出帧返回 None。
+
+        读 camera_adapter 的帧龄（单调时钟差），≤ ``_FRAME_ALIVE_MS`` 视为在流。
+        供 ``_corroborate_awake`` 纠正 camera-control:on 的假阴性。
+        """
+        adapter = self._camera_adapter()
+        if adapter is None:
+            return None
+        try:
+            age = adapter.frame_age_ms(did)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("frame age lookup failed for %s: %s", did, e)
+            return None
+        if age is None:
+            return None
+        return age <= _FRAME_ALIVE_MS
 
     async def _sync_camera_adapter(self) -> None:
         """Hot-sync camera connections after a scope change."""

--- a/backend/miloco/src/miloco/miot/service.py
+++ b/backend/miloco/src/miloco/miot/service.py
@@ -1067,8 +1067,7 @@ class MiotService:
         # 若不纠正，select_active 会把明明在拍的相机当「镜头关」踢出活跃集、丢掉感知。
         # 用帧龄一票否决属性说关的误读（只纠正 False→True，不反向覆盖）。
         awake_map = {
-            did: _corroborate_awake(raw_awake.get(did), self.camera_frames_flowing(did))
-            for did in cameras
+            did: self.corroborated_awake(did, raw_awake.get(did)) for did in cameras
         }
         # in_use = 活跃集：与拉流/投喂同一口径（select_active：未拉黑 + home + 三态 + 上限）。
         # 喂佐证后的 awake_map，醒着的相机不再因属性假阴性被误踢。
@@ -1269,6 +1268,13 @@ class MiotService:
         if age is None:
             return None
         return age <= _FRAME_ALIVE_MS
+
+    def corroborated_awake(self, did: str, raw_awake: bool | None) -> bool | None:
+        """对单台相机的镜头开关（awake）做帧流佐证——与 list_cameras_with_state 同口径。
+
+        给看门狗等调用点复用同一佐证逻辑，避免「list 佐证、看门狗裸读」的口径分裂。
+        """
+        return _corroborate_awake(raw_awake, self.camera_frames_flowing(did))
 
     async def _sync_camera_adapter(self) -> None:
         """Hot-sync camera connections after a scope change."""

--- a/backend/miloco/src/miloco/perception/collect/camera_adapter.py
+++ b/backend/miloco/src/miloco/perception/collect/camera_adapter.py
@@ -76,6 +76,12 @@ class _CameraDeviceState:
     # Clock calibration: epoch_delta = unix_ms - monotonic_ms (locked on first frame)
     # Used to convert monotonic wall_ms to unix timestamps for display.
     epoch_delta: int | None = None
+    # Monotonic wall_ms of the most recent decoded frame; None until first frame.
+    # Consumed by awake corroboration (service.camera_frames_flowing): the
+    # camera-control:on property has false negatives — a camera still emitting
+    # frames whose property reads on=False is not actually 镜头关/休眠; live frames
+    # veto the stale property read.
+    last_frame_wall_ms: int | None = None
 
 
 class CameraDeviceAdapter(BaseDeviceAdapter):
@@ -430,6 +436,7 @@ class CameraDeviceAdapter(BaseDeviceAdapter):
         to derive unix_ms for display.
         """
         wall_ms = _monotonic_ms()
+        state.last_frame_wall_ms = wall_ms
         if state.epoch_delta is None:
             state.epoch_delta = _unix_ms() - wall_ms
             logger.debug(
@@ -439,6 +446,18 @@ class CameraDeviceAdapter(BaseDeviceAdapter):
             )
         unix_ms = wall_ms + state.epoch_delta
         return wall_ms, unix_ms
+
+    def frame_age_ms(self, did: str) -> int | None:
+        """该机位距最近一帧的毫秒数；从未出过帧 / 未订阅返回 None。
+
+        单调时钟差值，不受系统时间调整影响。消费方（awake 佐证）用它判断
+        「帧流是否还活着」——camera-control:on 属性有假阴性，帧在流可一票否决
+        属性说关的误读。
+        """
+        state = self._devices.get(did)
+        if state is None or state.last_frame_wall_ms is None:
+            return None
+        return _monotonic_ms() - state.last_frame_wall_ms
 
     @staticmethod
     def _compute_decode_latency(

--- a/backend/miloco/src/miloco/perception/collect/camera_adapter.py
+++ b/backend/miloco/src/miloco/perception/collect/camera_adapter.py
@@ -436,7 +436,6 @@ class CameraDeviceAdapter(BaseDeviceAdapter):
         to derive unix_ms for display.
         """
         wall_ms = _monotonic_ms()
-        state.last_frame_wall_ms = wall_ms
         if state.epoch_delta is None:
             state.epoch_delta = _unix_ms() - wall_ms
             logger.debug(
@@ -508,6 +507,9 @@ class CameraDeviceAdapter(BaseDeviceAdapter):
                     h.skip_rolling()
                     return
                 wall_ms, unix_ms = self._calibrate(state, ts)
+                # 帧流佐证只用**视频**帧盖时刻：awake / camera-control 是镜头(视频)属性，
+                # 视频在出 = 镜头开着；音频单独在流不足以佐证镜头未关，故不在音频回调盖。
+                state.last_frame_wall_ms = wall_ms
                 decode_latency_ms = self._compute_decode_latency(
                     recv_unix_ms, decoded_unix_ms
                 )

--- a/backend/miloco/tests/perception/test_camera_adapter_decode_latency.py
+++ b/backend/miloco/tests/perception/test_camera_adapter_decode_latency.py
@@ -88,6 +88,29 @@ class TestComputeDecodeLatency:
         assert dec == 0.0
 
 
+class TestFrameAgeMs:
+    """frame_age_ms 给 awake 佐证提供「帧流是否还活着」的信号。"""
+
+    def test_never_emitted_returns_none(self):
+        adapter = CameraDeviceAdapter(miot_proxy=object())  # type: ignore[arg-type]
+        adapter._devices["cam1"] = _CameraDeviceState(did="cam1")  # 无 last_frame
+        assert adapter.frame_age_ms("cam1") is None
+
+    def test_unknown_did_returns_none(self):
+        adapter = CameraDeviceAdapter(miot_proxy=object())  # type: ignore[arg-type]
+        assert adapter.frame_age_ms("ghost") is None
+
+    def test_recent_frame_small_age(self, monkeypatch):
+        import miloco.perception.collect.camera_adapter as mod
+
+        adapter = CameraDeviceAdapter(miot_proxy=object())  # type: ignore[arg-type]
+        state = _CameraDeviceState(did="cam1")
+        state.last_frame_wall_ms = 10_000
+        adapter._devices["cam1"] = state
+        monkeypatch.setattr(mod, "_monotonic_ms", lambda: 10_500)
+        assert adapter.frame_age_ms("cam1") == 500
+
+
 class TestCallbackIntegration:
     """Drive the async decoded-frame callbacks end-to-end."""
 

--- a/backend/miloco/tests/test_miot_filter_and_cameras.py
+++ b/backend/miloco/tests/test_miot_filter_and_cameras.py
@@ -522,6 +522,21 @@ async def test_frames_flowing_vetoes_awake_false_negative():
 
 
 @pytest.mark.asyncio
+async def test_corroborated_awake_watchdog_path():
+    """看门狗分流走的 corroborated_awake：属性说关但帧在流 → 不判休眠（醒着，只是 watch
+    relay 没首帧）；属性说关且帧流已死 → 判休眠（提示去米家唤醒）。与 list 路径同口径。"""
+    svc = _make_service(cameras={"c1": _camera("c1")})
+    # 帧在流：即使属性假阴性 on=False，也不该判休眠
+    svc.camera_frames_flowing = lambda did: True  # type: ignore[assignment]
+    assert svc.corroborated_awake("c1", False) is True
+    # 帧流已死 + 属性说关：确认休眠
+    svc.camera_frames_flowing = lambda did: False  # type: ignore[assignment]
+    assert svc.corroborated_awake("c1", False) is False
+    # 属性说醒：原样，帧流不改写
+    assert svc.corroborated_awake("c1", True) is True
+
+
+@pytest.mark.asyncio
 async def test_awake_false_and_no_frames_stays_off():
     """属性说关且帧流已死 → 确认镜头关：awake=False，被 select_active 排除。"""
     cameras = {"c1": _camera("c1", home_id="H1")}

--- a/backend/miloco/tests/test_miot_filter_and_cameras.py
+++ b/backend/miloco/tests/test_miot_filter_and_cameras.py
@@ -479,6 +479,65 @@ async def test_list_cameras_with_state_flags():
     assert by_did["c4"]["connected"] is True
 
 
+# ─── awake 帧流佐证（纠正 camera-control:on 假阴性）───────────────────────────
+
+
+def test_corroborate_awake_matrix():
+    """帧流佐证 awake 的纯函数矩阵：只纠正 False→True（假阴性），不反向覆盖。"""
+    from miloco.miot.service import _corroborate_awake
+
+    # 属性说醒 / 未知：帧流不改写（醒着就是醒着；未知保持未知）
+    assert _corroborate_awake(True, False) is True
+    assert _corroborate_awake(True, None) is True
+    assert _corroborate_awake(None, True) is None
+    assert _corroborate_awake(None, None) is None
+    # 属性说关但帧在流：假阴性，纠正为醒
+    assert _corroborate_awake(False, True) is True
+    # 属性说关且帧流已死 / 无佐证：维持关
+    assert _corroborate_awake(False, False) is False
+    assert _corroborate_awake(False, None) is False
+
+
+@pytest.mark.asyncio
+async def test_frames_flowing_vetoes_awake_false_negative():
+    """真机假阴性场景：属性读 on=False 但帧在流 → 该相机不该被踢出活跃集，awake=True。
+
+    这修的是 #403 裸读属性的缺陷：单凭 camera-control:on 会把明明在拍的相机误判
+    镜头关、从 select_active 踢掉丢感知。帧流佐证一票否决属性说关的误读。
+    """
+    cameras = {"c1": _camera("c1", home_id="H1")}
+    kv = _FakeKV({ScopeConfigKeys.HOME_WHITE_LIST_KEY: json.dumps(["H1"])})
+    svc = _make_service(devices=dict(cameras), cameras=cameras, kv=kv)
+    # 属性读到假阴性 on=False
+    svc._miot_proxy.read_cameras_awake = AsyncMock(
+        side_effect=lambda dids, **kw: {"c1": False}
+    )
+    # 但帧还在流（帧龄新鲜）
+    svc.camera_frames_flowing = lambda did: True  # type: ignore[assignment]
+
+    out = await svc.list_cameras_with_state()
+    c1 = {c["did"]: c for c in out}["c1"]
+    assert c1["awake"] is True  # 佐证后纠正为醒
+    assert c1["in_use"] is True  # 没被 select_active 误踢
+
+
+@pytest.mark.asyncio
+async def test_awake_false_and_no_frames_stays_off():
+    """属性说关且帧流已死 → 确认镜头关：awake=False，被 select_active 排除。"""
+    cameras = {"c1": _camera("c1", home_id="H1")}
+    kv = _FakeKV({ScopeConfigKeys.HOME_WHITE_LIST_KEY: json.dumps(["H1"])})
+    svc = _make_service(devices=dict(cameras), cameras=cameras, kv=kv)
+    svc._miot_proxy.read_cameras_awake = AsyncMock(
+        side_effect=lambda dids, **kw: {"c1": False}
+    )
+    svc.camera_frames_flowing = lambda did: False  # type: ignore[assignment]
+
+    out = await svc.list_cameras_with_state()
+    c1 = {c["did"]: c for c in out}["c1"]
+    assert c1["awake"] is False
+    assert c1["in_use"] is False  # 镜头关 → 不活跃
+
+
 @pytest.mark.asyncio
 async def test_toggle_camera_writes_disabled():
     kv = _FakeKV({ScopeConfigKeys.HOME_WHITE_LIST_KEY: json.dumps(["H1"])})


### PR DESCRIPTION
## Summary

按 @Ada-xia 在 review 里的方向重做：#403 的「相机纳入观测范围」模型是既定方向，本 PR **不再包含**原来那套立意（画面属于住户 / 观看独立于感知 / 设备电源作为卡片一等轴 / 卡片三态重构），只把她点名「不浪费」的**取证内核**并进 #403 的 `awake` / `select_active` 模型。

已 reset 到 origin/main，外科式重新加入以下改动（+176/−14，5 文件，纯后端）。

## 问题：#403 的 `awake` 裸读属性，有假阴性

`camera-control:on` 存在**假阴性**——真机实测：一台**正在出帧**的相机，属性仍可能读到 `on=False`（云端缓存陈旧 / 型号语义差异）。#403 的 `select_active` 直接拿 `awake` 原始值做门，于是这台明明在拍的相机会被判成「镜头关」、**从活跃集踢出 → 感知丢掉一台在拍的相机**。

## 改动：用帧流佐证 `awake`

- **`_corroborate_awake(raw, frames_flowing)`**：帧在流一票否决属性说关的误读（**只纠正 False→True 这一种假阴性，不反向覆盖**）。佐证后的 `awake_map` 同时喂给 `select_active`（不再误踢）**和**列表输出的 `awake` 字段（前端看到的也是佐证后的值）。
- **帧龄管道**：`camera_adapter` 每解码一帧记 `last_frame_wall_ms`；`frame_age_ms(did)` 暴露帧龄（单调时钟差）；`service.camera_frames_flowing(did)` 包一层（≤30s 视为在流）。
- **看门狗分流**：首帧超时不再一律报 `camera_unreachable`——读镜头开关缓存，明确 `False`（镜头关/休眠）时分流成 `camera_sleeping`（提示「去米家唤醒」），其余仍 unreachable。

## 不包含（按 review 舍弃）

- 卡片上的电源 / 唤醒-休眠开关（设备控制交给既有 device CLI/skill）；
- 「画面独立于感知」/ 每台恒出 live / `sleeping` 做成一等可看状态 / `deriveCardState` 那套设备三态卡；
- 独立观看端点。换言之：**取证逻辑留、UI 立意让**。

## 测试

- 佐证纯函数矩阵（7 组）；「属性 off 但帧在流 → 留在活跃集、awake=True」；「属性 off 且无帧 → awake=False、踢出」；`frame_age_ms` 单测；
- `perception` + `miot` 全套 **997 passed**；`ruff` 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UoQdo1uiv3aecQVJ9RVVT
