### PR TITLE
feat(cli): device spec 按 service 分组输出并带上服务描述

### DIFF
--- a/cli/src/miloco_cli/commands/device.py
+++ b/cli/src/miloco_cli/commands/device.py
@@ -170,7 +170,8 @@ def device_spec(dids):
     单台：device spec <did>
     多台：device spec <did1> <did2> …   （各设备规格依次输出，设备之间空两行分隔）
 
-    对齐表格：每行一个 prop / action，列宽自适应。
+    按 service 分组：每个 service 一个标题行（服务类型 + 中文描述），其下平铺
+    该服务的 prop / action 行（prop 在前），列宽自适应。
     """
     from miloco_cli.client import api_get
 
@@ -191,7 +192,11 @@ def device_spec(dids):
 
 
 def _render_device_spec(dev: dict) -> str:
-    """DEVICE 头 + PROPERTIES + ACTIONS 两段，spec 行与 catalog 同款 pipe 形式。"""
+    """DEVICE 头 + 按 service 分组的 properties / actions。
+
+    每个 service 一个小节，标题行给出 ``service_type_name（service_description）``；
+    组内 spec 行与 catalog 同款 pipe 形式，spec_name 可直接复制给 device control。
+    """
     from miloco_cli.catalog import (
         _build_spec_line,
         _resolve_keys_for_device,
@@ -214,30 +219,45 @@ def _render_device_spec(dev: dict) -> str:
         return "\n".join(out)
 
     out.append("")
-    out.append("# 每行：iid  spec_name|access|format|constraint|unit（action 行：iid  spec_name|x|in_params）；字段含义同 catalog「# 数据格式」")
+    out.append("# 按 service 分组")
+    out.append("# prop.iid    spec_name|access|format|constraint|unit")
+    out.append("# action.iid  spec_name|x|in_params")
     out.append("# access：wr=读写 / w=只写 / r=只读 / x=动作")
 
     iid_to_key = _resolve_keys_for_device(spec)
-    prop_rows: list[tuple[str, str]] = []
-    action_rows: list[tuple[str, str]] = []
+
+    # 按 iid 里的 siid（prop.{siid}.{piid} / action.{siid}.{aiid}）分组，保留 spec 原序
+    # （dict 自 Python 3.7 起保证按插入顺序迭代）。
+    # service_type_name / service_description 是 service 级字段，取组内首个非空值即可。
+    services: dict[str, dict] = {}
     for iid, entry in spec.items():
         if not isinstance(entry, dict):
             continue
+        parts = iid.split(".")
+        siid = parts[1] if len(parts) >= 3 else "?"
+        svc = services.setdefault(
+            siid,
+            {"type_name": None, "description": None, "props": [], "actions": []},
+        )
+        if svc["type_name"] is None and entry.get("service_type_name"):
+            svc["type_name"] = entry["service_type_name"]
+        if svc["description"] is None and entry.get("service_description"):
+            svc["description"] = entry["service_description"]
         key = iid_to_key.get(iid) or iid
         line = _build_spec_line(iid, entry, key)
-        (action_rows if line.is_action else prop_rows).append((iid, line.render()))
+        (svc["actions"] if line.is_action else svc["props"]).append((iid, line.render()))
 
-    def _section(title: str, rows: list[tuple[str, str]]) -> None:
-        if not rows:
-            return
+    for siid, svc in services.items():
         out.append("")
-        out.append(f"{title} ({len(rows)}):")
+        header = f"[service {siid}] {svc['type_name'] or '-'}"
+        if svc["description"]:
+            header += f"（{svc['description']}）"
+        out.append(header)
+        # prop 行在前、action 行在后，直接平铺（iid 前缀已区分二者，无需小节标题 / 缩进）。
+        rows = svc["props"] + svc["actions"]
         width = max(len(iid) for iid, _ in rows)
         for iid, rendered in rows:
-            out.append(f"  {iid:<{width}}  {rendered}")
-
-    _section("properties", prop_rows)
-    _section("actions", action_rows)
+            out.append(f"{iid:<{width}}  {rendered}")
 
     return "\n".join(out)
 

--- a/cli/tests/test_commands.py
+++ b/cli/tests/test_commands.py
@@ -691,7 +691,7 @@ def test_device_spec_default_table(runner, fake_home_info):
     assert "home=我的家" in text
     assert "device_name=台灯" in text
     assert "room=客厅" in text
-    assert "properties" in text
+    assert "[service 2]" in text  # 按 service 分组的标题行
     assert "prop.2.1" in text
     mock.assert_called_once_with("/api/miot/devices/lamp_001/spec")
 
@@ -728,6 +728,51 @@ def test_device_spec_multiple_partial_failure(runner, fake_home_info):
         result = runner.invoke(cli, ["device", "spec", "good", "bad"])
     assert result.exit_code == 0
     assert "did=good" in result.output
+
+
+def test_device_spec_groups_by_service_with_description(runner, fake_home_info):
+    """spec 按 service 分组：标题行带 service_type_name（service_description），
+    props/action 归到各自 service 小节下。"""
+    with patch("miloco_cli.client.api_get") as mock:
+        mock.return_value = {
+            "code": 0,
+            "data": {
+                "did": "lamp_001",
+                "name": "台灯",
+                "online": True,
+                "category": "light",
+                "spec": {
+                    "prop.2.1": {
+                        "type_name": "on", "format": "bool",
+                        "writeable": True, "readable": True,
+                        "service_type_name": "light",
+                        "service_description": "灯光",
+                    },
+                    "action.2.1": {
+                        "type_name": "toggle",
+                        "service_type_name": "light",
+                        "service_description": "灯光",
+                    },
+                    "prop.3.1": {
+                        "type_name": "on", "format": "bool",
+                        "writeable": True, "readable": True,
+                        "service_type_name": "indicator-light",
+                        "service_description": "指示灯",
+                    },
+                },
+            },
+        }
+        result = runner.invoke(cli, ["device", "spec", "lamp_001"])
+    assert result.exit_code == 0
+    text = result.output
+    # 两个 service 各成小节，标题带类型与中文描述
+    assert "[service 2] light（灯光）" in text
+    assert "[service 3] indicator-light（指示灯）" in text
+    # action 归到 service 2 下，且在 service 3 标题之前出现
+    assert text.index("action.2.1") < text.index("[service 3]")
+    # 无 properties:/actions: 小节标题，行不缩进（iid 顶格）
+    assert "properties:" not in text and "actions:" not in text
+    assert "\nprop.2.1  " in text and "\naction.2.1  " in text
 
 
 def test_device_props_annotates_spec_name(runner, fake_home_info):


### PR DESCRIPTION
## 背景

`miloco-cli device spec <did>` 原来把设备所有 prop / action 平铺成 `properties` / `actions` 两大段，service 层信息（`service_type_name` / `service_description`）基本不露出——后端每条 spec entry 其实都带了这些字段，只在同名冲突时以 `@desc` 后缀间接体现。

## 改动

按 iid 里的 siid（`prop.{siid}.{piid}` / `action.{siid}.{aiid}`）分组，每个 service 一个小节：

- 标题行给出 `[service {siid}] service_type_name（service_description）`；
- 组内直接平铺 prop / action 行（prop 在前，iid 前缀已区分二者，无小节标题 / 缩进），列宽自适应；
- spec 行仍为 catalog 同款 pipe 形式，`spec_name` 可直接复制给 `device control`；
- 精简顶部图例说明。

## 效果

\`\`\`
did=spk1  device_name=音箱  category=speaker  online

# 按 service 分组
# prop.iid    spec_name|access|format|constraint|unit
# action.iid  spec_name|x|in_params
# access：wr=读写 / w=只写 / r=只读 / x=动作

[service 2] speaker（扬声器）
prop.2.1    volume|wr|uint8|[0,100;1]|percentage
action.2.1  play-text|x|text:string

[service 4] microphone（麦克风）
prop.4.1  mute|wr|bool
\`\`\`

## 测试

- 新增 \`test_device_spec_groups_by_service_with_description\`，覆盖分组标题、服务描述、prop/action 归属、无小节标题 / 顶格。
- 更新 \`test_device_spec_default_table\` 断言。
- CLI 全套测试通过。