### PR TITLE
feat: 新增 Web 升级提示与一键自升级

### DIFF
--- a/backend/miloco/src/miloco/admin/router.py
+++ b/backend/miloco/src/miloco/admin/router.py
@@ -10,12 +10,15 @@ import asyncio
 import json
 import logging
 import re
+import shlex
 import subprocess
+import time
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as pkg_version
 from pathlib import Path
 from typing import Literal
 
+import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field, StrictBool
 from sse_starlette.sse import EventSourceResponse
@@ -29,6 +32,7 @@ from miloco.observability import debug as debug_mod
 from miloco.perception.engine.omni import probe as _probe
 from miloco.schema.common_schema import NormalResponse
 from miloco.utils.agent_config import update_shared_config
+from miloco.utils.paths import miloco_home
 
 logger = logging.getLogger(name=__name__)
 
@@ -170,6 +174,412 @@ async def get_version(current_user: str = Depends(verify_token)):
             "version": version,
             "git": _git_info(version),
         },
+    )
+
+
+# ── 升级检测 / 一键升级 ────────────────────────────────────────────────
+# 发布只走 GitHub Release（CalVer tag）。检测 = 查 releases/latest（最新正式版）比对
+# 当前版本；一键升级 = detached 起官方 install.sh 的**非交互 agent 模式**——install.py
+# 默认 run() 在无 tty 时会 fail("non_interactive") 中止（main:1643-1645），故必须走
+# --agent-prepare/--agent-finish（它在 tty 检查前 return，全程无交互、保留现有 config）。
+# 仅 release/wheel 部署可一键升级；dev(git) 只提示 git pull。roll-forward，不回滚。
+_GH_REPO = "XiaoMi/xiaomi-miloco"
+_GH_LATEST_API = f"https://api.github.com/repos/{_GH_REPO}/releases/latest"
+_INSTALL_SH_URL = f"https://github.com/{_GH_REPO}/releases/latest/download/install.sh"
+_UPGRADE_CHECK_TTL_S = 6 * 3600
+# 失败（GitHub 不可达/限流）时的短退避 TTL：负缓存，避免故障期间每次开页都重打接口
+# （正是缓存要防的）。成功缓存 6h，失败仅缓存 10min 后重试。
+_UPGRADE_CHECK_NEG_TTL_S = 10 * 60
+
+# 服务端共享缓存（进程内），避免多用户每次打开页面都打 GitHub / 触发限流。
+_upgrade_check_cache: dict = {"ts": 0.0, "data": None}
+# 一键升级单飞标志（进程内；升级成功会重启 backend，重启后自然复位）。用时间戳而非
+# 布尔：正常路径靠重启复位，但若 detached 脚本在重启服务前就失败（如 curl 下载失败、
+# set -e 提前中止，service 从未停/起），当前 backend 会一直存活且标志永远为 True，导致
+# 后续一键升级永久 409。故加 TTL 自愈——超过 TTL 视为上次尝试已失败，允许重新触发。
+# **TTL 必须 ≥ 前端轮询超时（POLL_TIMEOUT_MS=20min）**：否则一次合法的慢升级（冷下载
+# 68MB 可达十几分钟）跑到 15min 后，第二个标签页仍看到缓存 has_update 触发 /run 就能通过
+# 单飞、起第二个 install.sh，与第一个抢共享下载缓存 + 抢 upgrade.log 截断 + 抢 service restart。
+_UPGRADE_SINGLEFLIGHT_TTL_S = 25 * 60
+# 单飞状态放进可变 dict 而非模块级标量：subscript 赋值是"就地修改"、非全局名重绑定，
+# 从而避开 CodeQL py/unused-global-variable 的跨调用误报（标量 global 在函数内写后当轮不再读，
+# 静态分析看不到"下次请求才读"而误判为写死）。语义不变：进程级、跨请求持久的单飞时间戳。
+_upgrade_state: dict[str, float] = {"started_at": 0.0}
+
+
+# 「已确认（dismiss）到的版本」：用户关闭升级 banner 即记录于此，之后该版本 banner 永久不再
+# 出现、直到出现更新的版本。**存后端**（MILOCO_HOME 下文件），不放浏览器——随服务器状态走：
+# 彻底卸载/重装即清零、跨浏览器一致、可测、不被浏览器缓存干扰。红点不看它（有更新就显）。
+def _dismiss_file() -> Path:
+    return miloco_home() / "upgrade_dismissed"
+
+
+def _read_dismissed() -> str | None:
+    try:
+        v = _dismiss_file().read_text(encoding="utf-8").strip()
+        return v or None
+    except FileNotFoundError:
+        return None
+    except Exception:
+        return None
+
+
+def _write_dismissed(version: str) -> None:
+    # 尽力持久化：写盘失败（磁盘满/权限）不该让"关 banner"这个纯 UI 动作 500。失败只记
+    # 日志、静默降级——banner 本次仍会隐藏（前端已就地更新），仅重载后可能再现。
+    try:
+        _dismiss_file().write_text(version.strip(), encoding="utf-8")
+    except Exception as e:
+        logger.warning("failed to persist dismissed version %s: %s", _scrub_log(version), e)
+
+
+def _scrub_log(value: object) -> str:
+    """中和插入日志的外部值里的 CR/LF，防日志伪造/注入（CodeQL py/log-injection）。"""
+    return str(value).replace("\r", " ").replace("\n", " ")
+
+
+def _deploy_kind() -> str:
+    """release = 正式发布版（干净 CalVer tag）；dev = git checkout / 未打 tag 的构建。
+
+    用**包版本串**判定而非 ``git rev-parse``：后者会沿目录向上误命中 $HOME / venv 所在的
+    无关 .git 仓库（如 dotfiles 仓），把正式 wheel 部署误判成 dev、白白禁用一键升级。
+    hatch-vcs 对非 tag 构建会写 ``.dev<N>`` / ``+g<sha>`` 本地段；干净 tag 版则没有。"""
+    v = _pkg_version()
+    if v == "unknown":
+        return "release"
+    return "dev" if (".dev" in v or _HATCH_VCS_LOCAL_RE.search(v)) else "release"
+
+
+def _norm_ver(v: str) -> str:
+    return v[1:] if v.startswith("v") else v
+
+
+def _latest_is_newer(current: str, latest: str) -> bool:
+    """latest 是否严格新于 current（按 PEP440/CalVer 解析，非字符串比较）。
+
+    packaging 是 miloco 的传递依赖（非直接声明）。若环境里缺失（ImportError）、
+    或版本串非法（InvalidVersion）、或任何解析异常，都**保守视为"无更新"**并静默降级——
+    绝不让 ``/upgrade/check`` 因版本比较抛错而 500（宁可不提示，也不误报/不崩）。
+    """
+    try:
+        from packaging.version import Version
+
+        return Version(_norm_ver(latest)) > Version(_norm_ver(current))
+    except Exception as e:
+        # latest 源自 GitHub tag_name（外部可控），current 源自本地包版本——统一经
+        # _scrub_log 中和 CR/LF，与 upgrade_run/_write_dismissed 一致地闭合日志注入这一类。
+        # 异常 e 也必须 _scrub_log：packaging 的 InvalidVersion 会把原始（未净化的）版本串
+        # 原样嵌进消息（"Invalid version: '<latest>'"），直接打 e 等于把 latest 的 CR/LF
+        # 从旁路重新带回日志、抵消上面对 latest 的净化——故一并中和。
+        logger.info(
+            "upgrade check: version compare failed (%s vs %s): %s",
+            _scrub_log(current),
+            _scrub_log(latest),
+            _scrub_log(e),
+        )
+        return False
+
+
+async def _fetch_latest_release() -> dict | None:
+    """查 GitHub releases/latest（最新正式版）。不可达 / 失败返回 None，不抛。"""
+    try:
+        async with httpx.AsyncClient(timeout=8.0) as client:
+            r = await client.get(
+                _GH_LATEST_API, headers={"Accept": "application/vnd.github+json"}
+            )
+        if r.status_code != 200:
+            return None
+        j = r.json()
+        tag = j.get("tag_name")
+        if not tag:
+            return None
+        return {"tag": tag, "html_url": j.get("html_url")}
+    except Exception as e:  # 网络不可达 / 超时 / 解析失败 → 静默降级，不打扰用户
+        # e 亦经 _scrub_log：JSONDecodeError 等可能把响应体片段（外部数据）嵌进消息，
+        # 与 _latest_is_newer 一致地闭合日志注入旁路。
+        logger.info("upgrade check: fetch latest release failed: %s", _scrub_log(e))
+        return None
+
+
+@router.get(
+    "/upgrade/check",
+    summary="Check whether a newer official release is available",
+    response_model=NormalResponse,
+)
+async def upgrade_check(
+    force: bool = Query(
+        False, description="跳过服务端缓存强制现查一次（供用户手动「检查更新」）"
+    ),
+    current_user: str = Depends(verify_token),
+):
+    """检测是否有新版本。前端打开页面时调一次（走服务端缓存、无轮询）；用户手动「检查更新」
+    时带 ``force=true`` 跳过缓存现查一次。GitHub 不可达时 ``reachable=false`` 且
+    ``has_update=false``——不报错、不打扰。dev(git) 部署不给一键升级，仅提示。"""
+    current = _pkg_version()
+    kind = _deploy_kind()
+    now = time.time()
+
+    # 负缓存：失败(rel=None)也缓存，但用更短 TTL 退避——ts==0 表示从未查过。
+    # force：用户手动检查，跳过缓存强制现查（结果仍写回缓存）。
+    ts = _upgrade_check_cache["ts"]
+    cached = _upgrade_check_cache["data"]
+    ttl = _UPGRADE_CHECK_TTL_S if cached is not None else _UPGRADE_CHECK_NEG_TTL_S
+    if force or ts == 0.0 or (now - ts) > ttl:
+        rel = await _fetch_latest_release()
+        if rel is not None:
+            _upgrade_check_cache["data"] = rel
+            _upgrade_check_cache["ts"] = now
+        elif cached is not None:
+            # 一次抖动（GitHub 限流/超时）不清空上次好结果——否则 banner 会因短暂不可达消失。
+            # 把 ts 回拨成"再过 NEG_TTL 就重试"，保留旧好值继续展示。
+            _upgrade_check_cache["ts"] = now - (
+                _UPGRADE_CHECK_TTL_S - _UPGRADE_CHECK_NEG_TTL_S
+            )
+            rel = cached
+        else:
+            # 从未成功过：记不可达，NEG_TTL 短退避后再试。
+            _upgrade_check_cache["data"] = None
+            _upgrade_check_cache["ts"] = now
+    else:
+        rel = cached
+
+    reachable = rel is not None
+    latest = _norm_ver(rel["tag"]) if reachable else None
+    has_update = bool(
+        reachable and kind == "release" and _latest_is_newer(current, rel["tag"])
+    )
+    return NormalResponse(
+        code=0,
+        message="upgrade check",
+        data={
+            "current": current,
+            "latest": latest,
+            "has_update": has_update,
+            "deploy_kind": kind,
+            "release_url": rel["html_url"] if reachable else None,
+            "reachable": reachable,
+            "checked_at": int(_upgrade_check_cache["ts"]),
+            # 已确认版本（后端持久化）。前端据此决定 banner 显隐：latest === dismissed 则不显。
+            "dismissed": _read_dismissed(),
+        },
+    )
+
+
+@router.post(
+    "/upgrade/dismiss",
+    summary="Dismiss the upgrade banner for a version (won't reappear until a newer release)",
+    response_model=NormalResponse,
+)
+async def upgrade_dismiss(
+    version: str = Query(..., description="要标记为已确认的版本号（一般传当前 latest）"),
+    current_user: str = Depends(verify_token),
+):
+    """用户关闭升级 banner 时调用：把该版本记为「已确认」并持久化到后端（MILOCO_HOME）。
+    之后 banner 对该版本永久不再出现，直到出现更新的版本。语义与存储位置解释见 `_read_dismissed`。"""
+    v = _norm_ver(version)
+    _write_dismissed(v)
+    return NormalResponse(code=0, message="dismissed", data={"dismissed": v})
+
+
+@router.post(
+    "/upgrade/run",
+    summary="Trigger a one-click upgrade to the latest official release",
+    response_model=NormalResponse,
+)
+async def upgrade_run(current_user: str = Depends(verify_token)):
+    """一键升级：detached 起官方 install.sh（非交互 agent 模式）覆盖安装并重启服务。
+    仅 release 部署可用；dev(git) 拒绝。升级进程脱离 backend 进程组，backend 被安装器
+    重启也不影响它；日志落 ``<log_dir>/upgrade.log``。roll-forward、不回滚——失败由
+    前端引导用户重跑 install.sh / 查日志。"""
+    if _deploy_kind() != "release":
+        raise HTTPException(
+            status_code=400,
+            detail="git checkout deployment: use `git pull`; one-click upgrade is disabled",
+        )
+    # 前置校验：确实有更新才升（防御纵深——前端已 gate 按钮，但直接 POST 也不该
+    # 触发"重装同版本"式的无谓重启）。latest 取自 /check 的服务端缓存；不可达/未查过
+    # 时保守拒绝，让前端先跑 check。
+    current = _pkg_version()
+    latest_rel = _upgrade_check_cache["data"]
+    target = _norm_ver(latest_rel["tag"]) if latest_rel else None
+    if not latest_rel or not _latest_is_newer(current, latest_rel["tag"]):
+        # 400（非 409）：与"已在升级中"区分开——前端据状态码判定，409=接管进度、400=失败提示。
+        raise HTTPException(
+            status_code=400,
+            detail="already on the latest release (or latest unknown); nothing to upgrade",
+        )
+    since_last = time.time() - _upgrade_state["started_at"]
+    if _upgrade_state["started_at"] and since_last < _UPGRADE_SINGLEFLIGHT_TTL_S:
+        # 单飞 TTL 内——但若上次尝试已在日志写下终态标记（done/failed），证明它已彻底
+        # 结束、无进程在跑（终态是脚本 exit 前最后一步 echo），提前解除单飞允许重试，
+        # 避免快失败（如 curl 连不上 GitHub/限流，install 从未跑、原 backend 从未重启）
+        # 后被硬锁满 TTL。这**不违反单飞不变量**（TTL 常量与「TTL ≥ 前端轮询超时」不等式
+        # 均不变，仅在有正向"已结束"证据时短路）：仍在跑的慢升级日志无终态标记 → 照旧 409，
+        # 不会起第二个 install.sh 与其抢下载缓存/日志/重启。此判定与 /run 其余部分同样无
+        # await，事件循环内原子执行；放行后 open("w") 会截断残留日志、重开一份干净的。
+        if _read_upgrade_phase() not in _UPGRADE_TERMINAL_PHASES:
+            raise HTTPException(
+                status_code=409, detail="an upgrade is already in progress"
+            )
+
+    launched = False
+    try:
+        settings = get_settings()
+        log_dir = Path(settings.directories.log_dir)
+        log_dir.mkdir(parents=True, exist_ok=True)
+        upgrade_log = log_dir / "upgrade.log"
+        home = miloco_home()
+        tmp_sh = home / ".upgrade-install.sh"
+
+        # 关键点：
+        #  - `export MILOCO_LANG=zh`：把安装器日志语言**钉死为中文**，使 /upgrade/status 的
+        #    阶段解析与服务器 LANG 无关（否则英文 locale 服务器上日志是英文、中文标记全不匹配、
+        #    进度失灵）。日志是内部产物，用户看到的步骤文字走前端 i18n、跟随网页语言，与此无关。
+        #  - 路径经 shlex.quote 防注入（MILOCO_HOME 来自环境变量，双引号内仍会展开 $()/反引号）。
+        #  - **不能用 `set -e`**：curl 下载失败（连不上 GitHub / 限流——恰是最常见的失败）会让
+        #    `set -e` 在写终态标记前就中止整脚本，日志无 AGENT_UPGRADE_FAILED，前端只能空等
+        #    20min 轮询超时才知失败。故改为把 curl 用 `|| rc=$?` 收进 rc、下载失败即跳过安装、
+        #    仍走到末尾 echo AGENT_UPGRADE_FAILED，保证任何失败都有终态标记（快失败）。
+        #  - 末尾无条件 `service start` 兜底 install.py 的 atexit 停服务（curl 失败时服务从未被
+        #    停、start 幂等无害）；prepare/finish 用 `&&`+`|| rc=$?`，失败也走到 service start
+        #    （roll-forward、不回滚），最后以安装码收尾。
+        #  - **终态标记**：install.py 在 prepare/finish 里会多次重启到新版本（新版本会"提前"
+        #    可达），单看版本变更会误判完成。故脚本在**全部跑完 + 最后一次 service start 之后**
+        #    才 echo AGENT_UPGRADE_DONE/FAILED 到日志——这是整个升级唯一可靠的终态信号，
+        #    /upgrade/status 据此报 done/failed，前端只认这个标记才判完成，不看中途版本变更。
+        #  - `export MILOCO_HOME` + `--agent-platform`：安装器**不会**从已装环境反推这两者。
+        #    install.py 的 _decide_agent_platform 在非交互 agent 模式下不读已持久化的
+        #    agent.platform，缺参即 fallback "openclaw"；MILOCO_HOME 缺失时又按该平台推默认
+        #    路径（hermes 部署实际在 ~/.hermes/miloco）。两者都靠继承 backend 环境不可靠 →
+        #    hermes 部署会被当成 openclaw 升级：插件步走 openclaw 分支（主机多半无 openclaw
+        #    CLI → 整体失败），hermes 的 adapter 部署 / config set / plugins enable /
+        #    post-install 对账整段被跳过。故显式读本端平台透传、并把本端实际 MILOCO_HOME
+        #    钉进子进程环境。
+        q_url = shlex.quote(_INSTALL_SH_URL)
+        q_sh = shlex.quote(str(tmp_sh))
+        q_home = shlex.quote(str(home))
+        # 白名单：install.py 的 --agent-platform 是 choices=["", "openclaw", "hermes"]，
+        # 传其它值 argparse 直接 exit(2)、整次升级失败。空/未知值不传，退回安装器默认。
+        platform = (settings.agent.platform or "").strip()
+        plat_flag = f" --agent-platform={platform}" if platform in ("openclaw", "hermes") else ""
+        script = (
+            f"export MILOCO_HOME={q_home}; export MILOCO_LANG=zh; rc=0; "
+            f"curl -fsSL {q_url} -o {q_sh} || rc=$?; "
+            'if [ "$rc" = "0" ]; then '
+            f"bash {q_sh} --agent-prepare{plat_flag} && "
+            f"bash {q_sh} --agent-finish{plat_flag} || rc=$?; "
+            "fi; "
+            "miloco-cli service start || true; "
+            'if [ "$rc" = "0" ]; then echo "AGENT_UPGRADE_DONE"; '
+            'else echo "AGENT_UPGRADE_FAILED rc=$rc"; fi; '
+            # 清理下载的临时安装脚本：放在终态标记 echo 之后，不影响进度/终态解析；
+            # 无论 done/failed 都删，避免 MILOCO_HOME 长期残留 .upgrade-install.sh。
+            f"rm -f {q_sh}; "
+            "exit $rc"
+        )
+        # 截断（"w"）：每次升级独立日志，避免上轮旧内容让 /upgrade/status 误报阶段。
+        logf = open(upgrade_log, "w")
+        try:
+            subprocess.Popen(
+                ["bash", "-lc", script],
+                cwd=str(home),
+                stdin=subprocess.DEVNULL,
+                stdout=logf,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,  # 脱离 backend 进程组/会话，重启 backend 不波及它
+            )
+            # 起进程成功即占单飞（在 finally 关 fd 之前置位）：即便随后 logf.close() 抛错走到
+            # except，也不会漏计已启动的进程、避免下一次 /run 与其并起第二个 install.sh。
+            launched = True
+            _upgrade_state["started_at"] = time.time()
+        finally:
+            logf.close()  # 子进程已 dup fd，父进程可关
+    except HTTPException:
+        raise
+    except Exception as e:
+        # 启动失败（未起任何进程）：显式释放单飞。否则若本次是「快失败后重试」（上一轮已写终态
+        # 标记、_upgrade_state["started_at"] 仍在 TTL 内），上面的 open("w") 已把日志截断、终态标记丢失
+        # （phase 退回 starting=非终态），而 _upgrade_state["started_at"] 未被本次刷新 → TTL 内后续 /run
+        # 恒 409 锁死用户，却根本没有进程在跑。未起进程即释放，允许立即重试（fail-open 且安全：
+        # 无进程 → 不会 racing）。
+        if not launched:
+            _upgrade_state["started_at"] = 0.0
+        logger.error("failed to launch upgrade process: %s", _scrub_log(e))
+        raise HTTPException(
+            status_code=500, detail="failed to launch upgrade process"
+        ) from e
+
+    # 审计日志刻意**不插入** target / current_user：current_user 恒为 None（verify_token
+    # 返回 None、仅做鉴权），target 源自 GitHub tag（外部可控）——两者都是 CodeQL 日志注入
+    # 的污点源。目标版本已随响应体 data.target 返回给调用方，无需再进日志。静态文案即可、
+    # 零外部值进日志，彻底闭合 py/log-injection（不靠脱敏兜）。
+    logger.info("one-click upgrade triggered")
+    return NormalResponse(
+        code=0,
+        message="upgrade started",
+        data={"started": True, "target": target},
+    )
+
+
+# upgrade.log 阶段锚点。取在日志中**出现位置最靠后**（rfind）的标记，而非列表顺序——
+# 因为安装器会先打印「安装核心组件」标题、再打印「正在下载」，按列表顺序会把整段下载误判成安装。
+# 升级子进程强制 MILOCO_LANG=zh（见 /upgrade/run），中文标记确定可匹配；归档名 `.tar.gz`
+# 与语言无关，作下载兜底锚点。done/failed 由 /upgrade/run 脚本在全部跑完后 echo，是整个升级
+# 唯一可靠的终态标记（位置必在最后）——前端只认它判完成，不看中途"提前"的版本变更。
+# 前端把 downloading/installing 映射到「下载」「安装」步，「重启」由前端凭后端连不上判定。
+_UPGRADE_STAGES = [
+    (".tar.gz", "downloading"),
+    ("正在下载", "downloading"),
+    ("安装核心组件", "installing"),
+    ("安装 miloco", "installing"),
+    ("初始化服务", "installing"),
+    ("引擎预热", "installing"),
+    ("准备感知模型", "installing"),
+    ("解压感知模型", "installing"),
+    ("AGENT_JSON", "installing"),
+    ("AGENT_UPGRADE_FAILED", "failed"),
+    ("AGENT_UPGRADE_DONE", "done"),
+]
+
+# 终态标记：脚本 exit 前的最后一步 echo，出现即证明升级子进程已彻底结束（无进程在跑）。
+_UPGRADE_TERMINAL_PHASES = ("done", "failed")
+
+
+def _read_upgrade_phase() -> str:
+    """从 upgrade.log 解析当前升级阶段（单一事实源，/upgrade/status 与单飞自愈共用）。
+
+    无日志 → idle；有日志但无任何锚点 → starting；否则取**出现位置最靠后**（rfind）
+    的阶段。强制 utf-8 解码：日志已被 MILOCO_LANG=zh 钉成中文，若按 locale 默认
+    （C/POSIX）解码中文标记会成 U+FFFD 全不匹配、进度失灵；errors="replace" 只兜底
+    非法字节，不改匹配。
+    """
+    settings = get_settings()
+    log = Path(settings.directories.log_dir) / "upgrade.log"
+    if not log.exists():
+        return "idle"
+    try:
+        text = log.read_text(encoding="utf-8", errors="replace")[-8000:]
+    except Exception:
+        text = ""
+    phase, best_pos = "starting", -1
+    for marker, ph in _UPGRADE_STAGES:
+        pos = text.rfind(marker)
+        if pos > best_pos:
+            best_pos, phase = pos, ph  # 取日志中出现位置最靠后的阶段
+    return phase
+
+
+@router.get(
+    "/upgrade/status",
+    summary="Progress of an in-flight one-click upgrade (parsed from upgrade.log)",
+    response_model=NormalResponse,
+)
+async def upgrade_status(current_user: str = Depends(verify_token)):
+    """升级阶段：从 upgrade.log 解析当前处于哪一阶段，供前端点亮对应步骤 / 判完成。
+    「重启」阶段本端点随 backend 一起消失（前端凭连不上判定）。
+    返回 phase ∈ {idle, starting, downloading, installing, done, failed}。"""
+    return NormalResponse(
+        code=0, message="upgrade status", data={"phase": _read_upgrade_phase()}
     )
 
 

