### PR TITLE
perf: 身份库为空时跳过成员匹配并放慢重复识别，省无意义 omni 开销

### DIFF
--- a/backend/miloco/src/miloco/perception/engine/config.py
+++ b/backend/miloco/src/miloco/perception/engine/config.py
@@ -133,6 +133,12 @@ class StabilityConfigDC:
     # 让"连续 N 次一致"更快凑齐。代价: 攒库阶段 omni 调用更密(仅 confirmed 且非冷却时;
     # 攒满即写并进冷却转慢, 不会持续高频)。
     recheck_interval_accumulating_sec: float = 10.0
+    # 身份库(persons)为空时 unknown track 的重派慢周期（秒）。库空=没有任何成员可匹配，
+    # unknown 常规 30s 重派唯一价值（等人转身/走近再匹配成员）恒为 0 → 放慢到此周期，只保留
+    # 周期性给 omni 翻 no_person 的机会（静物误检的延迟纠正），不破坏"永不永久静音"不变式。
+    # 只作用于 unknown；pending 不放慢（no_person 落定靠 pending 期连续投票，见 needs_omni_call）。
+    # 库非空自动回落到 recheck_interval_sec。按 engine_fps 换算成帧，与其它周期同款秒标定。
+    gallery_empty_recheck_sec: float = 600.0
     hysteresis_unmatched_count: int = 2
     # 时序一致性写库门 (tier_c 污染修复): 同一 person_id **连续 N 次 confirmed 重审一致**
     # 才允许写入 tier_c。把"显示用 commit"(灵敏, conf-aware 1/2/3 次) 跟"写库资格"(严格)

--- a/backend/miloco/src/miloco/perception/engine/identity/engine.py
+++ b/backend/miloco/src/miloco/perception/engine/identity/engine.py
@@ -494,6 +494,11 @@ class IdentityEngine:
             logger.warning("library.list_persons 异常，本窗口跳过身份库变化监听", exc_info=True)
         self._maybe_reset_on_library_change(person_refs, now_ts)
 
+        # 身份库(persons)为空 → 成员匹配不可能, 下方 needs_omni_call 对 unknown track 放慢重派
+        # (省无意义的周期重问; no_person 判定在 pending 期照常累积、不受影响)。person_refs is None
+        # (读库异常) 不当作空, 保守走常规间隔。注: pets 不计入 list_persons, 不影响此判定。
+        gallery_empty = person_refs is not None and len(person_refs) == 0
+
         # ----- 1. 维护 state（创建/promote/timeout）-----
         active_track_ids: set[int] = set()
         for tr in tracking_results:
@@ -611,6 +616,7 @@ class IdentityEngine:
                 self.config.stability,
                 self._engine_fps,
                 self.config.no_person.no_person_recheck_sec,
+                gallery_empty=gallery_empty,
             ):
                 continue
             # coasting（人离开/跟丢后纯 Kalman 预测残留）的 track 当窗口不进 omni

