### PR TITLE
fix(perception): 日志收窄到实际触发事件的摄像头

### DIFF
--- a/backend/miloco/src/miloco/database/connector.py
+++ b/backend/miloco/src/miloco/database/connector.py
@@ -311,7 +311,9 @@ class SQLiteConnector:
     def _create_meaningful_events_table(self, conn: sqlite3.Connection) -> None:
         """Create meaningful_events table.
 
-        每次推理 = 一行 event(同窗口 N 摄像头合并 1 行,device_ids JSON 记录参与摄像头).
+        每次推理 = 一行 event(同窗口 N 摄像头合并 1 行;device_ids JSON 记录本行真正相关的
+        摄像头——有 rule/suggestion/asr 命中时收窄到其 source_device_ids,否则退化为本次
+        推理中成功出图(可落盘)的全部摄像头).
         schema_version 字段(行级)标识本行按哪个 schema 版本写入;本期 INSERT 恒写 1,
         后续 ALTER TABLE 加字段时新行写 2,DAO 读取按版本走兼容分支.
         """

--- a/backend/miloco/src/miloco/database/meaningful_events_dao.py
+++ b/backend/miloco/src/miloco/database/meaningful_events_dao.py
@@ -5,7 +5,7 @@
 Meaningful events DAO — SQLite persistence.
 
 一次推理 = 一行 event(同窗口 N 摄像头合并 1 行;`device_ids` JSON 数组记录本行真正相关的摄像头——
-有 rule/suggestion/asr 命中时收窄到其 source_device_ids,否则退化为参与本次推理的全部摄像头).
+有 rule/suggestion/asr 命中时收窄到其 source_device_ids,否则退化为本次推理中成功出图(可落盘)的全部摄像头).
 schema_version 字段(行级)标识本行按哪个 schema 版本写入,本期 INSERT 恒写 1.
 """
 

--- a/backend/miloco/src/miloco/database/meaningful_events_dao.py
+++ b/backend/miloco/src/miloco/database/meaningful_events_dao.py
@@ -4,7 +4,8 @@
 """
 Meaningful events DAO — SQLite persistence.
 
-一次推理 = 一行 event(同窗口 N 摄像头合并 1 行;`device_ids` JSON 数组记录参与的全部摄像头).
+一次推理 = 一行 event(同窗口 N 摄像头合并 1 行;`device_ids` JSON 数组记录本行真正相关的摄像头——
+有 rule/suggestion/asr 命中时收窄到其 source_device_ids,否则退化为参与本次推理的全部摄像头).
 schema_version 字段(行级)标识本行按哪个 schema 版本写入,本期 INSERT 恒写 1.
 """
 

--- a/backend/miloco/src/miloco/perception/client.py
+++ b/backend/miloco/src/miloco/perception/client.py
@@ -857,6 +857,31 @@ class PerceptionEngineProxy:
 # ─── meaningful_events 后台持久化(异步,不阻塞 webhook 主路径)───────────
 
 
+def _collect_relevant_device_ids(result: RealtimePerceptionResult) -> list[str]:
+    """本行事件真正"有意义"的来源摄像头(去重,保序).
+
+    一次推理批次(processor.py 传入的 device_ids)可能包含全屋所有摄像头,但
+    matched_rules / suggestions / needs_response speech 各自的 source_device_ids
+    才是"引发这行事件"的那台/那几台摄像头(engine 逐设备跑 pipeline 时按
+    input_slice.device.did 精确注入,见 pipeline.py:_inject_source_meta)。
+    用于把展示的 clip 收窄到真正相关的摄像头,避免规则只绑玄关却带出书房画面。
+    """
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for item in (*result.matched_rules, *result.suggestions):
+        for did in item.source_device_ids:
+            if did not in seen:
+                seen.add(did)
+                ordered.append(did)
+    for s in result.speeches:
+        if s.needs_response and s.is_complete:
+            for did in s.source_device_ids:
+                if did not in seen:
+                    seen.add(did)
+                    ordered.append(did)
+    return ordered
+
+
 async def _persist_meaningful_event(
     *,
     result: RealtimePerceptionResult,
@@ -930,6 +955,20 @@ async def _persist_meaningful_event(
                     pass
 
         text = build_agent_text(result, rule_names=rule_names, rule_queries=rule_queries)
+
+        # relevant 为空(如老测试数据未标 source_device_ids)时保持原有全量列表不收窄;
+        # 否则 device_ids 和 artifacts.clips 必须同步收窄——两者分别驱动"日志展示哪些
+        # 摄像头"和"落盘哪些摄像头的 clip",不同步会导致不相关摄像头的 clip 被落盘、
+        # snapshot_count 与 device_ids 长度对不上(save_event_artifacts 文档的
+        # "0 ~ len(artifacts.clips)"不变量)。trace / gallery 不是按事件相关性归属的
+        # 产物,不参与收窄。
+        relevant_device_ids = _collect_relevant_device_ids(result)
+        if relevant_device_ids:
+            device_ids = [did for did in device_ids if did in relevant_device_ids]
+            artifacts.clips = {
+                did: payload for did, payload in artifacts.clips.items()
+                if did in relevant_device_ids
+            }
 
         insert_ok = dao.insert(
             event_id=event_id,

--- a/backend/miloco/src/miloco/perception/event_classifier.py
+++ b/backend/miloco/src/miloco/perception/event_classifier.py
@@ -5,9 +5,10 @@
 
 判断一次推理(全屋视图 result)是否有意义 + 计算 has_* 标志位.
 
-注:result 是 `_merge_results` 合并后的全屋视图;classifier 不关心 device 归属
-(device_ids 由 client.py 从 processor.py 入参直接传入);MatchedRule / Suggestion
-本来就是全屋视角概念,不区分单摄像头.
+注:result 是 `_merge_results` 合并后的全屋视图;classifier 本身只算 has_* 标志位,
+不关心 device 归属——device 层面的收窄(把 device_ids 收窄到真正触发事件的来源摄像头)
+由 client.py 的 `_collect_relevant_device_ids` 基于 matched_rules / suggestions /
+speeches 各自的 source_device_ids 另外处理,不在这里做.
 """
 
 from __future__ import annotations