--- a/backend/miloco/tests/admin/test_upgrade_endpoint.py
+++ b/backend/miloco/tests/admin/test_upgrade_endpoint.py
@@ -1,0 +1,701 @@
+"""升级检测 / 一键升级端点与 helper 的单元测试。
+
+覆盖（对齐规格 kind-percolating-valiant.md 的验证清单）:
+- 版本比较 `_latest_is_newer`：newer / equal / older / dev 后缀 / 非法串容错。
+- `_deploy_kind`：版本串含 hatch-vcs 本地段（.dev/+g）→ dev；干净 CalVer tag / unknown
+  → release（基于**版本串**判定，不依赖 .git 探测——见 router._deploy_kind 注释）。
+- `_norm_ver`：strip 前导 v。
+- `GET /upgrade/check`：release+有新版 → has_update；GitHub 不可达 → reachable=false、
+  不 500、has_update=false；dev 部署即使远端更新也 has_update=false（只提示不给一键）。
+- `POST /upgrade/run`：dev → 400；release → 起 detached 进程（Popen 被 mock）+ 单飞 409。
+- `POST /upgrade/run` 的安装器调用契约：显式 export MILOCO_HOME + 按本端 agent.platform
+  透传 --agent-platform（缺参时 install.py 会 fallback openclaw，hermes 部署会被装歪）。
+"""
+
+import asyncio
+import re
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import miloco.admin.router as R
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from miloco.admin.router import router
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    from miloco.config.settings import reset_settings
+
+    monkeypatch.setenv("MILOCO_HOME", str(tmp_path))
+    monkeypatch.delenv("MILOCO_DIRECTORIES__STORAGE", raising=False)
+    reset_settings()
+    # 每个用例都从干净的进程内缓存 / 单飞标志开始，避免用例间串味。
+    R._upgrade_check_cache = {"ts": 0.0, "data": None}
+    R._upgrade_state["started_at"] = 0.0
+    app = FastAPI()
+    app.include_router(router, prefix="/api")
+    yield TestClient(app)
+    reset_settings()
+    R._upgrade_check_cache = {"ts": 0.0, "data": None}
+    R._upgrade_state["started_at"] = 0.0
+
+
+# ─── _norm_ver ────────────────────────────────────────────────────────────────
+
+
+def test_norm_ver_strips_leading_v():
+    assert R._norm_ver("v2026.7.3") == "2026.7.3"
+    assert R._norm_ver("2026.7.3") == "2026.7.3"
+    assert R._norm_ver("") == ""
+
+
+# ─── _latest_is_newer ───────────────────────────────────────────────────────────
+
+
+class TestLatestIsNewer:
+    def test_strictly_newer(self):
+        assert R._latest_is_newer("2026.7.2", "2026.7.3") is True
+
+    def test_equal_is_not_newer(self):
+        assert R._latest_is_newer("2026.7.3", "2026.7.3") is False
+
+    def test_older_is_not_newer(self):
+        assert R._latest_is_newer("2026.7.3", "2026.7.2") is False
+
+    def test_v_prefix_normalized_both_sides(self):
+        assert R._latest_is_newer("v2026.7.2", "v2026.7.3") is True
+
+    def test_dev_suffix_pep440_prerelease_semantics(self):
+        # PEP440：`X.dev5` 是 `X` 的预发布，严格小于正式 X。故正式 tag 视为“更新”
+        # （dev 部署实际不给一键，此处只验证版本序关系正确）。
+        assert R._latest_is_newer("2026.7.3.dev5+g1234567", "2026.7.3") is True
+        assert R._latest_is_newer("2026.7.2.dev5+g1234567", "2026.7.3") is True
+        # 已在正式版之上的本地 dev 构建（领先 tag）→ 不算有更新。
+        assert R._latest_is_newer("2026.7.4.dev1+g1234567", "2026.7.3") is False
+
+    def test_invalid_version_string_is_graceful(self):
+        # 非法版本串不得抛（否则 /check 会 500）；保守视为无更新。
+        assert R._latest_is_newer("not-a-version", "2026.7.3") is False
+        assert R._latest_is_newer("2026.7.2", "garbage!!!") is False
+
+    def test_packaging_missing_is_graceful(self):
+        # packaging 是传递依赖；即便 ImportError 也应静默降级为“无更新”。
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *a, **k):
+            if name == "packaging.version" or name.startswith("packaging"):
+                raise ImportError("no packaging")
+            return real_import(name, *a, **k)
+
+        with patch("builtins.__import__", side_effect=fake_import):
+            assert R._latest_is_newer("2026.7.2", "2026.7.3") is False
+
+
+# ─── _deploy_kind ────────────────────────────────────────────────────────────────
+
+
+def test_deploy_kind_dev_when_version_has_local_segment():
+    # hatch-vcs 对非 tag 构建写 .dev/+g 本地段 → dev（与所在目录有无 .git 无关，
+    # 从而不会因 $HOME/venv 恰在某个无关 git 仓库里而把正式 wheel 误判成 dev）。
+    with patch(
+        "miloco.admin.router._pkg_version", return_value="2026.7.4.dev41+g1234567"
+    ):
+        assert R._deploy_kind() == "dev"
+
+
+def test_deploy_kind_release_when_clean_version():
+    with patch("miloco.admin.router._pkg_version", return_value="2026.7.3"):
+        assert R._deploy_kind() == "release"
+
+
+def test_deploy_kind_release_when_version_unknown():
+    with patch("miloco.admin.router._pkg_version", return_value="unknown"):
+        assert R._deploy_kind() == "release"
+
+
+# ─── GET /upgrade/check ─────────────────────────────────────────────────────────
+
+
+def test_check_release_has_update(client):
+    async def fake_fetch():
+        return {"tag": "v2026.7.3", "html_url": "https://gh/rel/2026.7.3"}
+
+    with (
+        # release 判定来自干净版本串 "2026.7.2"（无 .dev/+g 本地段），与 .git 无关。
+        patch("miloco.admin.router._pkg_version", return_value="2026.7.2"),
+        patch("miloco.admin.router._fetch_latest_release", side_effect=fake_fetch),
+    ):
+        resp = client.get("/api/admin/upgrade/check")
+    body = resp.json()
+    assert resp.status_code == 200
+    d = body["data"]
+    assert d["deploy_kind"] == "release"
+    assert d["reachable"] is True
+    assert d["current"] == "2026.7.2"
+    assert d["latest"] == "2026.7.3"
+    assert d["has_update"] is True
+    assert d["release_url"] == "https://gh/rel/2026.7.3"
+
+
+def test_check_up_to_date_no_update(client):
+    async def fake_fetch():
+        return {"tag": "v2026.7.2", "html_url": "https://gh/rel/2026.7.2"}
+
+    with (
+        patch("miloco.admin.router._pkg_version", return_value="2026.7.2"),
+        patch("miloco.admin.router._fetch_latest_release", side_effect=fake_fetch),
+    ):
+        resp = client.get("/api/admin/upgrade/check")
+    d = resp.json()["data"]
+    assert d["reachable"] is True
+    assert d["has_update"] is False
+
+
+def test_check_github_unreachable_graceful(client):
+    async def fake_fetch():
+        return None  # 不可达 / 超时 / 解析失败
+
+    with (
+        patch("miloco.admin.router._pkg_version", return_value="2026.7.2"),
+        patch("miloco.admin.router._fetch_latest_release", side_effect=fake_fetch),
+    ):
+        resp = client.get("/api/admin/upgrade/check")
+    assert resp.status_code == 200  # 关键：不 500
+    d = resp.json()["data"]
+    assert d["reachable"] is False
+    assert d["has_update"] is False
+    assert d["latest"] is None
+    assert d["release_url"] is None
+
+
+def test_check_dev_deploy_never_has_update(client):
+    async def fake_fetch():
+        return {"tag": "v2026.7.3", "html_url": "https://gh/rel/2026.7.3"}
+
+    with (
+        # dev = 版本带 hatch-vcs 本地段
+        patch(
+            "miloco.admin.router._pkg_version",
+            return_value="2026.7.2.dev5+g1234567",
+        ),
+        patch("miloco.admin.router._fetch_latest_release", side_effect=fake_fetch),
+    ):
+        resp = client.get("/api/admin/upgrade/check")
+    d = resp.json()["data"]
+    assert d["deploy_kind"] == "dev"
+    assert d["has_update"] is False  # dev 只提示、不判 has_update
+
+
+def test_check_uses_cache_within_ttl(client):
+    calls = {"n": 0}
+
+    async def fake_fetch():
+        calls["n"] += 1
+        return {"tag": "v2026.7.3", "html_url": "https://gh/rel"}
+
+    with (
+        patch("miloco.admin.router._pkg_version", return_value="2026.7.2"),
+        patch("miloco.admin.router._fetch_latest_release", side_effect=fake_fetch),
+    ):
+        client.get("/api/admin/upgrade/check")
+        client.get("/api/admin/upgrade/check")
+    assert calls["n"] == 1  # 第二次命中服务端缓存，不再打 GitHub
+
+
+def test_check_force_bypasses_fresh_cache(client):
+    # 用户手动「检查更新」：force=true 跳过仍新鲜的缓存、强制现查一次。
+    calls = {"n": 0}
+
+    async def fake_fetch():
+        calls["n"] += 1
+        return {"tag": "v2026.7.3", "html_url": "https://gh/rel"}
+
+    with (
+        patch("miloco.admin.router._pkg_version", return_value="2026.7.2"),
+        patch("miloco.admin.router._fetch_latest_release", side_effect=fake_fetch),
+    ):
+        client.get("/api/admin/upgrade/check")  # fetch #1，填缓存
+        client.get("/api/admin/upgrade/check")  # 命中缓存，不 fetch
+        client.get("/api/admin/upgrade/check?force=true")  # 跳过缓存 → fetch #2
+    assert calls["n"] == 2
+
+
+# ─── POST /upgrade/dismiss（已确认版本存后端，非浏览器）──────────────────────────
+
+
+def test_dismiss_persists_and_check_returns_it(client):
+    async def fake_fetch():
+        return {"tag": "v2026.7.3", "html_url": "https://gh/rel"}
+
+    with (
+        patch("miloco.admin.router._pkg_version", return_value="2026.7.2"),
+        patch("miloco.admin.router._fetch_latest_release", side_effect=fake_fetch),
+    ):
+        # 未 dismiss 时 check.dismissed 为空
+        assert client.get("/api/admin/upgrade/check").json()["data"]["dismissed"] is None
+        # 关 banner → POST dismiss（v 前缀被规整掉）
+        resp = client.post("/api/admin/upgrade/dismiss?version=v2026.7.3")
+        assert resp.status_code == 200
+        assert resp.json()["data"]["dismissed"] == "2026.7.3"
+        # check 现每次新读，带回已确认版本
+        assert (
+            client.get("/api/admin/upgrade/check").json()["data"]["dismissed"]
+            == "2026.7.3"
+        )
+
+
+def test_dismiss_read_write_roundtrip_and_reset(client, tmp_path):
+    # 存后端文件（MILOCO_HOME 下）；彻底删除 MILOCO_HOME 即清零——模拟"重装=干净"。
+    assert R._read_dismissed() is None
+    R._write_dismissed("v2026.7.3")
+    assert R._read_dismissed() == "v2026.7.3"  # _write 存原样，check 端点侧做 _norm_ver
+    (tmp_path / "upgrade_dismissed").unlink()
+    assert R._read_dismissed() is None
+
+
+# ─── POST /upgrade/run ──────────────────────────────────────────────────────────
+
+
+def _seed_cache_newer():
+    """把 /check 服务端缓存填成"远端有更新"，让 /run 的 has_update 前置校验通过。"""
+    R._upgrade_check_cache = {
+        "ts": 1.0,
+        "data": {"tag": "v2026.7.3", "html_url": "https://gh/rel/2026.7.3"},
+    }
+
+
+def test_run_rejected_on_dev_deploy(client):
+    _seed_cache_newer()
+    with patch(
+        "miloco.admin.router._pkg_version", return_value="2026.7.2.dev5+g1234567"
+    ):  # dev
+        resp = client.post("/api/admin/upgrade/run")
+    assert resp.status_code == 400
+
+
+def test_run_rejected_when_no_newer_release(client):
+    # release 部署但已是最新（缓存 latest == current）→ 400，不触发无谓重装。
+    R._upgrade_check_cache = {
+        "ts": 1.0,
+        "data": {"tag": "v2026.7.3", "html_url": "https://gh/rel"},
+    }
+    with patch("miloco.admin.router._pkg_version", return_value="2026.7.3"):
+        resp = client.post("/api/admin/upgrade/run")
+    # 400（非 409）：与"已在升级中"区分——前端 409 接管进度、400 提示失败。
+    assert resp.status_code == 400
+
+
+def test_run_rejected_when_latest_unknown(client):
+    # 从未成功 check（缓存空）→ 无法确认有更新 → 保守 400，引导前端先 check。
+    R._upgrade_check_cache = {"ts": 0.0, "data": None}
+    with patch("miloco.admin.router._pkg_version", return_value="2026.7.2"):
+        resp = client.post("/api/admin/upgrade/run")
+    assert resp.status_code == 400
+
+
+def test_run_starts_detached_and_singleflight(client):
+    launched = {"n": 0, "argv": None}
+
+    class FakePopen:
+        def __init__(self, *a, **k):
+            launched["n"] += 1
+            launched["argv"] = a[0] if a else k.get("args")
+            # 断言 detached 关键参数就位
+            assert k.get("start_new_session") is True
+            assert k.get("stdin") is not None
+
+    _seed_cache_newer()
+    with (
+        patch("miloco.admin.router._pkg_version", return_value="2026.7.2"),  # release
+        patch("miloco.admin.router.subprocess.Popen", FakePopen),
+    ):
+        resp1 = client.post("/api/admin/upgrade/run")
+        assert resp1.status_code == 200
+        assert resp1.json()["data"]["started"] is True
+        assert resp1.json()["data"]["target"] == "2026.7.3"
+        # 单飞：TTL 内二次触发被拒。
+        resp2 = client.post("/api/admin/upgrade/run")
+        assert resp2.status_code == 409
+    assert launched["n"] == 1  # 只起了一个进程
+
+    # 断言 detached 脚本的关键契约（回归保护——这些是进度/终态/安全的命脉）：
+    argv = launched["argv"]
+    assert argv[:2] == ["bash", "-lc"]
+    script = argv[2]
+    assert "export MILOCO_LANG=zh" in script  # 日志语言钉死 → 进度解析跨 locale 可靠
+    assert "--agent-prepare" in script and "--agent-finish" in script
+    assert "AGENT_UPGRADE_DONE" in script  # 终态标记：前端只认它判完成
+    assert "AGENT_UPGRADE_FAILED" in script
+    # 末尾无条件 service start：兜底 install.py 在 agent 流程 atexit 停掉的服务——这是
+    # 升级成功后把 backend 拉回来的唯一机制，缺它则每次成功升级都留下死掉的服务。
+    assert "miloco-cli service start" in script
+    # 路径经 shlex.quote（URL 是常量 https://…，quote 后不带引号但含 ://）
+    assert "https://github.com/XiaoMi/xiaomi-miloco" in script
+    # 回归：curl 下载失败也必须落到 AGENT_UPGRADE_FAILED（终态契约，快失败）——
+    # 不能用 set -e（会在写标记前提前中止），curl 须被 `|| rc=$?` 收进 rc。
+    assert "set -e" not in script
+    assert re.search(r"curl -fsSL \S+ -o \S+ \|\| rc=\$\?", script)
+    # MILOCO_HOME 必须显式 export（不靠继承 backend 环境）：缺它时 install.py 会按
+    # agent 平台推默认路径（openclaw→~/.openclaw/miloco），把升级装到别处。
+    assert re.search(r"export MILOCO_HOME=\S+;", script)
+
+
+def _run_and_capture_script(client) -> str:
+    """触发一次 /upgrade/run（Popen 被 mock），返回 detached 脚本正文。"""
+    captured = {"script": ""}
+
+    class FakePopen:
+        def __init__(self, *a, **k):
+            captured["script"] = (a[0] if a else k.get("args"))[2]
+
+    _seed_cache_newer()
+    with (
+        patch("miloco.admin.router._pkg_version", return_value="2026.7.2"),
+        patch("miloco.admin.router.subprocess.Popen", FakePopen),
+    ):
+        assert client.post("/api/admin/upgrade/run").status_code == 200
+    return captured["script"]
+
+
+class TestAgentPlatformPassthrough:
+    """跨 PR 契约：install.py 的 `_decide_agent_platform` 在非交互 agent 模式下**不读**
+    已持久化的 agent.platform，缺 --agent-platform 即 fallback openclaw。故 hermes 部署
+    必须由后端把自己的平台透传下去，否则升级会走 openclaw 插件分支（无 openclaw CLI →
+    整体失败），hermes 的 adapter/config/plugins/post-install 全被跳过。"""
+
+    def test_hermes_platform_forwarded_to_both_steps(self, client, monkeypatch):
+        from miloco.config.settings import reset_settings
+
+        monkeypatch.setenv("MILOCO_AGENT__PLATFORM", "hermes")
+        reset_settings()
+        script = _run_and_capture_script(client)
+        assert "--agent-prepare --agent-platform=hermes" in script
+        assert "--agent-finish --agent-platform=hermes" in script
+
+    def test_empty_platform_omits_flag(self, client):
+        # 未配平台（webhook 过渡模式）→ 不传，退回安装器默认，不改变既有行为。
+        script = _run_and_capture_script(client)
+        assert "--agent-platform" not in script
+
+    def test_unknown_platform_omits_flag(self, client, monkeypatch):
+        # install.py 的 --agent-platform 是 choices 白名单，未知值会让 argparse exit(2)、
+        # 整次升级失败 → 后端只透传已知值，未知值宁可退回默认。
+        from miloco.config.settings import reset_settings
+
+        monkeypatch.setenv("MILOCO_AGENT__PLATFORM", "some-future-platform")
+        reset_settings()
+        script = _run_and_capture_script(client)
+        assert "--agent-platform" not in script
+
+
+def test_run_singleflight_self_heals_after_ttl(client):
+    # 单飞标志超过 TTL 视为上次尝试已失败，允许重新触发（时间戳自愈，防永久 409）。
+    launched = {"n": 0}
+
+    class FakePopen:
+        def __init__(self, *a, **k):
+            launched["n"] += 1
+
+    _seed_cache_newer()
+    R._upgrade_state["started_at"] = time.time() - (R._UPGRADE_SINGLEFLIGHT_TTL_S + 5)
+    with (
+        patch("miloco.admin.router._pkg_version", return_value="2026.7.2"),
+        patch("miloco.admin.router.subprocess.Popen", FakePopen),
+    ):
+        resp = client.post("/api/admin/upgrade/run")
+    assert resp.status_code == 200
+    assert launched["n"] == 1
+
+
+def test_run_singleflight_released_on_terminal_marker(client):
+    # 快失败自愈：单飞标志仍在 TTL 内，但 upgrade.log 已写下终态标记（AGENT_UPGRADE_FAILED）→
+    # 上次尝试已彻底结束、无进程在跑 → 放行重试（200），而非硬锁满 25min 后才可再试。
+    launched = {"n": 0}
+
+    class FakePopen:
+        def __init__(self, *a, **k):
+            launched["n"] += 1
+
+    _seed_cache_newer()
+    R._upgrade_state["started_at"] = time.time()  # 刚"失败"，远在 TTL 内
+    _write_upgrade_log(
+        "▸ 正在下载 miloco 安装包...\nAGENT_UPGRADE_FAILED rc=6\n"  # curl 连不上 → 终态
+    )
+    with (
+        patch("miloco.admin.router._pkg_version", return_value="2026.7.2"),
+        patch("miloco.admin.router.subprocess.Popen", FakePopen),
+    ):
+        resp = client.post("/api/admin/upgrade/run")
+    assert resp.status_code == 200  # 终态证据 → 提前解除单飞
+    assert launched["n"] == 1
+
+
+def test_run_singleflight_held_while_upgrade_in_progress(client):
+    # 反向保护：单飞 TTL 内且日志处于**非终态**（installing，慢升级仍在跑）→ 必须仍 409，
+    # 不得起第二个 install.sh 抢下载缓存/日志/重启（不变量⑦保护的正是这一场景）。
+    launched = {"n": 0}
+
+    class FakePopen:
+        def __init__(self, *a, **k):
+            launched["n"] += 1
+
+    _seed_cache_newer()
+    R._upgrade_state["started_at"] = time.time()
+    _write_upgrade_log(
+        "▸ 正在下载 miloco 安装包...\n✓ miloco 安装包下载完成\n安装 miloco 服务端...\n"
+    )
+    with (
+        patch("miloco.admin.router._pkg_version", return_value="2026.7.2"),
+        patch("miloco.admin.router.subprocess.Popen", FakePopen),
+    ):
+        resp = client.post("/api/admin/upgrade/run")
+    assert resp.status_code == 409  # 非终态 → 单飞照旧生效
+    assert launched["n"] == 0  # 未起第二个进程
+
+
+def test_run_launch_failure_releases_singleflight(client):
+    # 回归：起进程失败（Popen 抛错）时必须释放单飞。场景 = 「快失败后重试」——上一轮已写终态
+    # 标记、_upgrade_state["started_at"] 仍在 TTL 内，本次经终态短路放行进入启动段，但 open("w") 先把
+    # 日志截断（终态标记丢失 → phase 退回 starting=非终态），Popen 随即抛错。若不释放单飞，
+    # _upgrade_state["started_at"] 仍指向上一轮、日志又已非终态 → 后续 /run 恒 409 锁死用户，却根本没有
+    # 进程在跑。启动失败即把 _upgrade_state["started_at"] 归零，允许立即重试。
+    class RaisingPopen:
+        def __init__(self, *a, **k):
+            raise OSError("bash not found")
+
+    _seed_cache_newer()
+    R._upgrade_state["started_at"] = time.time()  # 上一轮尝试仍在 TTL 内
+    _write_upgrade_log("▸ 正在下载 miloco 安装包...\nAGENT_UPGRADE_FAILED rc=6\n")  # 终态
+    with (
+        patch("miloco.admin.router._pkg_version", return_value="2026.7.2"),
+        patch("miloco.admin.router.subprocess.Popen", RaisingPopen),
+    ):
+        resp = client.post("/api/admin/upgrade/run")
+    assert resp.status_code == 500  # 启动失败 → 500
+    assert R._upgrade_state["started_at"] == 0.0  # 未起进程 → 单飞被释放，不会锁死后续重试
+
+    # 证明确实解锁：紧接着一次正常 /run（Popen 成功）应能立即起进程、返回 200。
+    launched = {"n": 0}
+
+    class FakePopen:
+        def __init__(self, *a, **k):
+            launched["n"] += 1
+
+    with (
+        patch("miloco.admin.router._pkg_version", return_value="2026.7.2"),
+        patch("miloco.admin.router.subprocess.Popen", FakePopen),
+    ):
+        resp2 = client.post("/api/admin/upgrade/run")
+    assert resp2.status_code == 200
+    assert launched["n"] == 1
+
+
+# ─── GET /upgrade/status（阶段解析）─────────────────────────────────────────────
+
+
+def _write_upgrade_log(text: str) -> None:
+    from miloco.config import get_settings
+
+    log_dir = Path(get_settings().directories.log_dir)
+    log_dir.mkdir(parents=True, exist_ok=True)
+    (log_dir / "upgrade.log").write_text(text, encoding="utf-8")
+
+
+def test_status_idle_when_no_log(client):
+    d = client.get("/api/admin/upgrade/status").json()["data"]
+    assert d["phase"] == "idle"
+    assert "running" not in d  # running 已移除（重启后进程内标志丢失，不可靠）
+    assert "percent" not in d  # percent 已移除，不再有虚假百分比
+
+
+def test_status_downloading_when_download_marker_is_latest(client):
+    # 关键回归：install.py 先打印「安装核心组件」标题、再打印「正在下载」。按出现位置最靠后
+    # 取阶段（rfind）→ 下载标记在后 → downloading（旧的"列表顺序"实现会误判成 installing）。
+    _write_upgrade_log(
+        "2/3 安装核心组件\n安装 miloco 服务和命令行工具\n"
+        "▸ 正在下载 miloco 安装包...\n  miloco-linux-x86_64-2026.7.3.tar.gz 12/68 MB\n"
+    )
+    d = client.get("/api/admin/upgrade/status").json()["data"]
+    assert d["phase"] == "downloading"
+
+
+def test_status_installing_when_install_marker_is_latest(client):
+    # 下载完成后出现更靠后的安装标记 → installing
+    _write_upgrade_log(
+        "▸ 正在下载 miloco 安装包...\n  miloco-linux-x86_64-2026.7.3.tar.gz\n"
+        "✓ miloco 安装包下载完成\n安装 miloco 服务端...\n"
+    )
+    d = client.get("/api/admin/upgrade/status").json()["data"]
+    assert d["phase"] == "installing"
+
+
+def test_status_done_marker(client):
+    # 脚本末尾 echo 的终态标记（位置在最后）→ done，前端只认它判完成
+    _write_upgrade_log("安装 miloco 服务端\n解压感知模型\nAGENT_UPGRADE_DONE\n")
+    d = client.get("/api/admin/upgrade/status").json()["data"]
+    assert d["phase"] == "done"
+
+
+def test_status_failed_marker(client):
+    _write_upgrade_log("安装 miloco 服务端\nAGENT_UPGRADE_FAILED rc=1\n")
+    d = client.get("/api/admin/upgrade/status").json()["data"]
+    assert d["phase"] == "failed"
+
+
+def test_status_starting_when_log_empty(client):
+    _write_upgrade_log("some unrelated preamble\n")
+    d = client.get("/api/admin/upgrade/status").json()["data"]
+    assert d["phase"] == "starting"
+
+
+# ─── 跨文件契约守护：进度锚点 vs 安装器文案 ──────────────────────────────────────
+
+
+def _find_installer_zh_json():
+    """从 router.py 向上找 scripts/i18n/zh.json（对目录层级不做硬编码假设）。"""
+    for base in Path(R.__file__).resolve().parents:
+        cand = base / "scripts" / "i18n" / "zh.json"
+        if cand.exists():
+            return cand
+    return None
+
+
+def test_upgrade_stage_anchors_exist_in_installer_zh_json():
+    # _read_upgrade_phase 靠 grep install.py 打印的中文日志文案判阶段，这些文案归属
+    # scripts/i18n/zh.json——二者是隐式的跨文件契约。install.py 一旦改文案，下载/安装步会
+    # **静默**失准（升级不坏：终态标记 AGENT_UPGRADE_* + 连不上判重启仍可靠，只是步骤高亮
+    # 漂移）。此测试把该耦合显式化，让安装器改文案时 CI 直接失败、提醒同步 _UPGRADE_STAGES。
+    zh_path = _find_installer_zh_json()
+    if zh_path is None:
+        pytest.skip("scripts/i18n/zh.json 不在源码树内（非源码运行环境），跳过契约守护")
+    zh_text = zh_path.read_text(encoding="utf-8")
+    # 只校验语言相关的中文锚点；.tar.gz / AGENT_* 是语言无关标记，不属该契约。
+    cn_anchors = [m for m, _ph in R._UPGRADE_STAGES if not m.isascii()]
+    assert cn_anchors, "预期 _UPGRADE_STAGES 含中文锚点，实为空——契约守护失效"
+    missing = [m for m in cn_anchors if m not in zh_text]
+    assert not missing, (
+        "以下进度锚点已不在 scripts/i18n/zh.json 中，install.py 文案疑似变更，"
+        f"请同步更新 router._UPGRADE_STAGES：{missing}"
+    )
+
+
+# ─── /check 缓存（正/负）────────────────────────────────────────────────────────
+
+
+def test_check_negative_caches_failure(client):
+    calls = {"n": 0}
+
+    async def fake_fetch():
+        calls["n"] += 1
+        return None  # 不可达
+
+    with (
+        patch("miloco.admin.router._pkg_version", return_value="2026.7.2"),
+        patch("miloco.admin.router._fetch_latest_release", side_effect=fake_fetch),
+    ):
+        client.get("/api/admin/upgrade/check")
+        client.get("/api/admin/upgrade/check")
+    assert calls["n"] == 1  # 失败也进负缓存，短 TTL 内不重复打 GitHub
+
+
+def test_check_keeps_last_good_on_transient_failure(client):
+    # 已有好结果后 GitHub 抖动（fetch=None）：保留上次好值，不清空 → banner 不会因一次
+    # 不可达而消失（has_update 仍为 true）。
+    seq = [
+        {"tag": "v2026.7.3", "html_url": "u"},  # 首次成功
+        None,  # 第二次抖动
+    ]
+
+    async def fake_fetch():
+        return seq.pop(0)
+
+    with (
+        patch("miloco.admin.router._pkg_version", return_value="2026.7.2"),
+        patch("miloco.admin.router._fetch_latest_release", side_effect=fake_fetch),
+    ):
+        r1 = client.get("/api/admin/upgrade/check").json()["data"]
+        assert r1["has_update"] is True and r1["reachable"] is True
+        # 强制过期以触发第二次 fetch（返回 None）
+        R._upgrade_check_cache["ts"] = time.time() - R._UPGRADE_CHECK_TTL_S - 5
+        r2 = client.get("/api/admin/upgrade/check").json()["data"]
+    assert r2["has_update"] is True  # 抖动没清空好值
+    assert r2["latest"] == "2026.7.3"
+
+
+def test_check_refetches_after_ttl(client):
+    calls = {"n": 0}
+
+    async def fake_fetch():
+        calls["n"] += 1
+        return {"tag": "v2026.7.3", "html_url": "u"}
+
+    with (
+        patch("miloco.admin.router._pkg_version", return_value="2026.7.2"),
+        patch("miloco.admin.router._fetch_latest_release", side_effect=fake_fetch),
+    ):
+        client.get("/api/admin/upgrade/check")  # fetch #1
+        R._upgrade_check_cache["ts"] = time.time() - R._UPGRADE_CHECK_TTL_S - 5
+        client.get("/api/admin/upgrade/check")  # 过期 → fetch #2
+    assert calls["n"] == 2
+
+
+# ─── _fetch_latest_release 真实分支（httpx 被 mock）────────────────────────────
+
+
+class _FakeResp:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class _FakeClient:
+    def __init__(self, resp):
+        self._resp = resp
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def get(self, *a, **k):
+        if isinstance(self._resp, Exception):
+            raise self._resp
+        return self._resp
+
+
+def _patch_httpx(resp):
+    return patch(
+        "miloco.admin.router.httpx.AsyncClient", lambda *a, **k: _FakeClient(resp)
+    )
+
+
+def test_fetch_latest_release_ok():
+    with _patch_httpx(_FakeResp(200, {"tag_name": "v2026.7.3", "html_url": "u"})):
+        assert asyncio.run(R._fetch_latest_release()) == {
+            "tag": "v2026.7.3",
+            "html_url": "u",
+        }
+
+
+def test_fetch_latest_release_non_200_returns_none():
+    with _patch_httpx(_FakeResp(403, {})):  # 限流 / 权限
+        assert asyncio.run(R._fetch_latest_release()) is None
+
+
+def test_fetch_latest_release_missing_tag_returns_none():
+    with _patch_httpx(_FakeResp(200, {"html_url": "u"})):
+        assert asyncio.run(R._fetch_latest_release()) is None
+
+
+def test_fetch_latest_release_exception_returns_none():
+    with _patch_httpx(RuntimeError("network down")):
+        assert asyncio.run(R._fetch_latest_release()) is None

