### PR TITLE
fix(perception): window_size-only 变更免重载模型 + video_short_edge 注释

### DIFF
--- a/backend/miloco/src/miloco/admin/router.py
+++ b/backend/miloco/src/miloco/admin/router.py
@@ -857,17 +857,19 @@ async def put_perception_config(body: PerceptionConfigBody, current_user: str = 
     if update:
         # omni_fps / window_size 是引擎/runner 构造时 cache 的，改这两个才需重启生效；
         # video_short_edge 每帧实时读 settings，写盘 + reset_settings 后下帧即生效，无需重启。
-        # 前端 drawer 三字段一起 PUT，故按「新值 != 旧值」判断，避免只拖分辨率也整机重启
-        # （重启会丢在途感知窗口、重置 tracker）。
-        need_restart = (
-            (body.omni_fps is not None and body.omni_fps != payload["omni_fps"])
-            or (body.window_size is not None and body.window_size != payload["window_size"])
-        )
+        # 前端 drawer 三字段一起 PUT，故按「新值 != 旧值」判断，避免只拖分辨率也重启。
+        omni_fps_changed = body.omni_fps is not None and body.omni_fps != payload["omni_fps"]
+        window_changed = body.window_size is not None and body.window_size != payload["window_size"]
+        # omni_fps 变才需重建引擎（重读构造期 cache 的 omni_fps，代价含模型重载）；window_size
+        # 只需 runner 重启（start 重读窗口）。故 window_size-only 时跳过 rebuild，省一次模型重载。
+        need_restart = omni_fps_changed or window_changed
         update_shared_config(**update)
         payload = _perception_config_payload()
         if need_restart:
             # config 已写盘(不可回滚)；重启若失败仅带 restart_ok=False，不冒泡成 500——
             # 否则前端会把「已保存+重启失败」误报成「保存失败」，误导用户以为改动丢失。
             # 同步等重启完成再返回。
-            payload["restart_ok"] = await manager.perception_service.apply_config_restart()
+            payload["restart_ok"] = await manager.perception_service.apply_config_restart(
+                rebuild_engine=omni_fps_changed
+            )
     return NormalResponse(code=0, message="ok", data=payload)

--- a/backend/miloco/src/miloco/perception/engine/config.py
+++ b/backend/miloco/src/miloco/perception/engine/config.py
@@ -17,7 +17,8 @@ class InputConfig:
     audio_overlap_ms: int = (
         100  # overlap window to reduce audio truncation at boundaries
     )
-    # 仅为接住 InputConfig(**engine_cfg["input"]) 的 kwargs（config.json 的 input 块含此键）。
+    # 仅为接住 InputConfig(**engine_cfg["input"]) 的 kwargs（settings.yaml 的 engine.input
+    # 默认含此键，config.json 亦可覆盖）。
     # 与 fps / omni_fps 不同：运行时真值由 _get_video_short_edge() 每帧读 settings 字典
     # （见 prompt_builder），不从此 dataclass 字段读——故改分辨率免重启。别照 fps 的先例
     # 在构造前设 config.input.video_short_edge 期望生效，那样会被静默忽略。

--- a/backend/miloco/src/miloco/perception/engine/config.py
+++ b/backend/miloco/src/miloco/perception/engine/config.py
@@ -17,6 +17,10 @@ class InputConfig:
     audio_overlap_ms: int = (
         100  # overlap window to reduce audio truncation at boundaries
     )
+    # 仅为接住 InputConfig(**engine_cfg["input"]) 的 kwargs（config.json 的 input 块含此键）。
+    # 与 fps / omni_fps 不同：运行时真值由 _get_video_short_edge() 每帧读 settings 字典
+    # （见 prompt_builder），不从此 dataclass 字段读——故改分辨率免重启。别照 fps 的先例
+    # 在构造前设 config.input.video_short_edge 期望生效，那样会被静默忽略。
     video_short_edge: int = 512
 
 

--- a/backend/miloco/src/miloco/perception/service.py
+++ b/backend/miloco/src/miloco/perception/service.py
@@ -66,11 +66,16 @@ class PerceptionService:
         async with self._lifecycle_lock:
             await self._pipeline.stop_to_unconfigured()
 
-    async def apply_config_restart(self) -> bool:
-        """感知参数变更后重启使新值生效：停 runner → 重建引擎 → 启 runner。
+    async def apply_config_restart(self, *, rebuild_engine: bool = True) -> bool:
+        """感知参数变更后重启使新值生效：停 runner →（按需重建引擎）→ 启 runner。
 
-        引擎构造时 cache 的 omni_fps 靠 rebuild 重读；runner 的 window_size 靠
-        start() 重读（见 runner.start）。运行时未启动则只重建引擎不拉起 runner。
+        ``rebuild_engine`` 拆开「重建引擎」与「重启 runner」两件事，各自最小化：
+          - omni_fps 变 → 需 ``rebuild_engine=True``：omni_fps 是引擎构造时 cache 的，
+            必须 rebuild（close + _init_engine）才重读，代价含模型重载（秒级）。
+          - window_size 变（omni_fps 不变）→ ``rebuild_engine=False``：window_size 靠
+            runner.start() 重读即可（见 runner.start），只 stop→start，跳过模型重载。
+        无论哪种，只要 was_running 都要 stop→start：rebuild 后新引擎实例需靠 start 重挂
+        inference executor；window_size-only 时 stop→start 也让 runner 重读窗口。
         全程持 lifecycle 锁,避免与并发的 start_engine/stop_engine 交错。
 
         返回重启是否成功。config 已由调用方写盘(不可回滚),重建失败(如磁盘满/
@@ -82,7 +87,8 @@ class PerceptionService:
                 was_running = self._engine.is_running
                 if was_running:
                     await self._engine.stop()
-                await self._pipeline.rebuild()
+                if rebuild_engine:
+                    await self._pipeline.rebuild()
                 if was_running:
                     await self._engine.start()
                 return True

--- a/backend/miloco/tests/perception/test_apply_config_restart.py
+++ b/backend/miloco/tests/perception/test_apply_config_restart.py
@@ -3,11 +3,15 @@
 
 """Tests for PerceptionService.apply_config_restart.
 
-「应用设置」改感知参数后需真正重建引擎(omni_fps)+ runner 重读(window_size)才生效。
-本方法:停 runner → 重建引擎 → 启 runner,全程持 lifecycle 锁串行化。覆盖:
+「应用设置」改感知参数后需真正生效：停 runner →（按需重建引擎）→ 启 runner,
+全程持 lifecycle 锁串行化。``rebuild_engine`` 拆开「重建引擎」与「重启 runner」：
+omni_fps 变才需 rebuild（重读构造期 cache,含模型重载）；window_size 变只需
+runner.start() 重读,跳过 rebuild。覆盖:
 
-- was_running=True:走 stop → rebuild → start,返 True
-- was_running=False:只 rebuild,不 stop/start(未运行时不误拉起 runner)
+- rebuild_engine=True + was_running:走 stop → rebuild → start,返 True
+- rebuild_engine=True + not running:只 rebuild,不 stop/start(不误拉起 runner)
+- rebuild_engine=False + was_running:stop → start 重启 runner,跳过 rebuild(不重载模型)
+- rebuild_engine=False + not running:全 no-op
 - 重建抛异常(如磁盘满/模型加载失败)→ 返 False 不冒泡(config 已写盘,由调用方
   据 restart_ok 区分「已保存但重启失败」,否则前端误报「保存失败」)
 - lifecycle 锁串行化 apply_config_restart 与并发 start/stop,防交错状态错乱
@@ -59,6 +63,32 @@ async def test_apply_config_restart_not_running_only_rebuilds():
 
     svc._pipeline.rebuild.assert_awaited_once()
     svc._engine.stop.assert_not_awaited()
+    svc._engine.start.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_apply_config_restart_no_rebuild_only_restarts_runner():
+    """rebuild_engine=False(仅 window_size 变):stop → start 重启 runner 重读窗口,
+    但跳过 rebuild——不重载模型。omni_fps 未变,引擎实例无需重建。"""
+    svc = _make_service(is_running=True)
+
+    assert await svc.apply_config_restart(rebuild_engine=False) is True
+
+    svc._engine.stop.assert_awaited_once()
+    svc._engine.start.assert_awaited_once()
+    svc._pipeline.rebuild.assert_not_awaited()  # 关键:未重建引擎、未重载模型
+
+
+@pytest.mark.asyncio
+async def test_apply_config_restart_no_rebuild_not_running_is_noop():
+    """rebuild_engine=False 且引擎未运行:什么都不做(不 stop/rebuild/start)。
+    window_size 靠下次 start 时 runner 重读,当前无 runner 在跑无需动。"""
+    svc = _make_service(is_running=False)
+
+    assert await svc.apply_config_restart(rebuild_engine=False) is True
+
+    svc._engine.stop.assert_not_awaited()
+    svc._pipeline.rebuild.assert_not_awaited()
     svc._engine.start.assert_not_awaited()
 
 


### PR DESCRIPTION
## Summary

优化「应用设置」修改感知参数后的重启开销 + 补一处易误导的字段注释。

### 1. window_size-only 变更免重载模型

`apply_config_restart` 原来无条件 `rebuild()` 引擎（含模型重载，秒级）。但三个可配参数里只有 `omni_fps` 是引擎构造时 cache 的、需 rebuild 才重读；`window_size` 靠 `runner.start()` 重读即可，不需重建引擎。

`apply_config_restart(*, rebuild_engine: bool)` 拆开「重建引擎」与「重启 runner」：
- `omni_fps` 变 → `stop → rebuild → start`
- `window_size` only → `stop → start`（跳过 rebuild，不重载模型）

避免用户只拖「感知窗口」滑块也整机重建、白重载模型、丢在途感知窗口 / 重置 tracker。

**部署机实测**：window_size-only 改动只有 `runner stopped/started` 两行日志、0.30s；omni_fps 改动才出现引擎构造痕迹。

### 2. `InputConfig.video_short_edge` 加注释

该 dataclass 字段无运行时消费方（真值走 `_get_video_short_edge()` 每帧读 settings），却与 `fps` / `omni_fps` 同结构，易被误当运行时入口。加注释说明：字段必须保留（接 `InputConfig(**engine_cfg["input"])` 的 kwargs，删了会 `TypeError`），运行时真值走 settings 实时读。

## Test plan

- [x] `test_apply_config_restart.py` 新增 2 用例（`rebuild_engine=False` 只 stop→start / 未运行时 no-op），7 passed
- [x] 部署机实测 window_size-only 不重建引擎、omni_fps 变才重建
- [x] ruff check 通过
