### PR TITLE
feat(dispatch): expire stale queued messages by TTL before sending

### DIFF
--- a/backend/miloco/src/miloco/config/settings.py
+++ b/backend/miloco/src/miloco/config/settings.py
@@ -116,6 +116,15 @@ class DispatcherSettings(BaseModel):
             "每会话 dispatcher 队列上限；超出时按 (类型优先级, 条目级优先级, 入队时间) 淘汰最不紧急者。"
         ),
     )
+    message_ttl_sec: float = Field(
+        default=300.0,
+        description=(
+            "待发送消息在队列中的最大存活时长（秒）；入队龄超过该值的消息在"
+            "「新消息入队」与「打包发送前」两处被清理，不再投递。<=0 = 关闭过期。"
+        ),
+    )
+    # 不加 ge=0.0：与 notify.dedup_window_sec 一致，<=0 语义为「关闭过期」；
+    # 加 ge 会让误配负值直接崩掉整个 settings 加载（后端起不来）。
 
 
 class OmniModelSettings(BaseModel):

--- a/backend/miloco/src/miloco/config/settings.yaml
+++ b/backend/miloco/src/miloco/config/settings.yaml
@@ -109,6 +109,7 @@ perception:
 dispatcher:
   turn_wait_timeout_ms: 180000   # 同步等待单个 agent turn 结束的超时（毫秒）
   max_queue: 10                  # 每会话队列上限；超出按 (类型优先级, 条目级优先级, 入队时间) 淘汰最不紧急者
+  message_ttl_sec: 300           # 待发送消息最大存活时长（秒）；入队龄超此值在入队/发送前清理，不再投递。<=0 关闭
 
 # 可观测性
 perf:

--- a/backend/miloco/src/miloco/dispatch/dispatcher.py
+++ b/backend/miloco/src/miloco/dispatch/dispatcher.py
@@ -8,8 +8,13 @@
 透明存储，按会话维护队列、同类合并、单飞投递，平台侧同一会话在途 turn 恒 ≤1。
 
 调度全部前置在 ``run_agent_turn``（openclaw ``agent`` webhook）之前完成——平台一旦
-入队不可取消 / 改序，故合并 / 淘汰 / 排序必须在此层做。合并 / 丢弃 / 超时三类
+入队不可取消 / 改序，故合并 / 淘汰 / 排序必须在此层做。合并 / 丢弃 / 超时 / 过期四类
 「静默动作」均带 WARN 日志兜底。
+
+过期（TTL）：每条事件记入队时刻 ``enqueued_at``，入队龄超过
+``dispatcher.message_ttl_sec`` 即为过期。过期清理在两处发生——「新消息入队」时
+（先腾出过期占用的空间，再判超长淘汰）与「打包发送前」（``_take_batch`` 取批前）。
+收发在同一台机器实时进行，故仅 backend 发送前统一判过期，插件侧不重复校验。
 """
 
 from __future__ import annotations
@@ -73,7 +78,7 @@ class _QueuedEvent:
     items: list[Any]  # 结构化条目（list[Speech] / list[Suggestion] / [RuleTriggerCallback] / [str]）
     builder: Builder  # 该类型格式化函数引用；同一类型恒为同一 builder
     priority: int  # 类型级优先级（来自 _ROUTE，数字小=优先）
-    enqueued_at: float  # time.monotonic()，用于同类合并排序 + 淘汰判旧
+    enqueued_at: float  # time.monotonic()，即消息创建时刻；用于同类合并排序 + 淘汰判旧 + 过期判龄
     intra_priority: int = 0  # 条目级优先级（数字小=优先）；无内层优先级的类型恒 0，仅参与淘汰、不改渲染序
     # 可选投递结果 future：需要区分「入队被接纳」与「真正送达平台」的 producer
     # （如 onboarding 终身一次性标记）传入；dispatcher 保证它在**每一条**丢弃/送达
@@ -163,8 +168,11 @@ class AgentDispatcher:
         )
         q = self._queues.setdefault(session_key, [])
         q.append(ev)
+        # 新消息入队即先清理过期条目腾空间，再判超长淘汰——这样过期者优先让位，
+        # 避免用「淘汰有效消息」去容纳一条本该被过期清掉的僵尸。
+        self._drop_expired(session_key)
         self._enforce_cap(session_key)
-        accepted = any(e is ev for e in q)
+        accepted = any(e is ev for e in self._queues.get(session_key, ()))
         self._kick(session_key)
         return accepted
 
@@ -189,6 +197,38 @@ class AgentDispatcher:
                 evicted,
                 cap,
             )
+
+    def _drop_expired(self, session_key: str) -> None:
+        """清理入队龄超过 ``message_ttl_sec`` 的过期事件（被淘汰即未送达）。
+
+        入队龄 = ``time.monotonic() - enqueued_at``。TTL<=0 视作关闭过期，直接返回。
+        过期属「静默丢弃」→ 逐条 resolve delivered=False + WARN 兜底。
+        """
+        ttl_sec = get_settings().dispatcher.message_ttl_sec
+        if ttl_sec <= 0:
+            return
+        q = self._queues.get(session_key)
+        if not q:
+            return
+        now = time.monotonic()
+        fresh: list[_QueuedEvent] = []
+        expired: list[_QueuedEvent] = []
+        for ev in q:
+            (expired if now - ev.enqueued_at > ttl_sec else fresh).append(ev)
+        if not expired:
+            return
+        self._queues[session_key] = fresh
+        for ev in expired:
+            _resolve_delivered(ev.delivered, False)
+        # [DROPPED] 标记便于在 miloco-backend.log 里 grep；附最旧条目的延迟时长。
+        max_age = max(now - ev.enqueued_at for ev in expired)
+        logger.warning(
+            "[DROPPED] dispatcher expired %d event(s) session=%s ttl_sec=%.1f max_delay_sec=%.1f",
+            len(expired),
+            session_key,
+            ttl_sec,
+            max_age,
+        )
 
     def _kick(self, session_key: str) -> None:
         if self._closed or session_key in self._draining:
@@ -215,7 +255,9 @@ class AgentDispatcher:
         """取会话内优先级最高的类型的全部事件，按入队时间升序，移出队列。
 
         每轮 turn 恒单一类型（同一 builder），保证「单头、统一编号」。
