### PR TITLE
feat(perception): inject system time into agent notification context

### DIFF
--- a/backend/miloco/src/miloco/perception/event_text_builder.py
+++ b/backend/miloco/src/miloco/perception/event_text_builder.py
@@ -167,6 +167,9 @@ def build_agent_text(
 ) -> str:
     """拼接 meaningful_events.text 字段（聚合三类信息，顺序固定：指令 → 提醒 → 规则）。"""
     parts: list[str] = []
+    # 在通知头部注入系统时间，让 agent 感知到当前时刻（用于判断时段/时效性）
+    if result.time:
+        parts.append(f"当前时间: {result.time}")
     if sp := build_speeches_text(_with_caption(result.speeches, result.caption)):
         parts.append(sp)
     if sg := build_suggestions_text(_with_caption(result.suggestions, result.caption)):


### PR DESCRIPTION
## Summary

在 agent 通知文本头部注入系统时间（`当前时间: HH:MM:SS`），让 agent 能感知到感知事件发生的时刻。

## Motivation

Resolves #42

当前 `build_agent_text` 生成的 `meaningful_events.text` 只包含事件块内的 `time_window`（格式 `[HH:MM:SS-HH:MM:SS]`），但没有在通知头部提供一个清晰的「当前系统时间」。这导致：

1. Agent 无法快速判断事件发生的时段（凌晨/白天/晚上）
2. 对于时效性判断（如"这是几分钟前的事"）缺乏参考

## Changes

在 `build_agent_text` 函数中，当 `result.time` 非空时，在通知文本头部添加 `当前时间: HH:MM:SS` 行。

```python
# 在通知头部注入系统时间，让 agent 感知到当前时刻（用于判断时段/时效性）
if result.time:
    parts.append(f"当前时间: {result.time}")
```

`result.time` 由 `PerceptionEngine._fmt_clock()` 生成，格式为部署时区的 `HH:MM:SS`，与 omni prompt 注入的 `current_time` 同源。

## Example

之前：
```
[感知引擎]提醒：
时间：10:30:15
来源：客厅的摄像头
...
```

之后：
```
当前时间: 10:30:15

[感知引擎]提醒：
时间：10:30:15
来源：客厅的摄像头
...
```

## Testing

- 当 `result.time` 为空字符串时，不添加时间头部（向后兼容）
- 当 `result.time` 有值时，时间头部出现在通知文本最前面