--- a/backend/miloco/src/miloco/perception/engine/identity/state.py
+++ b/backend/miloco/src/miloco/perception/engine/identity/state.py
@@ -444,6 +444,7 @@ def needs_omni_call(
     config: StabilityConfig,
     engine_fps: float,
     no_person_recheck_sec: float = 1200.0,
+    gallery_empty: bool = False,
 ) -> bool:
     """判断该 track 是否需要派发新的 omni 识别任务。
 
@@ -457,6 +458,12 @@ def needs_omni_call(
         unknown 首次重审 (count==0) 距 ≥ recheck//2                 → True   ← 抢翻转窗口
         unknown 后续重审 (count>0)  距 ≥ recheck 周期                → True
         unknown,   未达上述阈值                                    → False
+
+    ``gallery_empty=True``（身份库为空）时只改 unknown 分支：把重派周期从 recheck_interval_sec
+    放慢到 config.gallery_empty_recheck_sec（且不走 count==0 的 interval//2 抢翻转——库空无从翻成
+    成员）。库空下 unknown 常规重派唯一价值（等人转身/走近再匹配成员）恒为 0，放慢只留周期性
+    翻 no_person 的机会。**pending 分支不受影响**：no_person 落定靠 pending 期连续投票在
+    pending_timeout(60s) 内累计，放慢会破坏它。库非空时该参数无作用（等价旧行为）。
 
     重审周期(秒)在此入口按 ``engine_fps`` 换算成 frame_index 帧数(round(sec×fps)),
     与 max_age_sec 同款"秒标定、运行时换算", 改 fps 墙钟周期不漂移。
@@ -515,6 +522,12 @@ def needs_omni_call(
         # unknown 也走重审，让"刚登记的人"或"角度误判的人"能被自动识别上。
         # 自适应: 首次重审用 interval//2 (commit unknown 后最可能翻转的窗口——
         # 人刚入镜信息不全被误判, 几秒后全身入镜就该翻回),后续恢复正常间隔。
+        if gallery_empty:
+            # 库空: 没有任何成员可匹配, "等人转身/走近再匹配成员"的重派价值恒为 0 → 放慢到
+            # 库空专用慢周期, 只保留周期性给 omni 翻 no_person 的机会(静物误检延迟纠正)。不走
+            # count==0 的 interval//2 抢翻转(库空无从翻成成员)。库非空时不进此分支、回常规间隔。
+            interval = max(1, round(config.gallery_empty_recheck_sec * engine_fps))
+            return (now_frame - state.last_omni_call_frame) >= interval
         interval = max(1, round(config.recheck_interval_sec * engine_fps))
         if state.unknown_recheck_count == 0:
             interval = interval // 2

--- a/backend/miloco/src/miloco/perception/engine/omni/constants.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/constants.py
@@ -104,3 +104,10 @@ _EXAMPLE_CHAIN = """\
 本轮（节选）：当前时间 02:31:00；画面里小明坐在电脑前操作鼠标键盘；听到重物倒地声
 输出（speeches 无故省略）：
 {"caption":"小明坐在电脑前操作鼠标键盘，屏幕显示游戏画面","env_sounds":"重物倒地声","suggestions":[{"event":"听到重物倒地声","action":"提醒用户确认房间情况","urgency":"medium"}]}"""
+
+# 身份库为空（identity_match_disabled）时用的实例 B 变体：把示范专名换成泛称。库空窗口没有
+# 成员铺垫（实例 A 已被 gate 掉），caption 示范不该叫专名——与 caption 字段说明「没识别出的
+# 人写 某人 / 陌生人」一致。从 _EXAMPLE_CHAIN 派生而非另写一份，避免两份实例将来漂移；
+# assert 兜住「示范专名被改名致 replace 静默失效」。
+_EXAMPLE_CHAIN_NO_NAME = _EXAMPLE_CHAIN.replace("小明", "某人")
+assert "小明" not in _EXAMPLE_CHAIN_NO_NAME

--- a/backend/miloco/src/miloco/perception/engine/omni/field_registry.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/field_registry.py
@@ -74,6 +74,23 @@ IDENTITY = FieldSpec(
     requires_identity=True,
 )
 
+# 精简版 identity 字段：身份库为空（无任何注册成员）时用。此时"对上 gallery 成员"不可能，
+# 整套面部逐项核对规则都是死重（徒增 prompt token 与模型认知负担、并产出误导性的"无法与库中
+# 成员匹配"reason）。只保留 unknown↔no_person 这一判定——no_person（非人误检抑制）不依赖 gallery，
+# 是身份库为空时仍需保住的能力（name 仍走 <unknown|no_person>，下游 no_person 解析/落定链路不变）。
+IDENTITY_NO_MATCH = FieldSpec(
+    name="identities",
+    schema_literal='"identities":[{"track_id":<int>,"name":"<unknown|no_person>","confidence":0-1,"reason":"≤20字"}]',
+    spec_md="""## identities
+- 本轮无注册成员、不做成员匹配：只判每个"待识别 track"是「确有人体」还是「非人误检」，覆盖所有 track_id、不遗漏不新增
+- 确有人体（哪怕背影/侧身/局部/遮挡/模糊）→ name 填 "unknown"
+- 框内没有真实人体、只是家中非人物体被误框成人（如 3D 打印机、落地扇、衣帽架或搭挂/晾晒的衣物、落地绿植、纸箱行李堆 等外形易被误当成人的物体）→ name 填 "no_person"，纵使轮廓像人
+- 分不清是人还是物时倾向 unknown（别把真人误判成没人）
+- confidence = 对"是人 / 不是人"这一判断的把握；reason ≤20 字简述依据""",
+    requires_video=True,
+    requires_identity=True,
+)
+
 CAPTION = FieldSpec(
     name="caption",
     schema_literal='"caption":"详细描述"',
@@ -172,6 +189,9 @@ class SceneDescriptor:
     has_speech   —— 本轮 VAD 是否判出有真人声。音频过 gate（has_audio=True）但 VAD 判无
         人声（键鼠 / 底噪）时为 False → 只剥 speeches、保留 env_sounds。has_audio=False 时
         speeches 已被 requires_audio 剥掉，本标志无额外作用。
+    identity_match_disabled —— 身份库为空（无任何注册成员）时为 True：``identities`` 字段
+        改用精简版 ``IDENTITY_NO_MATCH``（只判 unknown↔no_person、不做成员匹配）。仅在
+        ``has_identity=True`` 时有意义；库非空时为 False，用完整匹配版 ``IDENTITY``。
     """
 
     route: Literal["video", "audio"]
