### PR TITLE
perf(engine): 持久 event loop + ONNX 推理异步化，修复线程泄漏

### DIFF
--- a/backend/miloco/src/miloco/perception/client.py
+++ b/backend/miloco/src/miloco/perception/client.py
@@ -17,7 +17,6 @@ import json
 import logging
 import time
 import uuid
-from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING
 
 from miloco.config import get_settings
@@ -37,6 +36,7 @@ from miloco.perception.event_text_builder import (
     build_suggestions_text,
     caption_for_dids,
 )
+from miloco.perception.inference_worker import InferenceWorker
 from miloco.perception.schema import PerceptionBatch
 from miloco.perception.snapshot_context import (
     ClipKind,
@@ -173,7 +173,7 @@ async def _run_with_trace_id(
 ):
     """新 event loop 入口:把主线程的 trace_id / artifacts set 回当前 Context.
 
-    ContextVar 不跨线程边界 — run_in_executor 在新线程里 asyncio.run() 起新 loop,
+    ContextVar 不跨线程边界 — submit 在 worker 线程里执行协程,
     主线程的 ContextVar 值全部 reset 成 default.必须显式抓主线程值,在新 loop 入口
     重新 set,omni 内部才能拿到.
     """
@@ -208,7 +208,7 @@ class PerceptionEngineProxy:
         self._status: str = "not_initialized"
         self._status_message: str = ""
         self._last_captions: dict[str, str] = {}
-        self._executor: ThreadPoolExecutor | None = None
+        self._inference_worker: InferenceWorker | None = None
         # 软停(stop_to_unconfigured)与在飞 perceive 互斥:teardown 必等当前推理完成,
         # 持锁期间进来的 perceive 在 if not ready 守卫处安全跳过 → 杜绝 use-after-close。
         self._engine_lock = asyncio.Lock()
@@ -294,7 +294,7 @@ class PerceptionEngineProxy:
         tick 自动重试——重型 ``_create_engine`` 每 tick 跑会阻塞 event loop。
 
         已 ``ready`` / ``not_initialized`` 直接返回 ``False``(no-op,不碰已有引擎实例)。
-        成功重建时 ``_init_engine`` 已把 lifecycle 翻到 ``READY``——``set_executor`` 守卫
+        成功重建时 ``_init_engine`` 已把 lifecycle 翻到 ``READY``——``set_inference_worker`` 守卫
         只认 ``STOPPED`` 不会帮翻,故必须在创建路径里显式置(``_init_engine`` 已做)。
         返回是否「本次转入 ready」。
         """
@@ -347,14 +347,14 @@ class PerceptionEngineProxy:
 
         return PerceptionEngine(config=config)
 
-    def set_executor(self, executor: ThreadPoolExecutor) -> None:
-        """Attach inference thread executor (called by engine at startup).
+    def set_inference_worker(self, worker: InferenceWorker) -> None:
+        """Attach persistent inference worker (called by engine at startup).
 
         Lifecycle: 仅 STOPPED → READY (stop_engine 后的热重启场景)。
         __init__ 已把 ENGINE 设过 READY/FAILED;FAILED 通常是永久性的
-        (模型缺失/API key 没配),不应被 set_executor 误唤醒回 READY。
+        (模型缺失/API key 没配),不应被 set_inference_worker 误唤醒回 READY。
         """
-        self._executor = executor
+        self._inference_worker = worker
         mon = get_monitor()
         state = mon.get_state(NodeName.ENGINE)
         if state and state.lifecycle == Lifecycle.STOPPED and self.perception_engine is not None:
@@ -436,12 +436,11 @@ class PerceptionEngineProxy:
         early_sent_rule_ids: set[tuple[str, str]] = set()
         early_sent_sugg_ids: set[int] = set()
 
-        # 当 self._executor is not None 时，本协程跑在 inference 线程的临时
-        # loop 上（asyncio.run 创建的）。engine 在此处 await callback 后，
-        # callback 内部任何 asyncio.create_task(...) 都会挂在临时 loop 上，
-        # asyncio.run 退出时会被 cancel —— 即使 caller 持有强引用也救不回来
-        # （问题不是 GC 是 loop 关闭）。把 callback 派发回主 loop 后，副作用
-        # （如 RuleRunner._spawn_fire）创建的 task 才有稳定的执行环境。
+        # 当 self._inference_worker is not None 时，本协程跑在 inference 线程
+        # 的持久 loop 上。engine 在此处 await callback 后，callback 内部任何
+        # asyncio.create_task(...) 都会挂在 worker loop 上，把 callback 派发回
+        # 主 loop 后，副作用（如 RuleRunner._spawn_fire）创建的 task 才有稳定
+        # 的执行环境。
         def _on_main_loop(coro_fn):
             async def wrapped(*args, **kwargs):
                 if asyncio.get_running_loop() is main_loop:
@@ -634,35 +633,32 @@ class PerceptionEngineProxy:
 
             main_loop = asyncio.get_running_loop()
             # 把持久 app loop 注入 PerceptionEngine→各 identity engine, 供 tier_c 写库协程
-            # run_coroutine_threadsafe 调度(脱离下方 asyncio.run 起的每窗临时 loop, 否则
-            # 写库协程会在窗末被 cancel, 候选永远写不进)。
+            # run_coroutine_threadsafe 调度(脱离下方 worker loop, 否则写库协程会在 worker
+            # shutdown 时被 cancel, 候选永远写不进)。
             if self.perception_engine is not None:
                 self.perception_engine.set_main_loop(main_loop)
-            # inference 线程通过 asyncio.run() 起新 loop,ContextVar 不跨 loop。
-            # 显式抓主线程的 trace_id / artifacts,在新 loop 入口 set 回去,
-            # 保证 omni / publish_event / push_clip_bytes / push_omni_trace 能拿到。
+            # 协程在主线程创建（closure 捕获主线程 trace_id / artifacts 值），通过
+            # InferenceWorker.submit() 调度到 worker 线程的持久 loop 上执行。
+            # 持久 loop 只创建一次 default executor，消除反复建/拆线程的开销和泄漏。
             trace_id = get_trace_id()
-            if self._executor is not None:
-                return await main_loop.run_in_executor(
-                    self._executor,
-                    lambda: asyncio.run(
-                        _run_with_trace_id(
-                            trace_id,
-                            self._realtime_perceive_impl(
-                                batched_snapshot,
-                                rules,
-                                device_count,
-                                convert_ms,
-                                main_loop,
-                                skipped_task_ids,
-                            ),
-                            artifacts=artifacts,
-                        )
-                    ),
+            if self._inference_worker is not None:
+                return await self._inference_worker.submit(
+                    _run_with_trace_id(
+                        trace_id,
+                        self._realtime_perceive_impl(
+                            batched_snapshot,
+                            rules,
+                            device_count,
+                            convert_ms,
+                            main_loop,
+                            skipped_task_ids,
+                        ),
+                        artifacts=artifacts,
+                    )
                 )
-            # 单线程路径(无 executor,测试 / runner 启动前的短窗口):processor 只传
+            # 单线程路径(无 worker,测试 / runner 启动前的短窗口):processor 只传
             # artifacts 不开 scope,这里手动开,保证 omni 内部 push_clip_bytes /
-            # push_omni_trace 能命中.executor 路径由上面 _run_with_trace_id 开,两条路径都覆盖.
+            # push_omni_trace 能命中——worker 路径由上面 _run_with_trace_id 开，两条路径都覆盖。
             if artifacts is not None:
                 with event_artifacts_scope(artifacts):
                     return await self._realtime_perceive_impl(
@@ -701,17 +697,13 @@ class PerceptionEngineProxy:
             if batch.end_timestamp and batch.start_timestamp:
                 _eng_h.add_window_ms(batch.end_timestamp - batch.start_timestamp)
 
-            if self._executor is not None:
-                loop = asyncio.get_running_loop()
+            if self._inference_worker is not None:
                 trace_id = get_trace_id()
-                return await loop.run_in_executor(
-                    self._executor,
-                    lambda: asyncio.run(
-                        _run_with_trace_id(
-                            trace_id,
-                            self._on_demand_perceive_impl(batched_snapshot, query),
-                        )
-                    ),
+                return await self._inference_worker.submit(
+                    _run_with_trace_id(
+                        trace_id,
+                        self._on_demand_perceive_impl(batched_snapshot, query),
+                    )
                 )
 
             return await self._on_demand_perceive_impl(batched_snapshot, query)

--- a/backend/miloco/src/miloco/perception/engine/gate/gate.py
+++ b/backend/miloco/src/miloco/perception/engine/gate/gate.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 import uuid
@@ -23,7 +24,7 @@ from miloco.perception.engine.types import (
 logger = logging.getLogger(__name__)
 
 
-def run_gate(
+async def run_gate(
     input_slice: InputSlice,
     config: GateConfig,
     input_fps: int = 1,
@@ -65,7 +66,7 @@ def run_gate(
     # 触发既有监控阈值。
     t = time.monotonic()
     speech_active, speech_prob = (
-        evaluate_speech(input_slice.audio_clip, config)
+        await asyncio.to_thread(evaluate_speech, input_slice.audio_clip, config)
         if audio_active
         else (False, 0.0)
     )

--- a/backend/miloco/src/miloco/perception/engine/gate/speech_vad.py
+++ b/backend/miloco/src/miloco/perception/engine/gate/speech_vad.py
@@ -27,6 +27,7 @@ _CONTEXT = 64  # silero 16kHz 每帧前置的上一帧尾部 context（模型实
 _SAMPLE_RATE = 16000
 
 _lock = threading.Lock()
+_inference_lock = threading.Lock()  # 保护全局 VAD session 并发 sess.run()（多设备并行推理）
 _session = None  # ort.InferenceSession | None
 _load_failed = False
 
@@ -94,9 +95,10 @@ def evaluate_speech(
     for i in range(0, pcm.size - _CHUNK + 1, _CHUNK):
         chunk = pcm[i : i + _CHUNK].reshape(1, _CHUNK)
         x = np.concatenate([context, chunk], axis=1)
-        out, state = sess.run(
-            ["output", "stateN"], {"input": x, "state": state, "sr": sr}
-        )
+        with _inference_lock:
+            out, state = sess.run(
+                ["output", "stateN"], {"input": x, "state": state, "sr": sr}
+            )
         context = chunk[:, -_CONTEXT:]
         p = float(out[0, 0])
         if p > peak:

--- a/backend/miloco/src/miloco/perception/engine/identity/identity.py
+++ b/backend/miloco/src/miloco/perception/engine/identity/identity.py
@@ -12,6 +12,7 @@ crop / motion / frame 选择——这些细节都在 IdentityEngine 内部。
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from typing import Any
 
@@ -58,8 +59,9 @@ async def run_identity(
         input_height=config.perception_input_height,
     )
 
-    # Step 1: tracking
-    tracking_resp = service.analyze(gate_packet.frames, fps=gate_packet.fps)
+    # Step 1: tracking (ONNX inference — offloaded to thread pool so the
+    # perception loop stays responsive and multi-device gather can overlap).
+    tracking_resp = await asyncio.to_thread(service.analyze, gate_packet.frames, fps=gate_packet.fps)
     output_frames = gate_packet.frames
 
     # Step 2: 调 IdentityEngine.process 获取 face_id 映射（异步派发 omni）

--- a/backend/miloco/src/miloco/perception/engine/pipeline.py
+++ b/backend/miloco/src/miloco/perception/engine/pipeline.py
@@ -297,7 +297,7 @@ async def run_pipeline(
     # Gate（本入口为无状态单次调用，无跨窗口基准可传，丢弃 last_checked / 两 ts）。
     # 注意:prev_frame 恒为 None → 视觉 gate 每次都走 cold-start 放行,本入口不会因静止画面 skipped。
     # 若将来把它放进循环复用,需自行在外维护 prev_frame 才能恢复静止 skip 语义。
-    gate_packet, gate_timing, _, _, _ = run_gate(input_slice, config.gate, config.input.fps)
+    gate_packet, gate_timing, _, _, _ = await run_gate(input_slice, config.gate, config.input.fps)
     timing["gate_ms"] = gate_timing.total_ms
     timing["gate_video_ms"] = gate_timing.video_ms
     timing["gate_audio_ms"] = gate_timing.audio_ms
@@ -481,7 +481,7 @@ async def run_batch_pipeline(
             gate_last_audio_pass_ts.get(did)
             if gate_last_audio_pass_ts is not None else None
         )
-        gate_packet, gate_timing, last_checked, new_last_v, new_last_a = run_gate(
+        gate_packet, gate_timing, last_checked, new_last_v, new_last_a = await run_gate(
             snapshot, config.gate, config.input.fps,
             prev_frame=prev_frame,
             last_visual_pass_ts=last_v,

--- a/backend/miloco/src/miloco/perception/inference_worker.py
+++ b/backend/miloco/src/miloco/perception/inference_worker.py
@@ -1,0 +1,191 @@
+"""
+InferenceWorker — persistent worker thread with a durable event loop.
+
+Replaces the ``asyncio.run()`` inside ``run_in_executor`` pattern. Instead of
+creating a fresh event loop (and its default ThreadPoolExecutor, 12 threads on
+an 8-core machine) on every perception tick, this module owns ONE loop that
+lives for the lifetime of the runner. Coroutines from the main event loop are
+submitted via ``run_coroutine_threadsafe`` and awaited across the thread
+boundary with ``asyncio.wrap_future``.
+
+Eliminates the three root causes of thread leak:
+1. ``asyncio.run()`` → new loop → new default executor (12 threads) per tick
+2. ``_get_fused_http_client`` loop-mismatch forced httpx client rebuild
+3. ``shutdown(wait=False)`` in runner.stop() left old worker threads unjoined
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Any, Coroutine, TypeVar
+
+T = TypeVar("T")
+
+
+class InferenceWorker:
+    """Persistent event loop, one "generation" (thread + loop) at a time.
+
+    Supports being stopped and started again on the *same* instance —
+    ``runner.py`` holds one ``InferenceWorker`` for the whole app lifetime.
+    The subtlety this class exists to get right: ``shutdown(wait=False)``
+    only *requests* the loop to stop — an in-flight ONNX call on the worker
+    thread cannot be preempted (asyncio cancellation is cooperative; a
+    running ``concurrent.futures.Future`` can't be force-stopped), so the
+    old thread may keep running for as long as that call takes to finish
+    naturally. ``start()`` therefore never waits for a previous generation
+    to fully drain before standing up the next one.
+
+    Each ``start()`` spawns a thread with its own brand-new ``loop`` object
+    (``asyncio.new_event_loop()`` — a fresh, unique object every call) as a
+    local variable closed over by that thread's target function, *not*
+    shared mutable ``self.`` state. ``self._loop`` always means "the current
+    generation"; a retiring generation's own local ``loop`` variable is a
+    different object, so its teardown (``run_until_complete`` etc.) runs
+    entirely on its own copy without racing whatever the current generation
+    is doing. The only coordination needed is in the teardown path, which
+    checks ``self._loop is loop`` — "is the object I created still the one
+    everyone else is using?" — before clearing the shared field, so a
+    still-draining old generation can never clobber a newer one that has
+    already taken over. The startup path needs no such check: ``start()``
+    blocks until the new thread's loop is fully installed before returning,
+    so two generations' startups can never interleave.
+    """
+
+    def __init__(self, thread_name: str = "perception-infer"):
+        self._thread_name = thread_name
+        # Always refer to the CURRENT generation; a retiring generation's
+        # thread never writes here once superseded (see ``_run_loop``).
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._thread: threading.Thread | None = None
+        self._shutdown_flag = True  # no generation running yet
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        """Launch a new generation and block until its loop is ready.
+
+        Safe to call again after ``shutdown()`` — even if the previous
+        generation's thread hasn't exited yet (it may still be draining a
+        non-preemptible call). This never waits on the old generation.
+        """
+        self._shutdown_flag = False
+        ready = threading.Event()
+        thread = threading.Thread(
+            target=self._run_loop,
+            args=(ready,),
+            name=self._thread_name,
+            daemon=True,
+        )
+        self._thread = thread
+        thread.start()
+        # Block until this generation's loop is set up — subsequent submit()
+        # calls can immediately use it. Local `ready`, not `self._ready`, so
+        # an overlapping start() (shouldn't happen from the single asyncio
+        # caller, but defensively) can't wait on the wrong event.
+        ready.wait()
+
+    def _run_loop(self, ready: threading.Event) -> None:
+        """Entry point for one generation's worker thread.
+
+        ``loop`` is a local variable for this thread's entire lifetime —
+        the finally-block below always operates on *this* generation's own
+        loop object, never on whatever ``self._loop`` happens to point to by
+        the time this thread finishes (a newer generation may have already
+        replaced it with a different loop object).
+        """
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        self._loop = loop
+        # Defer ready.set() to the first iteration of run_forever() so that
+        # "ready" means "the loop is actually running", not just "the object
+        # exists". This closes the window between set() and run_forever()
+        # where submit() would see is_running()==False and raise.
+        loop.call_soon(ready.set)
+        try:
+            loop.run_forever()
+        finally:
+            # Cancel all remaining tasks so they don't hold references.
+            pending = asyncio.all_tasks(loop)
+            for task in pending:
+                task.cancel()
+            # Gather with return_exceptions so cancellation errors don't
+            # propagate and prevent the loop from closing cleanly. Tasks
+            # blocked on a non-preemptible thread call (e.g. ONNX inference)
+            # won't actually be cancelled until that call finishes — this
+            # is exactly the "old generation drains on its own" wait, and it
+            # happens here, on this thread, off to the side of whatever the
+            # current generation is doing.
+            if pending:
+                loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+            loop.close()
+            # Only clear the shared field if nobody has superseded us — i.e.
+            # this loop object is still the one everyone else sees. If a
+            # newer start() already replaced it with a different loop
+            # object, leave it alone.
+            if self._loop is loop:
+                self._loop = None
+
+    async def submit(self, coro: Coroutine[Any, Any, T]) -> T:
+        """Submit a coroutine to the current generation's loop and await it.
+
+        ``coro`` must be created on the calling (main) thread. Its closure
+        may capture main-thread values (e.g. trace_id, artifacts). The
+        coroutine itself runs on the worker thread where the persistent loop
+        owns the correct ContextVar defaults and the shared httpx client.
+
+        Returns the coroutine's result. Raises the coroutine's exception
+        unchanged (including CancelledError) — the caller is responsible for
+        handling errors.
+        """
+        if self._shutdown_flag:
+            coro.close()
+            raise RuntimeError("InferenceWorker is shutting down")
+        loop = self._loop
+        if loop is None:
+            coro.close()
+            raise RuntimeError("InferenceWorker loop is not running (call start() first)")
+        if not loop.is_running():
+            coro.close()
+            raise RuntimeError("InferenceWorker loop has stopped")
+
+        fut = asyncio.run_coroutine_threadsafe(coro, loop)
+        try:
+            return await asyncio.wrap_future(fut)
+        except asyncio.CancelledError:
+            # If the caller is cancelled, still try to cancel the worker-side
+            # future so the worker loop doesn't keep running a dead coroutine.
+            fut.cancel()
+            raise
+
+    def shutdown(self, wait: bool = False, timeout: float = 5.0) -> None:
+        """Stop the current generation's loop and optionally join its thread.
+
+        ``wait=True`` blocks until the thread exits (up to ``timeout``
+        seconds) — this can take as long as whatever non-preemptible call is
+        currently in flight on it. In the normal production path
+        (runner.stop) we use ``wait=False`` to avoid blocking the main event
+        loop; the daemon thread cleans itself up on its own once it drains.
+        """
+        if self._shutdown_flag:
+            return
+        self._shutdown_flag = True
+        loop = self._loop
+        thread = self._thread
+        if loop is not None and loop.is_running():
+            # Schedule loop.stop() from any thread — the next iteration of
+            # run_forever() will return.
+            loop.call_soon_threadsafe(loop.stop)
+        if wait and thread is not None and thread.is_alive():
+            thread.join(timeout=timeout)
+
+    # ------------------------------------------------------------------
+    # Query helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def is_running(self) -> bool:
+        loop = self._loop
+        return not self._shutdown_flag and loop is not None and loop.is_running()

--- a/backend/miloco/src/miloco/perception/processor.py
+++ b/backend/miloco/src/miloco/perception/processor.py
@@ -13,7 +13,6 @@ import logging
 import re
 import time
 import uuid
-from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 
 from miloco.config import get_settings
@@ -35,6 +34,7 @@ from miloco.observability.types import (
 from miloco.perception.client import PerceptionEngineProxy
 from miloco.perception.collect.collector import MultimodalCollector
 from miloco.perception.engine.types import RealtimePerceptionResult
+from miloco.perception.inference_worker import InferenceWorker
 from miloco.perception.schema import (
     PerceptionBatch,
     PerceptionLatency,
@@ -122,8 +122,8 @@ class PipelineProcessor:
                 self._collector.peek_latest_frame
             )
 
-    def set_inference_executor(self, executor: ThreadPoolExecutor) -> None:
-        """Forward the inference executor to the engine proxy.
+    def set_inference_worker(self, worker: InferenceWorker) -> None:
+        """Forward the inference worker to the engine proxy.
 
         Lifecycle: STARTING → READY (success) / FAILED (异常)。
         """
@@ -131,7 +131,7 @@ class PipelineProcessor:
         mon.set_lifecycle(NodeName.PROCESSOR, Lifecycle.STARTING)
 
         try:
-            self._perception_engine_proxy.set_executor(executor)
+            self._perception_engine_proxy.set_inference_worker(worker)
         except Exception as e:
             state = mon.get_state(NodeName.PROCESSOR)
             if state and state.lifecycle == Lifecycle.STARTING:

--- a/backend/miloco/src/miloco/perception/runner.py
+++ b/backend/miloco/src/miloco/perception/runner.py
@@ -13,11 +13,11 @@ The perception loop reacts to two triggers:
 
 import asyncio
 import logging
-from concurrent.futures import ThreadPoolExecutor
 
 from miloco.config import get_settings
 from miloco.database.perception_repo import PerceptionLogRepo
 from miloco.perception.collect.collector import MultimodalCollector
+from miloco.perception.inference_worker import InferenceWorker
 from miloco.perception.processor import PipelineProcessor
 from miloco.perception.schema import EngineState, PerceptionEngineStatus
 
@@ -44,11 +44,14 @@ class PerceptionRunner:
         self._sync_devices_task: asyncio.Task | None = None
         self._window_ready = window_ready_event
 
-        # Dedicated single-thread executor for inference — keeps the main
-        # event loop free for stream frame callbacks.
-        self._inference_executor = ThreadPoolExecutor(
-            max_workers=1, thread_name_prefix="perception-infer"
-        )
+        # Persistent worker thread with a durable event loop for inference.
+        # Replaces the old ThreadPoolExecutor + asyncio.run() pattern that
+        # leaked threads via repeated default executor creation. Safe to
+        # stop() then start() again on this same instance — see its
+        # docstring for how it isolates each restart's thread/loop so a
+        # still-draining previous generation never blocks or races the new
+        # one.
+        self._inference_worker = InferenceWorker(thread_name="perception-infer")
 
     @property
     def is_running(self) -> bool:
@@ -90,20 +93,22 @@ class PerceptionRunner:
         # 不重读会导致「应用设置」改了 window_size 后引擎仍按旧值跑。
         self._collect_interval = get_settings().perception.collect.window_size
 
-        # Recreate executor if it was shut down by a previous stop()
-        if self._inference_executor._shutdown:
-            self._inference_executor = ThreadPoolExecutor(
-                max_workers=1, thread_name_prefix="perception-infer"
-            )
+        # Restart worker if it was stopped by a previous stop(). Safe even
+        # if that previous generation's thread hasn't exited yet (it may
+        # still be draining a non-preemptible ONNX call) — start() spins up
+        # a new generation on this same instance without waiting on the old
+        # one; see InferenceWorker's docstring.
+        if not self._inference_worker.is_running:
+            self._inference_worker.start()
 
         # 显式启动/重启(含「重启感知」按钮):全可恢复态重建一次,含 engine_init_failed
         # ——引擎构造失败(如临时磁盘满)补救后靠这条恢复,不在 tick 每秒重试重型构造。
-        # 必须在 set_inference_executor 之前,确保引擎已存在再挂 executor。
+        # 必须在 set_inference_worker 之前,确保引擎已存在再挂 worker。
         self._pipeline.try_reinit_engine(include_failed=True)
 
-        # Attach inference executor to engine proxy so perceive calls
+        # Attach inference worker to engine proxy so perceive calls
         # run in the dedicated thread, not on the main event loop.
-        self._pipeline.set_inference_executor(self._inference_executor)
+        self._pipeline.set_inference_worker(self._inference_worker)
 
         # Initial device sync before first tick
         await self._collector.sync_all_devices()
@@ -135,7 +140,7 @@ class PerceptionRunner:
         self._perception_task = None
         self._sync_devices_task = None
 
-        self._inference_executor.shutdown(wait=False)
+        self._inference_worker.shutdown(wait=False)
 
         # 关闭 perception engine（含 IdentityEngine dispatcher worker 等）
         try:

--- a/backend/miloco/tests/perception/engine/gate/test_gate.py
+++ b/backend/miloco/tests/perception/engine/gate/test_gate.py
@@ -33,19 +33,19 @@ def _loud_audio() -> np.ndarray:
 class TestGateOrchestrator:
     config = GateConfig()
 
-    def test_returns_none_when_no_change(self):
+    async def test_returns_none_when_no_change(self):
         frame = _solid_frame(100, 100, 100)
         s = create_input_slice("room", [frame] * 6, _silent_audio())
         # 有基准(非 cold-start)的静止窗才会被丢
-        packet, timing, _, _, _ = run_gate(s, self.config, prev_frame=_baseline())
+        packet, timing, _, _, _ = await run_gate(s, self.config, prev_frame=_baseline())
         assert packet is None
         assert not (timing.video_pass or timing.audio_pass)
 
-    def test_triggers_on_visual_change(self):
+    async def test_triggers_on_visual_change(self):
         gray = _solid_frame(100, 100, 100)
         white = _solid_frame(255, 255, 255)
         s = create_input_slice("room", [gray, gray, white, white, white, white], _silent_audio())
-        result, timing, _, _, _ = run_gate(s, self.config)
+        result, timing, _, _, _ = await run_gate(s, self.config)
 
         assert result is not None
         assert result.trigger.visual_changed
@@ -53,22 +53,22 @@ class TestGateOrchestrator:
         assert len(result.frames) == 6
         assert timing.video_pass and not timing.audio_pass
 
-    def test_triggers_on_audio(self):
+    async def test_triggers_on_audio(self):
         frame = _solid_frame(100, 100, 100)
         s = create_input_slice("room", [frame] * 6, _loud_audio())
-        result, timing, _, _, _ = run_gate(s, self.config, prev_frame=_baseline())
+        result, timing, _, _, _ = await run_gate(s, self.config, prev_frame=_baseline())
 
         assert result is not None
         assert not result.trigger.visual_changed
         assert result.trigger.audio_active
         assert not timing.video_pass and timing.audio_pass
 
-    def test_passes_all_data_through(self):
+    async def test_passes_all_data_through(self):
         gray = _solid_frame(100, 100, 100)
         white = _solid_frame(255, 255, 255)
         audio = _loud_audio()
         s = create_input_slice("room", [gray, gray, white, white, white, white], audio)
-        result, _timing, _, _, _ = run_gate(s, self.config)
+        result, _timing, _, _, _ = await run_gate(s, self.config)
 
         assert result is not None
         assert len(result.frames) == 6
@@ -101,12 +101,12 @@ class TestGateHold:
             lambda: now,
         )
 
-    def test_A1_cold_start_both_pass(self, monkeypatch):
+    async def test_A1_cold_start_both_pass(self, monkeypatch):
         self._patch_time(monkeypatch, 0.0)
         gray = _solid_frame(100, 100, 100)
         white = _solid_frame(255, 255, 255)
         s = create_input_slice("room", [gray, gray, white, white, white, white], _loud_audio())
-        packet, timing, _last_checked, new_v, new_a = run_gate(
+        packet, timing, _last_checked, new_v, new_a = await run_gate(
             s, self.config, last_visual_pass_ts=None, last_audio_pass_ts=None,
         )
         assert packet is not None
@@ -115,10 +115,10 @@ class TestGateHold:
         assert timing.hold_pass is False
         assert new_v == 0.0 and new_a == 0.0
 
-    def test_A2_cold_start_audio_only(self, monkeypatch):
+    async def test_A2_cold_start_audio_only(self, monkeypatch):
         self._patch_time(monkeypatch, 0.0)
         s = self._slice_no_change_loud()
-        packet, timing, _, new_v, new_a = run_gate(
+        packet, timing, _, new_v, new_a = await run_gate(
             s, self.config, prev_frame=_baseline(),
             last_visual_pass_ts=None, last_audio_pass_ts=None,
         )
@@ -127,10 +127,10 @@ class TestGateHold:
         assert packet.trigger.hold is False
         assert new_v is None and new_a == 0.0
 
-    def test_A3_cold_start_all_silent(self, monkeypatch):
+    async def test_A3_cold_start_all_silent(self, monkeypatch):
         self._patch_time(monkeypatch, 0.0)
         s = self._slice_no_change()
-        packet, timing, _, new_v, new_a = run_gate(
+        packet, timing, _, new_v, new_a = await run_gate(
             s, self.config, prev_frame=_baseline(),
             last_visual_pass_ts=None, last_audio_pass_ts=None,
         )
@@ -138,10 +138,10 @@ class TestGateHold:
         assert timing.hold_pass is False
         assert new_v is None and new_a is None
 
-    def test_A4_hold_within_window_all_silent(self, monkeypatch):
+    async def test_A4_hold_within_window_all_silent(self, monkeypatch):
         self._patch_time(monkeypatch, 3.0)
         s = self._slice_no_change()
-        packet, timing, _, new_v, new_a = run_gate(
+        packet, timing, _, new_v, new_a = await run_gate(
             s, self.config, prev_frame=_baseline(),
             last_visual_pass_ts=0.0, last_audio_pass_ts=0.0,
         )
@@ -152,10 +152,10 @@ class TestGateHold:
         assert timing.hold_pass is True
         assert new_v == 0.0 and new_a == 0.0
 
-    def test_A5_hold_within_window_audio_active(self, monkeypatch):
+    async def test_A5_hold_within_window_audio_active(self, monkeypatch):
         self._patch_time(monkeypatch, 6.0)
         s = self._slice_no_change_loud()
-        packet, _timing, _, new_v, new_a = run_gate(
+        packet, _timing, _, new_v, new_a = await run_gate(
             s, self.config, prev_frame=_baseline(),
             last_visual_pass_ts=0.0, last_audio_pass_ts=0.0,
         )
@@ -163,92 +163,92 @@ class TestGateHold:
         assert packet.trigger.hold is True
         assert new_v == 0.0 and new_a == 6.0
 
-    def test_A6_hold_recovered_visual(self, monkeypatch):
+    async def test_A6_hold_recovered_visual(self, monkeypatch):
         self._patch_time(monkeypatch, 30.0)
         s = self._slice_visual_change()
-        packet, _timing, _, new_v, new_a = run_gate(
+        packet, _timing, _, new_v, new_a = await run_gate(
             s, self.config, last_visual_pass_ts=0.0, last_audio_pass_ts=0.0,
         )
         assert packet is not None
         assert packet.trigger.hold is False
         assert new_v == 30.0
 
-    def test_A7_hold_boundary_inclusive(self, monkeypatch):
+    async def test_A7_hold_boundary_inclusive(self, monkeypatch):
         self._patch_time(monkeypatch, 360.0)
         s = self._slice_no_change()
-        packet, _timing, _, _, _ = run_gate(
+        packet, _timing, _, _, _ = await run_gate(
             s, self.config, prev_frame=_baseline(),
             last_visual_pass_ts=0.0, last_audio_pass_ts=0.0,
         )
         assert packet is not None
         assert packet.trigger.hold is True
 
-    def test_A8_hold_boundary_expired(self, monkeypatch):
+    async def test_A8_hold_boundary_expired(self, monkeypatch):
         self._patch_time(monkeypatch, 363.0)
         s = self._slice_no_change()
-        packet, timing, _, _, _ = run_gate(
+        packet, timing, _, _, _ = await run_gate(
             s, self.config, prev_frame=_baseline(),
             last_visual_pass_ts=0.0, last_audio_pass_ts=0.0,
         )
         assert packet is None
         assert timing.hold_pass is False
 
-    def test_A9_hold_expired_audio_only(self, monkeypatch):
+    async def test_A9_hold_expired_audio_only(self, monkeypatch):
         self._patch_time(monkeypatch, 363.0)
         s = self._slice_no_change_loud()
-        packet, _, _, _, new_a = run_gate(
+        packet, _, _, _, new_a = await run_gate(
             s, self.config, last_visual_pass_ts=0.0, last_audio_pass_ts=0.0,
         )
         assert packet is not None
         assert packet.trigger.hold is False
         assert new_a == 363.0
 
-    def test_A10_post_expired_visual_recovers(self, monkeypatch):
+    async def test_A10_post_expired_visual_recovers(self, monkeypatch):
         self._patch_time(monkeypatch, 400.0)
         s = self._slice_visual_change()
-        packet, _, _, new_v, _ = run_gate(
+        packet, _, _, new_v, _ = await run_gate(
             s, self.config, last_visual_pass_ts=0.0, last_audio_pass_ts=0.0,
         )
         assert packet is not None
         assert packet.trigger.hold is False
         assert new_v == 400.0
 
-    def test_A11_hold_disabled_zero(self, monkeypatch):
+    async def test_A11_hold_disabled_zero(self, monkeypatch):
         cfg = GateConfig(hold_duration_sec=0.0)
         self._patch_time(monkeypatch, 3.0)
         s = self._slice_no_change()
-        packet, _, _, _, _ = run_gate(
+        packet, _, _, _, _ = await run_gate(
             s, cfg, prev_frame=_baseline(),
             last_visual_pass_ts=0.0, last_audio_pass_ts=0.0,
         )
         assert packet is None
 
-    def test_A12_hold_disabled_does_not_block_real_pass(self, monkeypatch):
+    async def test_A12_hold_disabled_does_not_block_real_pass(self, monkeypatch):
         cfg = GateConfig(hold_duration_sec=0.0)
         self._patch_time(monkeypatch, 0.0)
         gray = _solid_frame(100, 100, 100)
         white = _solid_frame(255, 255, 255)
         s = create_input_slice("room", [gray, gray, white, white, white, white], _loud_audio())
-        packet, _, _, _, _ = run_gate(
+        packet, _, _, _, _ = await run_gate(
             s, cfg, last_visual_pass_ts=None, last_audio_pass_ts=None,
         )
         assert packet is not None
         assert packet.trigger.hold is False
 
-    def test_A13_last_v_only_refreshed_on_visual_changed(self, monkeypatch):
+    async def test_A13_last_v_only_refreshed_on_visual_changed(self, monkeypatch):
         self._patch_time(monkeypatch, 10.0)
         s = self._slice_no_change_loud()
-        _packet, _, _, new_v, new_a = run_gate(
+        _packet, _, _, new_v, new_a = await run_gate(
             s, self.config, prev_frame=_baseline(),
             last_visual_pass_ts=0.0, last_audio_pass_ts=0.0,
         )
         assert new_v == 0.0
         assert new_a == 10.0
 
-    def test_A14_last_a_only_refreshed_on_audio_active(self, monkeypatch):
+    async def test_A14_last_a_only_refreshed_on_audio_active(self, monkeypatch):
         self._patch_time(monkeypatch, 10.0)
         s = self._slice_visual_change()
-        _packet, _, _, new_v, new_a = run_gate(
+        _packet, _, _, new_v, new_a = await run_gate(
             s, self.config, last_visual_pass_ts=0.0, last_audio_pass_ts=0.0,
         )
         assert new_v == 10.0

--- a/backend/miloco/tests/perception/engine/run_stream_test.py
+++ b/backend/miloco/tests/perception/engine/run_stream_test.py
@@ -291,7 +291,7 @@ async def run_pipeline_with_timing(
     # --- Gate ---
     t0 = time.monotonic()
     # 流式 ad-hoc 入口无跨窗状态(prev_frame / hold ts),丢弃后 3 个返回项
-    gate_packet, _, _, _, _ = run_gate(input_slice, config.gate)
+    gate_packet, _, _, _, _ = await run_gate(input_slice, config.gate)
     timer.gate_ms = (time.monotonic() - t0) * 1000
     result["gate_packet"] = gate_packet
 

--- a/backend/miloco/tests/perception/engine/test_mimo_api.py
+++ b/backend/miloco/tests/perception/engine/test_mimo_api.py
@@ -48,15 +48,11 @@ DEFAULT_MAX_TOKENS = 1024
 # ---------------------------------------------------------------------------
 
 
-def prepare(video_path: str):
+async def prepare(video_path: str):
     """Run Gate → Edge on each window, extract prompts/images/audio, save to JSON."""
     from miloco.perception.engine.config import PerceptionConfig
     from miloco.perception.engine.gate.gate import run_gate
     from miloco.perception.engine.identity.identity import run_identity
-    from miloco.perception.engine.identity.speech_accumulator import (
-        SpeechAccumulator,
-        SpeechAccumulatorConfig,
-    )
     from miloco.perception.engine.identity.tracking_service import (
         create_tracking_service,
     )
@@ -68,9 +64,6 @@ def prepare(video_path: str):
     config = PerceptionConfig()
     windows = simulate_stream(video_path, 3, 3)
     tracking = create_tracking_service("real")
-    accumulator = SpeechAccumulator(
-        SpeechAccumulatorConfig(max_windows=config.identity.speech_max_windows)
-    )
     context = OmniContext(
         rule_conditions=[
             RuleCondition(
@@ -84,13 +77,13 @@ def prepare(video_path: str):
     test_data: list[dict] = []
 
     for i, (input_slice, win_start) in enumerate(windows):
-        gate_packet, _, _ = run_gate(input_slice, config.gate)
+        gate_packet, _, _, _, _ = await run_gate(input_slice, config.gate)
         if gate_packet is None:
             print(f"  窗口 #{i + 1} ({win_start:.0f}s): SKIPPED (gate)")
             continue
 
-        identity_packet = run_identity(
-            gate_packet, config.identity, tracking, accumulator
+        identity_packet = await run_identity(
+            gate_packet, config.identity, tracking
         )
 
         # Build prompt payload (same as pipeline)
@@ -441,7 +434,7 @@ async def main():
             print("[ERROR] prepare/all 模式需要指定视频路径")
             sys.exit(1)
         print(f"\n[准备] 从 {args.video} 提取测试数据...")
-        prepare(args.video)
+        await prepare(args.video)
 
     if args.command in ("run", "all"):
         print("\n[测试] 开始 MiMo API 测试...")

--- a/backend/miloco/tests/perception/engine/test_voice_mic_off.py
+++ b/backend/miloco/tests/perception/engine/test_voice_mic_off.py
@@ -148,7 +148,7 @@ class TestStripUnauthorizedVoiceAudio:
 class TestGateVideoOnlyAfterStrip:
     config = GateConfig()
 
-    def test_audio_only_stimulus_does_not_fire_when_stripped(self, monkeypatch):
+    async def test_audio_only_stimulus_does_not_fire_when_stripped(self, monkeypatch):
         """响亮音频 + 静止画面的未开启相机：剥离后 gate 不开窗（原本会 audio 触发）。
 
         传 prev_frame 基准帧隔离视觉 cold-start 放行——生产流式循环里 prev_frames
@@ -160,7 +160,7 @@ class TestGateVideoOnlyAfterStrip:
         prev = _preprocess(s.frames[0])
         # 对照：未剥离时 audio 触发开窗
         slice_before = create_input_slice("room", s.frames, s.audio_clip)
-        packet_before, timing_before, *_ = run_gate(
+        packet_before, timing_before, *_ = await run_gate(
             slice_before, self.config, prev_frame=prev
         )
         assert packet_before is not None and timing_before.audio_pass
@@ -168,14 +168,14 @@ class TestGateVideoOnlyAfterStrip:
         # 剥离后：同样刺激不再开窗
         eng._strip_unauthorized_voice_audio(BatchedSnapshot(snapshots=[s]))
         slice_after = create_input_slice("room", s.frames, s.audio_clip)
-        packet_after, timing_after, *_ = run_gate(
+        packet_after, timing_after, *_ = await run_gate(
             slice_after, self.config, prev_frame=prev
         )
         assert packet_after is None
         assert not timing_after.audio_pass
         assert timing_after.speech_prob == 0.0  # VAD 也被跳过（不做任何音频处理）
 
-    def test_video_stimulus_still_fires_with_audio_inactive(self, monkeypatch):
+    async def test_video_stimulus_still_fires_with_audio_inactive(self, monkeypatch):
         """视频刺激照常开窗，但 packet 的 audio 触发为 False、audio_clip 为空。"""
         monkeypatch.setattr(engine_api, "_voice_allowed_dids", lambda: set())
         eng = _make_engine()
@@ -192,19 +192,19 @@ class TestGateVideoOnlyAfterStrip:
         )
         eng._strip_unauthorized_voice_audio(BatchedSnapshot(snapshots=[s]))
         slice_ = create_input_slice("room", s.frames, s.audio_clip)
-        packet, timing, *_ = run_gate(slice_, self.config)
+        packet, timing, *_ = await run_gate(slice_, self.config)
         assert packet is not None and timing.video_pass
         assert not packet.trigger.audio_active
         assert packet.audio_clip.size == 0
 
-    def test_voice_on_cam_unchanged(self, monkeypatch):
+    async def test_voice_on_cam_unchanged(self, monkeypatch):
         """拾音已开启（在白名单内）的相机：audio 触发行为与改动前一致（对照组）。"""
         monkeypatch.setattr(engine_api, "_voice_allowed_dids", lambda: {"cam_on"})
         eng = _make_engine()
         s = _snapshot("cam_on")
         eng._strip_unauthorized_voice_audio(BatchedSnapshot(snapshots=[s]))
         slice_ = create_input_slice("room", s.frames, s.audio_clip)
-        packet, timing, *_ = run_gate(slice_, self.config)
+        packet, timing, *_ = await run_gate(slice_, self.config)
         assert packet is not None and timing.audio_pass
         assert packet.trigger.audio_active
 
@@ -213,7 +213,7 @@ class TestGateVideoOnlyAfterStrip:
 
 
 class TestPromptNoAudioTasksAfterStrip:
-    def _packet_from_stripped_gate(self):
+    async def _packet_from_stripped_gate(self):
         """走真实 run_gate 产出 trigger，再套进 IdentityPacket（与主链同构）。"""
         from miloco.perception.engine.types import (
             AudioAnalysis,
@@ -229,7 +229,7 @@ class TestPromptNoAudioTasksAfterStrip:
         white = np.full((64, 64, 3), 255, dtype=np.uint8)
         frames = [gray, gray, white, white, white, white]
         slice_ = create_input_slice("room", frames, np.array([], dtype=np.int16))
-        gate_packet, *_ = run_gate(slice_, GateConfig())
+        gate_packet, *_ = await run_gate(slice_, GateConfig())
         assert gate_packet is not None  # 视频触发
 
         return IdentityPacket(
@@ -253,22 +253,22 @@ class TestPromptNoAudioTasksAfterStrip:
             trigger=gate_packet.trigger,
         )
 
-    def test_schema_and_principle_drop_audio_tasks(self):
+    async def test_schema_and_principle_drop_audio_tasks(self):
         from miloco.perception.engine.omni.prompt_builder import build_prompt
         from miloco.perception.engine.types import OmniContext
 
-        payload = build_prompt(self._packet_from_stripped_gate(), OmniContext())
+        payload = build_prompt(await self._packet_from_stripped_gate(), OmniContext())
         sp = payload["system_prompt"]
         assert '"speeches"' not in sp
         assert '"env_sounds"' not in sp
         assert "本轮只有视频、没有音频" in sp  # _PRINCIPLE_VIDEO_NO_AUDIO
 
-    def test_audio_tasks_present_for_voice_on(self):
+    async def test_audio_tasks_present_for_voice_on(self):
         """对照组：audio_active=True（拾音开启）时 speeches/env_sounds 照常在 schema。"""
         from miloco.perception.engine.omni.prompt_builder import build_prompt
         from miloco.perception.engine.types import GateTrigger, OmniContext
 
-        ep = self._packet_from_stripped_gate()
+        ep = await self._packet_from_stripped_gate()
         ep.audio_clip = _loud_audio()
         ep.trigger = GateTrigger(
             visual_changed=True,

--- a/backend/miloco/tests/perception/test_engine_soft_stop.py
+++ b/backend/miloco/tests/perception/test_engine_soft_stop.py
@@ -33,7 +33,7 @@ def _make_proxy(engine=None) -> PerceptionEngineProxy:
     p._status = "ready" if engine is not None else "no_omni_api_key"
     p._status_message = ""
     p._last_captions = {}
-    p._executor = None
+    p._inference_worker = None
     p._engine_lock = asyncio.Lock()
     return p
 

--- a/backend/miloco/tests/perception/test_gate_timing.py
+++ b/backend/miloco/tests/perception/test_gate_timing.py
@@ -29,9 +29,9 @@ def _make_slice() -> DeviceSnapshot:
     )
 
 
-def test_run_gate_returns_packet_and_timing():
+async def test_run_gate_returns_packet_and_timing():
     cfg = GateConfig()
-    result = run_gate(_make_slice(), cfg, input_fps=1)
+    result = await run_gate(_make_slice(), cfg, input_fps=1)
     assert isinstance(result, tuple) and len(result) == 5
     _packet, timing, _last_checked, _new_last_v, _new_last_a = result
     assert isinstance(timing, GateTiming)

--- a/backend/miloco/tests/perception/test_inference_worker.py
+++ b/backend/miloco/tests/perception/test_inference_worker.py
@@ -1,0 +1,182 @@
+"""Tests for InferenceWorker — persistent event loop lifecycle and generation isolation."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from miloco.perception.inference_worker import InferenceWorker
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _return(val):
+    return val
+
+
+async def _raise(exc):
+    raise exc
+
+
+async def _probe_main_loop(main_loop: asyncio.AbstractEventLoop):
+    """Assert we are running on a *different* loop than the main one."""
+    current = asyncio.get_running_loop()
+    assert current is not main_loop, "expected probe to run on worker loop"
+    assert current is not None
+    return current
+
+
+# ---------------------------------------------------------------------------
+# submit — basic correctness
+# ---------------------------------------------------------------------------
+
+
+async def test_submit_runs_on_worker_loop_and_returns():
+    """submit() routes the coroutine to the worker thread's loop, not main."""
+    w = InferenceWorker()
+    w.start()
+    main_loop = asyncio.get_running_loop()
+
+    result = await w.submit(_return(42))
+    assert result == 42
+
+    worker_loop = await w.submit(_probe_main_loop(main_loop))
+    assert worker_loop is w._loop
+
+    w.shutdown(wait=True)
+
+
+async def test_submit_propagates_exception():
+    """submit() re-raises the coroutine's exception unchanged."""
+    w = InferenceWorker()
+    w.start()
+    with pytest.raises(ValueError, match="boom"):
+        await w.submit(_raise(ValueError("boom")))
+    w.shutdown(wait=True)
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle — start / shutdown / restart
+# ---------------------------------------------------------------------------
+
+
+async def test_is_running_reflects_lifecycle():
+    w = InferenceWorker()
+    assert not w.is_running
+    w.start()
+    assert w.is_running
+    w.shutdown(wait=True)
+    assert not w.is_running
+
+
+async def test_shutdown_flag_cleared_on_restart():
+    """shutdown → start clears the flag so submit() works again."""
+    w = InferenceWorker()
+    w.start()
+    assert w.is_running
+    w.shutdown(wait=True)
+    assert not w.is_running
+    w.start()
+    assert w.is_running
+    assert await w.submit(_return("alive")) == "alive"
+    w.shutdown(wait=True)
+
+
+async def test_restart_uses_new_generation_loop():
+    """A restarted worker gets a brand-new loop object."""
+    w = InferenceWorker()
+    w.start()
+    loop1 = w._loop
+    w.shutdown(wait=True)
+    assert w._loop is None  # self._loop is loop → cleared
+
+    w.start()
+    loop2 = w._loop
+    assert loop2 is not None
+    assert loop2 is not loop1  # new generation, new loop
+    assert await w.submit(_return("ok")) == "ok"
+    w.shutdown(wait=True)
+
+
+async def test_restart_without_joining_old_thread():
+    """start() after shutdown(wait=False) creates a usable new generation
+    even while the old thread is still draining."""
+    w = InferenceWorker()
+    w.start()
+    loop1 = w._loop
+
+    # Submit a coroutine that will be cancelled during shutdown —
+    # the old generation drains it in its finally block.
+    async def slow():
+        await asyncio.sleep(10)
+
+    # Fire-and-forget on the worker — shutdown won't wait for it.
+    asyncio.ensure_future(w.submit(slow()))  # noqa: RUF006
+
+    w.shutdown(wait=False)  # signal stop, don't join
+
+    # Immediately restart — old thread may still be draining slow()
+    w.start()
+    assert w.is_running
+    assert w._loop is not None
+    assert w._loop is not loop1  # new object
+
+    # New generation must be usable
+    assert await w.submit(_return("fresh")) == "fresh"
+    w.shutdown(wait=True)
+
+
+# ---------------------------------------------------------------------------
+# Rejection paths
+# ---------------------------------------------------------------------------
+
+
+async def test_submit_after_shutdown_raises():
+    w = InferenceWorker()
+    w.start()
+    w.shutdown(wait=True)
+    with pytest.raises(RuntimeError, match="shutting down"):
+        await w.submit(_return(1))
+
+
+async def test_submit_before_start_raises():
+    w = InferenceWorker()
+    # never started → _loop is None, _shutdown_flag is True (init default)
+    with pytest.raises(RuntimeError):
+        await w.submit(_return(1))
+
+
+async def test_coroutine_closed_on_guard_rejection():
+    """When submit() raises via a guard, the passed coroutine is .close()d
+    so Python does not warn about 'coroutine was never awaited' at GC time."""
+    w = InferenceWorker()
+    # Start then shut down so _shutdown_flag is True on next submit()
+    w.start()
+    w.shutdown(wait=True)
+
+    async def never_run():
+        pass  # pragma: no cover
+
+    coro = never_run()
+    with pytest.raises(RuntimeError, match="shutting down"):
+        await w.submit(coro)
+
+    # After close(), cr_frame is None — the coroutine is properly cleaned up
+    assert coro.cr_frame is None
+
+
+# ---------------------------------------------------------------------------
+# shutdown wait
+# ---------------------------------------------------------------------------
+
+
+async def test_shutdown_wait_joins_thread():
+    w = InferenceWorker()
+    w.start()
+    thread = w._thread
+    assert thread is not None and thread.is_alive()
+    w.shutdown(wait=True)
+    # After wait=True join, the daemon thread has exited
+    assert not thread.is_alive()

--- a/backend/miloco/tests/perception/test_proxy_reinit.py
+++ b/backend/miloco/tests/perception/test_proxy_reinit.py
@@ -40,7 +40,7 @@ def _make_proxy(status: str, *, engine=None, message: str = "stale") -> Percepti
     p._status = status
     p._status_message = message
     p._last_captions = {}
-    p._executor = None
+    p._inference_worker = None
     p._engine_lock = asyncio.Lock()
     return p
 

--- a/backend/miloco/tests/test_perception_client.py
+++ b/backend/miloco/tests/test_perception_client.py
@@ -3,13 +3,12 @@
 
 """Tests for PerceptionEngineProxy early-callback main-loop dispatch.
 
-Production path: realtime_perceive() offloads _realtime_perceive_impl to an
-inference thread via run_in_executor + asyncio.run, so the impl coroutine
-runs on a temporary event loop. The engine awaits early callbacks from that
-temp loop. Without dispatching back, any task spawned inside (e.g.
-RuleRunner._spawn_fire's create_task) ends up on the temp loop and gets
-cancelled when asyncio.run() exits — even when held in a strong-reference
-set, because the issue is loop closure, not GC.
+Production path: realtime_perceive() offloads _realtime_perceive_impl to a
+persistent worker thread via InferenceWorker.submit(). The impl coroutine
+runs on the worker's durable event loop. The engine awaits early callbacks
+from that worker loop. Without dispatching back, any task spawned inside
+(eg RuleRunner._spawn_fire's create_task) would end up on the worker loop.
+These tests verify the _on_main_loop dispatch keeps tasks on the main loop.
 """
 
 from __future__ import annotations
@@ -35,7 +34,7 @@ def proxy():
     p = PerceptionEngineProxy.__new__(PerceptionEngineProxy)
     p.perception_engine = MagicMock()
     p._last_captions = {}
-    p._executor = None
+    p._inference_worker = None
     return p
 
 
@@ -213,8 +212,8 @@ async def test_spawn_in_callback_survives_temp_loop_close(proxy):
     assert task.done() and not task.cancelled()
 
 
-async def test_no_executor_fallback_runs_callback_inline(proxy):
-    """When self._executor is None, _realtime_perceive_impl runs on the main
+async def test_no_worker_fallback_runs_callback_inline(proxy):
+    """When self._inference_worker is None, _realtime_perceive_impl runs on the main
     loop directly. The wrapper must short-circuit (current is main_loop) and
     not introduce cross-thread overhead."""
 

--- a/backend/miloco/tests/test_perception_client_rule_dispatch.py
+++ b/backend/miloco/tests/test_perception_client_rule_dispatch.py
@@ -24,7 +24,7 @@ def proxy():
     p = PerceptionEngineProxy.__new__(PerceptionEngineProxy)
     p.perception_engine = MagicMock()
     p._last_captions = {}
-    p._executor = None
+    p._inference_worker = None
     return p
 
 

--- a/backend/miloco/tests/test_perception_rule_e2e.py
+++ b/backend/miloco/tests/test_perception_rule_e2e.py
@@ -84,7 +84,7 @@ def proxy_with_runner(mock_miot_proxy, mock_log_repo):
     p = PerceptionEngineProxy.__new__(PerceptionEngineProxy)
     p.perception_engine = MagicMock()
     p._last_captions = {}
-    p._executor = None
+    p._inference_worker = None
 
     mock_task_record_service = MagicMock()
     mock_task_record_service.read_duration_target_state = MagicMock(return_value=None)


### PR DESCRIPTION
## 问题

Close #386

Miloco 2.0 长期运行后线程泄漏，`asyncio.run()` 在 `ThreadPoolExecutor` worker 线程里反复创建临时 event loop，导致：

1. **线程泄漏**：每次 `asyncio.run()` 创建临时 loop → 懒创建 default executor 线程 → `loop.close()` 时 join 清理不及时 → 跨 tick 累积 150+ 线程
2. **多设备串行**：ONNX 推理（VAD、YOLO、ReID）全部同步阻塞在 event loop 线程上，即使 `asyncio.gather` 也无法真正并行

## 修改方案

### 1. ThreadPoolExecutor → InferenceWorker（持久 event loop）

新增 `inference_worker.py`：daemon 线程运行 `loop.run_forever()`，替代每次 tick 的 `asyncio.run()`。一次创建，永久复用。

- 支持世代（generation）隔离：stop/start 时旧线程可能还在跑 ONNX 推理（不可抢占），start() 不等旧线程，直接起新线程/新 loop 作为当前代，旧代用自己的局部 loop 对象收尾
- `_get_fused_http_client` 的 loop-mismatch 问题自然消除

### 2. ONNX 推理 offload 到线程池（`asyncio.to_thread`）

- `gate.py`: `run_gate()` → `async def`，VAD 走 `to_thread`
- `identity.py`: `service.analyze()`（YOLO + ReID）走 `to_thread`
- `speech_vad.py`: 全局 VAD session 加 `_inference_lock` 保护并发调用
- `pipeline.py`: 调用方加 `await`

### 改动文件

| 文件 | 改动 |
|------|------|
| **新增** `inference_worker.py` | InferenceWorker 持久 loop 类（世代隔离、协程生命周期管理） |
| `client.py` | ThreadPoolExecutor → InferenceWorker |
| `runner.py` | 同上 |
| `processor.py` | set_inference_executor → set_inference_worker |
| `gate.py` | run_gate 改为 async，VAD 走 to_thread |
| `identity.py` | analyze() 走 to_thread |
| `speech_vad.py` | 全局 session 加 inference_lock |
| `pipeline.py` | run_gate 调用加 await |
| **新增** `test_inference_worker.py` | 10 用例：submit / restart / 世代隔离 / coro.close() / 拒止路径 |
| 9 个既有测试文件 | run_gate async/await 适配 + `_executor` → `_inference_worker` 重命名 |

## 验证

- **889 单元测试**全部通过（含新增 10 个 InferenceWorker 测试）
- **CI** 全绿（lint / backend-test / plugin-test / web-test / CodeQL / Quality）
- **cat@mac (M4)** 部署运行 **2h+**，2 台小米摄像机实时推理：
  - 线程数稳定 106-108（无泄漏）
  - CPU 15-24%，内存 1.5-2.2GB
  - RTF 0.02-0.06（远超实时）
  - Gate 7-35ms，Identity ONNX 40-78ms，Omni API 50ms-5s
  - 双相机 `asyncio.gather` 真正并行
  - restart 正常（108→90→107 线程，无泄漏）
  - VAD 在线程池正常工作，Omni 200 OK，语音/画面识别准确