### PR TITLE
feat(install): support --version to pass build version in --dev

### DIFF
--- a/scripts/i18n/en.json
+++ b/scripts/i18n/en.json
@@ -17,6 +17,7 @@
   "install.configure_python": "Configuring Python interpreter...",
   "install.python_ok": "Python %1 → %2",
   "install.dev_building": "Dev mode: building from source (takes a few minutes)...",
+  "install.version_needs_dev": "--version only applies to --dev builds; ignoring it for release install",
   "install.downloading_bundle": "Downloading miloco package...",
   "install.bundle_ok": "miloco package downloaded",
   "install.bundle_failed": "Package download failed: %1",

--- a/scripts/i18n/zh.json
+++ b/scripts/i18n/zh.json
@@ -17,6 +17,7 @@
   "install.configure_python": "配置 Python 解释器...",
   "install.python_ok": "Python %1 → %2",
   "install.dev_building": "开发模式：正在从源码构建（耗时数分钟）...",
+  "install.version_needs_dev": "--version 仅对 --dev 构建生效；release 安装将忽略该参数",
   "install.downloading_bundle": "正在下载 miloco 安装包...",
   "install.bundle_ok": "miloco 安装包下载完成",
   "install.bundle_failed": "安装包下载失败: %1",

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -555,6 +555,7 @@ class Installer:
         account_auth: str | None = None,
         miloco_home: Path,
         skip_openclaw: bool = False,
+        version: str | None = None,
     ) -> None:
         self.platform = plat
         self.ui = ui
@@ -564,6 +565,9 @@ class Installer:
         self.account_auth = account_auth
         self.miloco_home = miloco_home
         self.skip_openclaw = skip_openclaw
+        # 仅 --dev 有意义：透传给 build.sh --version，覆盖本地构建版本号，
+        # 方便指定版本号做本地安装测试（release 通道版本由下载归档决定，此值被忽略）。
+        self.version = version
         self.script_dir = Path(__file__).parent
         # dev 安装源：仓库 dist/（build.sh 产物）；release 下为下载归档解压后的缓存目录。
         self.dist_dir = self.script_dir.parent / "dist"
@@ -625,8 +629,13 @@ class Installer:
         if not build_sh.is_file():
             self.ui.fail(self.ui.i18n.t("error.dev_outside_repo"))
         self.ui.info(self.ui.i18n.t("install.dev_building"))
+        cmd = ["bash", str(build_sh)]
+        # 透传 --version 给 build.sh：本地构建版本号缺省由 setuptools_scm 从 git 派生，
+        # 指定后可覆盖，方便按指定版本号做本地安装测试。
+        if self.version:
+            cmd += ["--version", self.version]
         subprocess.run(
-            ["bash", str(build_sh)],
+            cmd,
             cwd=str(self.script_dir.parent),
             check=True,
         )
@@ -1543,6 +1552,14 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Dev install: build from source (scripts/build.sh) then install from dist/",
     )
+    parser.add_argument(
+        "--version",
+        dest="version",
+        default=None,
+        metavar="VER",
+        help="Override build version, forwarded to scripts/build.sh --version "
+        "(only takes effect with --dev; ignored for release install)",
+    )
     parser.add_argument("--lang", default=None, help="Language (en/zh)")
     parser.add_argument(
         "--omni-api-key",
@@ -1608,6 +1625,11 @@ def main() -> None:
     i18n = I18n(plat.lang, Path(__file__).parent)
     ui = UI(i18n)
 
+    # --version 只在 --dev 本地构建时透传给 build.sh；release 通道版本由下载归档决定，
+    # 此时给了也无效，提前 warn 避免住户误以为能指定 release 版本。
+    if args.version and not args.dev:
+        ui.warn(ui.i18n.t("install.version_needs_dev"))
+
     # Agent mode: --agent-prepare or --agent-finish implies non-interactive agent flow
     if args.agent_prepare or args.agent_finish:
         downloader = Downloader()
@@ -1620,6 +1642,7 @@ def main() -> None:
             account_auth=args.account_auth,
             miloco_home=miloco_home,
             skip_openclaw=args.skip_openclaw,
+            version=args.version,
         )
         atexit.register(installer._stop_service)
         atexit.register(installer._cleanup_install_cache)
@@ -1668,6 +1691,7 @@ def main() -> None:
         account_auth=args.account_auth,
         miloco_home=miloco_home,
         skip_openclaw=args.skip_openclaw,
+        version=args.version,
     )
 
     atexit.register(installer._stop_service)


### PR DESCRIPTION
## 背景

本地用 `--dev` 从源码构建安装时，版本号缺省由 `setuptools_scm` 从 git 派生，无法指定。做本地安装测试想验证某个特定版本号时不方便。

`scripts/build.sh` 本身已支持 `--version <ver>`，但 `install.py` 的 `--dev` 流程调用 `build.sh` 时没有透传该参数。

## 改动

**`scripts/install.py`**
- `parse_args()` 新增 `--version VER` 参数；help 说明仅 `--dev` 生效。
- `Installer.__init__` 新增 `version` 参数并保存。
- `_run_dev_build()`：当 `self.version` 有值时，给 `bash build.sh` 追加 `--version <ver>`。
- `main()`：把 `args.version` 传入两处 `Installer(...)`（普通模式 + agent 模式）；`--version` 未配 `--dev` 时提前 `warn`，避免误以为能指定 release 版本。

**`scripts/i18n/{en,zh}.json`**
- 新增 `install.version_needs_dev` 提示文案（中英）。

## 用法

```bash
bash scripts/install.sh --dev --version 2026.7.17
```

`install.sh` 已用 `"$@"` 透传全部参数 → `install.py --dev --version 2026.7.17` → `bash scripts/build.sh --version 2026.7.17` → build.sh 注入 `SETUPTOOLS_SCM_PRETEND_VERSION`，所有 wheel / manifest 拿到该版本。

## 验证

- ✅ `install.py` 编译通过，两个 i18n JSON 合法
- ✅ `--help` 正确显示 `--version VER`
- ✅ `--version` 未配 `--dev` 会先 warn 再在非交互检查处安全退出（不触碰任何东西）

> 注：未跑完整 `--dev` 构建（耗时数分钟且会改动本地安装/环境）。