@@ -179,6 +199,7 @@ class SceneDescriptor:
     stream: bool = False
     has_audio: bool = True
     has_speech: bool = True
+    identity_match_disabled: bool = False
 
     def selected_fields(self) -> list[FieldSpec]:
         order = _ORDER_STREAM if self.stream else _ORDER_NORMAL
@@ -190,7 +211,10 @@ class SceneDescriptor:
         if not self.has_speech:
             fields = [f for f in fields if not f.requires_speech]
         if self.has_identity:
-            fields = [_REGISTRY["identities"], *fields]
+            # 库空 → 精简版（不做成员匹配、只判 unknown/no_person）；两者 name 同为 "identities",
+            # 故 render_schema / render_field_spec / 解析层都无感。
+            ident = IDENTITY_NO_MATCH if self.identity_match_disabled else _REGISTRY["identities"]
+            fields = [ident, *fields]
         return fields
 
 

--- a/backend/miloco/src/miloco/perception/engine/omni/omni.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/omni.py
@@ -131,8 +131,13 @@ async def run_omni_fused(
     name_lookup: dict[str, str] = {}
     name_to_pid: dict[str, str] = {}
     role_counts: Counter[str] = Counter()  # library 全局角色计数，role 唯一性判断的权威来源
+    # 身份库(persons)为空 → 成员匹配不可能，改用精简版 identities prompt（只判 unknown/no_person、
+    # 不做成员匹配，见 field_registry.IDENTITY_NO_MATCH）。仅在 list_persons 成功且确为 0 时置
+    # True；读库异常（下方 except 落到 pass）保持 False，不把一次 IO 抖动误判成"库空"而错误关掉匹配。
+    person_lib_empty = False
     try:
         persons = list(identity_engine.library.list_persons())
+        person_lib_empty = len(persons) == 0
         role_counts = Counter(r.role for r in persons if r.role)
         for ref in persons:
             if ref.name:
@@ -159,6 +164,7 @@ async def run_omni_fused(
             gallery_snapshot=gallery_snapshot,
             config=fused_prompt_config,
             label_lookup=name_lookup,
+            matching_moot=person_lib_empty,
         )
         raw_response = await _call_omni_messages(payload["messages"], config)
     except OmniError as e:

--- a/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
@@ -169,6 +169,7 @@ def build_fused_payload(
     gallery_snapshot: dict[str, "GallerySamples"],
     config: FusedPromptConfig | None = None,
     label_lookup: "dict[str, str] | None" = None,
+    matching_moot: bool = False,
 ) -> dict:
     """构造 fused 主调用的 payload（身份识别和场景理解合并到同一次 omni 调用）。
 
@@ -189,6 +190,9 @@ def build_fused_payload(
         config:            FusedPromptConfig；None 走默认值
         label_lookup:      person_id → 姓名/标签 反查表（供 ``_build_device_header`` 渲染人名）；
                            None 时由本函数自动从 gallery_snapshot 构造
+        matching_moot:     身份库为空（无注册成员）→ 成员匹配不可能。True 时 identities 字段
+                           改精简版（只判 unknown/no_person）、gallery 段整段不渲染。no_person
+                           判定链路不变（见 field_registry.IDENTITY_NO_MATCH）。
 
     Returns:
         dict，含字段：
@@ -254,6 +258,7 @@ def build_fused_payload(
         route="video", has_identity=bool(candidates), stream=False,
         has_audio=_batch_video_has_audio(packets),
         has_speech=_batch_video_has_speech(packets),
+        identity_match_disabled=matching_moot,
     )
     system_prompt = build_system_prompt(scene, include_home_profile=False)
     user_content = _build_fused_user_content(
@@ -265,6 +270,7 @@ def build_fused_payload(
         video_fps=fps,
         cfg=cfg,
         label_lookup=label_lookup,
+        matching_moot=matching_moot,
     )
 
     messages = _assemble_fused_messages(
@@ -558,11 +564,16 @@ def _build_fused_user_content(
     video_fps: int,
     cfg: FusedPromptConfig,
     label_lookup: "dict[str, str] | None" = None,
+    matching_moot: bool = False,
 ) -> list[dict]:
     """构建 user 消息的 content 列表（text/image_url/video_url 块交错）。
 
     fused 模式专用：与纯文本版 ``_build_user_content`` 不同，本函数返回
     ``list[dict]``（OpenAI 多模态 content array），不是 ``str``。
+
+    ``matching_moot=True``（身份库为空）时整个 gallery 段不渲染——库空无成员可比对，
+    identities 已由精简版 spec 指示"只判 unknown/no_person"（见 build_fused_payload），
+    此处不再塞"<gallery>库为空…"这类无用文本。待识别 track 列表仍照常渲染（no_person 判定按 track 给结论）。
     """
     gallery_content: list[dict] = []
 
@@ -572,7 +583,10 @@ def _build_fused_user_content(
     # 人，omni 容易把他的脸贴到 gallery 里最相似的另一位 → 错认（caption/speeches
     # 全跟着错），代价比"漏识别"高一个量级。face 是 nice-to-have，单人 face 失败不
     # 触发放弃。
-    if candidates:
+    #
+    # matching_moot（身份库为空）→ 整段跳过：库空无成员可比对，精简版 identities spec 已
+    # 指示只判 unknown/no_person，不需要 gallery 图，也不再塞"库为空"占位文本。
+    if candidates and not matching_moot:
         if gallery_snapshot:
             # 渲染上限保护：超出 cfg.max_gallery_persons 仅取前 N 人，避免 prompt token 爆
             gallery_items = list(gallery_snapshot.items())

--- a/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
@@ -38,6 +38,7 @@ from .constants import (
     _COMMONSENSE,
     _COMMONSENSE_AUDIO,
     _EXAMPLE_CHAIN,
+    _EXAMPLE_CHAIN_NO_NAME,
     _EXAMPLE_IDENTITY,
     _HISTORY_HEADER,
     _OUTPUT_MODE_FREE,
@@ -506,7 +507,11 @@ def _render_examples(scene: SceneDescriptor) -> str:
     examples = []
     if scene.has_identity and scene.has_speech and not scene.identity_match_disabled:
         examples.append(_EXAMPLE_IDENTITY)
-    examples.append(_EXAMPLE_CHAIN)
+    # 库空时实例 B 用泛称版：此窗无成员铺垫（实例 A 已 gate 掉），caption 示范不该叫专名，
+    # 与「库空不产成员名」收敛一致。库非空照旧用带名版（其"小明"由上方实例 A 的 gallery 铺垫）。
+    examples.append(
+        _EXAMPLE_CHAIN_NO_NAME if scene.identity_match_disabled else _EXAMPLE_CHAIN
+    )
     return "# 输出实例\n\n" + "\n\n".join(examples)
 
 

--- a/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
@@ -460,7 +460,12 @@ def _render_task_list(scene: SceneDescriptor) -> str:
         av = av2 = "视频"
     items: list[str] = []
     if scene.has_identity:
-        items.append("身份识别：对照图片库，识别画面中的人对应库中哪一位（或都不是）")
+        if scene.identity_match_disabled:
+            # 库空：没有成员可对照，任务收敛为「判真人 / 非人误检」，与精简版 identities spec 一致，
+            # 不再写「对照图片库…库中哪一位」这类成员匹配任务（否则与精简 spec 自相矛盾、白占 token）。
+            items.append("身份识别：判断画面中每个目标是真人还是被误检成人的非人物体（本轮无注册成员，不做成员匹配）")
+        else:
+            items.append("身份识别：对照图片库，识别画面中的人对应库中哪一位（或都不是）")
     if scene.route == "video":
         items.append("视频理解：描述画面中的人、宠物、物体，优先描述动态部分")
     if scene.has_audio:
@@ -490,11 +495,16 @@ def _render_examples(scene: SceneDescriptor) -> str:
     has_speech=False（VAD 判无人声、speeches 已剥）时：实例 A 的输出含 speeches（且是
     needs_response 指令），留着会与剥掉的 schema 矛盾、并重新诱导脑补人声指令，故不附
     实例 A（身份判定已由「## identities」充分约束）；实例 B 无 speeches、照常附。
+
+    identity_match_disabled=True（库空）时同样不附实例 A：它演示的是成员匹配（摆
+    ``<gallery>`` 成员、输出成员名 + 五官匹配 reason），与库空的精简版 identities
+    spec / schema（只判 unknown/no_person、无 gallery）自相矛盾，且抵消库空省 token 的
+    目标；身份任务已由精简版「## identities」充分约束。实例 B 无 identities 字段、照常附。
     """
     if scene.route == "audio" or not scene.has_audio:
         return ""
     examples = []
-    if scene.has_identity and scene.has_speech:
+    if scene.has_identity and scene.has_speech and not scene.identity_match_disabled:
         examples.append(_EXAMPLE_IDENTITY)
     examples.append(_EXAMPLE_CHAIN)
     return "# 输出实例\n\n" + "\n\n".join(examples)

--- a/backend/miloco/tests/perception/engine/identity/test_state.py
+++ b/backend/miloco/tests/perception/engine/identity/test_state.py
@@ -475,3 +475,42 @@ class TestNeedsOmniCallPendingNextWindow:
         # inflight 仍挡(每 omni 窗最多一次)
         st.inflight = True
         assert needs_omni_call(st, 2, 101.0, 5.0, cfg, _FPS) is False
+
+
+class TestNeedsOmniCallGalleryEmpty:
+    """身份库为空时的重派节流（Part 2）：只放慢 unknown 到 gallery_empty_recheck_sec，
+    pending 不动（no_person 落定靠 pending 期连续投票，放慢会破坏它）。库非空行为不变。
+    """
+
+    def test_unknown_gallery_empty_uses_slow_recheck(self):
+        cfg = _config()
+        state = TrackIdentityState(track_id=1, status="unknown")
+        slow = _frames(cfg.gallery_empty_recheck_sec)   # 600s
+        normal = _frames(cfg.recheck_interval_sec)      # 30s
+        # 常规 30s 到点也不派（要等库空慢周期）
+        assert needs_omni_call(state, normal, 0.0, 0.0, cfg, _FPS, gallery_empty=True) is False
+        assert needs_omni_call(state, slow - 1, 0.0, 0.0, cfg, _FPS, gallery_empty=True) is False
+        assert needs_omni_call(state, slow, 0.0, 0.0, cfg, _FPS, gallery_empty=True) is True
+
+    def test_unknown_gallery_empty_ignores_half_interval(self):
+        """库空不走 count==0 的 interval//2 抢翻转（库空无从翻成成员）。"""
+        cfg = _config()
+        state = TrackIdentityState(track_id=1, status="unknown")
+        assert state.unknown_recheck_count == 0
+        slow = _frames(cfg.gallery_empty_recheck_sec)
+        assert needs_omni_call(state, slow // 2, 0.0, 0.0, cfg, _FPS, gallery_empty=True) is False
+
+    def test_pending_gallery_empty_still_immediate(self):
+        """pending 不受库空影响，仍下窗即派——保住 no_person 在 pending_timeout 内攒够票。"""
+        cfg = _config()
+        state = TrackIdentityState(track_id=1, status="pending")
+        assert needs_omni_call(state, 1, 0.0, 0.0, cfg, _FPS, gallery_empty=True) is True
+        assert needs_omni_call(state, 10_000, 0.0, 0.0, cfg, _FPS, gallery_empty=True) is True
+
+    def test_unknown_gallery_nonempty_unchanged(self):
+        """gallery_empty=False（库非空/默认）→ unknown 仍走 30s（首次 //2），行为不变。"""
+        cfg = _config()
+        state = TrackIdentityState(track_id=1, status="unknown")
+        half = _frames(cfg.recheck_interval_sec) // 2
+        assert needs_omni_call(state, half - 1, 0.0, 0.0, cfg, _FPS, gallery_empty=False) is False
+        assert needs_omni_call(state, half, 0.0, 0.0, cfg, _FPS, gallery_empty=False) is True

--- a/backend/miloco/tests/perception/engine/omni/test_prompt_builder.py
+++ b/backend/miloco/tests/perception/engine/omni/test_prompt_builder.py
@@ -1274,3 +1274,72 @@ class TestIdentityMatchDisabled:
         main_text = "\n".join(b.get("text", "") for b in main if b.get("type") == "text")
         assert "库为空" in main_text
         assert self._MATCH_ONLY_MARKER in system_prompt
+
+    # ---- follow-up（PR #407 code review）：库空时「任务描述 / 示例」也须收敛，非只 gallery/字段说明 ----
+    _TASK_MATCH_MARKER = "对照图片库"    # 只在完整版「# 任务」身份行里出现
+    _EXAMPLE_A_MARKER = "## 实例 A"       # 只在成员匹配 few-shot（实例 A）里出现
+
+    def test_task_list_slim_when_matching_moot(self):
+        from miloco.perception.engine.omni.field_registry import SceneDescriptor
+        from miloco.perception.engine.omni.prompt_builder import _render_task_list
+
+        slim = _render_task_list(SceneDescriptor(
+            route="video", has_identity=True, has_audio=True, has_speech=True,
+            identity_match_disabled=True))
+        assert self._TASK_MATCH_MARKER not in slim
+        assert "库中哪一位" not in slim
+        assert "不做成员匹配" in slim
+
+    def test_task_list_full_when_gallery_present(self):
+        from miloco.perception.engine.omni.field_registry import SceneDescriptor
+        from miloco.perception.engine.omni.prompt_builder import _render_task_list
+
+        full = _render_task_list(SceneDescriptor(
+            route="video", has_identity=True, has_audio=True, has_speech=True,
+            identity_match_disabled=False))
+        assert self._TASK_MATCH_MARKER in full
+
+    def test_example_a_dropped_when_matching_moot(self):
+        from miloco.perception.engine.omni.field_registry import SceneDescriptor
+        from miloco.perception.engine.omni.prompt_builder import _render_examples
+
+        # has_speech=True：未修复时实例 A 本会注入，确保断言有意义
+        out = _render_examples(SceneDescriptor(
+            route="video", has_identity=True, has_audio=True, has_speech=True,
+            identity_match_disabled=True))
+        assert self._EXAMPLE_A_MARKER not in out   # 成员匹配 few-shot 不注入
+        assert "实例 B" in out                       # 通用观察 few-shot 照常
+
+    def test_example_a_present_when_gallery_present(self):
+        from miloco.perception.engine.omni.field_registry import SceneDescriptor
+        from miloco.perception.engine.omni.prompt_builder import _render_examples
+
+        out = _render_examples(SceneDescriptor(
+            route="video", has_identity=True, has_audio=True, has_speech=True,
+            identity_match_disabled=False))
+        assert self._EXAMPLE_A_MARKER in out
+
+    def test_system_prompt_no_member_matching_leak_when_moot(self):
+        """整类 catch-all：库空 system prompt 不得残留任何成员匹配内容（任务描述 /
+        字段说明规则 / few-shot 示例），且带精简版标记。has_speech=True 让实例 A 在
+        未修复时本会注入——确保 absence 断言不是空断言。将来新增身份 prompt 段若漏 gate，
+        这条会红。"""
+        from miloco.perception.engine.omni.field_registry import SceneDescriptor
+        from miloco.perception.engine.omni.prompt_builder import build_system_prompt
+
+        moot = SceneDescriptor(
+            route="video", has_identity=True, has_audio=True, has_speech=True,
+            identity_match_disabled=True)
+        sp = build_system_prompt(moot, include_home_profile=False)
+        for leak in (self._TASK_MATCH_MARKER, "库中哪一位",
+                     self._EXAMPLE_A_MARKER, self._MATCH_ONLY_MARKER):
+            assert leak not in sp, f"库空 system prompt 残留成员匹配内容: {leak!r}"
+        assert self._NO_MATCH_MARKER in sp
+
+        # 正向对照：库非空同场景，上述 marker 确实存在（证明 absence 断言非空断言）
+        full = build_system_prompt(SceneDescriptor(
+            route="video", has_identity=True, has_audio=True, has_speech=True,
+            identity_match_disabled=False), include_home_profile=False)
+        assert self._TASK_MATCH_MARKER in full
+        assert self._EXAMPLE_A_MARKER in full
+        assert self._MATCH_ONLY_MARKER in full

--- a/backend/miloco/tests/perception/engine/omni/test_prompt_builder.py
+++ b/backend/miloco/tests/perception/engine/omni/test_prompt_builder.py
@@ -1182,3 +1182,95 @@ class TestNoAudioPromptDropsAudioFieldRefs:
         assert "speeches" in sp
         assert "env_sounds" in sp
         assert "音频理解" in sp
+
+
+# =============================================================================
+# 身份库为空 → identity 精简为 no_person-only（matching_moot / identity_match_disabled）
+# =============================================================================
+class TestIdentityMatchDisabled:
+    """库空时 identities 字段改精简版（只判 unknown/no_person、不做成员匹配）。
+
+    这是"gallery 为空不该激活成员匹配"修复的 prompt 侧断言：schema 的 name 域收成
+    <unknown|no_person>、字段说明砍掉全套面部匹配规则、gallery 段整段不渲染；no_person
+    判定链路不动（name 仍走 no_person）。库非空（默认 matching_moot=False）行为不变。
+    """
+
+    _MATCH_ONLY_MARKER = "本人正向吻合"   # 只在完整版 IDENTITY spec 里出现
+    _NO_MATCH_MARKER = "不做成员匹配"     # 只在精简版 IDENTITY_NO_MATCH spec 里出现
+
+    def test_render_schema_name_domain_collapses(self):
+        from miloco.perception.engine.omni.field_registry import SceneDescriptor
+        from miloco.perception.engine.omni.prompt_builder import render_schema
+
+        slim = render_schema(SceneDescriptor(
+            route="video", has_identity=True, identity_match_disabled=True))
+        full = render_schema(SceneDescriptor(
+            route="video", has_identity=True, identity_match_disabled=False))
+        assert '"name":"<unknown|no_person>"' in slim
+        assert "姓名" not in slim
+        assert '"name":"<姓名|unknown|no_person>"' in full
+
+    def test_render_field_spec_drops_matching_rules(self):
+        from miloco.perception.engine.omni.field_registry import SceneDescriptor
+        from miloco.perception.engine.omni.prompt_builder import render_field_spec
+
+        slim = render_field_spec(SceneDescriptor(
+            route="video", has_identity=True, identity_match_disabled=True))
+        full = render_field_spec(SceneDescriptor(
+            route="video", has_identity=True, identity_match_disabled=False))
+        # 精简版：有 no_person 判据、无成员匹配规则
+        assert self._NO_MATCH_MARKER in slim
+        assert self._MATCH_ONLY_MARKER not in slim
+        assert "no_person" in slim
+        # 完整版：保留匹配规则（回归保护）
+        assert self._MATCH_ONLY_MARKER in full
+        assert self._NO_MATCH_MARKER not in full
+
+    def _candidate(self):
+        from miloco.perception.engine.identity.dispatcher import IdentityQueryItem
+        return IdentityQueryItem(
+            track_id=7, bbox_xyxy_norm=(100, 100, 200, 400), face_visible=False)
+
+    def test_matching_moot_skips_gallery_block_keeps_track_list(self):
+        from miloco.perception.engine.omni.prompt_builder import build_fused_payload
+
+        with patch(
+            "miloco.perception.engine.omni.prompt_builder.get_home_profile_prefix",
+            return_value="",
+        ):
+            fused = build_fused_payload(
+                packets=[_video_route_packet()], context=OmniContext(),
+                candidates=[self._candidate()], gallery_snapshot={},
+                matching_moot=True,
+            )
+        messages = fused["messages"]
+        system_prompt = messages[0]["content"]
+        main = _multimodal_user_content(messages)
+        main_text = "\n".join(b.get("text", "") for b in main if b.get("type") == "text")
+
+        # 主 user：无 gallery 段（连"库为空"占位文本都不塞），但待识别 track 列表仍在
+        assert "<gallery>" not in main_text
+        assert "库为空" not in main_text
+        assert "待识别 track" in main_text
+        # system prompt：用精简版 identity spec
+        assert self._NO_MATCH_MARKER in system_prompt
+        assert self._MATCH_ONLY_MARKER not in system_prompt
+
+    def test_default_matching_moot_false_keeps_empty_gallery_placeholder(self):
+        """回归保护：matching_moot 默认 False 时，库空仍走旧行为（塞"库为空"占位 + 完整匹配 spec）。"""
+        from miloco.perception.engine.omni.prompt_builder import build_fused_payload
+
+        with patch(
+            "miloco.perception.engine.omni.prompt_builder.get_home_profile_prefix",
+            return_value="",
+        ):
+            fused = build_fused_payload(
+                packets=[_video_route_packet()], context=OmniContext(),
+                candidates=[self._candidate()], gallery_snapshot={},
+            )
+        messages = fused["messages"]
+        system_prompt = messages[0]["content"]
+        main = _multimodal_user_content(messages)
+        main_text = "\n".join(b.get("text", "") for b in main if b.get("type") == "text")
+        assert "库为空" in main_text
+        assert self._MATCH_ONLY_MARKER in system_prompt

--- a/backend/miloco/tests/perception/engine/omni/test_prompt_builder.py
+++ b/backend/miloco/tests/perception/engine/omni/test_prompt_builder.py
@@ -1309,6 +1309,9 @@ class TestIdentityMatchDisabled:
             identity_match_disabled=True))
         assert self._EXAMPLE_A_MARKER not in out   # 成员匹配 few-shot 不注入
         assert "实例 B" in out                       # 通用观察 few-shot 照常