--- a/knowledge/03-features/one-click-upgrade.md
+++ b/knowledge/03-features/one-click-upgrade.md
@@ -1,0 +1,114 @@
+# 一键升级（Web 升级提示 + 自升级）
+
+## 背景与目标
+
+Miloco 只经 GitHub Release 发布（CalVer tag，各平台归档 + `install.sh`）。过去用户无从在面板得知有新版本，升级只能到主机上手动重跑 `install.sh`。本能力让 Web 主动、克制地提示新正式版并支持一键升级，把"知道有新版 + 完成升级"收进家庭面板，降低升级门槛。
+
+核心难点是**自升级**：提供 Web 的后端**自己就是被升级的对象、又是拉起升级的人**——升级过程中它会重启（甚至多次重启）自己，界面与进度必须扛过这次"自我重启"，并在新版本真正就绪后让页面自动切过去。
+
+---
+
+## 产品面
+
+### 能做什么
+
+- **被动提示、零主动打扰**：打开页面查一次，有新正式版时出一条顶部窄 banner + 侧栏版本号旁一个提示点；无轮询、不弹窗打扰。
+- **提示点常驻、banner 可按版本关**：只要有可升级新版，侧栏提示点就常驻（低调入口，不受关闭影响）；关掉顶部 banner = 按版本"已确认"，该版本在出现**更新的**版本前不再出 banner（永久、不设时限，仅关 banner 触发、点升级入口不算）。**已确认状态存后端、不放浏览器**——随服务器状态走、重装即清零，换浏览器 / 清缓存都不影响。
+- **侧栏版本号随时可点**：有已知更新 → 开确认弹窗引导升级；无已知更新 → 现查一次 GitHub（跳过缓存），结果就在同一弹窗里显示"已是最新"或"暂时无法检查"，连不上时绝不误报"已是最新"。
+- **一键升级**：确认弹窗 → 升级中显示「下载 → 安装 → 重启」三步实时进度 → 完成后自动刷新到新版本。
+- **不锁死用户**：升级中可「转入后台」（升级继续跑、完成仍自动刷新）；失败或超时给出可操作提示（刷新确认 / 稍后重试 / 联系管理员）。
+
+### 能力边界
+
+- **仅 release 部署可一键升级**：归档 / wheel 部署才给一键；git checkout(dev) 部署不出 banner 与提示点（按 release 门控隐藏）；侧栏版本号入口仍可点，但点击（检查更新）只会提示"请 `git pull` 更新后重启"，不给一键升级——不谎称"已是最新"。
+- **只提示官方 latest 正式版**：不提示预发布版。
+- **roll-forward、不回滚**：升级失败则保持在原版本并引导重试，不自动降级。
+- **检测依赖能连到 GitHub**：连不上时静默不提示（不打扰、不报错），不影响其它功能。
+
+---
+
+## 研发面
+
+### 架构概览（数据流）
+
+检测与执行两条链路，均为 admin 端点（`/api/admin/upgrade/*`，走统一鉴权）；执行链路刻意**复用官方安装器**而非自研升级编排。
+
+```
+打开页面 → GET /upgrade/check（admin/router.py::upgrade_check）
+  查 GitHub releases/latest + 比对当前版本 + 判 deploy_kind，结果服务端缓存（可带 force 跳缓存现查）
+  → 有新版：侧栏提示点常驻（web Sidebar）+ 顶部 banner（web UpgradeNotice）
+    提示点只看"有没有可升级新版"；banner 另受"已确认版本"门控
+
+关 banner → POST /upgrade/dismiss（admin/router.py::upgrade_dismiss）
+  按版本把"已确认"记到后端；下次 check 随 data.dismissed 返回，banner 据此门控（提示点不看它）
+
+点升级 → POST /upgrade/run（admin/router.py::upgrade_run）
+  仅 release 放行；起一个**脱离后端会话**的独立进程（start_new_session）：
+    curl 官方 install.sh → bash --agent-prepare && --agent-finish → miloco-cli service start
+    （子进程带上本端的 MILOCO_HOME 与 agent 平台，见下方设计决策）
+    → 全部完成后向 upgrade.log 追加终态标记 AGENT_UPGRADE_DONE / AGENT_UPGRADE_FAILED
+  注：安装器会在中途多次重启后端，令新版本"提前"可达
+
+升级中 → 前端定时轮询：
+  GET /upgrade/status（admin/router.py::upgrade_status）读 upgrade.log → 报当前阶段
+    后端正被重启、连不上 = 前端点亮「重启」步（把断连当进度信号，非报错）
+    读到 AGENT_UPGRADE_DONE = 完成 → 前端 location.reload() 拉新版本（含新注入 token）
+    读到 AGENT_UPGRADE_FAILED = 失败 → 前端显失败提示（仍在原版本）
+```
+
+### 核心模块
+
+| 类 / 符号                                          | 文件                                                                | 职责                                                                                                            |
+| -------------------------------------------------- | ------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `upgrade_check` / `upgrade_run` / `upgrade_status` | `admin/router.py`                                                   | 检测 / 触发 / 进度三端点：版本比较、deploy_kind 判定、GitHub 查询与服务端缓存、detached 起进程、日志阶段解析    |
+| `UpgradeNotice`                                    | `web/src/components/UpgradeNotice.tsx`                              | 升级 UI：banner + 确认弹窗 + 升级中三步进度 + 失败/超时态；轮询 status、完成刷新                                |
+| `Sidebar`（页脚版本行）                            | `web/src/components/Sidebar.tsx`                                    | 侧栏底部版本号 + 提示点，作为常驻升级入口                                                                       |
+| `useUpgrade` / `lib/upgrade`                       | `web/src/hooks/useUpgrade.ts` / `web/src/lib/upgrade.ts`            | check 结果跨组件共享（window 事件）+ 手动强制现查、dismiss 写后端并广播、banner/点可见性与阶段→步骤映射等纯逻辑 |
+| `install.sh` agent 模式                            | `scripts/install.py`（见 [开发指南](../06-dev-guide/dev-guide.md)） | 实际装包 / 重启服务，被 `upgrade_run` 复用；本模块不自研这段                                                    |
+
+### 关键设计决策
+
+**自升级如何扛过自身重启**（本模块最核心的"为什么"）——后端既提供 UI、又是被升级对象、又拉起升级，三点保证升级中界面与进度不断：① UI 是浏览器里**已加载的前端**，后端 down 时页面照常渲染，只是数据（进度）暂取不到；② 升级进程用 `start_new_session` **脱离后端进程组/会话**，后端被自己重启杀掉也不影响它继续跑、继续写日志；③ 进度来自 `upgrade_status` 读**磁盘上的 `upgrade.log`**，跨后端重启一直可读，哪个后端实例活着都能报。后端真正不可达的几秒，前端把"连不上"当作「重启中」信号点亮，而非报错。
+
+**完成只认日志终态标记，不看版本变更**——`install.py` 在 agent-prepare / agent-finish 里会多次重启到新版本，令新版本在升级还没真正干完（模型未解压、插件未装）时就"提前"可达；若以"版本号变了"判完成会误刷到半成品后端。故脚本在**全部完成之后**才向日志追加 `AGENT_UPGRADE_DONE`，前端只认这个终态标记触发刷新（失败追加 `AGENT_UPGRADE_FAILED`）。
+
+**复用官方 `install.sh`、不自研升级编排**——`upgrade_run` 只是 detached 调用安装器的非交互 agent 模式（`--agent-prepare` / `--agent-finish`，见 [开发指南](../06-dev-guide/dev-guide.md)），保证"Web 一键升级"与"手动安装"走同一条路径、行为一致，避免维护两套升级逻辑。
+
+**检测与显示的语言解耦**——升级子进程强制 `MILOCO_LANG=zh`，让 `upgrade.log` 语言确定，`upgrade_status` 的阶段解析不受服务器 locale 影响；而用户看到的步骤文字走前端 i18n、跟随网页语言。日志是内部产物、用户不可见，两者互不影响。
+
+**release / dev 判定基于包版本串**——用 hatch-vcs 版本本地段（`.dev` / `+g<sha>`）判定部署类型，而非目录里有无 `.git`；避免 wheel 恰好装在某个 git 仓库子目录里被误判成 dev、错误禁用一键升级。
+
+**"已确认版本"（dismiss）存后端、不存浏览器；提示点与它解耦**——关 banner 写到后端、随 `/upgrade/check` 的 `dismissed` 字段回来，而非浏览器 localStorage：这样重装即清零（可复现测试）、跨浏览器一致、不被清缓存等浏览器行为干扰。且**只有关 banner 才算 dismiss**（点升级入口不算——那是去升级、不是"不看了"）；侧栏提示点只看"有没有可升级新版"、不看 dismiss，关掉 banner 后仍常驻，作为低调的复查入口，避免"明明有新版却什么提示都没有"。
+
+**升级子进程必须带上本端的部署身份**——安装器的非交互 agent 模式不会从已装环境反推"装在哪、装给哪个 agent 平台"，缺省按 openclaw 处理。不透传则 hermes 部署的一键升级会被当成 openclaw 升级：插件步走错分支而失败，hermes 侧的适配器部署与配置对账整段被跳过。故 `upgrade_run` 起子进程时显式带上本端的 `MILOCO_HOME` 与 `agent.platform`，让"Web 一键升级"与"手动安装"落在同一套部署身份上。
+
+**单飞防并发 + roll-forward**——`upgrade_run` 用进程内单飞标志防止并发升级；不做回滚，失败保持原版本、靠再发新版本修复。
+
+> 具体阈值（缓存 / 轮询 / 单飞 TTL、轮询间隔与超时）、字段与状态码全表属实现细节，见 `admin/router.py` 与 `web/src/components/UpgradeNotice.tsx`，此处不展开。
+
+### 对外契约语义
+
+- **`GET /upgrade/check`**（可带 `force` 跳缓存现查，供手动"检查更新"）：返回当前版本、最新版本、是否有更新、部署类型（release / dev）、GitHub 是否可达、后端已确认版本 `dismissed` 等；不可达时静默降级为"无更新、不可达"，不报错。
+- **`POST /upgrade/dismiss`**：按版本把"已确认"记到后端；下次 `check` 随 `dismissed` 返回，banner 据此门控（提示点不受影响）。
+- **`POST /upgrade/run`**：仅 release 部署放行；dev 部署 / 无更新归一为「失败」类状态码拒绝，「已在升级中」另用一类状态码拒绝——供前端区分"提示失败"与"接管进度"。放行后立即返回，升级在 detached 进程异步进行。
+- **`GET /upgrade/status`**：报升级阶段（`idle` / 下载 / 安装 / `done` / `failed` 等），供前端点亮步骤、判完成、判失败。
+
+字段、状态码取值见 `admin/router.py`。
+
+### 如果我要改一键升级相关功能
+
+| 修改目标                                       | 去看哪个文件                                                        |
+| ---------------------------------------------- | ------------------------------------------------------------------- |
+| 检测 / 版本比较 / deploy_kind / GitHub 缓存    | `admin/router.py`（`upgrade_check` 及其 helper）                    |
+| 手动检查更新（force）/ 已确认版本(dismiss)存储 | `admin/router.py`（`upgrade_check` 的 `force`、`upgrade_dismiss`）  |
+| 升级触发脚本 / 终态标记 / 单飞                 | `admin/router.py`（`upgrade_run`）                                  |
+| 进度阶段解析（日志标记）                       | `admin/router.py`（`upgrade_status` + 阶段标记表）                  |
+| 升级 UI / 三步进度 / 完成刷新 / 失败态         | `web/src/components/UpgradeNotice.tsx`                              |
+| 提示点 / 版本号页脚入口                        | `web/src/components/Sidebar.tsx`                                    |
+| 提示可见性 / 已确认版本 / 阶段映射（纯逻辑）   | `web/src/lib/upgrade.ts`、`web/src/hooks/useUpgrade.ts`             |
+| 实际装包 / 重启流程                            | `scripts/install.py`（见 [开发指南](../06-dev-guide/dev-guide.md)） |
+
+### 与其他模块的关系
+
+- **安装器**：复用 `install.sh` 的 agent 模式，装包 / 重启的真实流程见 [开发指南](../06-dev-guide/dev-guide.md)；升级卡住 / 失败的排查见 [故障排查](../06-dev-guide/troubleshooting.md)。
+- **设计规范**：banner / 确认弹窗 / 进度状态点复用 [设计规范](../07-design/README.md) 的既有 token 与模式（状态用点不用块）。

