### PR TITLE
fix(web): clarify device status semantics

### DIFF
--- a/web/src/api/real.ts
+++ b/web/src/api/real.ts
@@ -682,6 +682,7 @@ export async function realListDevices(): Promise<Device[]> {
       room: cleanRoom(d.room),
       online: d.online,
       statusText: humanDeviceStatus(d, mainSwitch?.current, valueByIid),
+      statusKind: deviceStatusKind(d, mainSwitch?.current, valueByIid),
       dangerous,
       mainSwitch,
       props: allProps,
@@ -791,47 +792,65 @@ const STATUS_TEXT: Record<string, StatusText> = {
   },
 };
 
+function lockStatusKind(
+  d: BackendDevice,
+  values: Map<string, unknown>,
+): Device["statusKind"] {
+  const stateProp = Object.entries(d.spec ?? {}).find(([, spec]) => spec.type_name === "door-state");
+  if (stateProp) {
+    const [iid, spec] = stateProp;
+    const value = values.get(iid);
+    const optionName = spec.value_list?.find((item) => item.value === value)?.name;
+    if (optionName?.includes("Unlocked") || optionName?.includes("Ajar") || optionName?.includes("Not Close")) {
+      return "unlocked";
+    }
+    if (optionName?.includes("Locked") || optionName?.includes("Closed Properly")) {
+      return "locked";
+    }
+  }
+  const v = values.get("prop.2.1");
+  if (typeof v === "boolean") return v ? "locked" : "unlocked";
+  return "connected";
+}
+
+function deviceStatusKind(
+  d: BackendDevice,
+  mainOn: boolean | undefined,
+  values: Map<string, unknown>,
+): Device["statusKind"] {
+  if (!d.online) return "offline";
+  if (mapCategory(d.category) === "lock") return lockStatusKind(d, values);
+  if (mainOn === undefined) return "connected";
+  return mainOn ? "on" : "off";
+}
+
 function humanDeviceStatus(
   d: BackendDevice,
   mainOn: boolean | undefined,
   values: Map<string, unknown>,
 ): string {
   const s = STATUS_TEXT[langKey()] ?? STATUS_TEXT.zh;
-  if (!d.online) return s.offline;
-  const cat = mapCategory(d.category);
+  const kind = deviceStatusKind(d, mainOn, values);
+  if (kind === "offline") return s.offline;
+  if (kind === "locked") return s.locked;
+  if (kind === "unlocked") return s.unlocked;
+  if (kind === "connected") return s.connected;
 
-  if (cat === "lock") {
-    const stateProp = Object.entries(d.spec ?? {}).find(([, spec]) => spec.type_name === "door-state");
-    if (stateProp) {
-      const [iid, spec] = stateProp;
-      const value = values.get(iid);
-      const optionName = spec.value_list?.find((item) => item.value === value)?.name;
-      if (optionName?.includes("Unlocked") || optionName?.includes("Ajar") || optionName?.includes("Not Close")) {
-        return s.unlocked;
-      }
-      if (optionName?.includes("Locked") || optionName?.includes("Closed Properly")) {
-        return s.locked;
-      }
-    }
-    const v = values.get("prop.2.1");
-    if (typeof v === "boolean") return v ? s.locked : s.unlocked;
-    return s.connected;
-  }
-  if (mainOn === undefined) return s.connected;
+  const cat = mapCategory(d.category);
   if (cat === "aircond") {
-    if (!mainOn) return s.off;
+    if (kind === "off") return s.off;
     const t = values.get("prop.2.5") ?? values.get("prop.2.4");
     if (typeof t === "number") return `${t}°C`;
     return s.running;
   }
   if (cat === "purifier") {
-    if (!mainOn) return s.off;
+    if (kind === "off") return s.off;
     const mode = values.get("prop.2.4");
     if (mode === 1) return s.sleepMode;
     if (mode === 0) return s.autoMode;
     return s.running;
   }
-  return mainOn ? s.on : s.off;
+  return kind === "on" ? s.on : s.off;
 }
 
 export async function realControlDeviceProp(

--- a/web/src/api/real.ts
+++ b/web/src/api/real.ts
@@ -801,8 +801,21 @@ function humanDeviceStatus(
   const cat = mapCategory(d.category);
 
   if (cat === "lock") {
+    const stateProp = Object.entries(d.spec ?? {}).find(([, spec]) => spec.type_name === "door-state");
+    if (stateProp) {
+      const [iid, spec] = stateProp;
+      const value = values.get(iid);
+      const optionName = spec.value_list?.find((item) => item.value === value)?.name;
+      if (optionName?.includes("Unlocked") || optionName?.includes("Ajar") || optionName?.includes("Not Close")) {
+        return s.unlocked;
+      }
+      if (optionName?.includes("Locked") || optionName?.includes("Closed Properly")) {
+        return s.locked;
+      }
+    }
     const v = values.get("prop.2.1");
-    return v ? s.locked : s.unlocked;
+    if (typeof v === "boolean") return v ? s.locked : s.unlocked;
+    return s.connected;
   }
   if (mainOn === undefined) return s.connected;
   if (cat === "aircond") {

--- a/web/src/api/real.ts
+++ b/web/src/api/real.ts
@@ -674,6 +674,7 @@ export async function realListDevices(): Promise<Device[]> {
     const allProps: DeviceProperty[] = Object.entries(d.spec ?? {})
       .filter(([iid]) => iid.startsWith("prop."))
       .map(([iid, spec]) => mapProp(iid, spec, valueByIid.get(iid)));
+    const statusKind = deviceStatusKind(d, mainSwitch?.current, valueByIid);
 
     return {
       did: d.did,
@@ -681,8 +682,8 @@ export async function realListDevices(): Promise<Device[]> {
       category: cat,
       room: cleanRoom(d.room),
       online: d.online,
-      statusText: humanDeviceStatus(d, mainSwitch?.current, valueByIid),
-      statusKind: deviceStatusKind(d, mainSwitch?.current, valueByIid),
+      statusText: humanDeviceStatus(d, valueByIid, statusKind),
+      statusKind,
       dangerous,
       mainSwitch,
       props: allProps,
@@ -826,11 +827,10 @@ function deviceStatusKind(
 
 function humanDeviceStatus(
   d: BackendDevice,
-  mainOn: boolean | undefined,
   values: Map<string, unknown>,
+  kind: Device["statusKind"],
 ): string {
   const s = STATUS_TEXT[langKey()] ?? STATUS_TEXT.zh;
-  const kind = deviceStatusKind(d, mainOn, values);
   if (kind === "offline") return s.offline;
   if (kind === "locked") return s.locked;
   if (kind === "unlocked") return s.unlocked;

--- a/web/src/components/DevicesByRoom.tsx
+++ b/web/src/components/DevicesByRoom.tsx
@@ -195,7 +195,7 @@ function DeviceRow({ device }: RowProps) {
   const offline = !device.online;
   const ms = device.mainSwitch;
   const isOn = !offline && (ms?.current ?? false);
-  const isUnlocked = !offline && device.category === "lock" && device.statusText === "未锁";
+  const isUnlocked = device.statusKind === "unlocked";
 
   // 状态提示同色表达：在线=绿，离线=灰，需要注意=warning。
   let dotColor = "bg-text-tertiary";

--- a/web/src/components/DevicesByRoom.tsx
+++ b/web/src/components/DevicesByRoom.tsx
@@ -4,7 +4,7 @@
  * 视觉规格：
  * - 房间标题行用 chevron + 名字 + mono 计数 meta
  * - 设备行：紧凑（44px 高），左侧图标 + 名字 + 状态点+状态文字 + 主开关 + ⋯
- * - 离线设备状态点用 warn 色
+ * - 状态点与状态文案同色：在线绿、离线灰；异常态预留 warning
  * - 场景行底部 hairline 分隔
  */
 
@@ -195,19 +195,20 @@ function DeviceRow({ device }: RowProps) {
   const offline = !device.online;
   const ms = device.mainSwitch;
   const isOn = !offline && (ms?.current ?? false);
+  const isUnlocked = !offline && device.category === "lock" && device.statusText === "未锁";
 
-  // 状态点颜色:离线=warn,开=ok,关=tertiary,危险设备(锁)=info
+  // 状态提示同色表达：在线=绿，离线=灰，需要注意=warning。
   let dotColor = "bg-text-tertiary";
   let dotRing = "var(--color-bg-tertiary)";
-  if (offline) {
+  let statusTextColor = "text-text-tertiary";
+  if (isUnlocked) {
     dotColor = "bg-warning";
     dotRing = "var(--color-warning-bg)";
-  } else if (device.category === "lock") {
-    dotColor = "bg-info";
-    dotRing = "var(--color-info-bg)";
-  } else if (isOn) {
+    statusTextColor = "text-warning";
+  } else if (!offline) {
     dotColor = "bg-success";
     dotRing = "var(--color-success-bg)";
+    statusTextColor = "text-success";
   }
 
   // v5：纯展示，不响应点击。原 DeviceQuickSheet 弹窗已删（控制能力暂未补齐
@@ -246,9 +247,7 @@ function DeviceRow({ device }: RowProps) {
             boxShadow: `0 0 0 3px ${dotRing}`,
           }}
         />
-        <span
-          className={`text-caption-mono ${offline ? "text-warning" : "text-text-secondary"}`}
-        >
+        <span className={`text-caption-mono ${statusTextColor}`}>
           {device.statusText}
         </span>
       </span>

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -80,6 +80,8 @@ export interface Device {
   online: boolean;
   // 概览状态文本（"开着" / "26°C 制冷" / "睡眠档"）
   statusText: string;
+  // 机器可读状态分类；UI 颜色/逻辑不要依赖本地化文案。
+  statusKind: "offline" | "locked" | "unlocked" | "on" | "off" | "connected";
   // 是否危险设备（门锁/燃气/烟雾），需要二次确认
   dangerous: boolean;
   // 主开关 prop（单按钮直控；为 null 时只能从 sheet 进）

--- a/web/tests/real.test.ts
+++ b/web/tests/real.test.ts
@@ -9,8 +9,10 @@
  */
 
 import { describe, it, expect, vi, afterEach } from "vitest";
+import i18n from "@/i18n";
 import {
   realListActivity,
+  realListDevices,
   realGetUsageStats,
   realGetOmniConfig,
   realUpdateOmniConfig,
@@ -29,6 +31,7 @@ const originalFetch = globalThis.fetch;
 afterEach(() => {
   vi.restoreAllMocks();
   globalThis.fetch = originalFetch;
+  i18n.changeLanguage("zh");
   _resetUsageStatsCache(); // 清掉用量请求级缓存，保证用例间隔离
 });
 
@@ -65,6 +68,54 @@ function mockFetch(events: unknown[]) {
     ),
   ) as unknown as typeof fetch;
 }
+
+describe("realListDevices — device status contract", () => {
+  it("maps lock warning state to statusKind independently from localized statusText", async () => {
+    mockFetchByUrl({
+      "/api/miot/home": {
+        code: 0,
+        message: "ok",
+        data: {
+          devices: [
+            {
+              did: "lock-1",
+              name: "Front Door",
+              online: true,
+              model: "lock.model",
+              room: "Entry",
+              category: "lock",
+              spec: {
+                "prop.2.1": {
+                  format: "uint8",
+                  type_name: "door-state",
+                  value_list: [
+                    { name: "Locked", value: 1 },
+                    { name: "Unlocked", value: 2 },
+                  ],
+                },
+              },
+            },
+          ],
+          areas: [],
+          scenes: [],
+          persons: [],
+        },
+      },
+      "/api/miot/devices/lock-1/status": {
+        code: 0,
+        message: "ok",
+        data: { properties: [{ iid: "prop.2.1", value: 2, code: 0 }] },
+      },
+    });
+
+    await i18n.changeLanguage("en");
+    const devices = await realListDevices();
+    expect(devices[0]).toMatchObject({
+      statusText: "Unlocked",
+      statusKind: "unlocked",
+    });
+  });
+});
 
 describe("realListActivity — /api/events 契约", () => {
   it("BackendMeaningfulEvent → ActivityEvent 字段映射", async () => {


### PR DESCRIPTION
## Summary
- add machine-readable device status kind for frontend status rendering
- resolve smart lock locked/unlocked state from MIoT door-state enum before legacy boolean fallback
- keep device row status color logic based on status semantics instead of localized text

Split from #360 so status semantics can be reviewed independently from device grouping.

## Verification
- `cd web && corepack pnpm build`
- `cd web && NODE_OPTIONS='--no-experimental-webstorage' ./node_modules/.bin/vitest run tests/real.test.ts`