+        # 库空实例 B 用泛称版：无成员铺垫的窗口不示范 caption 叫专名
+        assert "小明" not in out
+        assert "某人坐在电脑前" in out
 
     def test_example_a_present_when_gallery_present(self):
         from miloco.perception.engine.omni.field_registry import SceneDescriptor
@@ -1318,6 +1321,8 @@ class TestIdentityMatchDisabled:
             route="video", has_identity=True, has_audio=True, has_speech=True,
             identity_match_disabled=False))
         assert self._EXAMPLE_A_MARKER in out
+        # 库非空用带名版实例 B（专名由实例 A 的 gallery 铺垫），非泛称版
+        assert "小明坐在电脑前" in out
 
     def test_system_prompt_no_member_matching_leak_when_moot(self):
         """整类 catch-all：库空 system prompt 不得残留任何成员匹配内容（任务描述 /


### PR DESCRIPTION
## 概述

身份库为空（一个成员都没注册）时，感知仍会激活成员识别——这与「空库不该激活身份识别」的设计预期不符。本 MR 以「是否有注册成员」为唯一开关做两处收敛：库空时不再让主识别调用做无意义的成员匹配、并放慢对已判 unknown 目标的周期性重问——省下这部分用于 identity 的 prompt，也让同一次主调用里的模型更专注于场景描述等其他任务；注册第一个成员即自动恢复全部常规行为。

术语（仅解释本项目可能不熟的点）：**fused 主识别调用**指感知每个时间窗把「场景描述」与「身份识别」合并的那一次多模态模型调用；**no_person** 指模型判出「框里其实没有真人、是被误检成人的静物（衣帽架 / 办公椅 / 晾晒衣物等）」，用来抑制凭空描述出陌生人，区别于 **unknown**（确有人但不认识）。

## 1. 身份库为空时跳过成员匹配（省无意义 prompt 开销、判定理由不再误导）· perf

**问题**：身份库一个成员都没注册时，每个目标仍被塞进主识别调用做「对着参考图逐项核对面部」的成员匹配。库空根本无人可匹配，模型只会对每个目标回 unknown，还产出误导性的「无法与库中成员匹配」类理由；整套面部核对规则与参考图纯属白占 prompt、徒增模型认知负担。

**解决方案**：
- **以注册成员数为开关**：主识别调用侧按「成功读到成员且数量为 0」判库空；读库异常时保守视为非空，不因一次 IO 抖动误判成空而错误关掉匹配。
- **库空改用精简身份判定**：身份字段收敛为只判「确有人体（unknown）/ 非人误检（no_person）」，不再注入整套面部核对规则；参考图段整段不渲染（库空本就无图，连「库为空」占位文本也一并去掉）。
- **保住非人误检抑制**：no_person 不依赖参考图，其判定与落定链路完全不动——库空时仍能把误检成人的静物挡在描述之外。

## 2. 身份库为空时放慢对 unknown 目标的周期性重问（砍掉长跑期无用重复识别）· perf

**问题**：库空时被判为 unknown 的目标会被每约 30s 周期性重问一次身份，而这个重问的唯一价值（等人转身 / 走近再匹配到成员）在库空时恒为 0——长时间在场的目标被持续无用地重复识别（实测单个久留目标 16 分钟被重问 33 次，全部 unknown）。

**解决方案**：
- **只放慢 unknown 态重问**：新增可配置的空库重问周期（默认 10 分钟），库空时 unknown 目标按此慢周期重问，并跳过「首次重审加倍频率」的抢翻转（库空无从翻成成员）。
- **刻意不动首次识别节流**：no_person 的落定依赖首次识别阶段在超时窗内连续投票累计，放慢该阶段会让它攒不满票而失效——故只放慢 unknown、完整保留首次识别节流。慢周期仍周期性留给模型翻 no_person 的机会，任何目标都不会被永久静音。
- **注册即恢复**：库从空变非空由既有的身份库变化监听触发全员重判，下一窗立即恢复常规匹配与节流；反向删到空自动收敛。

## 测试与兼容性

- **怎么验**：新增 prompt 装配单测（库空时输出结构收敛为 unknown/no_person、砍掉匹配规则、不渲染参考图段、仍保留待识别目标列表；库非空走完整匹配的回归）+ 状态机单测（unknown 走慢周期、不加倍、首次识别节流不受影响、库非空行为不变）。真机灰度：库空环境重启后身份理由全变「人 / 非人」判定、no_person 正常落定（办公椅被判非人）、久留 unknown 目标不再高频重问、常规场景描述与既有功能无回归。
- **兼容 / 回滚**：以「有无注册成员」为唯一开关，库非空时全部行为与改动前等价；空库重问周期是新增配置项、带默认值，回滚仅需还原文件、无数据迁移。
- **风险提醒**：本组偏「减少无意义调用」，需同时确认没有削弱应有能力——重点验两头：注册第一个成员后匹配与节流即时恢复；空库下 no_person 仍能挡住静物误报（别只验「省了调用」这一头）。