--- a/knowledge/06-dev-guide/troubleshooting.md
+++ b/knowledge/06-dev-guide/troubleshooting.md
@@ -146,6 +146,18 @@ Set-NetFirewallHyperVVMSetting -Name '{40E0AC32-46A5-438A-A0B2-2B479E8F2E90}' -D
 
 ---
 
+## 一键升级
+
+（Web 面板的升级提示 + 一键升级，设计见 [一键升级](../03-features/one-click-upgrade.md)。）
+
+| 现象                          | 排查 / 解决                                                                                                                                                                                       |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 面板不出"有新版本"提示        | 仅 release（归档/wheel）部署才提示；git checkout(dev) 部署不显示升级入口（改走 `git pull` 重装）；且需能连到 GitHub（连不上时静默不提示）                                                         |
+| dev(git) 部署想升级但没有按钮 | 一键升级仅 release 开放；dev 到主机 `git pull` 后按 [开发指南](dev-guide.md) 重装（后端对 dev 的 `/upgrade/run` 也直接拒绝）                                                                      |
+| 升级卡住 / 页面显示失败或超时 | 看 `$MILOCO_HOME/log/upgrade.log` 是否还在写（冷升级要下大包 + 解压模型，可能数分钟）；确认服务已回来（`miloco-cli service status`）；仍失败则到主机重跑 `install.sh`（roll-forward，不自动回滚） |
+
+---
+
 ## 日志位置
 
 | 日志          | 路径                                                                        |