--- a/backend/miloco/src/miloco/perception/schema.py
+++ b/backend/miloco/src/miloco/perception/schema.py
@@ -497,7 +497,7 @@ class MeaningfulEvent(BaseModel):
         default_factory=list,
         description=(
             "本次事件相关的 device_id 列表(对齐实际可落盘 frames)。有 rule/suggestion/asr "
-            "命中时收窄到其 source_device_ids,否则为参与本次推理的全部摄像头"
+            "命中时收窄到其 source_device_ids,否则退化为本次推理中成功出图(可落盘)的全部摄像头"
         ),
     )
     rule_names: dict[str, str] = Field(

--- a/backend/miloco/src/miloco/perception/schema.py
+++ b/backend/miloco/src/miloco/perception/schema.py
@@ -478,7 +478,8 @@ class PerceptionLogEntry(BaseModel):
 class MeaningfulEvent(BaseModel):
     """有意义事件(family-ui Activity tab 展示用).
 
-    一次推理 = 一行 event;同窗口 N 摄像头合并 1 行,device_ids JSON 记录参与摄像头.
+    一次推理 = 一行 event;同窗口 N 摄像头合并 1 行,device_ids JSON 记录本行真正相关的摄像头
+    (语义详见下方 device_ids 字段的 description).
     `text` 字段与 agent webhook 收到的同一段聚合文本(B2 单源真值).
     响应不含 payload_json / schema_version / created_at(后端复盘用,API 不返).
     """

--- a/backend/miloco/src/miloco/perception/schema.py
+++ b/backend/miloco/src/miloco/perception/schema.py
@@ -495,7 +495,10 @@ class MeaningfulEvent(BaseModel):
     )
     device_ids: list[str] = Field(
         default_factory=list,
-        description="参与本次推理的 device_id 列表(对齐实际可落盘 frames)",
+        description=(
+            "本次事件相关的 device_id 列表(对齐实际可落盘 frames)。有 rule/suggestion/asr "
+            "命中时收窄到其 source_device_ids,否则为参与本次推理的全部摄像头"
+        ),
     )
     rule_names: dict[str, str] = Field(
         default_factory=dict,

--- a/backend/miloco/tests/test_meaningful_events_integration.py
+++ b/backend/miloco/tests/test_meaningful_events_integration.py
@@ -121,11 +121,18 @@ async def test_end_to_end_rule_hit(isolated_env, client):
 
 @pytest.mark.asyncio
 async def test_end_to_end_multi_camera(isolated_env, client):
-    """多摄像头同窗口 → 1 行 event + N device 各自 clip."""
+    """多摄像头同窗口 → 1 行 event(R10 核心不变量),但 device_ids/clip 只暴露
+    真正引发这行事件的摄像头(cam_living_01),同批次里无关的 cam_kitchen_01
+    不应该出现——否则会复现"规则只绑一个摄像头,日志却带出另一台画面"的 bug。
+    """
     from miloco.perception.client import _persist_meaningful_event
 
     result = RealtimePerceptionResult(
-        matched_rules=[MatchedRule(rule_id="r1", reason="x")],
+        matched_rules=[
+            MatchedRule(
+                rule_id="r1", reason="x", source_device_ids=["cam_living_01"],
+            )
+        ],
         speeches=[
             Speech(
                 needs_response=True, speaker="u", content="开灯", is_complete=True,
@@ -149,16 +156,18 @@ async def test_end_to_end_multi_camera(isolated_env, client):
     e = events[0]
     assert e["has_rule_hit"] is True
     assert e["has_asr"] is True
-    assert set(e["device_ids"]) == {"cam_living_01", "cam_kitchen_01"}
-    # 2 device 各 1 个 clip → snapshot_count = 2
-    assert e["snapshot_count"] == 2
+    assert e["device_ids"] == ["cam_living_01"]
+    # 无关的 cam_kitchen_01 不落盘,snapshot_count 只算真正相关的 1 个
+    assert e["snapshot_count"] == 1
 
     eid = e["event_id"]
-    # 两个摄像头各自路径都能拉到
-    for did in ("cam_living_01", "cam_kitchen_01"):
-        r = client.get(f"/api/events/{eid}/clip/{did}")
-        assert r.status_code == 200
-        assert r.headers["content-type"] == "video/mp4"
+    r = client.get(f"/api/events/{eid}/clip/cam_living_01")
+    assert r.status_code == 200
+    assert r.headers["content-type"] == "video/mp4"
+
+    # 无关摄像头既不在 device_ids 里,也没有 clip 文件落盘 → 404
+    r = client.get(f"/api/events/{eid}/clip/cam_kitchen_01")
+    assert r.status_code == 404
 
 
 @pytest.mark.asyncio

--- a/backend/miloco/tests/test_persist_meaningful_event.py
+++ b/backend/miloco/tests/test_persist_meaningful_event.py
@@ -520,3 +520,84 @@ class TestPersistMeaningfulEvent:
         assert len(rows) == 1
         assert rows[0]["device_ids"] == []
         assert rows[0]["snapshot_count"] == 0
+
+    async def test_device_ids_narrowed_by_suggestion_source(self, isolated_db, dao):
+        """建议(suggestion)单独驱动收窄:来源摄像头之外的相机不该被带出来."""
+        result = RealtimePerceptionResult(
+            suggestions=[
+                Suggestion(event="高温", action="开窗", source_device_ids=["cam_kitchen"]),
+            ]
+        )
+        await _persist_meaningful_event(
+            result=result,
+            device_ids=["cam_kitchen", "cam_bedroom"],
+            artifacts=_artifacts({
+                "cam_kitchen": _clip_payload(1),
+                "cam_bedroom": _clip_payload(2),
+            }),
+        )
+
+        rows = dao.query()
+        assert len(rows) == 1
+        assert rows[0]["device_ids"] == ["cam_kitchen"]
+        assert rows[0]["snapshot_count"] == 1
+
+    async def test_needs_response_false_speech_excluded_from_narrowing(
+        self, isolated_db, dao
+    ):
+        """needs_response=False 的闲聊,即使带了 source_device_ids,也不该被收窄
+        进 device_ids——只有规则命中的书房才该展示,客厅的闲聊画面不该带出来."""
+        result = RealtimePerceptionResult(
+            matched_rules=[
+                MatchedRule(
+                    rule_id="r1", reason="x", source_device_ids=["cam_study"],
+                )
+            ],
+            speeches=[
+                Speech(
+                    needs_response=False, speaker="妈妈", content="今天好热",
+                    is_complete=True, source_device_ids=["cam_living_01"],
+                )
+            ],
+        )
+        await _persist_meaningful_event(
+            result=result,
+            device_ids=["cam_study", "cam_living_01"],
+            artifacts=_artifacts({
+                "cam_study": _clip_payload(1),
+                "cam_living_01": _clip_payload(2),
+            }),
+        )
+
+        rows = dao.query()
+        assert len(rows) == 1
+        assert rows[0]["device_ids"] == ["cam_study"]
+        assert rows[0]["snapshot_count"] == 1
+
+    async def test_mixed_source_one_empty_does_not_trigger_full_fallback(
+        self, isolated_db, dao
+    ):
+        """混合来源:一条规则命中未标 source_device_ids(如老规则/引擎异常兜底),
+        另一条正常带 source——整体 relevant 集合非空,应正常收窄,不该因为其中一条
+        缺失来源就整体退化成展示全量摄像头."""
+        result = RealtimePerceptionResult(
+            matched_rules=[
+                MatchedRule(rule_id="legacy_rule", reason="老规则未标来源"),
+                MatchedRule(
+                    rule_id="r2", reason="x", source_device_ids=["cam_entrance"],
+                ),
+            ]
+        )
+        await _persist_meaningful_event(
+            result=result,
+            device_ids=["cam_entrance", "cam_kitchen"],
+            artifacts=_artifacts({
+                "cam_entrance": _clip_payload(1),
+                "cam_kitchen": _clip_payload(2),
+            }),
+        )
+
+        rows = dao.query()
+        assert len(rows) == 1
+        assert rows[0]["device_ids"] == ["cam_entrance"]
+        assert rows[0]["snapshot_count"] == 1

--- a/backend/miloco/tests/test_persist_meaningful_event.py
+++ b/backend/miloco/tests/test_persist_meaningful_event.py
@@ -429,3 +429,94 @@ class TestPersistMeaningfulEvent:
         rows = dao.query()
         assert len(rows) == 1
         assert rows[0]["device_ids"] == ["cam_with_clip"]
+
+    async def test_device_ids_narrowed_to_rule_source(self, isolated_db, dao):
+        """规则只在玄关摄像头命中(source_device_ids=[玄关 did]),同批次里书房
+        摄像头也产出了 clip,但 device_ids 应只保留玄关,不带出书房画面;书房的
+        clip 也不应该被落盘,snapshot_count 应跟 device_ids 同步收窄。
+
+        复现 bug:日志页面规则提醒只绑玄关,却展示了书房的画面。
+        """
+        result = RealtimePerceptionResult(
+            matched_rules=[
+                MatchedRule(
+                    rule_id="r1", reason="陌生人进入玄关",
+                    source_device_ids=["cam_entrance"],
+                )
+            ]
+        )
+        clips_by_device = {
+            "cam_entrance": _clip_payload(1),
+            "cam_study": _clip_payload(2),
+        }
+
+        await _persist_meaningful_event(
+            result=result,
+            device_ids=["cam_entrance", "cam_study"],
+            artifacts=_artifacts(clips_by_device),
+        )
+
+        rows = dao.query()
+        assert len(rows) == 1
+        assert rows[0]["device_ids"] == ["cam_entrance"]
+        assert rows[0]["snapshot_count"] == 1
+
+        from miloco.perception.snapshot_writer import get_snapshot_root
+
+        event_dir = get_snapshot_root() / rows[0]["id"]
+        assert (event_dir / "cam_entrance" / "clip.mp4").exists()
+        assert not (event_dir / "cam_study").exists()
+
+    async def test_device_ids_union_across_rules_and_asr(self, isolated_db, dao):
+        """同一行事件里规则命中书房、语音指令来自客厅(拾音白名单相机)→ device_ids
+        取两者并集,无关的卧室不落盘."""
+        result = RealtimePerceptionResult(
+            matched_rules=[
+                MatchedRule(
+                    rule_id="r1", reason="x", source_device_ids=["cam_study"],
+                )
+            ],
+            speeches=[
+                Speech(
+                    needs_response=True, speaker="用户", content="开灯",
+                    is_complete=True, source_device_ids=["cam_living_01"],
+                )
+            ],
+        )
+        clips_by_device = {
+            "cam_study": _clip_payload(1),
+            "cam_living_01": _clip_payload(2),
+            "cam_bedroom": _clip_payload(3),
+        }
+
+        await _persist_meaningful_event(
+            result=result,
+            device_ids=["cam_study", "cam_living_01", "cam_bedroom"],
+            artifacts=_artifacts(clips_by_device),
+        )
+
+        rows = dao.query()
+        assert len(rows) == 1
+        assert rows[0]["device_ids"] == ["cam_study", "cam_living_01"]
+        assert rows[0]["snapshot_count"] == 2
+
+    async def test_device_ids_empty_when_source_has_no_clip(self, isolated_db, dao):
+        """规则命中的摄像头(cam_entrance)本身没有可用 clip,同批次里不相关的
+        cam_study 却有 clip——不应静默回退展示 cam_study,device_ids 该收窄为空."""
+        result = RealtimePerceptionResult(
+            matched_rules=[
+                MatchedRule(
+                    rule_id="r1", reason="x", source_device_ids=["cam_entrance"],
+                )
+            ]
+        )
+        await _persist_meaningful_event(
+            result=result,
+            device_ids=["cam_study"],
+            artifacts=_artifacts({"cam_study": _clip_payload(1)}),
+        )
+
+        rows = dao.query()
+        assert len(rows) == 1
+        assert rows[0]["device_ids"] == []
+        assert rows[0]["snapshot_count"] == 0

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -96,8 +96,8 @@ export interface Scene {
 // ── 活动事件(meaningful_events)─────────────────────────────
 // 数据源:GET /api/events(perception/events_router).
 // 一次感知推理 = 一行 event;同窗口 N 摄像头合并 1 行,device_ids 记录本行真正相关的
-// 摄像头——有 rule/suggestion/asr 命中时收窄到其 source_device_ids,否则为参与本次
-// 推理的全部摄像头.
+// 摄像头——有 rule/suggestion/asr 命中时收窄到其 source_device_ids,否则退化为本次
+// 推理中成功出图(可落盘)的全部摄像头.
 // `text` 字段是 agent webhook 收到的同一段聚合文本(单源真值,B2 约束).
 //
 // has_rule_hit / has_suggestion / has_asr 只用于诊断,**UI 不渲染 badge**(B14:

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -95,7 +95,9 @@ export interface Scene {
 
 // ── 活动事件(meaningful_events)─────────────────────────────
 // 数据源:GET /api/events(perception/events_router).
-// 一次感知推理 = 一行 event;同窗口 N 摄像头合并 1 行,device_ids 记录参与摄像头.
+// 一次感知推理 = 一行 event;同窗口 N 摄像头合并 1 行,device_ids 记录本行真正相关的
+// 摄像头——有 rule/suggestion/asr 命中时收窄到其 source_device_ids,否则为参与本次
+// 推理的全部摄像头.
 // `text` 字段是 agent webhook 收到的同一段聚合文本(单源真值,B2 约束).
 //
 // has_rule_hit / has_suggestion / has_asr 只用于诊断,**UI 不渲染 badge**(B14:
@@ -110,7 +112,7 @@ export interface ActivityEvent {
   /** 成功落 clip 的 device 数(0 ~ len(device_ids);每 device 1 个 mp4/m4a 文件);
    *  字段名沿用历史,语义现是 device 数而非帧数.0 表示 metadata-only(磁盘满 / 落盘失败) */
   snapshot_count: number;
-  /** 参与本次推理的 device_id 列表;clip URL 拼接用(eventClipUrl) */
+  /** 本次事件相关的 device_id 列表;clip URL 拼接用(eventClipUrl) */
   device_ids: string[];
   /** rule_id → rule_name 映射;UI 渲染规则提醒时把 [rule_id] 替换成 rule_name */
   rule_names?: Record<string, string>;


### PR DESCRIPTION
## Summary
- 一次感知批次会跨房间合并多台摄像头,`meaningful_events.device_ids` 之前取的是整批所有出图的摄像头,导致规则/建议/语音提醒的日志把无关摄像头的画面也带出来展示(例如规则只绑玄关摄像头,日志却带出书房摄像头的画面)
- 改为把 `device_ids` 和 `artifacts.clips` 一起收窄到 `matched_rules` / `suggestions` / `needs_response speech` 各自 `source_device_ids` 的并集,两者同步收窄避免落盘计数(`snapshot_count`)与 `device_ids` 长度对不上
- `source_device_ids` 全部为空时(如老数据未标注)保持原有全量列表,兼容老行为
- 同步更新了前后端 `device_ids` 字段的说明注释,避免文档漂移

## Test plan
- [x] `test_persist_meaningful_event.py` 新增 3 个用例:规则命中收窄到单一来源摄像头、规则+语音并集、来源摄像头本身无 clip 时不回退到无关摄像头
- [x] 更新 `test_meaningful_events_integration.py::test_end_to_end_multi_camera`,断言无关摄像头的 clip 请求返回 404
- [x] `ruff check` 通过
- [x] 全量 pytest 跑过(唯一失败项是环境本身泄漏了真实 API key 导致的无关 settings 测试失败,与本次改动无关,已用 `git stash` 验证)