+        取批前先清理过期条目：僵尸消息绝不打包进本轮 turn。
         """
+        self._drop_expired(session_key)
         q = self._queues.get(session_key)
         if not q:
             return []

--- a/backend/miloco/tests/dispatch/test_dispatcher.py
+++ b/backend/miloco/tests/dispatch/test_dispatcher.py
@@ -87,12 +87,15 @@ def patched(monkeypatch):
         )
 
     monkeypatch.setattr(disp_mod, "track_agent_run", fake_track)
+    # message_ttl_sec 默认给一个极大值 → 现有用例不触发过期；过期专项用例各自覆盖。
     monkeypatch.setattr(
         disp_mod,
         "get_settings",
         lambda: SimpleNamespace(
             dispatcher=SimpleNamespace(
-                turn_wait_timeout_ms=30_000, max_queue=MAX_QUEUE
+                turn_wait_timeout_ms=30_000,
+                max_queue=MAX_QUEUE,
+                message_ttl_sec=1e9,
             )
         ),
     )
@@ -168,6 +171,82 @@ def test_enforce_cap_type_priority_dominates_intra():
 
     assert len(q) == MAX_QUEUE
     assert all(e.event_type == "interaction" for e in q)
+
+
+def _patch_ttl(monkeypatch, ttl_sec: float, max_queue: int = MAX_QUEUE) -> None:
+    """Point disp_mod.get_settings at a stub with the given message_ttl_sec."""
+    monkeypatch.setattr(
+        disp_mod,
+        "get_settings",
+        lambda: SimpleNamespace(
+            dispatcher=SimpleNamespace(
+                turn_wait_timeout_ms=30_000,
+                max_queue=max_queue,
+                message_ttl_sec=ttl_sec,
+            )
+        ),
+    )
+
+
+def test_drop_expired_evicts_aged_keeps_fresh(monkeypatch):
+    """入队龄超过 TTL 的清掉，龄内的保留。"""
+    _patch_ttl(monkeypatch, ttl_sec=10.0)
+    d = AgentDispatcher()
+    sk = "agent:main:miloco"
+    now = time.monotonic()
+    q = d._queues.setdefault(sk, [])
+    q.append(_QueuedEvent("interaction", ["old"], _join, 0, now - 60))  # 60s 前，过期
+    q.append(_QueuedEvent("interaction", ["fresh"], _join, 0, now - 1))  # 1s 前，未过期
+
+    d._drop_expired(sk)
+
+    assert [e.items[0] for e in d._queues[sk]] == ["fresh"]
+
+
+def test_drop_expired_disabled_when_ttl_non_positive(monkeypatch):
+    """TTL<=0 关闭过期：再旧也不清。"""
+    _patch_ttl(monkeypatch, ttl_sec=0.0)
+    d = AgentDispatcher()
+    sk = "agent:main:miloco"
+    now = time.monotonic()
+    q = d._queues.setdefault(sk, [])
+    q.append(_QueuedEvent("interaction", ["ancient"], _join, 0, now - 10_000))
+
+    d._drop_expired(sk)
+
+    assert [e.items[0] for e in d._queues[sk]] == ["ancient"]
+
+
+@pytest.mark.asyncio
+async def test_drop_expired_resolves_delivered_false(monkeypatch):
+    """过期即丢弃 → delivered future resolve False（与淘汰同语义）。"""
+    _patch_ttl(monkeypatch, ttl_sec=10.0)
+    d = AgentDispatcher()
+    sk = "agent:main:miloco"
+    now = time.monotonic()
+    fut = asyncio.get_event_loop().create_future()
+    ev = _QueuedEvent("interaction", ["old"], _join, 0, now - 60)
+    ev.delivered = fut
+    d._queues.setdefault(sk, []).append(ev)
+
+    d._drop_expired(sk)
+
+    assert fut.result() is False
+
+
+def test_take_batch_drops_expired_before_packing(monkeypatch):
+    """打包发送前先清过期：僵尸消息绝不进本轮 turn。"""
+    _patch_ttl(monkeypatch, ttl_sec=10.0)
+    d = AgentDispatcher()
+    sk = "agent:main:miloco"
+    now = time.monotonic()
+    q = d._queues.setdefault(sk, [])
+    q.append(_QueuedEvent("interaction", ["stale"], _join, 0, now - 60))
+    q.append(_QueuedEvent("interaction", ["live"], _join, 0, now - 1))
+
+    batch = d._take_batch(sk)
+
+    assert [e.items[0] for e in batch] == ["live"]
 
 
 def test_take_batch_render_order_ignores_intra_priority():
@@ -417,6 +496,71 @@ async def test_dispatch_returns_false_when_new_event_evicted(patched):
         await d.stop()
 
     assert accepted is False
+
+
+@pytest.mark.asyncio
+async def test_dispatch_expired_freed_space_admits_new_event(patched, monkeypatch):
+    """新消息入队时清理过期腾空间：满队全过期 → 新消息不被超长淘汰而被接纳。"""
+    _patch_ttl(monkeypatch, ttl_sec=10.0)
+    d = AgentDispatcher()
+    await d.start()
+    monkeypatch.setattr(d, "_kick", lambda sk: None)  # 冻结 drainer，留住队列供检查
+    sk = "agent:main:miloco"
+    now = time.monotonic()
+    q = d._queues.setdefault(sk, [])
+    for i in range(MAX_QUEUE):  # 满队，且全部过期
+        q.append(_QueuedEvent("interaction", [f"i{i}"], _join, 0, now - 60))
+    try:
+        # 若无过期清理，bind 最不紧急会被自己的超额 append 淘汰（False）；
+        # 过期清理先腾空 → bind 被接纳。
+        accepted = await d.dispatch("bind", ["late"], _join)
+        assert accepted is True
+        assert [e.items[0] for e in d._queues[sk]] == ["late"]
+    finally:
+        await d.stop()
+
+
+@pytest.mark.asyncio
+async def test_expired_event_dropped_before_send(patched, monkeypatch):
+    """过期条目在发送前被清：turn 只收到新鲜内容，过期者 delivered=False。"""
+    _patch_ttl(monkeypatch, ttl_sec=10.0)
+    d = AgentDispatcher()
+    await d.start()
+    sk = "agent:main:miloco"
+    now = time.monotonic()
+    stale_fut = asyncio.get_event_loop().create_future()
+    stale = _QueuedEvent("interaction", ["stale"], _join, 0, now - 60)
+    stale.delivered = stale_fut
+    try:
+        d._queues.setdefault(sk, []).append(stale)  # 预置一条过期
+        await d.dispatch("interaction", ["fresh"], _join)  # 新鲜的触发 drain
+        await _settle(d)
+    finally:
+        await d.stop()
+
+    assert len(patched.turns) == 1
+    assert patched.turns[0].msg == "fresh"  # 仅新鲜条目送出
+    assert stale_fut.result() is False  # 过期条目未送达
+
+
+@pytest.mark.asyncio
+async def test_ttl_disabled_keeps_aged_events(patched, monkeypatch):
+    """TTL<=0 关闭过期：陈旧条目照常送出。"""
+    _patch_ttl(monkeypatch, ttl_sec=0.0)
+    d = AgentDispatcher()
+    await d.start()
+    sk = "agent:main:miloco"
+    now = time.monotonic()
+    try:
+        d._queues.setdefault(sk, []).append(
+            _QueuedEvent("interaction", ["ancient"], _join, 0, now - 10_000)
+        )
+        d._kick(sk)
+        await _settle(d)
+    finally:
+        await d.stop()
+
+    assert [t.msg for t in patched.turns] == ["ancient"]
 
 
 @pytest.mark.asyncio

--- a/backend/miloco/tests/home_profile/test_onboarding_trigger.py
+++ b/backend/miloco/tests/home_profile/test_onboarding_trigger.py
@@ -252,7 +252,9 @@ async def real_dispatcher(monkeypatch):
         disp_mod,
         "get_settings",
         lambda: SimpleNamespace(
-            dispatcher=SimpleNamespace(turn_wait_timeout_ms=1_000, max_queue=16)
+            dispatcher=SimpleNamespace(
+                turn_wait_timeout_ms=1_000, max_queue=16, message_ttl_sec=1e9
+            )
         ),
     )
     monkeypatch.setattr(AgentDispatcher, "_TRANSPORT_BACKOFF_S", 0.001)


### PR DESCRIPTION
## 背景

关联 issue #317：Miloco 通过 webhook 推送到 OpenClaw `miloco-suggest` 通道，当用户离线（如深夜）时消息在队列积压，数小时后才补发，场景早已过期，推送失去意义且造成困惑。

## 方案

在 backend 侧 dispatcher 为待发送消息队列增加基于**入队龄**的过期（TTL）清理。队列本就记录每条事件的创建时刻 `enqueued_at`（`time.monotonic()`），本 PR 据此在**发送前**统一判过期。

### 改动

- **可配置过期时长**：新增 `dispatcher.message_ttl_sec`（默认 `300` 秒，即 5 分钟，与 issue 建议阈值一致；`<=0` 关闭过期）。沿用 `notify.dedup_window_sec` 的「不加 `ge` 校验、`<=0` 即关闭」约定，误配负值不会拖垮 settings 加载。属内部运行参数，不进 `settings.schema.json`。
- **`_drop_expired()`**：清理入队龄（`now - enqueued_at`）超过 TTL 的事件，逐条 `resolve delivered=False`（与超长淘汰同语义），并打 `[DROPPED]` WARN 日志（含 session、ttl、最旧条目延迟时长），便于在 `miloco-backend.log` grep。
- **两处调用**：
  1. `dispatch()` 新消息入队后、`_enforce_cap` 前——过期者优先让位腾空间，避免用「淘汰有效消息」去容纳本该被过期清掉的僵尸；
  2. `_take_batch()` 取批前——过期消息绝不打包进本轮 agent turn。
- **不重复校验**：收发在同一台机器实时进行，故仅 backend 发送前判过期，TS 插件侧无需重复校验。

## 关联 issue 与 PR

围绕 #317「离线消息积压/过期补发」，社区已有多个不同层面的方案，本 PR 与它们的关系如下：

### 同一问题（#317）的多种实现（层面不同，择一落地或组合）

| PR | 层面 | 过期判据 | 作用范围 | TS 侧改动 |
|----|------|----------|----------|-----------|
| **#414（本 PR）** | dispatcher 队列层 | **入队龄** `now - enqueued_at` | **所有事件类型**（interaction/rule/suggestion/bind/onboarding） | 无需 |
| #359 | perception 流水线层 | suggestion 的 **`time_window` 业务事件时间** | 仅 suggestion（early 流式 + 终态 batch 两路） | 无 |
| #347 | perception→dispatch + webhook | 感知**事件时间戳** | 仅 `miloco-suggest` 批次；并把 `createdAtMs/expiresAtMs` 透传给 OpenClaw | 有（webhook 侧再校验） |

**关键区别**：本 PR 以「消息在队列里待了多久」为判据，通用于所有会话/事件类型，只在 backend 单点处理；#359/#347 以「底层感知事件发生多久了」为判据，仅覆盖 suggestion。二者在常规链路下基本等价（入队紧跟事件产生），主要在队列因单飞被慢 turn 阻塞、或引擎无人值守积压（见 #318）时体现差异。

### 相关但正交的改动

- **#413**（Resolves #42）：在 agent 通知文本头注入 `当前时间: HH:MM:SS`，让 agent 具备时段/时效判断的上下文。与本 PR 互补——本 PR 负责「过期即弃推」，#413 负责「让 agent 感知时刻」。
- **#318**（已关闭，supervisor 托管致引擎夜间自动重启）：#317 报告者指出它是夜间推送积压量的**诱因之一**；#318 修复后积压来源减少，但用户离线导致的 OpenClaw 侧排队延迟仍需本 PR 这类发送前过期机制兜底。

## 测试

- 新增 7 个单测（纯逻辑 + 异步）：过期淘汰/关闭/腾空间/发送前清理/`delivered` 语义；同步修正两处 settings stub。
- `tests/dispatch/` + `tests/home_profile/test_onboarding_trigger.py`：全部通过。
- `ruff check`：clean。

Closes #317