@@ -154,6 +166,7 @@ Set-NetFirewallHyperVVMSetting -Name '{40E0AC32-46A5-438A-A0B2-2B479E8F2E90}' -D
 | supervisor    | `$MILOCO_HOME/log/supervisord.log`                                          |
 | CLI 调试      | `$MILOCO_HOME/log/miloco-cli.log`（`debug=true` 时启用）                    |
 | OpenClaw 插件 | `$MILOCO_HOME/log/openclaw-plugin.log`（需插件配置）                        |
+| 一键升级      | `$MILOCO_HOME/log/upgrade.log`（一键升级进度与终态标记 DONE/FAILED）        |
 
 ---
 

--- a/knowledge/README.md
+++ b/knowledge/README.md
@@ -155,6 +155,7 @@ knowledge/
   - [实时摄像头观看](03-features/live-camera-view.md)
   - [设备欢迎](03-features/device-welcome.md)
   - [事件反馈打包](03-features/event-feedback.md)
+  - [一键升级](03-features/one-click-upgrade.md)
 - **04-testing** — [评测方法论](04-testing/README.md)
 - **05-external-deps**
   - [MiOT SDK](05-external-deps/sdk-miot.md)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -34,6 +34,7 @@ import { SettingsDrawer } from "./components/SettingsDrawer";
 import { HomeSwitcher } from "./components/HomeSwitcher";
 import { OmniHealthBanner } from "./components/OmniHealthBanner";
 import { StatusRibbon } from "./components/StatusRibbon";
+import UpgradeNotice from "./components/UpgradeNotice";
 import { HeroNow } from "./components/HeroNow";
 import { DevicesByRoom } from "./components/DevicesByRoom";
 import { ActivityFeed } from "./components/ActivityFeed";
@@ -587,6 +588,9 @@ function MainApp() {
             }}
           />
         )}
+
+        {/* 升级提示 banner（仅 release 部署 + 有新版 + 未按版本 dismiss 时显示）*/}
+        <UpgradeNotice />
 
         {/* tab 内容——这里是唯一会滚的区域 */}
         <main className="flex-1 overflow-y-auto min-h-0">

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -48,6 +48,8 @@ import type {
   OmniProfileRef,
   OmniTestResult,
   OmniModelsResult,
+  UpgradeCheck,
+  UpgradeStatus,
 } from "@/lib/types";
 export type { ScopeHome };
 
@@ -64,7 +66,10 @@ export async function bindMiot(): Promise<{ oauthUrl: string }> {
   return impl.realBindMiot();
 }
 
