### PR TITLE
fix: omni "认不出已注册成员"——注册补写 meta 真名 + orphan/存储漂移可观测化

### DIFF
--- a/backend/miloco/src/miloco/database/connector.py
+++ b/backend/miloco/src/miloco/database/connector.py
@@ -57,8 +57,13 @@ class SQLiteConnector:
                     # 走 fresh 路径:_create_tables 会先跑 db-level PRAGMA
                     # (auto_vacuum 只对空库生效,缺表兜底建一旦先建了表就来不及了)。
                     if not existing_tables:
-                        logger.info(
-                            "Empty pre-created db file, running fresh init"
+                        # WARNING 而非 INFO:老部署突然读到一个"文件在但零表"的空 db,几乎必是
+                        # home/db 路径配错(读错了文件),而非正常首启——一旦静默 fresh init,
+                        # person 表建空,已注册成员从 roster 消失、omni 渲染"暂无已注册成员"。
+                        logger.warning(
+                            "Empty pre-created db file, running fresh init: %s "
+                            "(若本应有历史数据，请核实 MILOCO_HOME / database 路径是否漂移)",
+                            self.db_path,
                         )
                         self._create_tables(conn)
                         logger.info(
@@ -182,8 +187,11 @@ class SQLiteConnector:
 
                     logger.info("Database loaded successfully: %s", self.db_path)
             else:
-                logger.info(
-                    "Database file does not exist, creating new database: %s",
+                # WARNING 而非 INFO:除首次装机,产品运行中突然新建 db 基本等于"读错了 home/
+                # 路径"——新库 person 表为空,已注册成员从 roster 消失、omni 渲染"暂无已注册成员"。
+                logger.warning(
+                    "Database file does not exist, creating new database: %s "
+                    "(非首次装机时请核实 MILOCO_HOME / database 路径是否漂移)",
                     self.db_path,
                 )
                 # Create database connection and initialize table structure

--- a/backend/miloco/src/miloco/main.py
+++ b/backend/miloco/src/miloco/main.py
@@ -296,6 +296,17 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
 
     # Initialize node event log
     settings = get_settings()
+    # 启动即并排打出三条 single-source-of-truth 路径。home（MILOCO_HOME）漂移、或 db 与
+    # identity_lib 被解耦时（samples 在盘但 SQL 空 → omni roster 渲染“暂无已注册成员”），
+    # 这一行能一眼判出后端实际读的是哪套存储、二者是否同锚。
+    try:
+        from miloco.perception.engine.identity.config_loader import resolve_library_root
+        logger.info(
+            "存储路径: workspace_dir=%s | database=%s | identity_lib=%s",
+            settings.directories.workspace_dir, settings.database_path, resolve_library_root(),
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning("打印存储路径失败（忽略）", exc_info=True)
     log_dir = settings.directories.log_dir
     log_dir.mkdir(parents=True, exist_ok=True)
     event_log = NodeEventLog(str(log_dir / "node_events.log"))

--- a/backend/miloco/src/miloco/perception/engine/identity/meta_sync.py
+++ b/backend/miloco/src/miloco/perception/engine/identity/meta_sync.py
@@ -69,7 +69,17 @@ def sync_person_meta_from_sql(library) -> dict:
     except Exception:  # noqa: BLE001
         pass
 
-    if synced or orphans:
+    if orphans:
+        # orphan = 盘上有 person 目录但 SQL 无对应行。这些人不进 SQL 驱动的家庭档案 roster,
+        # omni prompt 会渲染成"(暂无已注册成员)"——正是该类上报的症状。升 WARNING 并点明含义,
+        # 让静默矛盾变可操作信号（成因多为 home/db 漂移，或删人时 rmtree 残留；修复留人工裁决）。
+        logger.warning(
+            "meta sync 完成：synced=%d orphans=%d total=%d —— 有 %d 个 person 目录在盘但 SQL 无对应行,"
+            "这些成员不会进家庭档案 roster、omni 可能渲染“暂无已注册成员”;"
+            "常见成因：MILOCO_HOME/db 路径漂移，或删除成员时目录未清干净。请人工核实后决定重注册 / 恢复 db / 删目录。",
+            synced, orphans, len(persons), orphans,
+        )
+    elif synced:
         logger.info(
             "meta sync 完成：synced=%d orphans=%d total=%d", synced, orphans, len(persons)
         )

--- a/backend/miloco/src/miloco/person/router.py
+++ b/backend/miloco/src/miloco/person/router.py
@@ -247,11 +247,13 @@ async def register_sample(
         current_user, person_id, body_image.filename, face_image.filename if face_image else None,
     )
 
-    # person_id 校验：格式白名单 + 必须已在 DB 中注册
-    # 防止 ../ 等路径穿越构造，同时拒绝对未注册 ID 写文件
+    # person_id 校验：格式白名单（防 ../ 路径穿越）+ 必须已在 DB 中注册。
+    # 一次 get_person 兼做存在性校验（缺失返 None→404）与后面写 meta 的真名来源,
+    # 不再 exists()+get_person 查两遍。
     if not _PERSON_ID_RE.match(person_id):
         raise HTTPException(status_code=400, detail="Invalid person_id format")
-    if not manager.person_service.exists(person_id):
+    person = manager.person_service.get_person(person_id)
+    if person is None:
         raise HTTPException(status_code=404, detail=f"Person '{person_id}' not found")
 
     body_arr = await _decode_image_upload(body_image)
@@ -277,11 +279,10 @@ async def register_sample(
         except Exception:  # noqa: BLE001
             logger.warning("ReID emb 抽取失败 person_id=%s (登记继续)", person_id, exc_info=True)
 
-    # 取 person 真名一并写进 meta.json——与 register_sample_batch 对齐。否则单图登记只落
+    # person 真名一并写进 meta.json——与 register_sample_batch 对齐。否则单图登记只落
     # body 图、不写 name,感知层 list_persons 读不到 name → omni gallery 渲染退化成 UUID
-    # 而非姓名(表现为"认不出已注册成员")。SQL 是 name 单一事实源。
-    person = manager.person_service.get_person(person_id)
-    name = person.name if person else None
+    # 而非姓名(表现为"认不出已注册成员")。SQL 是 name 单一事实源。person 上面已查、非 None。
+    name = person.name
 
     ok = library.add_tier_a_sample(
         person_id=person_id,
@@ -2051,6 +2052,12 @@ async def register_from_cluster(
     # member_id 绑定既有成员且未带 member_name 时,commit 不写 meta name → 从 SQL 补齐,
     # 避免感知层 get_name 读空、omni gallery 退化成 UUID。
     _ensure_meta_name_from_sql(result.person_id)
+    # 从簇注册可能按 name 新建成员，级联刷新家庭档案 md 让新成员进档案（与 register_commit
+    # 对齐）；否则新建成员不会立即进 profile.md 的家庭成员名册。
+    try:
+        manager.home_profile_service.commit()
+    except Exception as e:  # noqa: BLE001
+        logger.warning("级联刷新家庭档案失败(register_from_cluster) person_id=%s: %s", result.person_id, e)
 
     # commit 成功 → 关闭 cluster 全部成员的写入 gate(决策 1.1 α 行为)
     try:

--- a/backend/miloco/src/miloco/person/router.py
+++ b/backend/miloco/src/miloco/person/router.py
@@ -280,7 +280,7 @@ async def register_sample(
     # 取 person 真名一并写进 meta.json——与 register_sample_batch 对齐。否则单图登记只落
     # body 图、不写 name,感知层 list_persons 读不到 name → omni gallery 渲染退化成 UUID
     # 而非姓名(表现为"认不出已注册成员")。SQL 是 name 单一事实源。
-    person = next((p for p in manager.person_service.list_persons() if p.id == person_id), None)
+    person = manager.person_service.get_person(person_id)
     name = person.name if person else None
 
     ok = library.add_tier_a_sample(
@@ -386,7 +386,7 @@ async def register_sample_batch(
     # 取 person 的 name(真名) —— batch endpoint 不接 name 入参, 从 person 库查出来传进
     # library 写进 meta.json, 否则感知层 list_persons 读不到 name → omni prompt 渲染退化
     # 成 UUID 而非姓名。
-    person = next((p for p in manager.person_service.list_persons() if p.id == person_id), None)
+    person = manager.person_service.get_person(person_id)
     name = person.name if person else None
 
     # ReID extractor 借 perception service 现场抽 emb, 给 body 路径落 .npy。

--- a/backend/miloco/src/miloco/person/router.py
+++ b/backend/miloco/src/miloco/person/router.py
@@ -379,16 +379,17 @@ async def register_sample_batch(
     )
     if not _PERSON_ID_RE.match(person_id):
         raise HTTPException(status_code=400, detail="Invalid person_id format")
-    if not manager.person_service.exists(person_id):
+    # 一次 get_person 兼做存在性校验（缺失返 None→404）与下面写 meta 的真名来源,与单图端点对齐,
+    # 不再 exists()+get_person 查两遍。
+    person = manager.person_service.get_person(person_id)
+    if person is None:
         raise HTTPException(status_code=404, detail=f"Person '{person_id}' not found")
     if not body.items:
         raise HTTPException(status_code=400, detail="items 不能为空")
 
-    # 取 person 的 name(真名) —— batch endpoint 不接 name 入参, 从 person 库查出来传进
-    # library 写进 meta.json, 否则感知层 list_persons 读不到 name → omni prompt 渲染退化
-    # 成 UUID 而非姓名。
-    person = manager.person_service.get_person(person_id)
-    name = person.name if person else None
+    # person 真名 —— batch endpoint 不接 name 入参, 从 person 库查出来传进 library 写进
+    # meta.json, 否则感知层 list_persons 读不到 name → omni prompt 渲染退化成 UUID 而非姓名。
+    name = person.name
 
     # ReID extractor 借 perception service 现场抽 emb, 给 body 路径落 .npy。
     # 无活动 tracker 时返 None, 抽取失败也吞掉, 不阻塞登记主流程。

--- a/backend/miloco/src/miloco/person/router.py
+++ b/backend/miloco/src/miloco/person/router.py
@@ -203,6 +203,27 @@ def _resolve_member(member_id: str | None, name: str | None, role: str | None) -
     return None
 
 
+def _ensure_meta_name_from_sql(person_id: str) -> None:
+    """commit 后兜底:仅当 meta.json 尚无 name 时,从 SQL(name 单一事实源)补一次真名。
+
+    按 member_id 绑定既有成员且未带 member_name 时,commit_pending →
+    add_tier_a_samples_batch(name=None) 不写 meta name(registration_session 设计:
+    member_name 为 None 就"不覆盖、保留 meta 原值")。若该 person 首次注册即走这条
+    member_id 绑定路径,meta 从没被写过 name → 一直留空 → 感知层 get_name 读空 →
+    omni gallery 标签退化成 UUID(与单图端点同一类缺口)。这里用 SQL 补齐,只在缺失时
+    写、不动已有 name;幂等、best-effort,失败仅 warn 不阻塞注册主流程。
+    """
+    try:
+        library = _get_identity_library()
+        if library.get_name(person_id):
+            return
+        person = manager.person_service.get_person(person_id)
+        if person is not None and person.name:
+            library.set_meta(person_id, name=person.name)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("commit 后回填 meta name 失败 person_id=%s: %s", person_id, e)
+
+
 @router.post(
     "/persons/{person_id}/samples",
     summary="Register Identity Sample (Tier A)",
@@ -256,11 +277,18 @@ async def register_sample(
         except Exception:  # noqa: BLE001
             logger.warning("ReID emb 抽取失败 person_id=%s (登记继续)", person_id, exc_info=True)
 
+    # 取 person 真名一并写进 meta.json——与 register_sample_batch 对齐。否则单图登记只落
+    # body 图、不写 name,感知层 list_persons 读不到 name → omni gallery 渲染退化成 UUID
+    # 而非姓名(表现为"认不出已注册成员")。SQL 是 name 单一事实源。
+    person = next((p for p in manager.person_service.list_persons() if p.id == person_id), None)
+    name = person.name if person else None
+
     ok = library.add_tier_a_sample(
         person_id=person_id,
         body_crop=body_arr,
         face_crop=face_arr,
         source=source,
+        name=name,
         reid_embedding=reid_emb,
     )
     if not ok:
@@ -1445,6 +1473,9 @@ async def register_commit(
             status_code=410,
             detail="pending session 过期 / 不存在 / 无目标身份",
         )
+    # member_id 绑定既有成员且未带 member_name 时,commit 不写 meta name → 从 SQL 补齐,
+    # 避免感知层 get_name 读空、omni gallery 退化成 UUID。
+    _ensure_meta_name_from_sql(result.person_id)
     # 注册可能按 name 新建成员（member_id 缺失时），级联刷新家庭档案 md 让新成员进档案，否则 profile.md 不刷新
     try:
         manager.home_profile_service.commit()
@@ -2016,6 +2047,10 @@ async def register_from_cluster(
     )
     if result is None:
         raise HTTPException(status_code=410, detail="提交失败(筛选无可用样本)")
+
+    # member_id 绑定既有成员且未带 member_name 时,commit 不写 meta name → 从 SQL 补齐,
+    # 避免感知层 get_name 读空、omni gallery 退化成 UUID。
+    _ensure_meta_name_from_sql(result.person_id)
 
     # commit 成功 → 关闭 cluster 全部成员的写入 gate(决策 1.1 α 行为)
     try:

--- a/backend/miloco/tests/test_person_router_sample_name_meta.py
+++ b/backend/miloco/tests/test_person_router_sample_name_meta.py
@@ -1,0 +1,117 @@
+"""注册路径把真名写进 meta.json 的回归护栏（单图端点 + commit 兜底）。
+
+背景：感知层 list_persons() / omni gallery 的姓名来自 meta.json。若注册只落 body 图、
+不写 meta name，gallery 标签退化成 UUID（表现为"认不出已注册成员"）。本测试守两条缺口：
+- 单图端点 register_sample：过去漏传 name → 断言它现在从 SQL 取真名写进 meta。
+- commit 按 member_id 绑定且未带 member_name 时不写 meta name → _ensure_meta_name_from_sql
+  从 SQL 兜底；断言"缺失即补、已有不覆盖、SQL 无对应行则安全不动"。
+
+沿用 samples_batch 测试的做法：不引 TestClient，直接 await 路由协程 / 调 helper，
+用真实 IdentityLibrary(tmp_path) + 桩掉模块级 manager。
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import cv2
+import numpy as np
+import pytest
+from miloco.perception.engine.identity.library import IdentityLibrary
+from miloco.person import router as prouter
+from miloco.person.router import _ensure_meta_name_from_sql, register_sample
+
+_PID = "22222222-2222-4222-8222-222222222222"
+_NAME = "朱小朱"
+
+
+def _jpeg_bytes(seed: int = 0) -> bytes:
+    rng = np.random.default_rng(seed)
+    img = rng.integers(0, 255, size=(64, 64, 3), dtype=np.uint8)
+    ok, buf = cv2.imencode(".jpg", img)
+    assert ok
+    return buf.tobytes()
+
+
+class _Upload:
+    """最小 UploadFile 桩：register_sample 只用到 async read() 与 filename。"""
+
+    def __init__(self, data: bytes, filename: str = "body.jpg"):
+        self._data = data
+        self.filename = filename
+
+    async def read(self) -> bytes:
+        return self._data
+
+
+def _patch_manager(monkeypatch, *, persons: list) -> None:
+    """把模块级 manager 换成桩：person_service.{exists,list_persons,get_person} +
+    perception_service.get_reid_extractor。persons 里每项需带 id / name（可带 role）。"""
+    by_id = {p.id: p for p in persons}
+    monkeypatch.setattr(
+        prouter, "manager",
+        SimpleNamespace(
+            person_service=SimpleNamespace(
+                exists=lambda person_id: person_id in by_id,
+                list_persons=lambda: list(persons),
+                get_person=lambda person_id: by_id.get(person_id),
+            ),
+            perception_service=SimpleNamespace(get_reid_extractor=lambda: None),
+        ),
+    )
+
+
+@pytest.fixture
+def lib(tmp_path, monkeypatch) -> IdentityLibrary:
+    library = IdentityLibrary(tmp_path / "identity_lib")
+    monkeypatch.setattr(prouter, "_get_identity_library", lambda: library)
+    return library
+
+
+# ─── 单图端点：注册后 meta.json 必须有真名 ───────────────────────────────────
+
+
+async def test_register_sample_writes_meta_name(lib: IdentityLibrary, monkeypatch):
+    _patch_manager(monkeypatch, persons=[SimpleNamespace(id=_PID, name=_NAME, role=None)])
+    # 直接调协程绕过 FastAPI，File/Form 默认值仍是 marker 对象——face_image/source 必须显式传，
+    # 否则 File(None) 是 truthy、会命中 face_image.filename 崩溃。
+    res = await register_sample(
+        _PID, body_image=_Upload(_jpeg_bytes()), face_image=None,
+        source="user_upload", current_user="t",
+    )
+    assert res.code == 0
+    # 关键护栏：单图登记后 meta.json 能读到真名，否则 omni gallery 退化成 UUID。
+    assert lib.get_name(_PID) == _NAME
+
+
+# ─── commit 兜底：_ensure_meta_name_from_sql ────────────────────────────────
+
+
+def _seed_nameless_person(lib: IdentityLibrary) -> None:
+    """模拟"有 body 样本目录、但 meta.json 无 name"的坏状态（member_id 绑定漏写 name）。"""
+    body = np.zeros((64, 64, 3), dtype=np.uint8)
+    assert lib.add_tier_a_sample(_PID, body_crop=body)  # 不传 name → meta 无 name
+    assert lib.get_name(_PID) is None
+
+
+def test_ensure_meta_name_backfills_when_missing(lib: IdentityLibrary, monkeypatch):
+    _seed_nameless_person(lib)
+    _patch_manager(monkeypatch, persons=[SimpleNamespace(id=_PID, name=_NAME, role=None)])
+    _ensure_meta_name_from_sql(_PID)
+    assert lib.get_name(_PID) == _NAME
+
+
+def test_ensure_meta_name_no_overwrite_when_present(lib: IdentityLibrary, monkeypatch):
+    body = np.zeros((64, 64, 3), dtype=np.uint8)
+    assert lib.add_tier_a_sample(_PID, body_crop=body, name="原名")
+    # SQL 里是另一个名字，但 meta 已有 name → 不覆盖（漂移交给 meta_sync / update_person）。
+    _patch_manager(monkeypatch, persons=[SimpleNamespace(id=_PID, name=_NAME, role=None)])
+    _ensure_meta_name_from_sql(_PID)
+    assert lib.get_name(_PID) == "原名"
+
+
+def test_ensure_meta_name_noop_when_sql_missing(lib: IdentityLibrary, monkeypatch):
+    _seed_nameless_person(lib)
+    _patch_manager(monkeypatch, persons=[])  # SQL 无对应行（orphan）→ 无从补，安全不动。
+    _ensure_meta_name_from_sql(_PID)
+    assert lib.get_name(_PID) is None

--- a/backend/miloco/tests/test_person_router_samples_batch.py
+++ b/backend/miloco/tests/test_person_router_samples_batch.py
@@ -39,15 +39,14 @@ def _jpeg_b64(seed: int = 0) -> str:
 def lib(tmp_path, monkeypatch) -> IdentityLibrary:
     library = IdentityLibrary(tmp_path / "identity_lib")
     monkeypatch.setattr(prouter, "_get_identity_library", lambda: library)
-    # 端点用到 manager.person_service.{exists,get_person} + perception_service.
-    # get_reid_extractor;person_service 是只读 property、不能直接 setattr,故整体把
-    # 模块级 manager 替换成桩。get_person 按 id 返带 name 的 person 供 batch 查 name;
+    # 端点用到 manager.person_service.get_person + perception_service.get_reid_extractor;
+    # person_service 是只读 property、不能直接 setattr,故整体把模块级 manager 替换成桩。
+    # get_person 按 id 返带 name 的 person：既做存在性校验(缺失→404)又供 batch 查 name;
     # get_reid_extractor 返 None(本测试只验容量契约,不验 ReID/name 写入)。
     monkeypatch.setattr(
         prouter, "manager",
         SimpleNamespace(
             person_service=SimpleNamespace(
-                exists=lambda person_id: True,
                 get_person=lambda person_id: (
                     SimpleNamespace(id=_PID, name="测试") if person_id == _PID else None
                 ),

--- a/backend/miloco/tests/test_person_router_samples_batch.py
+++ b/backend/miloco/tests/test_person_router_samples_batch.py
@@ -39,16 +39,18 @@ def _jpeg_b64(seed: int = 0) -> str:
 def lib(tmp_path, monkeypatch) -> IdentityLibrary:
     library = IdentityLibrary(tmp_path / "identity_lib")
     monkeypatch.setattr(prouter, "_get_identity_library", lambda: library)
-    # 端点用到 manager.person_service.{exists,list_persons} + perception_service.
+    # 端点用到 manager.person_service.{exists,get_person} + perception_service.
     # get_reid_extractor;person_service 是只读 property、不能直接 setattr,故整体把
-    # 模块级 manager 替换成桩。list_persons 返回带 id/name 的 person 供 batch 查 name;
+    # 模块级 manager 替换成桩。get_person 按 id 返带 name 的 person 供 batch 查 name;
     # get_reid_extractor 返 None(本测试只验容量契约,不验 ReID/name 写入)。
     monkeypatch.setattr(
         prouter, "manager",
         SimpleNamespace(
             person_service=SimpleNamespace(
                 exists=lambda person_id: True,
-                list_persons=lambda: [SimpleNamespace(id=_PID, name="测试")],
+                get_person=lambda person_id: (
+                    SimpleNamespace(id=_PID, name="测试") if person_id == _PID else None
+                ),
             ),
             perception_service=SimpleNamespace(get_reid_extractor=lambda: None),
         ),


### PR DESCRIPTION
## 概述

针对"某成员已注册（样本在盘）、但 omni 把他当无名人 / 报无已注册成员"这一类反馈。排查发现是两件事叠加，本 PR 一并处理：

1. 部分注册路径只落了样本图，却没把成员真名写进「感知层读取的目录级元信息」（omni 参考图 gallery 的显示名只认它）→ 成员在 gallery 里退化成裸 UUID、无法被解析成姓名。
2. 字面"暂无已注册成员"由「家庭档案成员名册」渲染，而名册数据源是数据库 person 表；当后端存储路径漂移、或存在"样本在盘但数据库无行"的孤儿（orphan）时名册为空——且这类不一致此前全程静默、无从定位。

本 PR 从源头修复第 1 项，并把第 2 项**变得可观测（只检测暴露、不改数据）**。

术语：**meta**＝每个成员目录下的元信息（真名 / 角色，感知层每窗读取）；**gallery**＝喂给 omni 的候选成员参考图；**名册**＝注入 omni 的家庭档案成员清单；**orphan**＝身份库有成员目录但数据库无对应行。

## 1. 注册补写 meta 真名（gallery 用真名而非 UUID）· fix

**问题**：单图样本登记入口、以及"按已有成员 id 绑定且未带姓名"的注册提交，都只写样本图、不写 meta 真名；感知层的成员列表 / gallery 只从 meta 取名，于是该成员在 omni 参考图里被标成裸 UUID、识别时被当作无名人。此前只有靠重启时的元信息回填才能恢复。

**解决方案**：
- **单图端点与批量端点对齐**：登记时从数据库（真名的单一事实源）取名一并写入 meta。
- **提交路径幂等兜底**：按已有成员 id 绑定且未带名的提交，在提交成功后仅当 meta 尚无名时从数据库补一次——已有名不覆盖、数据库无对应行则不动。
- **回归测试**：覆盖单图登记后 meta 有名，以及兜底"缺失即补 / 已有不覆盖 / 无源不动"三态。

## 2. 存储路径 / orphan 漂移可观测化（真凶不再静默）· feat

**问题**：字面"暂无已注册成员"的根因多为环境/运维——家目录或数据库路径漂移（后端读到另一套空存储），或删除成员时目录未清干净留下孤儿；名册随之为空，而这类漂移此前无任何显性信号，问题不可定位。

**解决方案**：
- **启动打印存储三路径**：并排输出 工作目录 / 数据库 / 身份库 三条实际路径，一眼判断是否同锚、家目录是否漂移。
- **运行期新建 / 空库升为告警**：数据库文件缺失或"有文件无表"时由 info 提级 warning 并提示核实路径——非首次装机时几乎等于读错了库。
- **孤儿目录汇总升为告警**：启动同步检出孤儿时提级 warning，并点明后果（不进名册、可能触发"暂无已注册成员"）。
- **明确不做**：不从孤儿目录反向重建数据库行——那会让用户主动删除的成员被静默复活。

## 测试与兼容性

- **怎么验**：新增 4 个注册路径单测全绿；既有元信息同步测试无回归；改动文件通过 ruff。第 2 节为日志 / 日志级别变更，运行行为不变。
- **兼容 / 回滚**：纯后端，无 schema / 数据迁移；缺省行为不变（带名注册照旧，只补上缺名场景）；可安全回滚。
- **风险提醒**：本 PR **不修复**"暂无已注册成员"的环境根因（路径漂移 / 孤儿），只让其可见——真正闭环需在**出现症状的那台部署机**上按启动日志与孤儿告警核实并纠正环境，勿把"合并本 PR"当作该反馈已闭环。