-export async function authorizeMiot(code: string, state: string): Promise<void> {
+export async function authorizeMiot(
+  code: string,
+  state: string,
+): Promise<void> {
   return impl.realAuthorizeMiot(code, state);
 }
 
@@ -403,7 +408,9 @@ export async function switchScopeHome(homeId: string): Promise<void> {
   return impl.realSwitchScopeHome(homeId);
 }
 
-export async function listScopeCameras(homeId?: HomeId): Promise<ScopeCamera[]> {
+export async function listScopeCameras(
+  homeId?: HomeId,
+): Promise<ScopeCamera[]> {
   if (!isPrimary(homeId)) return [];
   return impl.realListScopeCameras();
 }
@@ -461,8 +468,18 @@ export async function submitEventFeedback(
   errorTypes: string[],
   feedbackText: string,
   includeGallery: boolean,
-): Promise<{ uploaded: boolean; upload_key?: string; pack_path: string; pack_size_bytes: number }> {
-  return impl.realSubmitEventFeedback(eventId, errorTypes, feedbackText, includeGallery);
+): Promise<{
+  uploaded: boolean;
+  upload_key?: string;
+  pack_path: string;
+  pack_size_bytes: number;
+}> {
+  return impl.realSubmitEventFeedback(
+    eventId,
+    errorTypes,
+    feedbackText,
+    includeGallery,
+  );
 }
 
 export async function revealDir(path: string): Promise<void> {
@@ -563,6 +580,23 @@ export function subscribeOmniHealth(
 // (backend 重启会断 SSE,重连意味着 config 可能已变)。
 export const OMNI_CONFIG_STALE_EVENT = "miloco:omni-config-stale";
 
+// ── 升级检测 / 一键升级 ────────────────────────────────
+export async function upgradeCheck(force = false): Promise<UpgradeCheck> {
+  return impl.realUpgradeCheck(force);
+}
+
+export async function triggerUpgrade(): Promise<void> {
+  return impl.realTriggerUpgrade();
+}
+
+export async function upgradeStatus(): Promise<UpgradeStatus> {
+  return impl.realUpgradeStatus();
+}
+
+export async function dismissUpgrade(version: string): Promise<void> {
+  return impl.realDismissUpgrade(version);
+}
+
 // ── 性能 tab（observability）────────────────────────────
 // backend observability/router.py 不走 Normal 包装,直接返回原始 JSON。
 
@@ -579,9 +613,7 @@ function windowToSince(w: PerfWindow): number {
 
 export async function getPerfSummary(w: PerfWindow): Promise<PerfSummary> {
   const since = windowToSince(w);
-  return apiFetch<PerfSummary>(
-    `/api/stats?metric=summary&since=${since}`,
-  );
+  return apiFetch<PerfSummary>(`/api/stats?metric=summary&since=${since}`);
 }
 
 export async function getPerfRtfSeries(
@@ -657,9 +689,7 @@ export async function listPerfTraces(
   limit: number = 100,
 ): Promise<PerfTraceRow[]> {
   const since = windowToSince(w);
-  return apiFetch<PerfTraceRow[]>(
-    `/api/traces?since=${since}&limit=${limit}`,
-  );
+  return apiFetch<PerfTraceRow[]>(`/api/traces?since=${since}&limit=${limit}`);
 }
 
 export async function listPerfAgentRuns(

--- a/web/src/api/real.ts
+++ b/web/src/api/real.ts
@@ -40,6 +40,8 @@ import type {
   OmniProfileRef,
   OmniTestResult,
   OmniModelsResult,
+  UpgradeCheck,
+  UpgradeStatus,
 } from "@/lib/types";
 
 // backend NormalResponse 包装：{ code, message, data }
@@ -301,14 +303,11 @@ export async function realEnrollPersonSample(
   form.append("source", "family_ui");
 
   // 直接 fetch，不走 apiFetch（避免被设上 Content-Type: application/json）
-  const resp = await fetch(
-    `/api/identity/persons/${personId}/samples`,
-    {
-      method: "POST",
-      body: form,
-      headers: authHeaders(),
-    },
-  );
+  const resp = await fetch(`/api/identity/persons/${personId}/samples`, {
+    method: "POST",
+    body: form,
+    headers: authHeaders(),
+  });
   if (!resp.ok) {
     const body = await resp.json().catch(() => ({}));
     throw new Error(body.message ?? body.detail ?? `HTTP ${resp.status}`);
@@ -641,7 +640,8 @@ function langKey(): string {
 // 避免「请求 200 但条目没动」的静默失败。
 function assertOpsOk(results: HomeOpResult[]): void {
   const failed = results.find((r) => !r.ok);
-  if (failed) throw new Error(failed.message ?? i18n.t("miot.opFail", { op: failed.op }));
+  if (failed)
+    throw new Error(failed.message ?? i18n.t("miot.opFail", { op: failed.op }));
 }
 
 export async function realListHomeEntries(
@@ -672,7 +672,9 @@ export async function realProfileWrite(
   return r.data;  // add op 回新条目 id，供调用方做「失败重试改走 update」的续做
 }
 
-export async function realCandidateWrite(ops: HomeCandidateOp[]): Promise<void> {
+export async function realCandidateWrite(
+  ops: HomeCandidateOp[],
+): Promise<void> {
   const r = await apiFetch<Normal<HomeOpResult[]>>(
     "/api/home-profile/candidates:write",
     {
@@ -1257,7 +1259,9 @@ export async function realToggleScopeCamera(
 ): Promise<void> {
   await apiFetch<Normal<unknown>>("/api/miot/scope/cameras", {
     method: "PUT",
-    body: JSON.stringify({ items: dids.map((did) => ({ did, in_use: inUse })) }),
+    body: JSON.stringify({
+      items: dids.map((did) => ({ did, in_use: inUse })),
+    }),
   });
   // 写后立即 invalidate + 主动 prefetch homeCache(同 switchScopeHome 同款消 race)。
   invalidateMiotHomeCache();
@@ -1409,10 +1413,7 @@ export async function realSubmitOnDemandFeedback(
  * - 视频路径:含 H264 + AAC
  * - audio-only 路径:仅 AAC(浏览器 <video> 控件能 render audio-only track)
  */
-export function realEventClipUrl(
-  event_id: string,
-  device_id: string,
-): string {
+export function realEventClipUrl(event_id: string, device_id: string): string {
   const token = resolveToken();
   const base = `/api/events/${encodeURIComponent(event_id)}/clip/${encodeURIComponent(device_id)}`;
   return token ? `${base}?token=${encodeURIComponent(token)}` : base;
@@ -1495,7 +1496,9 @@ export function realSubscribeEvents(
   }
   es.addEventListener("new_event", (ev) => {
     try {
-      const payload = JSON.parse((ev as MessageEvent).data) as BackendMeaningfulEvent;
+      const payload = JSON.parse(
+        (ev as MessageEvent).data,
+      ) as BackendMeaningfulEvent;
       onEvent({
         id: payload.event_id,
         timestamp: payload.timestamp,
@@ -1526,9 +1529,20 @@ export async function realSubmitEventFeedback(
   errorTypes: string[],
   feedbackText: string,
   includeGallery: boolean,
-): Promise<{ uploaded: boolean; upload_key?: string; pack_path: string; pack_size_bytes: number }> {
+): Promise<{
+  uploaded: boolean;
+  upload_key?: string;
+  pack_path: string;
+  pack_size_bytes: number;
+}> {
   const resp = await apiFetch<
-    Normal<{ event_id: string; pack_path: string; pack_size_bytes: number; uploaded: boolean; upload_key: string | null }>
+    Normal<{
+      event_id: string;
+      pack_path: string;
+      pack_size_bytes: number;
+      uploaded: boolean;
+      upload_key: string | null;
+    }>
   >("/api/admin/events/feedback", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -1699,8 +1713,14 @@ function unitsToStats(
   let calls = 0;
   // 预置两种调用类型，保证 realtime / on_demand 都恒显示（无数据则为 0）。
   const byType = new Map<UsageCallType, UsageGroup>([
-    ["realtime", { key: "realtime", calls: 0, tokens: 0, breakdown: emptyBreakdown() }],
-    ["on_demand", { key: "on_demand", calls: 0, tokens: 0, breakdown: emptyBreakdown() }],
+    [
+      "realtime",
+      { key: "realtime", calls: 0, tokens: 0, breakdown: emptyBreakdown() },
+    ],
+    [
+      "on_demand",
+      { key: "on_demand", calls: 0, tokens: 0, breakdown: emptyBreakdown() },
+    ],
   ]);
   const rowMap = new Map<string, UsageRow>();
 
@@ -1824,7 +1844,8 @@ export async function realUpdateOmniConfig(
     base_url: input.base_url,
   };
   if (input.api_key) body.api_key = input.api_key;
-  if (input.original_label !== undefined) body.original_label = input.original_label;
+  if (input.original_label !== undefined)
+    body.original_label = input.original_label;
   if (input.activate !== undefined) body.activate = input.activate;
   const r = await apiFetch<Normal<OmniConfigState>>("/api/admin/omni-config", {
     method: "PUT",
@@ -1864,6 +1885,38 @@ export async function realDeactivateOmniConfig(
     { method: "POST", body: JSON.stringify(ref) },
   );
   return r.data;
+}
+
+// ── 升级检测 / 一键升级 ──────────────────────────────────────────────
+// check：打开页面查一次（后端缓存数小时，GitHub 不可达时 reachable=false，不报错）。
+export async function realUpgradeCheck(force = false): Promise<UpgradeCheck> {
+  // force=true：用户手动「检查更新」，后端跳过服务端缓存现查一次。
+  const r = await apiFetch<Normal<UpgradeCheck>>(
+    `/api/admin/upgrade/check${force ? "?force=true" : ""}`,
+  );
+  return r.data;
+}
+
+// run：仅 release 部署可用；后端 detached 起官方 install.sh 覆盖安装并重启服务。
+// 返回值前端不消费（进度靠轮询 /upgrade/status 判定），故 void。
+export async function realTriggerUpgrade(): Promise<void> {
+  await apiFetch<Normal<unknown>>("/api/admin/upgrade/run", {
+    method: "POST",
+  });
+}
+
+// 升级中轮询：解析 upgrade.log 得到当前阶段 / 终态（done/failed）。
+export async function realUpgradeStatus(): Promise<UpgradeStatus> {
+  const r = await apiFetch<Normal<UpgradeStatus>>("/api/admin/upgrade/status");
+  return r.data;
+}
+
+// 关闭 banner = 把该版本记为「已确认」，持久化到后端（不放浏览器）。之后该版本 banner 不再出现。
+export async function realDismissUpgrade(version: string): Promise<void> {
+  await apiFetch<Normal<unknown>>(
+    `/api/admin/upgrade/dismiss?version=${encodeURIComponent(version)}`,
+    { method: "POST" },
+  );
 }
 
 // 拉取某 Base URL 下可用模型列表（供模型下拉）。api_key 留空则用同 base_url 已存 key。
@@ -1960,7 +2013,11 @@ async function fetchUsageStats(
         `&since=${startMs}&until=${startMs + ONE_DAY_MS}`,
     );
     const rows = r.data.rows ?? [];
-    return unitsToStats(period, rows.map(bucketToUnit), bucketTimeline(rows, binMinutes));
+    return unitsToStats(
+      period,
+      rows.map(bucketToUnit),
+      bucketTimeline(rows, binMinutes),
+    );
   }
 
   // week / month：滚动近 N 天（含今天）的 daily 聚合
@@ -1975,7 +2032,6 @@ async function fetchUsageStats(
   const rows = r.data.rows ?? [];
   return unitsToStats(period, rows.map(rowToUnit), dailyTimeline(rows, days));
 }
-
 
 // ── 任务（task）─────────────────────────────────────────────
 // summary 视图 = task 基础字段 + record 进度摘要（window=day：progress 走 snapshot，

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -18,6 +18,8 @@ import { useRef } from "react";
 import type { ComponentType, SVGProps } from "react";
 import { useTranslation } from "react-i18next";
 import type { HomeStatus } from "@/lib/types";
+import { updateAvailable } from "@/lib/upgrade";
+import { useUpgradeInfo, requestOpenUpgrade } from "@/hooks/useUpgrade";
 import { MiotAccountButton } from "./MiotAccountButton";
 import {
   IconNow,
@@ -108,8 +110,29 @@ interface Props {
   onOpenSettings?: () => void;
 }
 
-export function Sidebar({ active, onChange, miot, onOpenMiotBind, onMiotChanged, onOpenSettings }: Props) {
+export function Sidebar({
+  active,
+  onChange,
+  miot,
+  onOpenMiotBind,
+  onMiotChanged,
+  onOpenSettings,
+}: Props) {
   const { t } = useTranslation();
+  // 底部版本号：有可升级新版时整行变可点入口（点击=确认该版本 + 打开升级弹窗，意图经
+  // window 事件转给 UpgradeNotice，本组件不耦合弹窗 UI）。提示点（右上角橙点）与顶部 banner
+  // 共用同一"已确认版本"——点了入口 / 关了 banner 即消，直到出现更新的版本才再现。
+  const upgradeInfo = useUpgradeInfo();
+  const hasUpdate = updateAvailable(upgradeInfo);
+  // 红点 = 只要存在可升级新版就常驻显示（被动指示器），**不受 dismiss 影响**——顶部 banner
+  // 才是可按版本关闭的 naggy 提示。此前红点也跟 banner 共用 dismiss，导致"确认过某版本后红点
+  // 就再也不冒"；用户要的是"更新版本存在红点就在"，故解耦：红点看 hasUpdate、banner 看 dismiss。
+  const showDot = hasUpdate;
+  const versionText = t("update.versionLabel", {
+    version: __APP_VERSION__.startsWith("v")
+      ? __APP_VERSION__
+      : `v${__APP_VERSION__}`,
+  });
   // 整个底部账号 row 当 hit area:onClick 转发给内部 MiotAccountButton 的
   // button DOM 触发同款交互(已绑 toggle popover / 未绑 onBind)。住户不用瞄准
   // 32x32 头像那一小点,点 row 任意位置都行。wrapperRef 传给 MiotAccountButton
@@ -118,9 +141,7 @@ export function Sidebar({ active, onChange, miot, onOpenMiotBind, onMiotChanged,
   const accountBtnRef = useRef<HTMLButtonElement>(null);
   const accountRowRef = useRef<HTMLDivElement>(null);
   return (
-    <aside
-      className="hidden md:flex flex-col shrink-0 border-r border-border bg-bg-secondary w-[15%] min-w-[172px]"
-    >
+    <aside className="hidden md:flex flex-col shrink-0 border-r border-border bg-bg-secondary w-[15%] min-w-[172px]">
       {/* 品牌区:M logo + Miloco,高度跟主区 TopBar 一致(64px)*/}
       <header
         className="flex items-center gap-2.5 shrink-0"
@@ -152,14 +173,13 @@ export function Sidebar({ active, onChange, miot, onOpenMiotBind, onMiotChanged,
           />
         </svg>
         <span className="text-title text-text-primary">Miloco</span>
-        {/* 构建版本号（vite define 注入）：生产为 vYYYY.M.D，dev 为 git describe */}
-        <span className="text-caption text-text-tertiary self-end mb-1 truncate" title={__APP_VERSION__}>
-          {__APP_VERSION__}
-        </span>
       </header>
 
       {/* Tab 列表 */}
-      <nav className="flex-1 px-2 py-2.5 space-y-0.5 overflow-y-auto" aria-label={t("nav.aria")}>
+      <nav
+        className="flex-1 px-2 py-2.5 space-y-0.5 overflow-y-auto"
+        aria-label={t("nav.aria")}
+      >
         {TABS.map((tab) => {
           const on = active === tab.key;
           const Icon = tab.Icon;
@@ -177,17 +197,13 @@ export function Sidebar({ active, onChange, miot, onOpenMiotBind, onMiotChanged,
               }`}
             >
               {/* 图标:激活时 brand-primary 橙 + 填充态,默认 inherit currentColor + 描边态 */}
-              <span
-                className={`shrink-0 ${on ? "text-brand-primary" : ""}`}
-              >
+              <span className={`shrink-0 ${on ? "text-brand-primary" : ""}`}>
                 <Icon active={on} width={24} height={24} />
               </span>
               <span className="flex flex-col leading-tight">
                 <span className="text-title">{t(tab.labelKey)}</span>
                 {/* 副标题用 tertiary 灰阶,自动适配 light/dark */}
-                <span
-                  className="text-caption text-text-tertiary"
-                >
+                <span className="text-caption text-text-tertiary">
                   {t(tab.hintKey)}
                 </span>
               </span>
@@ -268,6 +284,41 @@ export function Sidebar({ active, onChange, miot, onOpenMiotBind, onMiotChanged,
           </button>
         )}
       </div>
+
+      {/* 版本号页脚：低频元信息置于侧栏底部（07-design 无位置硬规，元数据用
+          caption/tertiary）。v 前缀 + "版本" 标注，明确其为版本而非裸数字。
+          **整行始终可点**：有新版时点击直接进升级确认（右上角挂提示点，复用 StatusRibbon/
+          banner 的 5px 点 + 3px brand-soft 环）；无新版时点击 = 现查一次更新（结果在弹窗里给：
+          最新 / 无法检查 / dev）。是否弹确认 vs 检查由 UpgradeNotice 据 info 决定，本组件只
+          发意图（requestOpenUpgrade），确认某版本也由 UpgradeNotice 落。 */}
+      <button
+        type="button"
+        onClick={requestOpenUpgrade}
+        aria-label={
+          hasUpdate
+            ? t("update.footerUpdateAria", { version: upgradeInfo!.latest })
+            : t("update.footerCheckAria")
+        }
+        title={
+          hasUpdate
+            ? t("update.footerUpdateAria", { version: upgradeInfo!.latest })
+            : t("update.footerCheckAria")
+        }
+        className="w-full flex items-start justify-between gap-1 px-3 pb-2 pt-1 text-caption-mono text-text-tertiary hover:text-text-primary transition-colors"
+      >
+        <span className="truncate">{versionText}</span>
+        {showDot && (
+          <span
+            aria-hidden
+            className="shrink-0 rounded-full bg-brand-primary"
+            style={{
+              width: 5,
+              height: 5,
+              boxShadow: "0 0 0 3px var(--color-brand-soft)",
+            }}
+          />
+        )}
+      </button>
     </aside>
   );
 }

--- a/web/src/components/UpgradeNotice.tsx
+++ b/web/src/components/UpgradeNotice.tsx
@@ -1,0 +1,510 @@
+/**
+ * 升级提示 + 一键升级（仅 release 部署）。
+ *
+ * 设计取向（对齐 knowledge/07-design + 需求"要体现但别太频繁"）：
+ *  - 零主动打扰：打开页面查一次（后端缓存数小时），无轮询、无 toast 主动弹。
+ *  - 被动 + 可按版本 dismiss：一条克制的窄 banner（StatusRibbon 视觉语汇：5px 点 + 文字 +
+ *    CTA）。关闭 banner 时调 POST /upgrade/dismiss，把"已确认版本"记到**后端**（非浏览器
+ *    localStorage），该版本永久不再出现、直到出现更新的版本。banner 显隐看 info.dismissed。
+ *  - 侧栏红点独立：只要有可升级新版就常驻显示（与 dismiss 无关），常驻低调入口。
+ *  - 只有用户点"升级"才有打扰型交互（确认弹窗 + 升级中全屏态）。
+ *  - dev(git) 部署不出 banner（deploy_kind==="dev"）。
+ *
+ * 进度呈现（真实、跨语言）：竖排「状态点 + 文字」三步——下载 → 安装 → 重启（完成=刷新，
+ * 不单列）。检测与显示解耦：显示文字走 i18n 跟随网页语言；进度/终态只认 /upgrade/status
+ * 解析 upgrade.log 的结果——downloading/installing 分下载/安装步、连不上(throw)=重启步、
+ * done 标记(AGENT_UPGRADE_DONE)=完成、failed 标记=失败。**不看 /version 版本变更判完成**：
+ * install.py 会在中途多次重启到新版本、令其"提前"可达，只有末尾 done 标记才是可靠终态。
+ *
+ * 视觉规范：语义 token 类，dialog z-[60] + rounded-2xl + anim-in（同 ConfirmUnbindDialog），
+ * 状态用点不用块（.status-dot*），Esc 关闭走 useEscClose（确认/检查/结果浮层，升级中除外）。
+ */
+
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { triggerUpgrade, upgradeStatus } from "@/api";
+import { ApiError } from "@/api/client";
+import {
+  shouldShowUpgradeBanner,
+  updateAvailable,
+  phaseToStep,
+  classifyPollError,
+  PERSISTENT_ERROR_LIMIT,
+  UPGRADE_STEPS,
+  type UpgradePhase,
+} from "@/lib/upgrade";
+import {
+  useUpgradeInfo,
+  dismissUpgrade,
+  refreshUpgradeInfo,
+  OPEN_UPGRADE_EVENT,
+} from "@/hooks/useUpgrade";
+import { toast } from "@/components/Toast";
+import { useEscClose } from "@/hooks/useEscClose";
+import { IconX, IconAlert } from "@/lib/icons";
+
+const POLL_INTERVAL_MS = 2_500;
+// 冷升级要下载 ~68MB 安装包 + 解压模型 + 两趟 install.py，慢网络下轻松破 5min（实测
+// 235kB/s ≈ 5min 只够下载）。超时给足 20min，避免真在进行时被误判"失败"并停轮询。
+const POLL_TIMEOUT_MS = 20 * 60_000;
+// 超过这个时长仍在升级 → 追加一句"首次升级下大包、需数分钟"的安抚，但不判失败、继续轮询。
+const SLOW_HINT_MS = 3 * 60_000;
+// 「重启」是最后一步（后端连不上时点亮）。
+const RESTART_STEP = UPGRADE_STEPS.length - 1;
+
+type Phase = UpgradePhase;
+
+export default function UpgradeNotice() {
+  const { t } = useTranslation();
+  const info = useUpgradeInfo();
+  const [phase, setPhase] = useState<Phase>("idle");
+  // 步骤指示器：stepIndex 单调不回退，指向 UPGRADE_STEPS 里当前到达的步骤。
+  const [stepIndex, setStepIndex] = useState(0);
+  // 升级耗时超过 SLOW_HINT_MS 时置真：追加安抚文案，不判失败。
+  const [slow, setSlow] = useState(false);
+  // 升级中弹窗被用户主动隐藏到后台（升级继续跑、完成仍自动刷新）——避免 20min 硬锁死。
+  const [hidden, setHidden] = useState(false);
+  // 确认按钮 in-flight 禁用，防双击起两个升级（第二个会 409）。
+  const [submitting, setSubmitting] = useState(false);
+  const pollTimer = useRef<number | null>(null);
+  const reloadTimer = useRef<number | null>(null);
+  // t 不放进轮询 effect 依赖（否则切语言会重置进度 + 起第二个轮询循环）——用 ref 取最新。
+  const tRef = useRef(t);
+  tRef.current = t;
+  // open 事件处理器只绑一次（[] deps），用 ref 取最新 info/phase，避免闭包读到旧值。
+  const infoRef = useRef(info);
+  infoRef.current = info;
+  const phaseRef = useRef(phase);
+  phaseRef.current = phase;
+
+  // 侧栏底部升级入口点击 → 跨组件意图（走 window 事件解耦）：
+  //  - idle + 已知有新版：打开升级确认弹窗（不 dismiss——dismiss 只由关 banner 触发）；
+  //  - idle + 未知/无新版：进入 checking → 现查一次（弹窗显 loading），查完分流；
+  //  - 非 idle（升级中/结果态）：仅把"转入后台"隐藏的窗重新唤出，不改 phase、不打断升级。
+  useEffect(() => {
+    const open = () => {
+      setHidden(false);
+      if (phaseRef.current !== "idle") return;
+      setPhase(updateAvailable(infoRef.current) ? "confirm" : "checking");
+    };
+    window.addEventListener(OPEN_UPGRADE_EVENT, open);
+    return () => window.removeEventListener(OPEN_UPGRADE_EVENT, open);
+  }, []);
+
+  // 手动检查更新：进入 checking 后强制现查一次（force，跳后端缓存）。有可升级新版 → 直接进
+  // 确认弹窗，但**不**在此顺手 dismiss——这是用户主动"查"出来的新版，若立刻确认掉，取消后
+  // 用来提醒它的提示点/banner 就再也不冒了；不 dismiss 才能让它照常浮现。无新版 → checked
+  // 结果态（已是最新 / 无法检查）。全程复用同一弹窗、无 toast。
+  useEffect(() => {
+    if (phase !== "checking") return;
+    let cancelled = false;
+    (async () => {
+      const r = await refreshUpgradeInfo();
+      if (cancelled) return;
+      setPhase(updateAvailable(r) ? "confirm" : "checked");
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [phase]);
+
+  // 三个非升级中的浮层（确认 / loading / 结果）都可 Esc 关闭；升级中/终态浮层刻意不给
+  // Esc（不在升级途中误关，超时/失败态只经"刷新页面"退出）。
+  useEscClose(
+    phase === "confirm" || phase === "checked" || phase === "checking",
+    () => setPhase("idle"),
+  );
+
+  // 升级中轮询 /upgrade/status（唯一数据源）：
+  //  - phase="done"  → 升级真正跑完（脚本末尾 echo 的终态标记）→ 刷新页面；
+  //  - phase="failed"→ 升级失败 → 转失败提示；
+  //  - 连不上（throw）/ 502-504 → 后端正在重启 → 点亮"重启"步；
+  //  - 401/403 → 鉴权失败 → 立即转失败；其余 HTTP 错连续 N 次 → 转失败（不空等超时）；
+  //  - 其余（downloading/installing/starting）→ 映射到 下载/安装 步。
+  // 不看 /version 版本变更判完成——install.py 会在 prepare/finish 中途多次重启到新版本，
+  // 新版本"提前"可达，单看版本会误判完成并把页面刷到还没装完的后端上（终态只认 done 标记）。
+  // 步骤单调不回退（Math.max）。
+  useEffect(() => {
+    if (phase !== "upgrading") return;
+    const startedAt = Date.now();
+    const deadline = startedAt + POLL_TIMEOUT_MS;
+    let cancelled = false;
+    setStepIndex(0);
+    setSlow(false);
+    setHidden(false);
+
+    const bump = (idx: number) => setStepIndex((s) => Math.max(s, idx));
+    // 连续「后端有应答但报非网关错」计数：达到 PERSISTENT_ERROR_LIMIT 判失败。
+    // 成功一次即清零（重启窗口里的偶发错误不该累积）。
+    let persistentErrors = 0;
+
+    const tick = async () => {
+      if (cancelled) return;
+      if (Date.now() > deadline) {
+        setPhase("timeout");
+        return;
+      }
+      if (Date.now() - startedAt > SLOW_HINT_MS) setSlow(true);
+
+      try {
+        const s = await upgradeStatus();
+        if (cancelled) return;
+        if (s.phase === "done") {
+          setStepIndex(UPGRADE_STEPS.length); // 越过末步 → 全部点亮为已完成
+          toast(tRef.current("update.success"), "ok");
+          reloadTimer.current = window.setTimeout(
+            () => window.location.reload(),
+            800,
+          );
+          return;
+        }
+        if (s.phase === "failed") {
+          // 后端写下 AGENT_UPGRADE_FAILED（如 curl 连不上 GitHub，数秒内即失败）→ 独立
+          // 失败态。不复用 timeout 文案：那句"未在预期时间内完成"会在失败后数秒就弹出、
+          // 与后端刻意做的"快失败"自相矛盾。roll-forward 下后端已回到原版本、可正常刷新。
+          setPhase("failed");
+          return;
+        }
+        bump(phaseToStep(s.phase));
+        persistentErrors = 0; // 成功一次 → 之前的零星错误不再累积
+      } catch (e) {
+        if (cancelled) return;
+        // 把错误分三类而非一律当"重启中"（见 lib/upgrade.classifyPollError）：连不上 /
+        // 502-504 才是重启；401/403 立刻转失败；其余（400/404/500…）是后端在应答的持续性
+        // 故障，连续 N 次后转失败暴露真因，而不是显示"重启中"空等 20min 超时。
+        // roll-forward：转失败时后端仍在原版本，刷新即可。
+        const kind = classifyPollError(e instanceof ApiError ? e.status : null);
+        if (kind === "auth") {
+          toast(tRef.current("update.authError"), "danger");
+          setPhase("failed");
+          return;
+        }
+        if (kind === "error") {
+          persistentErrors += 1;
+          if (persistentErrors >= PERSISTENT_ERROR_LIMIT) {
+            const msg = e instanceof Error ? e.message : String(e);
+            toast(tRef.current("update.statusError", { msg }), "danger");
+            setPhase("failed");
+            return;
+          }
+        } else {
+          persistentErrors = 0;
+        }
+        bump(RESTART_STEP); // 连不上 / 网关暂不可用 = 正在重启
+      }
+      if (cancelled) return;
+      pollTimer.current = window.setTimeout(tick, POLL_INTERVAL_MS);
+    };
+    pollTimer.current = window.setTimeout(tick, POLL_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      if (pollTimer.current) window.clearTimeout(pollTimer.current);
+      if (reloadTimer.current) window.clearTimeout(reloadTimer.current);
+    };
+  }, [phase]);
+
+  function onDismiss() {
+    if (!info?.latest) return;
+    // 关 banner = 后端记录"已确认到该版本"（持久化、非浏览器）；成功后 banner 立即隐藏，
+    // 该版本永久不再提示、直到出现更新版本。失败则不记（banner 保留），不阻塞——
+    // 显式吞掉 rejection：dismissUpgrade 仅在成功后才更新 _info，失败时 banner 天然保留，
+    // 此处 catch 只为避免 fire-and-forget 的未处理 promise rejection（非改语义）。
+    void dismissUpgrade(info.latest).catch(() => {});
+  }
+
+  async function onConfirmUpgrade() {
+    if (submitting) return;
+    setSubmitting(true);
+    try {
+      await triggerUpgrade();
+      setPhase("upgrading");
+    } catch (e) {
+      // 409 = 后端已有升级在跑（双击 / 多标签）→ 接管进度，不当失败。
+      if (e instanceof ApiError && e.status === 409) {
+        setPhase("upgrading");
+        return;
+      }
+      const msg = e instanceof Error ? e.message : String(e);
+      toast(t("update.failed", { msg }), "danger");
+      setPhase("idle");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const showBanner = shouldShowUpgradeBanner(info, phase);
+  const showProgressModal =
+    (phase === "upgrading" && !hidden) ||
+    phase === "timeout" ||
+    phase === "failed";
+
+  return (
+    <>
+      {showBanner && info?.latest && (
+        <div className="shrink-0 mx-4 md:mx-8 mt-2 flex items-center gap-2 rounded-xl border border-border bg-bg-secondary px-4 py-2 shadow-sm">
+          <span
+            aria-hidden
+            className="shrink-0 rounded-full bg-brand-primary"
+            style={{
+              width: 5,
+              height: 5,
+              boxShadow: "0 0 0 3px var(--color-brand-soft)",
+            }}
+          />
+          <span className="text-body text-text-primary">
+            {t("update.newVersion", { version: info.latest })}
+          </span>
+          {info.release_url && (
+            <a
+              href={info.release_url}
+              target="_blank"
+              rel="noreferrer"
+              className="text-caption text-text-secondary hover:text-text-primary underline underline-offset-2"
+            >
+              {t("update.releaseNotes")}
+            </a>
+          )}
+          <div className="ml-auto flex items-center gap-1">
+            <button
+              type="button"
+              onClick={() => setPhase("confirm")}
+              className="rounded-md bg-brand-primary px-3 py-1 text-caption text-white hover:bg-brand-accent transition-colors"
+            >
+              {t("update.upgrade")}
+            </button>
+            <button
+              type="button"
+              aria-label={t("update.dismiss")}
+              onClick={onDismiss}
+              className="p-1 rounded-md text-text-tertiary hover:text-text-primary hover:bg-bg-tertiary transition-colors"
+            >
+              <IconX aria-hidden />
+            </button>
+          </div>
+        </div>
+      )}
+
+      {phase === "confirm" && info?.latest && (
+        <div
+          className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 p-4"
+          onClick={() => setPhase("idle")}
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="upgrade-confirm-title"
+            className="w-[90%] max-w-md bg-bg-secondary border border-border rounded-2xl shadow-lg p-6 anim-in"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center gap-2 mb-3">
+              <IconAlert aria-hidden />
+              <h2
+                id="upgrade-confirm-title"
+                className="text-title font-semibold text-text-primary"
+              >
+                {t("update.confirmTitle", { version: info.latest })}
+              </h2>
+            </div>
+            <p className="text-body text-text-secondary mb-6">
+              {t("update.confirmBody")}
+            </p>
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setPhase("idle")}
+                className="rounded-lg px-4 py-2 text-body bg-bg-primary border border-border text-text-primary hover:border-border-strong transition-colors"
+              >
+                {t("update.cancel")}
+              </button>
+              <button
+                type="button"
+                onClick={onConfirmUpgrade}
+                disabled={submitting}
+                className="rounded-lg bg-brand-primary px-4 py-2 text-body text-white hover:bg-brand-accent transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+              >
+                {t("update.confirm")}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {phase === "checking" && (
+        <div
+          className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 p-4"
+          onClick={() => setPhase("idle")}
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-live="polite"
+            aria-label={t("update.checking")}
+            className="w-[90%] max-w-md bg-bg-secondary border border-border rounded-2xl shadow-lg p-6 anim-in text-center"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="inline-flex items-center gap-2 text-body text-text-secondary">
+              {/* loading 走全站 animate-pulse 点语汇（07-design），不新造 spinner */}
+              <span
+                aria-hidden
+                className="inline-block w-2 h-2 rounded-full bg-text-tertiary animate-pulse"
+              />
+              {t("update.checking")}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {phase === "checked" && (
+        <div
+          className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 p-4"
+          onClick={() => setPhase("idle")}
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="upgrade-checked-title"
+            className="w-[90%] max-w-md bg-bg-secondary border border-border rounded-2xl shadow-lg p-6 anim-in"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center gap-2 mb-3">
+              <IconAlert aria-hidden />
+              <h2
+                id="upgrade-checked-title"
+                className="text-title font-semibold text-text-primary"
+              >
+                {t("update.checkTitle")}
+              </h2>
+            </div>
+            <p className="text-body text-text-secondary mb-6">
+              {/* has_update 为真时不会走到 checked（去了 confirm），故此处结果有三种：
+                  dev(git) 部署——引导 git pull（一键升级对 dev 不适用，dev 优先判定，避免
+                  谎称"已是最新"）/ 连不上——诚实告知"无法检查" / 已是最新。 */}
+              {info?.deploy_kind === "dev"
+                ? t("update.devDeploy")
+                : !info || !info.reachable
+                  ? t("update.checkFailed")
+                  : t("update.upToDate", { version: info.current })}
+            </p>
+            <div className="flex justify-end">
+              <button
+                type="button"
+                onClick={() => setPhase("idle")}
+                className="rounded-lg px-4 py-2 text-body bg-bg-primary border border-border text-text-primary hover:border-border-strong transition-colors"
+              >
+                {t("update.gotIt")}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {showProgressModal && info?.latest && (
+        <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 p-4">
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="upgrade-progress-title"
+            aria-live="polite"
+            className="w-[90%] max-w-md bg-bg-secondary border border-border rounded-2xl shadow-lg p-6 anim-in text-center"
+          >
+            {phase === "upgrading" ? (
+              <>
+                <h2
+                  id="upgrade-progress-title"
+                  className="text-title font-semibold text-text-primary mb-5"
+                >
+                  {t("update.upgrading", { version: info.latest })}
+                </h2>
+                {/* 步骤清单：竖排「状态点 + 文字」，走设计铁律②「状态用点不用块」——
+                    已完成=绿点(status-dot-ok)、进行中=橙点脉冲(status-dot-brand)、
+                    未开始=灰点(status-dot-muted)。不显示虚假百分比。左对齐块整体居中。 */}
+                <ol className="mx-auto flex w-fit flex-col items-start gap-3">
+                  {UPGRADE_STEPS.map((key, i) => {
+                    const done = i < stepIndex;
+                    const current = i === stepIndex;
+                    return (
+                      <li
+                        key={key}
+                        className="inline-flex items-center gap-2.5"
+                        aria-current={current ? "step" : undefined}
+                      >
+                        <span
+                          aria-hidden
+                          className={
+                            done
+                              ? "status-dot status-dot-ok"
+                              : current
+                                ? "status-dot status-dot-brand animate-pulse"
+                                : "status-dot status-dot-muted"
+                          }
+                        />
+                        <span
+                          className={`text-body ${
+                            current
+                              ? "font-semibold text-text-primary"
+                              : done
+                                ? "text-text-secondary"
+                                : "text-text-tertiary"
+                          }`}
+                        >
+                          {t(`update.step.${key}`)}
+                        </span>
+                      </li>
+                    );
+                  })}
+                </ol>
+                <p className="mt-5 text-body text-text-secondary">
+                  {t("update.upgradingHint")}
+                </p>
+                {slow && (
+                  <p className="mt-2 text-caption text-text-tertiary">
+                    {t("update.slowHint")}
+                  </p>
+                )}
+                {/* 逃生口：不硬锁——可隐藏到后台，升级继续跑、完成仍自动刷新。 */}
+                <button
+                  type="button"
+                  onClick={() => setHidden(true)}
+                  className="mt-4 text-caption text-text-tertiary hover:text-text-secondary underline underline-offset-2 transition-colors"
+                >
+                  {t("update.runInBackground")}
+                </button>
+              </>
+            ) : (
+              <>
+                <div className="flex items-center justify-center gap-2 mb-2">
+                  <IconAlert aria-hidden />
+                  <h2
+                    id="upgrade-progress-title"
+                    className="text-title font-semibold text-text-primary"
+                  >
+                    {t(
+                      phase === "failed"
+                        ? "update.failedTitle"
+                        : "update.timeoutTitle",
+                    )}
+                  </h2>
+                </div>
+                <p className="text-body text-text-secondary mb-6">
+                  {t(
+                    phase === "failed"
+                      ? "update.failedHint"
+                      : "update.timeoutHint",
+                  )}
+                </p>
+                <button
+                  type="button"
+                  onClick={() => window.location.reload()}
+                  className="rounded-lg bg-brand-primary px-4 py-2 text-body text-white hover:bg-brand-accent transition-colors"
+                >
+                  {t("update.refresh")}
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/web/src/hooks/useUpgrade.ts
+++ b/web/src/hooks/useUpgrade.ts
@@ -1,0 +1,68 @@
+/**
+ * 升级检测的共享入口 —— 让侧栏底部提示点（Sidebar）与升级 banner/弹窗（UpgradeNotice）
+ * 共用同一次 /upgrade/check 网络请求，并用一个 window 自定义事件解耦"点提示点 → 打开升级
+ * 确认弹窗"的跨组件意图（沿用本仓 useTheme 的 hook + window 事件模式，仓内不用 React Context）。
+ *
+ * 为什么 fetch 放这里而不放 lib/upgrade.ts：lib/upgrade.ts 刻意保持纯、零副作用依赖
+ * （node 单测直接 import），不能牵入 api/网络层。
+ */
+
+import { useEffect, useState } from "react";
+import { upgradeCheck, dismissUpgrade as apiDismissUpgrade } from "@/api";
+import type { UpgradeCheck } from "@/lib/types";
+
+/** 点侧栏提示点 → 请求打开升级确认弹窗的意图事件。 */
+export const OPEN_UPGRADE_EVENT = "miloco-open-upgrade";
+
+// 模块级共享存储：整个页面生命周期打开时查一次（走服务端缓存），结果广播给所有挂
+// useUpgradeInfo 的组件（Sidebar + UpgradeNotice 共用同一结果，不重复打网络）。用户手动
+// 「检查更新」时经 refreshUpgradeInfo 强制现查一次并同样广播。查询异常 → null（静默）。
+let _info: UpgradeCheck | null = null;
+let _started = false;
+const INFO_EVENT = "miloco-upgrade-info";
+
+async function loadUpgradeInfo(force = false): Promise<UpgradeCheck | null> {
+  const r = await upgradeCheck(force).catch(() => null);
+  _info = r;
+  window.dispatchEvent(new Event(INFO_EVENT));
+  return r;
+}
+
+/** 手动「检查更新」：强制跳过缓存现查一次并广播（供侧栏版本号入口点击时用）。 */
+export function refreshUpgradeInfo(): Promise<UpgradeCheck | null> {
+  return loadUpgradeInfo(true);
+}
+
+/** 订阅共享的升级信息；首个挂载者触发"打开页面查一次"（走缓存），后续订阅广播实时同步。 */
+export function useUpgradeInfo(): UpgradeCheck | null {
+  const [info, setInfo] = useState<UpgradeCheck | null>(_info);
+  useEffect(() => {
+    const h = () => setInfo(_info);
+    window.addEventListener(INFO_EVENT, h);
+    if (!_started) {
+      _started = true;
+      loadUpgradeInfo(false);
+    } else {
+      setInfo(_info);
+    }
+    return () => window.removeEventListener(INFO_EVENT, h);
+  }, []);
+  return info;
+}
+
+/** 请求打开升级确认弹窗（由 UpgradeNotice 监听 OPEN_UPGRADE_EVENT 响应）。 */
+export function requestOpenUpgrade(): void {
+  window.dispatchEvent(new Event(OPEN_UPGRADE_EVENT));
+}
+
+// ── "已确认到某版本"（dismiss）——存后端、不放浏览器 ──────────────────────────
+// 关闭 banner 时调用：POST 记到后端，并就地把共享 info.dismissed 更新为该版本 + 广播，
+// 让 banner 立即隐藏（无需再打 GitHub 重查）。已确认版本随 /upgrade/check 一起返回（info.dismissed），
+// 语义：latest === dismissed 时 banner 不显，直到出现更新版本；红点不看它（有更新就显）。
+export async function dismissUpgrade(version: string): Promise<void> {
+  await apiDismissUpgrade(version);
+  if (_info) {
+    _info = { ..._info, dismissed: version };
+    window.dispatchEvent(new Event(INFO_EVENT));
+  }
+}

--- a/web/src/i18n/locales/en/update.json
+++ b/web/src/i18n/locales/en/update.json
@@ -1,0 +1,39 @@
+{
+  "update": {
+    "newVersion": "New version {{version}} available",
+    "releaseNotes": "Release notes",
+    "upgrade": "Upgrade",
+    "dismiss": "Dismiss",
+    "confirmTitle": "Upgrade to {{version}}?",
+    "confirmBody": "Perception and automation will be briefly interrupted (a few minutes) during the upgrade; the page will reconnect automatically. Upgrade now?",
+    "cancel": "Cancel",
+    "confirm": "Upgrade",
+    "upgrading": "Upgrading to {{version}}…",
+    "upgradingHint": "Please keep this page open — it will refresh automatically when the upgrade completes.",
+    "slowHint": "A first-time upgrade downloads a large package and may take several minutes — please wait.",
+    "success": "Upgrade complete, refreshing…",
+    "runInBackground": "Move to background (reopen via the version in the sidebar)",
+    "refresh": "Refresh page",
+    "timeoutTitle": "Upgrade didn't finish in the expected time",
+    "timeoutHint": "The upgrade may still be running in the background, or it may not have succeeded. Refresh the page later to check; if it stays unavailable for a long time, please ask your administrator for help.",
+    "failedTitle": "Upgrade didn't succeed",
+    "failedHint": "This upgrade could not be completed and you're still running the current version. Refresh the page to confirm; you can retry the upgrade later, and if it keeps failing please ask your administrator for help.",
+    "failed": "Failed to start the upgrade: {{msg}}",
+    "step": {
+      "download": "Download update",
+      "install": "Install components",
+      "restart": "Restart service"
+    },
+    "versionLabel": "Version {{version}}",
+    "footerUpdateAria": "New version {{version}} available — click to upgrade",
+    "footerCheckAria": "Check for updates",
+    "checking": "Checking for updates…",
+    "checkTitle": "Check for updates",
+    "upToDate": "You're already on the latest version ({{version}})",
+    "devDeploy": "This is a git source deployment — run git pull and restart the service to update (one-click upgrade is for release deployments only)",
+    "checkFailed": "Couldn't check for updates right now (update server unreachable)",
+    "authError": "Authentication failed during the upgrade (your session may have expired). Refresh and sign in again to check the upgrade result.",
+    "statusError": "Couldn't read upgrade progress: {{msg}}. The upgrade may still be running in the background — refresh the page later to check.",
+    "gotIt": "Got it"
+  }
+}

--- a/web/src/i18n/locales/zh/update.json
+++ b/web/src/i18n/locales/zh/update.json
@@ -1,0 +1,39 @@
+{
+  "update": {
+    "newVersion": "有新版本 {{version}}",
+    "releaseNotes": "更新日志",
+    "upgrade": "升级",
+    "dismiss": "关闭",
+    "confirmTitle": "升级到 {{version}}？",
+    "confirmBody": "升级期间感知与自动化会短暂中断（约数分钟），页面会自动重连。确定现在升级吗？",
+    "cancel": "取消",
+    "confirm": "确定升级",
+    "upgrading": "正在升级到 {{version}}…",
+    "upgradingHint": "请保持页面打开，升级完成后会自动刷新。",
+    "slowHint": "首次升级需下载较大安装包，可能持续数分钟，请耐心等待。",
+    "success": "升级完成，正在刷新…",
+    "runInBackground": "转入后台（升级继续，点侧栏版本号可重新打开）",
+    "refresh": "刷新页面",
+    "timeoutTitle": "升级未在预期时间内完成",
+    "timeoutHint": "升级可能仍在后台进行，也可能未成功。稍后刷新页面确认即可；若长时间仍无法打开，请联系管理员协助。",
+    "failedTitle": "升级未成功",
+    "failedHint": "本次升级未能完成，当前仍运行在原版本。请刷新页面确认；可稍后重试升级，若反复失败请联系管理员协助。",
+    "failed": "启动升级失败：{{msg}}",
+    "step": {
+      "download": "下载新版本",
+      "install": "安装组件",
+      "restart": "重启服务"
+    },
+    "versionLabel": "版本 {{version}}",
+    "footerUpdateAria": "有新版本 {{version}}，点击升级",
+    "footerCheckAria": "点击检查更新",
+    "checking": "正在检查更新…",
+    "checkTitle": "检查更新",
+    "upToDate": "当前已是最新版本（{{version}}）",
+    "devDeploy": "当前为 git 源码部署，请用 git pull 更新代码后重启服务（一键升级仅用于正式版部署）",
+    "checkFailed": "暂时无法检查更新，请稍后再试（连不上更新服务器）",
+    "authError": "升级中身份校验失败（登录状态可能已过期），请刷新页面重新登录后确认升级结果",
+    "statusError": "无法获取升级进度：{{msg}}。升级可能仍在后台进行，请稍后刷新页面确认",
+    "gotIt": "知道了"
+  }
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -763,3 +763,21 @@ export interface Task {
   // 详情抽屉「有价值的详情」：驱动规则，随 summary 一并返回。
   ruleBriefs: TaskRuleBrief[];
 }
+
+// ── 升级检测 / 一键升级（对齐 backend /api/admin/upgrade/*、/version） ──
+export interface UpgradeCheck {
+  current: string;
+  latest: string | null;
+  has_update: boolean;
+  deploy_kind: "release" | "dev";
+  release_url: string | null;
+  reachable: boolean;
+  checked_at: number;
+  /** 后端持久化的「已确认版本」；banner 在 latest === dismissed 时不显（存后端，非浏览器）。 */
+  dismissed: string | null;
+}
+
+export interface UpgradeStatus {
+  /** idle | starting | downloading | installing | done | failed —— 前端据此点亮步骤 / 判完成。 */
+  phase: string;
+}

--- a/web/src/lib/upgrade.ts
+++ b/web/src/lib/upgrade.ts
@@ -1,0 +1,94 @@
+/**
+ * 升级 banner 可见性 / 步骤映射 / 完成判定 —— 纯函数，单一事实源。
+ *
+ * 抽成纯函数便于单测（web 测试跑 node 环境、无 jsdom；且本文件刻意不 import api/客户端，
+ * 保持零副作用依赖）。banner 门控：有可一键升级的 release 新版、当前 idle、且用户没按这个
+ * 版本 dismiss 过时才显示。关掉即对该版本**永久**不再提示，仅当出现更新的版本才再现
+ * （或用户主动点侧栏底部的升级入口）——不设时间限制。
+ */
+
+import type { UpgradeCheck } from "@/lib/types";
+
+// checking = 用户手动检查更新、正在现查（弹窗显 loading）；checked = 查完但无可升级新版
+// （弹窗显"已是最新 / 无法检查"结果）。其余同前。
+export type UpgradePhase =
+  | "idle"
+  | "checking"
+  | "checked"
+  | "confirm"
+  | "upgrading"
+  | "timeout"
+  | "failed";
+
+// 升级步骤（下载 → 安装 → 重启）。「完成」不单列成步——重启完即完成、届时直接刷新页面。
+export const UPGRADE_STEPS = ["download", "install", "restart"] as const;
+export type UpgradeStepKey = (typeof UPGRADE_STEPS)[number];
+
+// 后端 /upgrade/status 的 phase → 步骤下标。restart 阶段不来自 status（后端那时已重启、
+// 端点消失），由前端「轮询 /upgrade/status 连不上（throw）」判定，故这里只映射 下载 / 安装。
+const PHASE_TO_STEP: Record<string, number> = {
+  idle: 0,
+  starting: 0,
+  downloading: 0,
+  installing: 1,
+};
+
+export function phaseToStep(phase: string): number {
+  return PHASE_TO_STEP[phase] ?? 0;
+}
+
+// 轮询 /upgrade/status 出错时的解读。
+//  - restarting：后端不可达（fetch throw）、网关类 5xx（502/503/504，nginx/supervisord 在
+//    backend 重启窗口里的典型应答），或非 4xx/5xx 却解析失败（反代 / captive portal 在后端
+//    下线时回 200 + HTML，client.ts 包成 status=200 的 ApiError）→ 都是"重启中"，
+//    点亮重启步、继续轮询；
+//  - auth：401/403（升级中 token 轮换）→ 立刻转失败并提示，别让用户空等 20min 超时；
+//  - error：后端确实在应答且报错（400/404/500…）→ 持续性故障，不是重启。连续若干次后
+//    转失败暴露真因（单次容忍：重启窗口里偶发一次 5xx 不该判死）。
+export type PollErrorKind = "restarting" | "auth" | "error";
+
+// 网关类状态码 = 反代已在、后端未起 → 与"连不上"同义。
+const RESTART_STATUSES = new Set([502, 503, 504]);
+
+/** @param status HTTP 状态码；null = fetch 直接 throw（连不上，非 HTTP 错误）。 */
+export function classifyPollError(status: number | null): PollErrorKind {
+  // status < 400 = HTTP 层没报错、只是响应体不是预期 JSON（中间层兜底页），按连不上处理。
+  if (status === null || status < 400 || RESTART_STATUSES.has(status))
+    return "restarting";
+  if (status === 401 || status === 403) return "auth";
+  return "error";
+}
+
+// 连续多少次 "error" 才判失败（低于此数按重启处理，容忍重启窗口的偶发错误）。
+export const PERSISTENT_ERROR_LIMIT = 3;
+
+/**
+ * 是否"有可一键升级的新版本"——用于侧栏底部版本号旁那个常驻提示点。
+ * 与 banner 不同：不受 dismiss 影响（dot 是常驻低调入口，关掉 banner 后仍在）。
+ */
+export function updateAvailable(info: UpgradeCheck | null): boolean {
+  return (
+    !!info && info.has_update && info.deploy_kind === "release" && !!info.latest
+  );
+}
+
+/**
+ * 侧栏底部提示点直接用 updateAvailable 判定（有可升级新版即常驻显示，不受 dismiss 影响）。
+ * 可关闭的是下面的 banner——按版本 dismiss，**dismiss 状态由后端返回（info.dismissed），
+ * 不再放浏览器**。
+ *
+ * 是否显示"有新版本"窄 banner：有可升级新版 + idle + 该版本未被 dismiss（latest !== dismissed）。
+ *
+ * @param info  后端 /upgrade/check 结果（含 dismissed；null=尚未查到/查询失败）
+ * @param phase 当前交互阶段（confirm/upgrading/… 时不显示 banner）
+ */
+export function shouldShowUpgradeBanner(
+  info: UpgradeCheck | null,
+  phase: UpgradePhase,
+): boolean {
+  return (
+    updateAvailable(info) &&
+    phase === "idle" &&
+    info!.dismissed !== info!.latest
+  );
+}

--- a/web/src/styles/theme.css
+++ b/web/src/styles/theme.css
@@ -335,6 +335,14 @@ select:focus-visible {
   animation: fade-in-up var(--duration-slow) var(--easing-emphasized);
 }
 
+/* 尊重系统"减少动态效果"偏好：关掉入场动画与脉冲等循环动效（a11y / 前庭敏感用户）。 */
+@media (prefers-reduced-motion: reduce) {
+  .anim-in,
+  .animate-pulse {
+    animation: none !important;
+  }
+}
+
 /* 隐藏滚动条但保留滚动功能（横向 chip 列表） */
 .scrollbar-none {
   scrollbar-width: none;
@@ -423,6 +431,10 @@ select:focus-visible {
 .status-dot-brand {
   background: var(--color-brand-primary);
   box-shadow: 0 0 0 3px var(--color-brand-soft);
+}
+.status-dot-muted {
+  background: var(--color-text-tertiary);
+  box-shadow: 0 0 0 3px var(--color-bg-tertiary);
 }
 
 /* deprecated alias 保留(已经被 .text-caption-mono 替代,

--- a/web/tests/upgrade.test.ts
+++ b/web/tests/upgrade.test.ts
@@ -1,0 +1,146 @@
+/**
+ * 升级纯函数单测（node 环境，无 DOM）：banner 可见性、更新可用性、完成判定、阶段→步骤映射。
+ *
+ * 覆盖：有新版才出、dev 部署不出、按版本 dismiss（同版本永久不出 / 更新版本再出）、
+ * 弹窗/升级中态占屏时 banner 让位、info 缺失/不可达时不出；updateAvailable（侧栏红点门控：
+ * 有可升级新版即常驻显示，与 dismiss 无关）；phaseToStep（阶段→步骤映射）；
+ * classifyPollError（轮询出错的解读：重启中 / 鉴权失败 / 持续性故障）。
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  shouldShowUpgradeBanner,
+  updateAvailable,
+  phaseToStep,
+  classifyPollError,
+  PERSISTENT_ERROR_LIMIT,
+} from "@/lib/upgrade";
+import type { UpgradeCheck } from "@/lib/types";
+
+function mk(over: Partial<UpgradeCheck> = {}): UpgradeCheck {
+  return {
+    current: "2026.7.2",
+    latest: "2026.7.3",
+    has_update: true,
+    deploy_kind: "release",
+    release_url: "https://gh/rel/2026.7.3",
+    reachable: true,
+    checked_at: 0,
+    dismissed: null, // 已确认版本来自后端 /upgrade/check（不再是浏览器 localStorage）
+    ...over,
+  };
+}
+
+describe("shouldShowUpgradeBanner（dismissed 取自 info，即后端返回）", () => {
+  it("release + 有新版 + 未 dismiss + idle → 显示", () => {
+    expect(shouldShowUpgradeBanner(mk(), "idle")).toBe(true);
+  });
+
+  it("info 为 null（尚未查到/查询失败）→ 不显示", () => {
+    expect(shouldShowUpgradeBanner(null, "idle")).toBe(false);
+  });
+
+  it("无新版（has_update=false）→ 不显示", () => {
+    expect(shouldShowUpgradeBanner(mk({ has_update: false }), "idle")).toBe(
+      false,
+    );
+  });
+
+  it("dev(git) 部署即使有新版也不显示（只提示 git pull）", () => {
+    expect(shouldShowUpgradeBanner(mk({ deploy_kind: "dev" }), "idle")).toBe(
+      false,
+    );
+  });
+
+  it("GitHub 不可达（latest=null）→ 不显示", () => {
+    expect(
+      shouldShowUpgradeBanner(
+        mk({ reachable: false, latest: null, has_update: false }),
+        "idle",
+      ),
+    ).toBe(false);
+  });
+
+  it("后端已记录该版本 dismissed（latest===dismissed）→ 不显示", () => {
+    expect(
+      shouldShowUpgradeBanner(
+        mk({ latest: "2026.7.3", dismissed: "2026.7.3" }),
+        "idle",
+      ),
+    ).toBe(false);
+  });
+
+  it("dismissed 的是旧版本、又出更新版本 → 重新显示", () => {
+    expect(
+      shouldShowUpgradeBanner(
+        mk({ latest: "2026.7.4", dismissed: "2026.7.3" }),
+        "idle",
+      ),
+    ).toBe(true);
+  });
+
+  it.each(["confirm", "upgrading", "timeout", "failed"] as const)(
+    "phase=%s（弹窗/升级中态占屏）→ banner 让位不显示",
+    (phase) => {
+      expect(shouldShowUpgradeBanner(mk(), phase)).toBe(false);
+    },
+  );
+});
+
+describe("updateAvailable（侧栏红点门控：有可升级新版即显示，与 dismiss 无关）", () => {
+  it("release + 有新版 → true", () => {
+    expect(updateAvailable(mk())).toBe(true);
+  });
+  it("dev 部署 → false", () => {
+    expect(updateAvailable(mk({ deploy_kind: "dev" }))).toBe(false);
+  });
+  it("无新版 → false", () => {
+    expect(updateAvailable(mk({ has_update: false }))).toBe(false);
+  });
+  it("null → false", () => {
+    expect(updateAvailable(null)).toBe(false);
+  });
+});
+
+describe("phaseToStep（/upgrade/status phase → 步骤下标）", () => {
+  it("下载阶段 → 0", () => {
+    expect(phaseToStep("starting")).toBe(0);
+    expect(phaseToStep("downloading")).toBe(0);
+    expect(phaseToStep("idle")).toBe(0);
+  });
+  it("安装阶段 → 1", () => {
+    expect(phaseToStep("installing")).toBe(1);
+  });
+  it("未知 phase（含 done/failed，由轮询单独处理）→ 兜底 0", () => {
+    expect(phaseToStep("whatever")).toBe(0);
+    expect(phaseToStep("done")).toBe(0);
+    expect(phaseToStep("failed")).toBe(0);
+  });
+});
+
+describe("classifyPollError（轮询出错的解读，别把所有错都当「重启中」）", () => {
+  it("连不上（fetch throw，无状态码）→ 重启中", () => {
+    expect(classifyPollError(null)).toBe("restarting");
+  });
+  it("网关类 5xx（反代已在、后端未起）→ 重启中", () => {
+    expect(classifyPollError(502)).toBe("restarting");
+    expect(classifyPollError(503)).toBe("restarting");
+    expect(classifyPollError(504)).toBe("restarting");
+  });
+  it("200 + 非 JSON（反代/captive portal 兜底页）→ 重启中，不判失败", () => {
+    expect(classifyPollError(200)).toBe("restarting");
+    expect(classifyPollError(302)).toBe("restarting");
+  });
+  it("401/403（升级中 token 轮换）→ 鉴权失败，立即暴露", () => {
+    expect(classifyPollError(401)).toBe("auth");
+    expect(classifyPollError(403)).toBe("auth");
+  });
+  it("后端在应答的其它错（400/404/500）→ 持续性故障，不是重启", () => {
+    expect(classifyPollError(400)).toBe("error");
+    expect(classifyPollError(404)).toBe("error");
+    expect(classifyPollError(500)).toBe("error");
+  });
+  it("容忍阈值 > 1（重启窗口的偶发一次错误不判死）", () => {
+    expect(PERSISTENT_ERROR_LIMIT).toBeGreaterThan(1);
+  });
+});


### PR DESCRIPTION
打开面板即被动提示官方 latest 正式版，并支持一键完成自升级，把"知道有新版 + 完成升级"收进家庭面板、降低升级门槛。

- 检测：打开页面查一次 GitHub releases/latest + 服务端缓存（带 force 可手动现查）；连不上静默降级、不打扰不报错
- 提示：有可升级新版时侧栏版本号旁常驻提示点 + 顶部窄 banner；banner 可按版本关，"已确认版本"存后端（重装即清零、跨浏览器一致），提示点与之解耦
- 升级：确认后复用官方 install.sh 非交互 agent 模式、detached 执行以扛过后端自我重启；前端轮询 /upgrade/status 显示下载→安装→重启三步进度，读到终态标记后自动刷新到新版本
- 边界：仅 release 部署放行，dev(git) 部署引导 git pull；roll-forward 不回滚
- 后端：admin/upgrade/{check,run,status,dismiss} 端点 + 单测
- 前端：UpgradeNotice / Sidebar 入口 / useUpgrade / lib/upgrade + i18n(zh,en)
- 知识库：新增 03-features/one-click-upgrade.md，补故障排查条目