### PR TITLE
feat(identity): 家人成员手动更换头像，显式头像独立存到 avatars/

### DIFF
--- a/backend/miloco/src/miloco/perception/engine/identity/_avatar.py
+++ b/backend/miloco/src/miloco/perception/engine/identity/_avatar.py
@@ -20,10 +20,21 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import tempfile
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+# subject_id 白名单：人的 UUID 与宠物 pet_<hex> 都只含这些字符。用作路径/日志前一律
+# 强制校验——helper 不盲信调用方，从源头杜绝路径穿越与日志注入（纵深防御）。
+_SAFE_SUBJECT_ID = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def _safe_subject_id(subject_id: str) -> str:
+    if not _SAFE_SUBJECT_ID.fullmatch(subject_id or ""):
+        raise ValueError(f"非法 subject_id: {subject_id!r}")
+    return subject_id
 
 # 允许的头像扩展名（小写、无点）；_EXT_ORDER 供确定性遍历（正常只存在一个）。
 AVATAR_EXTS = frozenset({"jpg", "jpeg", "png", "webp"})
@@ -69,8 +80,9 @@ def _avatar_dir(root: Path, kind: str) -> Path:
 def avatar_path(root: Path, kind: str, subject_id: str) -> Path | None:
     """返回 ``<root>/avatars/<kind>/<id>.<ext>`` 中实际存在的那张（无则 None）。
 
-    逐 ext 精确探测（不 glob）：subject_id 已由上层白名单校验，此处不引入 glob 语义。
+    逐 ext 精确探测（不 glob）；subject_id 先过白名单校验，杜绝路径穿越。
     """
+    subject_id = _safe_subject_id(subject_id)
     d = _avatar_dir(root, kind)
     for ext in _EXT_ORDER:
         p = d / f"{subject_id}.{ext}"
@@ -86,6 +98,7 @@ def avatar_ext(root: Path, kind: str, subject_id: str) -> str | None:
 
 def set_avatar(root: Path, kind: str, subject_id: str, data: bytes, ext: str) -> str:
     """原子写头像并清掉该 subject 的其它扩展名旧图；返回规范化后的 ext。"""
+    subject_id = _safe_subject_id(subject_id)
     norm = normalize_avatar_ext(ext)
     if not data:
         raise ValueError("头像数据为空")
@@ -96,10 +109,11 @@ def set_avatar(root: Path, kind: str, subject_id: str, data: bytes, ext: str) ->
 
 def remove_avatar(root: Path, kind: str, subject_id: str) -> None:
     """删掉该 subject 的所有头像文件（恢复默认 / 删除实体级联时用）。"""
-    _remove(root, kind, subject_id, keep=None)
+    _remove(root, kind, _safe_subject_id(subject_id), keep=None)
 
 
 def _remove(root: Path, kind: str, subject_id: str, keep: str | None) -> None:
+    subject_id = _safe_subject_id(subject_id)
     d = _avatar_dir(root, kind)
     keep_name = f"{subject_id}.{keep}" if keep else None
     for ext in _EXT_ORDER:

--- a/backend/miloco/src/miloco/perception/engine/identity/_avatar.py
+++ b/backend/miloco/src/miloco/perception/engine/identity/_avatar.py
@@ -77,15 +77,25 @@ def _avatar_dir(root: Path, kind: str) -> Path:
     return Path(root) / "avatars" / kind
 
 
+def _avatar_file(root: Path, kind: str, subject_id: str, ext: str) -> Path:
+    """构造 ``avatars/<kind>/<id>.<ext>`` 并双重防穿越：白名单 id + 规范化后仍须落在该
+    目录内（后者是 CodeQL 认可的 path-containment sanitizer：os.path.realpath + commonpath）。"""
+    subject_id = _safe_subject_id(subject_id)
+    d = _avatar_dir(root, kind)
+    p = d / f"{subject_id}.{ext}"
+    base = os.path.realpath(d)
+    if os.path.commonpath((base, os.path.realpath(p))) != base:
+        raise ValueError(f"非法 subject_id: {subject_id!r}")
+    return p
+
+
 def avatar_path(root: Path, kind: str, subject_id: str) -> Path | None:
     """返回 ``<root>/avatars/<kind>/<id>.<ext>`` 中实际存在的那张（无则 None）。
 
-    逐 ext 精确探测（不 glob）；subject_id 先过白名单校验，杜绝路径穿越。
+    逐 ext 精确探测（不 glob）；路径经白名单 + containment 校验，杜绝穿越。
     """
-    subject_id = _safe_subject_id(subject_id)
-    d = _avatar_dir(root, kind)
     for ext in _EXT_ORDER:
-        p = d / f"{subject_id}.{ext}"
+        p = _avatar_file(root, kind, subject_id, ext)
         if p.is_file():
             return p
     return None
@@ -98,26 +108,24 @@ def avatar_ext(root: Path, kind: str, subject_id: str) -> str | None:
 
 def set_avatar(root: Path, kind: str, subject_id: str, data: bytes, ext: str) -> str:
     """原子写头像并清掉该 subject 的其它扩展名旧图；返回规范化后的 ext。"""
-    subject_id = _safe_subject_id(subject_id)
     norm = normalize_avatar_ext(ext)
     if not data:
         raise ValueError("头像数据为空")
-    _atomic_write(_avatar_dir(root, kind) / f"{subject_id}.{norm}", data)
+    _atomic_write(_avatar_file(root, kind, subject_id, norm), data)
     _remove(root, kind, subject_id, keep=norm)
     return norm
 
 
 def remove_avatar(root: Path, kind: str, subject_id: str) -> None:
     """删掉该 subject 的所有头像文件（恢复默认 / 删除实体级联时用）。"""
-    _remove(root, kind, _safe_subject_id(subject_id), keep=None)
+    _remove(root, kind, subject_id, keep=None)
 
 
 def _remove(root: Path, kind: str, subject_id: str, keep: str | None) -> None:
     subject_id = _safe_subject_id(subject_id)
-    d = _avatar_dir(root, kind)
     keep_name = f"{subject_id}.{keep}" if keep else None
     for ext in _EXT_ORDER:
-        p = d / f"{subject_id}.{ext}"
+        p = _avatar_file(root, kind, subject_id, ext)
         if keep_name and p.name == keep_name:
             continue
         if p.is_file():

--- a/backend/miloco/src/miloco/perception/engine/identity/_avatar.py
+++ b/backend/miloco/src/miloco/perception/engine/identity/_avatar.py
@@ -1,0 +1,140 @@
+# Copyright (C) 2025 Xiaomi Corporation
+# This software may be used and distributed according to the terms of the Xiaomi Miloco License Agreement.
+
+"""统一头像存取（人 / 宠物共用）。
+
+落点：``<lib_root>/avatars/<kind>/<subject_id>.<ext>``，其中 ``kind`` ∈ {"persons",
+"pets"}。**展示头像与识别数据分离**——识别数据在 ``<lib_root>/persons/`` 与
+``<lib_root>/pets/``，头像统一在 ``<lib_root>/avatars/``。
+
+``avatars/`` 与 ``persons/`` / ``pets/`` 平级：``IdentityLibrary`` 只遍历
+``root/persons``、``PetLibrary`` 只遍历 ``root/pets``，两者都从不遍历 ``root`` 本身，
+故 ``avatars/`` 不会被任何识别扫描误触——给未录入的人设头像也**不会**扰动
+IdentityEngine 的 person 快照（不新建 ``persons/<id>/`` 目录）。
+
+头像**纯展示**：不进 person 表 / ReID / gallery / 识别参照。文件在盘即为权威
+（ext 由文件名推导，无需 meta 指针）。
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# 允许的头像扩展名（小写、无点）；_EXT_ORDER 供确定性遍历（正常只存在一个）。
+AVATAR_EXTS = frozenset({"jpg", "jpeg", "png", "webp"})
+_EXT_ORDER = ("jpg", "jpeg", "png", "webp")
+_AVATAR_MEDIA = {
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "png": "image/png",
+    "webp": "image/webp",
+}
+
+
+def normalize_avatar_ext(ext: str) -> str:
+    e = (ext or "").lower().lstrip(".")
+    if e not in AVATAR_EXTS:
+        raise ValueError(f"不支持的头像格式: {ext!r}（允许 {sorted(AVATAR_EXTS)}）")
+    return e
+
+
+def media_type(ext: str) -> str:
+    return _AVATAR_MEDIA.get((ext or "").lower().lstrip("."), "application/octet-stream")
+
+
+def _atomic_write(path: Path, data: bytes) -> None:
+    """write-temp-then-rename 原子落盘 + fsync——避免崩溃留"半张图"。"""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    finally:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+
+
+def _avatar_dir(root: Path, kind: str) -> Path:
+    return Path(root) / "avatars" / kind
+
+
+def avatar_path(root: Path, kind: str, subject_id: str) -> Path | None:
+    """返回 ``<root>/avatars/<kind>/<id>.<ext>`` 中实际存在的那张（无则 None）。
+
+    逐 ext 精确探测（不 glob）：subject_id 已由上层白名单校验，此处不引入 glob 语义。
+    """
+    d = _avatar_dir(root, kind)
+    for ext in _EXT_ORDER:
+        p = d / f"{subject_id}.{ext}"
+        if p.is_file():
+            return p
+    return None
+
+
+def avatar_ext(root: Path, kind: str, subject_id: str) -> str | None:
+    p = avatar_path(root, kind, subject_id)
+    return p.suffix.lstrip(".").lower() if p else None
+
+
+def set_avatar(root: Path, kind: str, subject_id: str, data: bytes, ext: str) -> str:
+    """原子写头像并清掉该 subject 的其它扩展名旧图；返回规范化后的 ext。"""
+    norm = normalize_avatar_ext(ext)
+    if not data:
+        raise ValueError("头像数据为空")
+    _atomic_write(_avatar_dir(root, kind) / f"{subject_id}.{norm}", data)
+    _remove(root, kind, subject_id, keep=norm)
+    return norm
+
+
+def remove_avatar(root: Path, kind: str, subject_id: str) -> None:
+    """删掉该 subject 的所有头像文件（恢复默认 / 删除实体级联时用）。"""
+    _remove(root, kind, subject_id, keep=None)
+
+
+def _remove(root: Path, kind: str, subject_id: str, keep: str | None) -> None:
+    d = _avatar_dir(root, kind)
+    keep_name = f"{subject_id}.{keep}" if keep else None
+    for ext in _EXT_ORDER:
+        p = d / f"{subject_id}.{ext}"
+        if keep_name and p.name == keep_name:
+            continue
+        if p.is_file():
+            try:
+                p.unlink()
+            except OSError:  # noqa: PERF203
+                logger.warning("删除旧头像失败: %s", p, exc_info=True)
+
+
+def list_avatar_exts(root: Path, kind: str) -> dict[str, str]:
+    """一次扫描 ``avatars/<kind>/`` 返回 ``{subject_id: ext}``，供列表端点批量取。"""
+    d = _avatar_dir(root, kind)
+    out: dict[str, str] = {}
+    if not d.is_dir():
+        return out
+    for p in d.iterdir():
+        if not p.is_file():
+            continue
+        ext = p.suffix.lstrip(".").lower()
+        if ext in AVATAR_EXTS:
+            out[p.stem] = ext
+    return out
+
+
+__all__ = [
+    "AVATAR_EXTS",
+    "avatar_ext",
+    "avatar_path",
+    "list_avatar_exts",
+    "media_type",
+    "normalize_avatar_ext",
+    "remove_avatar",
+    "set_avatar",
+]

--- a/backend/miloco/src/miloco/perception/engine/identity/library.py
+++ b/backend/miloco/src/miloco/perception/engine/identity/library.py
@@ -49,6 +49,7 @@ import cv2
 import numpy as np
 from numpy.typing import NDArray
 
+from miloco.perception.engine.identity import _avatar
 from miloco.perception.engine.identity._image_utils import (
     hamming as _hamming,
 )
@@ -550,6 +551,28 @@ class IdentityLibrary:
         """该 person 在文件层是否已有目录(已注册样本/meta)。封装 persons_dir/<id> 布局,
         供调用方做"无样本 person 不建目录"之类的守卫, 不必自己拼内部路径。"""
         return (self.persons_dir / person_id).is_dir()
+
+    # ── 显式头像（展示层）────────────────────────────────────────────────────
+    # 落点 <root>/avatars/persons/<id>.<ext>，与 tier_a/tier_c 识别数据分离；**不建
+    # persons/<id>/ 目录**——给没录入的人设头像也不会让空目录进 list_persons、
+    # 从而不扰动 IdentityEngine 的 person 快照。展示优先级由调用方决定（显式头像 >
+    # 否则回落 tier_a face[0]），见 person/router 的 GET /avatar。
+
+    def person_avatar_path(self, person_id: str) -> Path | None:
+        """显式头像文件路径（无则 None）。"""
+        return _avatar.avatar_path(self.root, "persons", person_id)
+
+    def set_person_avatar(self, person_id: str, data: bytes, ext: str) -> str:
+        """写显式头像，返回规范化后的 ext。"""
+        return _avatar.set_avatar(self.root, "persons", person_id, data, ext)
+
+    def clear_person_avatar(self, person_id: str) -> None:
+        """清显式头像（"恢复默认"→下次读取回落 face[0]）。"""
+        _avatar.remove_avatar(self.root, "persons", person_id)
+
+    def list_person_avatar_exts(self) -> dict[str, str]:
+        """一次扫描返回 ``{person_id: ext}``，供 list_persons 批量填 avatar_ext。"""
+        return _avatar.list_avatar_exts(self.root, "persons")
 
     def add_face_only_sample(self, person_id: str, face_crop, source: str = "user_upload") -> bool:
         """只写一张 face_*.png + sidecar, 绕过 add_tier_a_sample 的"必须有 body"约束。

--- a/backend/miloco/src/miloco/person/router.py
+++ b/backend/miloco/src/miloco/person/router.py
@@ -7,7 +7,6 @@ import asyncio
 import logging
 import re
 import threading
-from pathlib import Path
 
 import cv2
 import numpy as np
@@ -732,6 +731,19 @@ async def read_tier_sample(
 # =============================================================================
 
 
+def _sniff_image_ext(data: bytes) -> str | None:
+    """按文件头魔数判定真实图片格式（jpg/png/webp），不看文件名后缀——杜绝「后缀与
+    内容不符」，让盘上后缀 / Content-Type / 真实字节恒一致；不在白名单则 None。
+    （不引 imghdr——3.13 已移除；也不引 Pillow 新依赖。）"""
+    if data[:3] == b"\xff\xd8\xff":
+        return "jpg"
+    if data[:8] == b"\x89PNG\r\n\x1a\n":
+        return "png"
+    if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "webp"
+    return None
+
+
 @router.post(
     "/persons/{person_id}/avatar", summary="Upload Person Avatar", response_model=NormalResponse
 )
@@ -745,11 +757,13 @@ async def upload_person_avatar(
     if not manager.person_service.exists(person_id):
         raise HTTPException(status_code=404, detail="person 不存在")
     data = await image.read()
-    # 校验确为可解码图片：挡「后缀是图、内容不是图」的坏字节（用现有 cv2，同 enroll 口径，
-    # 不引额外依赖）。避免坏字节被落盘后按 image/* 发回。
+    # 先确认能解码（挡垃圾字节），再按魔数取真实格式作落盘扩展名——不信任文件名后缀，
+    # 让 盘上后缀 / Content-Type / 真实字节 三者恒一致（同 enroll 口径用 cv2、不引新依赖）。
     if cv2.imdecode(np.frombuffer(data, np.uint8), cv2.IMREAD_COLOR) is None:
         raise HTTPException(status_code=400, detail="无法识别的图片")
-    ext = Path(image.filename or "").suffix.lstrip(".").lower()
+    ext = _sniff_image_ext(data)
+    if ext is None:
+        raise HTTPException(status_code=400, detail="不支持的图片格式（仅 jpg/png/webp）")
     try:
         norm = _get_identity_library().set_person_avatar(person_id, data=data, ext=ext)
     except ValueError as e:

--- a/backend/miloco/src/miloco/person/router.py
+++ b/backend/miloco/src/miloco/person/router.py
@@ -31,7 +31,8 @@ from miloco.utils.paths import miloco_home
 _PERSON_ID_RE = re.compile(
     r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z"
 )
-# 头像上传大小上限：前端裁剪产物恒 ~20-50KB，直连 API 兜底防超大文件读进内存。
+# 头像上传大小上限：前端裁剪产物恒 ~20-50KB；直连 API 时用 image.size 前置闸拦超大包
+# （不必先读进内存）、读后 len 兜底。
 _MAX_AVATAR_BYTES = 5 * 1024 * 1024
 
 logger = logging.getLogger(__name__)
@@ -760,8 +761,11 @@ async def upload_person_avatar(
         raise HTTPException(status_code=400, detail="Invalid person_id format")
     if not manager.person_service.exists(person_id):
         raise HTTPException(status_code=404, detail="person 不存在")
+    # 前置闸：用 multipart 自带的字节数拦超大包，不必先读进内存（size 缺失时靠读后兜底）。
+    if image.size is not None and image.size > _MAX_AVATAR_BYTES:
+        raise HTTPException(status_code=400, detail="图片过大（上限 5 MB）")
     data = await image.read()
-    if len(data) > _MAX_AVATAR_BYTES:
+    if len(data) > _MAX_AVATAR_BYTES:  # size 缺失时兜底
         raise HTTPException(status_code=400, detail="图片过大（上限 5 MB）")
     # 先确认能解码（挡垃圾字节），再按魔数取真实格式作落盘扩展名——不信任文件名后缀，
     # 让 盘上后缀 / Content-Type / 真实字节 三者恒一致（同 enroll 口径用 cv2、不引新依赖）。

--- a/backend/miloco/src/miloco/person/router.py
+++ b/backend/miloco/src/miloco/person/router.py
@@ -7,6 +7,7 @@ import asyncio
 import logging
 import re
 import threading
+from pathlib import Path
 
 import cv2
 import numpy as np
@@ -18,6 +19,7 @@ from miloco.config import get_settings, register_reset_hook
 from miloco.database.person_repo import UNSET
 from miloco.manager import get_manager
 from miloco.middleware import verify_token
+from miloco.perception.engine.identity import _avatar
 from miloco.perception.engine.identity.config_loader import resolve_library_root
 from miloco.perception.engine.identity.library import IdentityLibrary, _list_crop_files
 from miloco.person.schema import PersonCreate, PersonUpdate, _normalize_optional_str
@@ -44,11 +46,16 @@ async def list_persons(current_user: str = Depends(verify_token)):
     logger.info("List persons - user: %s", current_user)
     persons = manager.person_service.list_persons()
     # PersonRef 索引化:避免 N×M scan
+    refs: dict = {}
+    avatar_exts: dict = {}
     try:
-        refs = {r.person_id: r for r in _get_identity_library().list_persons()}
+        lib = _get_identity_library()
+        refs = {r.person_id: r for r in lib.list_persons()}
+        # 显式头像扩展名（<root>/avatars/persons/<id>.<ext>）一次扫描批量取，供前端
+        # 决定头像取自"显式头像"还是回落 face[0]。
+        avatar_exts = lib.list_person_avatar_exts()
     except Exception as exc:  # noqa: BLE001
         logger.warning("list_persons: 读 identity_lib 失败,sample 计数归零: %s", exc)
-        refs = {}
     data = []
     for p in persons:
         d = p.model_dump()
@@ -56,6 +63,7 @@ async def list_persons(current_user: str = Depends(verify_token)):
         d["num_tier_a_body"] = r.num_tier_a_body if r else 0
         d["num_tier_c"] = r.num_tier_c if r else 0
         d["has_tier_a"] = bool(r and r.has_tier_a)
+        d["avatar_ext"] = avatar_exts.get(p.id)
         data.append(d)
     return NormalResponse(
         code=0,
@@ -131,9 +139,12 @@ async def delete_person(person_id: str, current_user: str = Depends(verify_token
         raise HTTPException(status_code=400, detail="Invalid person_id format")
     manager.person_service.delete_person(person_id)
     # 级联删 identity_lib 文件——否则 list_persons / gallery 仍含此人，
-    # omni 会继续把画面中的人识别为已删除成员
+    # omni 会继续把画面中的人识别为已删除成员。顺带清 <root>/avatars/persons/<id>.*
+    # （显式头像在 avatars/ 树、不在 persons/<id>/ 内，rmtree 清不到，须显式删）。
     try:
-        _get_identity_library().delete_person(person_id)
+        lib = _get_identity_library()
+        lib.delete_person(person_id)
+        lib.clear_person_avatar(person_id)
     except Exception as e:  # noqa: BLE001
         logger.warning("级联删除 identity_lib 失败 person_id=%s: %s", person_id, e)
     # 级联清家庭档案：移除该成员绑定的候选+正式条目并重渲染 md，
@@ -712,6 +723,74 @@ async def read_tier_sample(
     # 落盘格式 jpg→png 迁移后, Content-Type 随实际后缀走, 否则浏览器按 jpeg 解析 png 字节会坏图
     media_type = "image/png" if path.suffix.lower() == ".png" else "image/jpeg"
     return FileResponse(str(path), media_type=media_type)
+
+
+# =============================================================================
+# 显式头像（手动上传，展示层）——落 <root>/avatars/persons/<id>.<ext>，与识别样本分离。
+# 不建 persons/<id>/ 目录，故给"没录入的人"设头像也不扰动 IdentityEngine 快照。
+# 读取优先级：显式头像 > 回落 tier_a face[0]（旧行为）> 404（前端显示占位色块）。
+# =============================================================================
+
+
+@router.post(
+    "/persons/{person_id}/avatar", summary="Upload Person Avatar", response_model=NormalResponse
+)
+async def upload_person_avatar(
+    person_id: str,
+    image: UploadFile = File(..., description="头像图片（jpg/jpeg/png/webp）"),
+    current_user: str = Depends(verify_token),
+):
+    if not _PERSON_ID_RE.match(person_id):
+        raise HTTPException(status_code=400, detail="Invalid person_id format")
+    if not manager.person_service.exists(person_id):
+        raise HTTPException(status_code=404, detail="person 不存在")
+    data = await image.read()
+    ext = Path(image.filename or "").suffix.lstrip(".").lower()
+    try:
+        norm = _get_identity_library().set_person_avatar(person_id, data=data, ext=ext)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    return NormalResponse(
+        code=0, message="Avatar updated", data={"id": person_id, "avatar_ext": norm}
+    )
+
+
+@router.get(
+    "/persons/{person_id}/avatar",
+    summary="Get Person Avatar（显式头像，无则回落 tier_a face[0]）",
+)
+async def get_person_avatar(person_id: str, current_user: str = Depends(verify_token)):
+    if not _PERSON_ID_RE.match(person_id):
+        raise HTTPException(status_code=400, detail="Invalid person_id format")
+    library = _get_identity_library()
+    # 1) 显式头像优先
+    path = library.person_avatar_path(person_id)
+    if path is not None:
+        return FileResponse(
+            str(path), media_type=_avatar.media_type(path.suffix.lstrip(".").lower())
+        )
+    # 2) 回落 tier_a face[0]（字母序首张，旧 PersonAvatar 行为）
+    _body, face = _list_tier_a_files_dict(person_id)
+    if face:
+        fpath = library.persons_dir / person_id / "tier_a" / face[0]["filename"]
+        if fpath.is_file():
+            media = "image/png" if fpath.suffix.lower() == ".png" else "image/jpeg"
+            return FileResponse(str(fpath), media_type=media)
+    raise HTTPException(status_code=404, detail="avatar 不存在")
+
+
+@router.delete(
+    "/persons/{person_id}/avatar",
+    summary="Delete Person Avatar（清显式头像，恢复默认 face[0]）",
+    response_model=NormalResponse,
+)
+async def delete_person_avatar(person_id: str, current_user: str = Depends(verify_token)):
+    if not _PERSON_ID_RE.match(person_id):
+        raise HTTPException(status_code=400, detail="Invalid person_id format")
+    _get_identity_library().clear_person_avatar(person_id)
+    return NormalResponse(
+        code=0, message="Avatar cleared", data={"id": person_id, "avatar_ext": None}
+    )
 
 
 @router.get(

--- a/backend/miloco/src/miloco/person/router.py
+++ b/backend/miloco/src/miloco/person/router.py
@@ -26,8 +26,10 @@ from miloco.schema.common_schema import NormalResponse
 from miloco.utils.paths import miloco_home
 
 # 严格 UUID4 白名单：拒绝路径分隔符、`..` 等可构造路径穿越的字符
+# 用 \Z（而非 $）严格锚定串尾：$ 会放过结尾一个换行（re.match 下 "uuid\n" 也 match），
+# \Z 不会——杜绝带尾随换行的 id 混入。
 _PERSON_ID_RE = re.compile(
-    r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z"
 )
 
 logger = logging.getLogger(__name__)

--- a/backend/miloco/src/miloco/person/router.py
+++ b/backend/miloco/src/miloco/person/router.py
@@ -745,6 +745,10 @@ async def upload_person_avatar(
     if not manager.person_service.exists(person_id):
         raise HTTPException(status_code=404, detail="person 不存在")
     data = await image.read()
+    # 校验确为可解码图片：挡「后缀是图、内容不是图」的坏字节（用现有 cv2，同 enroll 口径，
+    # 不引额外依赖）。避免坏字节被落盘后按 image/* 发回。
+    if cv2.imdecode(np.frombuffer(data, np.uint8), cv2.IMREAD_COLOR) is None:
+        raise HTTPException(status_code=400, detail="无法识别的图片")
     ext = Path(image.filename or "").suffix.lstrip(".").lower()
     try:
         norm = _get_identity_library().set_person_avatar(person_id, data=data, ext=ext)

--- a/backend/miloco/src/miloco/person/router.py
+++ b/backend/miloco/src/miloco/person/router.py
@@ -31,6 +31,8 @@ from miloco.utils.paths import miloco_home
 _PERSON_ID_RE = re.compile(
     r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\Z"
 )
+# 头像上传大小上限：前端裁剪产物恒 ~20-50KB，直连 API 兜底防超大文件读进内存。
+_MAX_AVATAR_BYTES = 5 * 1024 * 1024
 
 logger = logging.getLogger(__name__)
 
@@ -759,6 +761,8 @@ async def upload_person_avatar(
     if not manager.person_service.exists(person_id):
         raise HTTPException(status_code=404, detail="person 不存在")
     data = await image.read()
+    if len(data) > _MAX_AVATAR_BYTES:
+        raise HTTPException(status_code=400, detail="图片过大（上限 5 MB）")
     # 先确认能解码（挡垃圾字节），再按魔数取真实格式作落盘扩展名——不信任文件名后缀，
     # 让 盘上后缀 / Content-Type / 真实字节 三者恒一致（同 enroll 口径用 cv2、不引新依赖）。
     if cv2.imdecode(np.frombuffer(data, np.uint8), cv2.IMREAD_COLOR) is None:

--- a/backend/miloco/tests/test_person_router_avatar.py
+++ b/backend/miloco/tests/test_person_router_avatar.py
@@ -168,9 +168,18 @@ async def test_post_bad_bytes_400(wired):
 
 
 async def test_post_too_large_400(wired):
-    # 超过大小上限（>5MB）→ 400（在解码前就拦下）
+    # 超大包、有 size：走前置闸（不读进内存）→ 400
     big = _PNG + b"\x00" * (5 * 1024 * 1024)
-    up = UploadFile(filename="a.png", file=io.BytesIO(big))
+    up = UploadFile(filename="a.png", file=io.BytesIO(big), size=len(big))
+    with pytest.raises(HTTPException) as ei:
+        await upload_person_avatar(_PID, image=up, current_user="t")
+    assert ei.value.status_code == 400
+
+
+async def test_post_too_large_no_size_400(wired):
+    # size 缺失：走读后 len 兜底 → 仍 400
+    big = _PNG + b"\x00" * (5 * 1024 * 1024)
+    up = UploadFile(filename="a.png", file=io.BytesIO(big))  # size=None
     with pytest.raises(HTTPException) as ei:
         await upload_person_avatar(_PID, image=up, current_user="t")
     assert ei.value.status_code == 400

--- a/backend/miloco/tests/test_person_router_avatar.py
+++ b/backend/miloco/tests/test_person_router_avatar.py
@@ -1,0 +1,150 @@
+"""人类成员「显式头像」单测（B-统一：avatars/persons/<id>.<ext>，展示层）。
+
+覆盖：库层 set/path/clear/list_exts + **零引擎扰动不变量**（设/删头像不建 persons/<id>/）；
+端点解析优先级（显式头像 > 回落 tier_a face[0] > 404）；POST 存在性校验；DELETE 恢复默认。
+"""
+from __future__ import annotations
+
+import io
+
+import pytest
+from fastapi import HTTPException, UploadFile
+from fastapi.responses import FileResponse
+from miloco.perception.engine.identity.library import IdentityLibrary
+from miloco.person import router as prouter
+from miloco.person.router import (
+    delete_person_avatar,
+    get_person_avatar,
+    upload_person_avatar,
+)
+
+_PID = "33333333-3333-4333-8333-333333333333"
+
+
+@pytest.fixture
+def lib(tmp_path):
+    return IdentityLibrary(tmp_path)
+
+
+@pytest.fixture
+def wired(monkeypatch, lib):
+    """把路由的 _get_identity_library + manager.person_service 指到本 tmp 库/桩。"""
+    monkeypatch.setattr(prouter, "_get_identity_library", lambda: lib)
+    monkeypatch.setattr(
+        prouter, "manager",
+        type("M", (), {"person_service": type("P", (), {"exists": staticmethod(lambda pid: True)})()})(),
+    )
+    return lib
+
+
+# ── 库层 ──────────────────────────────────────────────────────────────────
+
+def test_set_path_clear(lib):
+    assert lib.person_avatar_path(_PID) is None
+    norm = lib.set_person_avatar(_PID, data=b"\xff\xd8\xffX", ext="JPG")
+    assert norm == "jpg"
+    p = lib.person_avatar_path(_PID)
+    assert p is not None and p.is_file()
+    assert p == lib.root / "avatars" / "persons" / f"{_PID}.jpg"
+    assert lib.list_person_avatar_exts() == {_PID: "jpg"}
+    lib.clear_person_avatar(_PID)
+    assert lib.person_avatar_path(_PID) is None
+    assert lib.list_person_avatar_exts() == {}
+
+
+def test_ext_change_removes_old(lib):
+    lib.set_person_avatar(_PID, data=b"a", ext="jpg")
+    lib.set_person_avatar(_PID, data=b"b", ext="png")
+    d = lib.root / "avatars" / "persons"
+    assert sorted(x.name for x in d.glob(f"{_PID}.*")) == [f"{_PID}.png"]
+    assert lib.person_avatar_path(_PID).read_bytes() == b"b"
+
+
+def test_zero_engine_perturbation(lib):
+    """**关键不变量**：给（没录入的）人设/删头像绝不创建 persons/<id>/ 目录，
+    从而不会让空目录进 list_persons、扰动 IdentityEngine 快照。"""
+    lib.set_person_avatar(_PID, data=b"x", ext="png")
+    assert not (lib.persons_dir / _PID).exists()
+    assert lib.list_persons() == []  # 引擎快照来源为空，无扰动
+    lib.clear_person_avatar(_PID)
+    assert not (lib.persons_dir / _PID).exists()
+
+
+def test_bad_ext_raises(lib):
+    with pytest.raises(ValueError):
+        lib.set_person_avatar(_PID, data=b"x", ext="gif")
+
+
+# ── 端点：GET 解析优先级 ─────────────────────────────────────────────────────
+
+async def test_get_explicit_avatar(wired, lib):
+    lib.set_person_avatar(_PID, data=b"x", ext="png")
+    resp = await get_person_avatar(_PID, current_user="t")
+    assert isinstance(resp, FileResponse)
+    assert str(resp.path).endswith(f"avatars/persons/{_PID}.png")
+
+
+async def test_get_fallback_face(wired, lib):
+    # 无显式头像但有 tier_a face → 回落 face[0]（旧行为）
+    tier_a = lib.persons_dir / _PID / "tier_a"
+    tier_a.mkdir(parents=True)
+    (tier_a / "face_1.jpg").write_bytes(b"\xff\xd8\xffFACE")
+    resp = await get_person_avatar(_PID, current_user="t")
+    assert isinstance(resp, FileResponse)
+    assert str(resp.path).endswith("tier_a/face_1.jpg")
+
+
+async def test_get_404_when_none(wired):
+    with pytest.raises(HTTPException) as ei:
+        await get_person_avatar(_PID, current_user="t")
+    assert ei.value.status_code == 404
+
+
+async def test_explicit_beats_face(wired, lib):
+    tier_a = lib.persons_dir / _PID / "tier_a"
+    tier_a.mkdir(parents=True)
+    (tier_a / "face_1.jpg").write_bytes(b"FACE")
+    lib.set_person_avatar(_PID, data=b"EXPLICIT", ext="png")
+    resp = await get_person_avatar(_PID, current_user="t")
+    assert str(resp.path).endswith(f"avatars/persons/{_PID}.png")
+
+
+# ── 端点：POST / DELETE ─────────────────────────────────────────────────────
+
+async def test_post_sets_avatar(wired, lib):
+    up = UploadFile(filename="a.png", file=io.BytesIO(b"\x89PNGdata"))
+    res = await upload_person_avatar(_PID, image=up, current_user="t")
+    assert res.code == 0 and res.data["avatar_ext"] == "png"
+    assert lib.person_avatar_path(_PID) is not None
+
+
+async def test_post_404_no_person(monkeypatch, lib):
+    monkeypatch.setattr(prouter, "_get_identity_library", lambda: lib)
+    monkeypatch.setattr(
+        prouter, "manager",
+        type("M", (), {"person_service": type("P", (), {"exists": staticmethod(lambda pid: False)})()})(),
+    )
+    up = UploadFile(filename="a.png", file=io.BytesIO(b"x"))
+    with pytest.raises(HTTPException) as ei:
+        await upload_person_avatar(_PID, image=up, current_user="t")
+    assert ei.value.status_code == 404
+
+
+async def test_post_bad_ext_400(wired):
+    up = UploadFile(filename="a.gif", file=io.BytesIO(b"x"))
+    with pytest.raises(HTTPException) as ei:
+        await upload_person_avatar(_PID, image=up, current_user="t")
+    assert ei.value.status_code == 400
+
+
+async def test_delete_clears(wired, lib):
+    lib.set_person_avatar(_PID, data=b"x", ext="png")
+    res = await delete_person_avatar(_PID, current_user="t")
+    assert res.code == 0 and res.data["avatar_ext"] is None
+    assert lib.person_avatar_path(_PID) is None
+
+
+async def test_bad_id_400(wired):
+    with pytest.raises(HTTPException) as ei:
+        await get_person_avatar("../etc/passwd", current_user="t")
+    assert ei.value.status_code == 400

--- a/backend/miloco/tests/test_person_router_avatar.py
+++ b/backend/miloco/tests/test_person_router_avatar.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import io
 
+import cv2
+import numpy as np
 import pytest
 from fastapi import HTTPException, UploadFile
 from fastapi.responses import FileResponse
@@ -19,6 +21,8 @@ from miloco.person.router import (
 )
 
 _PID = "33333333-3333-4333-8333-333333333333"
+# 真·PNG 字节（cv2 可解码），供需要「合法图片」的端点用例
+_PNG = cv2.imencode(".png", np.zeros((4, 4, 3), np.uint8))[1].tobytes()
 
 
 @pytest.fixture
@@ -119,7 +123,7 @@ async def test_explicit_beats_face(wired, lib):
 # ── 端点：POST / DELETE ─────────────────────────────────────────────────────
 
 async def test_post_sets_avatar(wired, lib):
-    up = UploadFile(filename="a.png", file=io.BytesIO(b"\x89PNGdata"))
+    up = UploadFile(filename="a.png", file=io.BytesIO(_PNG))
     res = await upload_person_avatar(_PID, image=up, current_user="t")
     assert res.code == 0 and res.data["avatar_ext"] == "png"
     assert lib.person_avatar_path(_PID) is not None
@@ -138,7 +142,16 @@ async def test_post_404_no_person(monkeypatch, lib):
 
 
 async def test_post_bad_ext_400(wired):
-    up = UploadFile(filename="a.gif", file=io.BytesIO(b"x"))
+    # 合法图片、但后缀不在白名单 → 400（走 ext 校验，不被字节校验提前拦）
+    up = UploadFile(filename="a.gif", file=io.BytesIO(_PNG))
+    with pytest.raises(HTTPException) as ei:
+        await upload_person_avatar(_PID, image=up, current_user="t")
+    assert ei.value.status_code == 400
+
+
+async def test_post_bad_bytes_400(wired):
+    # 后缀合法、但内容不是可解码图片 → 400
+    up = UploadFile(filename="a.png", file=io.BytesIO(b"not-an-image"))
     with pytest.raises(HTTPException) as ei:
         await upload_person_avatar(_PID, image=up, current_user="t")
     assert ei.value.status_code == 400

--- a/backend/miloco/tests/test_person_router_avatar.py
+++ b/backend/miloco/tests/test_person_router_avatar.py
@@ -167,6 +167,15 @@ async def test_post_bad_bytes_400(wired):
     assert ei.value.status_code == 400
 
 
+async def test_post_too_large_400(wired):
+    # 超过大小上限（>5MB）→ 400（在解码前就拦下）
+    big = _PNG + b"\x00" * (5 * 1024 * 1024)
+    up = UploadFile(filename="a.png", file=io.BytesIO(big))
+    with pytest.raises(HTTPException) as ei:
+        await upload_person_avatar(_PID, image=up, current_user="t")
+    assert ei.value.status_code == 400
+
+
 async def test_delete_clears(wired, lib):
     lib.set_person_avatar(_PID, data=b"x", ext="png")
     res = await delete_person_avatar(_PID, current_user="t")

--- a/backend/miloco/tests/test_person_router_avatar.py
+++ b/backend/miloco/tests/test_person_router_avatar.py
@@ -75,6 +75,13 @@ def test_bad_ext_raises(lib):
         lib.set_person_avatar(_PID, data=b"x", ext="gif")
 
 
+def test_bad_subject_id_raises(lib):
+    """路径穿越防御：非法 id（含 / . 或 ..）在库层即 raise、不落盘。"""
+    for bad in ("../etc/passwd", "a/b", "..", "x.y", ""):
+        with pytest.raises(ValueError):
+            lib.set_person_avatar(bad, data=b"x", ext="png")
+
+
 # ── 端点：GET 解析优先级 ─────────────────────────────────────────────────────
 
 async def test_get_explicit_avatar(wired, lib):

--- a/backend/miloco/tests/test_person_router_avatar.py
+++ b/backend/miloco/tests/test_person_router_avatar.py
@@ -178,3 +178,10 @@ async def test_bad_id_400(wired):
     with pytest.raises(HTTPException) as ei:
         await get_person_avatar("../etc/passwd", current_user="t")
     assert ei.value.status_code == 400
+
+
+async def test_trailing_newline_id_400(wired):
+    # UUID 带结尾换行：正则用 \Z 严格锚尾，应 400（不被 re.match 的 $ 放过）
+    with pytest.raises(HTTPException) as ei:
+        await get_person_avatar(_PID + "\n", current_user="t")
+    assert ei.value.status_code == 400

--- a/backend/miloco/tests/test_person_router_avatar.py
+++ b/backend/miloco/tests/test_person_router_avatar.py
@@ -21,8 +21,10 @@ from miloco.person.router import (
 )
 
 _PID = "33333333-3333-4333-8333-333333333333"
-# 真·PNG 字节（cv2 可解码），供需要「合法图片」的端点用例
+# 真·PNG / BMP 字节（cv2 可解码），供端点用例：PNG 是白名单格式；BMP 用于「可解码但
+# 非白名单格式」→ 400 的用例。
 _PNG = cv2.imencode(".png", np.zeros((4, 4, 3), np.uint8))[1].tobytes()
+_BMP = cv2.imencode(".bmp", np.zeros((4, 4, 3), np.uint8))[1].tobytes()
 
 
 @pytest.fixture
@@ -141,12 +143,20 @@ async def test_post_404_no_person(monkeypatch, lib):
     assert ei.value.status_code == 404
 
 
-async def test_post_bad_ext_400(wired):
-    # 合法图片、但后缀不在白名单 → 400（走 ext 校验，不被字节校验提前拦）
-    up = UploadFile(filename="a.gif", file=io.BytesIO(_PNG))
+async def test_post_unsupported_format_400(wired):
+    # 内容可解码但非白名单格式（BMP）→ 400（格式由内容定，不看文件名后缀）
+    up = UploadFile(filename="a.png", file=io.BytesIO(_BMP))
     with pytest.raises(HTTPException) as ei:
         await upload_person_avatar(_PID, image=up, current_user="t")
     assert ei.value.status_code == 400
+
+
+async def test_post_ext_from_content_not_filename(wired, lib):
+    # 落盘扩展名取自真实内容而非文件名后缀：真 PNG 命名 x.jpg → 存成 png
+    up = UploadFile(filename="x.jpg", file=io.BytesIO(_PNG))
+    res = await upload_person_avatar(_PID, image=up, current_user="t")
+    assert res.data["avatar_ext"] == "png"
+    assert lib.person_avatar_path(_PID).suffix == ".png"
 
 
 async def test_post_bad_bytes_400(wired):

--- a/backend/miloco/tests/test_person_router_cascade.py
+++ b/backend/miloco/tests/test_person_router_cascade.py
@@ -43,8 +43,12 @@ def calls(monkeypatch):
     )
     monkeypatch.setattr(
         prouter, "_get_identity_library",
-        lambda: SimpleNamespace(delete_person=lambda pid: rec["lib_delete"].append(pid)),
+        lambda: SimpleNamespace(
+            delete_person=lambda pid: rec["lib_delete"].append(pid),
+            clear_person_avatar=lambda pid: rec["clear_avatar"].append(pid),
+        ),
     )
+    rec["clear_avatar"] = []
     return rec
 
 
@@ -53,6 +57,8 @@ async def test_delete_person_cascades_remove_subject(calls):
     assert res.code == 0
     assert calls["lib_delete"] == [_PID]
     assert calls["remove"] == [_PID]
+    # 级联清显式头像（avatars/persons/<id>.*，不在 persons/<id>/ 内）
+    assert calls["clear_avatar"] == [_PID]
 
 
 async def test_update_person_cascades_commit(calls):

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -111,6 +111,19 @@ export async function enrollPersonSample(
   return impl.realEnrollPersonSample(personId, imageBase64);
 }
 
+// 手动头像：上传显式头像 / 清除（恢复默认→回落 tier_a face[0]）
+export async function uploadPersonAvatar(
+  personId: string,
+  image: Blob,
+  filename: string,
+): Promise<void> {
+  return impl.realUploadPersonAvatar(personId, image, filename);
+}
+
+export async function deletePersonAvatar(personId: string): Promise<void> {
+  return impl.realDeletePersonAvatar(personId);
+}
+
 // ── 家庭档案（home_profile）────────────────────────────────
 // UI 只调这组语义函数；snake_case 的 op 构造全收在 real.ts，组件不碰。
 function today(): string {

--- a/web/src/api/real.ts
+++ b/web/src/api/real.ts
@@ -168,6 +168,8 @@ interface BackendPerson {
   num_tier_a_body?: number;
   num_tier_c?: number;
   has_tier_a?: boolean;
+  // 手动上传的显式头像后缀（avatars/persons/<id>.<ext>）；无则 null
+  avatar_ext?: string | null;
   created_at?: string;
   updated_at?: string;
 }
@@ -238,6 +240,7 @@ export async function realListPersons(): Promise<Person[]> {
       faceEnrolled: p.has_tier_a ?? p.face_enrolled,
       voiceEnrolled: p.voice_enrolled,
       avatarHue: i % 6,
+      avatarExt: p.avatar_ext ?? null,
     };
   });
 }
@@ -306,6 +309,31 @@ export async function realEnrollPersonSample(
     const body = await resp.json().catch(() => ({}));
     throw new Error(body.message ?? body.detail ?? `HTTP ${resp.status}`);
   }
+}
+
+export async function realUploadPersonAvatar(
+  personId: string,
+  image: Blob,
+  filename: string,
+): Promise<void> {
+  const form = new FormData();
+  form.append("image", image, filename);
+  const resp = await fetch(`/api/identity/persons/${personId}/avatar`, {
+    method: "POST",
+    body: form,
+    headers: authHeaders(),
+  });
+  if (!resp.ok) {
+    const body = await resp.json().catch(() => ({}));
+    throw new Error(body.message ?? body.detail ?? `HTTP ${resp.status}`);
+  }
+}
+
+// 清显式头像（恢复默认→读取回落 tier_a face[0]）
+export async function realDeletePersonAvatar(personId: string): Promise<void> {
+  await apiFetch<Normal<unknown>>(`/api/identity/persons/${personId}/avatar`, {
+    method: "DELETE",
+  });
 }
 
 // ── 家庭档案（home_profile：候选区 / 正式区记忆）─────────────

--- a/web/src/components/AvatarCropEditor.tsx
+++ b/web/src/components/AvatarCropEditor.tsx
@@ -1,12 +1,10 @@
 /**
  * 头像裁剪编辑器（手写，纯 React + canvas + pointer，不引库）。
  * 圆形取景框内定位一张源图：拖动平移、滚轮 / 滑杆缩放，图像始终铺满取景框。
- * 有 initialBox（如 grounding 头部归一化 [x,y,w,h]）时，初始把该框贴合取景框；
- * 否则居中 cover。确认时把可见区域绘到 OUT×OUT 离屏 canvas → JPEG blob。
- *
- * 上传头像与「自动生成外观描述」两条路线都经本组件确认，产物统一是裁好的方图 blob。
+ * 有 initialBox（归一化 [x,y,w,h]）时初始把该框贴合取景框；否则居中 cover。
+ * 确认时把可见区域绘到 OUT×OUT 离屏 canvas → JPEG blob。
  */
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useEscClose } from "@/hooks/useEscClose";
 import { IconX } from "@/lib/icons";
@@ -16,8 +14,8 @@ const OUT = 256; // 输出方图边长（px）
 const MAX_ZOOM = 4;
 
 interface Props {
-  /** 源图：上传的文件 或 base64（自动生成的 crop）。 */
-  source: { file: File } | { b64: string };
+  /** 源图：用户选的图片文件。 */
+  source: { file: File };
   /** 头部等归一化初始框 [x,y,w,h]（相对源图），用作默认裁剪范围。 */
   initialBox?: number[] | null;
   onCancel: () => void;
@@ -31,20 +29,14 @@ export function AvatarCropEditor({
   onConfirm,
 }: Props) {
   const { t } = useTranslation();
-  const src = useMemo(() => {
-    if ("b64" in source) {
-      // 仅接受 base64 字符再拼 data URL，挡住畸形/注入输入（避免 DOM 文本被当 HTML）
-      const b64 = /^[A-Za-z0-9+/=]*$/.test(source.b64) ? source.b64 : "";
-      return `data:image/jpeg;base64,${b64}`;
-    }
-    return URL.createObjectURL(source.file);
-  }, [source]);
+  // objectURL 的创建与回收同处一个 effect 生命周期（不放渲染期）：source 变化 / 卸载时
+  // 都 revoke 到对应的旧 URL，杜绝泄漏。
+  const [src, setSrc] = useState<string | null>(null);
   useEffect(() => {
-    // 仅 file 分支创建了 objectURL，需回收
-    return () => {
-      if ("file" in source) URL.revokeObjectURL(src);
-    };
-  }, [src, source]);
+    const url = URL.createObjectURL(source.file);
+    setSrc(url);
+    return () => URL.revokeObjectURL(url);
+  }, [source]);
 
   const imgRef = useRef<HTMLImageElement>(null);
   const frameRef = useRef<HTMLDivElement>(null);
@@ -210,7 +202,7 @@ export function AvatarCropEditor({
             {/* eslint-disable-next-line jsx-a11y/alt-text */}
             <img
               ref={imgRef}
-              src={src}
+              src={src ?? undefined}
               onLoad={onImgLoad}
               draggable={false}
               alt=""

--- a/web/src/components/AvatarCropEditor.tsx
+++ b/web/src/components/AvatarCropEditor.tsx
@@ -180,17 +180,17 @@ export function AvatarCropEditor({
       <div
         role="dialog"
         aria-modal="true"
-        aria-label={t("pet.cropTitle")}
+        aria-label={t("avatar.cropTitle")}
         className="w-full max-w-sm bg-bg-secondary border border-border rounded-t-2xl md:rounded-xl shadow-sm p-6 anim-in"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between mb-3">
-          <h3 className="text-title text-text-primary">{t("pet.cropTitle")}</h3>
+          <h3 className="text-title text-text-primary">{t("avatar.cropTitle")}</h3>
           <button
             type="button"
             onClick={onCancel}
             className="rounded-full p-1 text-text-secondary hover:text-text-primary"
-            aria-label={t("pet.cancel")}
+            aria-label={t("avatar.cancel")}
           >
             <IconX />
           </button>
@@ -223,11 +223,11 @@ export function AvatarCropEditor({
               }}
             />
           </div>
-          <p className="text-caption text-text-tertiary">{t("pet.cropHint")}</p>
+          <p className="text-caption text-text-tertiary">{t("avatar.cropHint")}</p>
 
           <div className="w-full flex items-center gap-3">
             <span className="text-caption text-text-secondary shrink-0">
-              {t("pet.cropZoom")}
+              {t("avatar.cropZoom")}
             </span>
             <input
               type="range"
@@ -246,7 +246,7 @@ export function AvatarCropEditor({
             disabled={!dims}
             className="w-full py-2 rounded-lg bg-brand-primary text-white hover:bg-brand-accent disabled:opacity-60"
           >
-            {t("pet.cropConfirm")}
+            {t("avatar.cropConfirm")}
           </button>
         </div>
       </div>

--- a/web/src/components/AvatarCropEditor.tsx
+++ b/web/src/components/AvatarCropEditor.tsx
@@ -1,0 +1,255 @@
+/**
+ * 头像裁剪编辑器（手写，纯 React + canvas + pointer，不引库）。
+ * 圆形取景框内定位一张源图：拖动平移、滚轮 / 滑杆缩放，图像始终铺满取景框。
+ * 有 initialBox（如 grounding 头部归一化 [x,y,w,h]）时，初始把该框贴合取景框；
+ * 否则居中 cover。确认时把可见区域绘到 OUT×OUT 离屏 canvas → JPEG blob。
+ *
+ * 上传头像与「自动生成外观描述」两条路线都经本组件确认，产物统一是裁好的方图 blob。
+ */
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useEscClose } from "@/hooks/useEscClose";
+import { IconX } from "@/lib/icons";
+
+const FRAME = 240; // 取景框边长（px）
+const OUT = 256; // 输出方图边长（px）
+const MAX_ZOOM = 4;
+
+interface Props {
+  /** 源图：上传的文件 或 base64（自动生成的 crop）。 */
+  source: { file: File } | { b64: string };
+  /** 头部等归一化初始框 [x,y,w,h]（相对源图），用作默认裁剪范围。 */
+  initialBox?: number[] | null;
+  onCancel: () => void;
+  onConfirm: (blob: Blob) => void;
+}
+
+export function AvatarCropEditor({
+  source,
+  initialBox,
+  onCancel,
+  onConfirm,
+}: Props) {
+  const { t } = useTranslation();
+  const src = useMemo(
+    () =>
+      "b64" in source
+        ? `data:image/jpeg;base64,${source.b64}`
+        : URL.createObjectURL(source.file),
+    [source],
+  );
+  useEffect(() => {
+    // 仅 file 分支创建了 objectURL，需回收
+    return () => {
+      if ("file" in source) URL.revokeObjectURL(src);
+    };
+  }, [src, source]);
+
+  const imgRef = useRef<HTMLImageElement>(null);
+  const frameRef = useRef<HTMLDivElement>(null);
+  const [dims, setDims] = useState<{ w: number; h: number } | null>(null);
+  const [zoom, setZoom] = useState(1); // ≥1 的缩放倍数（相对 coverScale）
+  const [pos, setPos] = useState({ x: 0, y: 0 }); // 图像左上相对取景框左上的位移（px）
+  const drag = useRef<{ px: number; py: number; x: number; y: number } | null>(
+    null,
+  );
+
+  useEscClose(true, onCancel);
+
+  // coverScale：让源图恰好铺满取景框的最小缩放（frame px / natural px）
+  const coverScale = dims ? Math.max(FRAME / dims.w, FRAME / dims.h) : 1;
+  const scale = coverScale * zoom;
+
+  // 钳制位移使图像始终铺满取景框；可显式传 d（首帧 dims 尚未入 state 时用局部值）。
+  const clampWith = (
+    p: { x: number; y: number },
+    s: number,
+    d: { w: number; h: number } | null,
+  ) => {
+    if (!d) return p;
+    return {
+      x: Math.min(0, Math.max(FRAME - d.w * s, p.x)),
+      y: Math.min(0, Math.max(FRAME - d.h * s, p.y)),
+    };
+  };
+  const clampPos = (p: { x: number; y: number }, s: number) =>
+    clampWith(p, s, dims);
+
+  // 图片加载完成：读自然尺寸，按 initialBox / 居中算初始缩放与位移
+  const onImgLoad = () => {
+    const el = imgRef.current;
+    if (!el) return;
+    const w = el.naturalWidth;
+    const h = el.naturalHeight;
+    setDims({ w, h });
+    const cover = Math.max(FRAME / w, FRAME / h);
+    let s = cover;
+    let cx = w / 2;
+    let cy = h / 2;
+    if (initialBox && initialBox.length === 4) {
+      const [bx, by, bw, bh] = initialBox;
+      const boxW = Math.max(1, bw * w);
+      const boxH = Math.max(1, bh * h);
+      cx = (bx + bw / 2) * w;
+      cy = (by + bh / 2) * h;
+      // 让头部框以 ~85% 占满取景框，但不低于 cover（保证铺满）
+      s = Math.min(
+        MAX_ZOOM * cover,
+        Math.max(cover, (FRAME * 0.85) / Math.max(boxW, boxH)),
+      );
+    }
+    setZoom(s / cover);
+    setPos(clampWith({ x: FRAME / 2 - cx * s, y: FRAME / 2 - cy * s }, s, { w, h }));
+  };
+
+  // 缩放时保持取景框中心对应的图像点不动
+  const applyZoom = (nextZoom: number) => {
+    if (!dims) return;
+    const z = Math.min(MAX_ZOOM, Math.max(1, nextZoom));
+    const sOld = coverScale * zoom;
+    const sNew = coverScale * z;
+    const centerImgX = (FRAME / 2 - pos.x) / sOld;
+    const centerImgY = (FRAME / 2 - pos.y) / sOld;
+    setZoom(z);
+    setPos(
+      clampPos(
+        { x: FRAME / 2 - centerImgX * sNew, y: FRAME / 2 - centerImgY * sNew },
+        sNew,
+      ),
+    );
+  };
+
+  // 滚轮缩放（非 passive，阻止页面滚动）
+  useEffect(() => {
+    const el = frameRef.current;
+    if (!el) return;
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      applyZoom(zoom * (1 - e.deltaY * 0.0015));
+    };
+    el.addEventListener("wheel", onWheel, { passive: false });
+    return () => el.removeEventListener("wheel", onWheel);
+  });
+
+  const onPointerDown = (e: React.PointerEvent) => {
+    e.currentTarget.setPointerCapture(e.pointerId);
+    drag.current = { px: e.clientX, py: e.clientY, x: pos.x, y: pos.y };
+  };
+  const onPointerMove = (e: React.PointerEvent) => {
+    const d = drag.current;
+    if (!d) return;
+    setPos(
+      clampPos(
+        { x: d.x + (e.clientX - d.px), y: d.y + (e.clientY - d.py) },
+        scale,
+      ),
+    );
+  };
+  const onPointerUp = (e: React.PointerEvent) => {
+    drag.current = null;
+    e.currentTarget.releasePointerCapture(e.pointerId);
+  };
+
+  const confirm = () => {
+    const el = imgRef.current;
+    if (!el || !dims) return;
+    // 取景框左上/尺寸映射回源图自然像素
+    const sx = -pos.x / scale;
+    const sy = -pos.y / scale;
+    const sSize = FRAME / scale;
+    const canvas = document.createElement("canvas");
+    canvas.width = OUT;
+    canvas.height = OUT;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.drawImage(el, sx, sy, sSize, sSize, 0, 0, OUT, OUT);
+    canvas.toBlob(
+      (blob) => {
+        if (blob) onConfirm(blob);
+      },
+      "image/jpeg",
+      0.9,
+    );
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[80] flex items-end md:items-center justify-center bg-black/50"
+      onClick={onCancel}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={t("pet.cropTitle")}
+        className="w-full max-w-sm bg-bg-secondary border border-border rounded-t-2xl md:rounded-xl shadow-sm p-6 anim-in"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-3">
+          <h3 className="text-title text-text-primary">{t("pet.cropTitle")}</h3>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-full p-1 text-text-secondary hover:text-text-primary"
+            aria-label={t("pet.cancel")}
+          >
+            <IconX />
+          </button>
+        </div>
+
+        <div className="flex flex-col items-center gap-3">
+          <div
+            ref={frameRef}
+            onPointerDown={onPointerDown}
+            onPointerMove={onPointerMove}
+            onPointerUp={onPointerUp}
+            onPointerCancel={onPointerUp}
+            style={{ width: FRAME, height: FRAME }}
+            className="relative overflow-hidden rounded-full border border-border bg-bg-tertiary touch-none cursor-grab active:cursor-grabbing select-none"
+          >
+            {/* eslint-disable-next-line jsx-a11y/alt-text */}
+            <img
+              ref={imgRef}
+              src={src}
+              onLoad={onImgLoad}
+              draggable={false}
+              alt=""
+              style={{
+                position: "absolute",
+                left: pos.x,
+                top: pos.y,
+                width: dims ? dims.w * scale : undefined,
+                height: dims ? dims.h * scale : undefined,
+                maxWidth: "none",
+              }}
+            />
+          </div>
+          <p className="text-caption text-text-tertiary">{t("pet.cropHint")}</p>
+
+          <div className="w-full flex items-center gap-3">
+            <span className="text-caption text-text-secondary shrink-0">
+              {t("pet.cropZoom")}
+            </span>
+            <input
+              type="range"
+              min={1}
+              max={MAX_ZOOM}
+              step={0.01}
+              value={zoom}
+              onChange={(e) => applyZoom(Number(e.target.value))}
+              className="flex-1 accent-brand-primary"
+            />
+          </div>
+
+          <button
+            type="button"
+            onClick={confirm}
+            disabled={!dims}
+            className="w-full py-2 rounded-lg bg-brand-primary text-white hover:bg-brand-accent disabled:opacity-60"
+          >
+            {t("pet.cropConfirm")}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/AvatarCropEditor.tsx
+++ b/web/src/components/AvatarCropEditor.tsx
@@ -31,13 +31,14 @@ export function AvatarCropEditor({
   onConfirm,
 }: Props) {
   const { t } = useTranslation();
-  const src = useMemo(
-    () =>
-      "b64" in source
-        ? `data:image/jpeg;base64,${source.b64}`
-        : URL.createObjectURL(source.file),
-    [source],
-  );
+  const src = useMemo(() => {
+    if ("b64" in source) {
+      // 仅接受 base64 字符再拼 data URL，挡住畸形/注入输入（避免 DOM 文本被当 HTML）
+      const b64 = /^[A-Za-z0-9+/=]*$/.test(source.b64) ? source.b64 : "";
+      return `data:image/jpeg;base64,${b64}`;
+    }
+    return URL.createObjectURL(source.file);
+  }, [source]);
   useEffect(() => {
     // 仅 file 分支创建了 objectURL，需回收
     return () => {

--- a/web/src/components/PersonAvatar.tsx
+++ b/web/src/components/PersonAvatar.tsx
@@ -44,7 +44,7 @@ export function PersonAvatar({ person, size = 28, badge = false }: Props) {
     (async () => {
       try {
         // <img> 挂不了 Bearer header，故 fetch + blobURL（与旧实现同因）；单一 URL
-        // 交后端解析显式头像 or 回落 face[0]。avatarExt 入 dep：换/清头像后自动刷新。
+        // 交后端解析显式头像 or 回落 face[0]。
         const imgRes = await fetch(`/api/identity/persons/${person.id}/avatar`, {
           cache: "no-store",
           headers: authHeaders(),
@@ -69,7 +69,11 @@ export function PersonAvatar({ person, size = 28, badge = false }: Props) {
         URL.revokeObjectURL(url);
       }
     };
-  }, [person.id, hasAvatar, person.avatarExt]);
+    // 依赖整个 person 对象而非仅 avatarExt：同扩展名替换头像（jpg→jpg）时 avatarExt
+    // 值不变，只盯它会漏刷新（显示旧图）。useAsync 的 data 仅在 reload 时才产生新
+    // person 对象，而换/清头像保存后正好触发 persons.reload() → 新对象 → 重新拉图；
+    // 平时 re-render 引用不变、不会多拉。
+  }, [person, hasAvatar]);
 
   return (
     <span

--- a/web/src/components/PersonAvatar.tsx
+++ b/web/src/components/PersonAvatar.tsx
@@ -24,19 +24,18 @@ interface Props {
   badge?: boolean;
 }
 
-interface SampleList {
-  face?: { filename: string }[];
-}
-
 export function PersonAvatar({ person, size = 28, badge = false }: Props) {
   const [src, setSrc] = useState<string | null>(null);
   const enrolled = person.faceEnrolled;
+  // 有显式头像 或 已录入(可回落 tier_a face[0]) 才拉图；都无则占位色块。
+  // 后端 GET /avatar 内部按「显式头像 > face[0] > 404」解析，前端只需一条 URL。
+  const hasAvatar = enrolled || !!person.avatarExt;
   const iconSize = Math.round(size * 0.58);
   const palette = paletteFor(person.avatarHue);
   const badgeSize = Math.max(14, Math.round(size * 0.34));
 
   useEffect(() => {
-    if (!enrolled) {
+    if (!hasAvatar) {
       setSrc(null);
       return;
     }
@@ -44,23 +43,12 @@ export function PersonAvatar({ person, size = 28, badge = false }: Props) {
     let objectUrl: string | null = null;
     (async () => {
       try {
-        const r = await fetch(`/api/identity/persons/${person.id}/samples`, {
+        // <img> 挂不了 Bearer header，故 fetch + blobURL（与旧实现同因）；单一 URL
+        // 交后端解析显式头像 or 回落 face[0]。avatarExt 入 dep：换/清头像后自动刷新。
+        const imgRes = await fetch(`/api/identity/persons/${person.id}/avatar`, {
           cache: "no-store",
           headers: authHeaders(),
         });
-        if (!r.ok) return;
-        const json = (await r.json()) as { data?: SampleList };
-        const filename = json.data?.face?.[0]?.filename;
-        if (!filename || cancelled) return;
-        // 不能直接 <img src="/api/...">:/sample/{tier}/{filename} 端点要求
-        // Bearer token,而 <img> 元素没法挂 Authorization header。dev 下走
-        // vite proxy::attachAuth 注入还能跑;prod 下后端直发 SPA,前端用 Bearer
-        // header 鉴权,<img> 直接拿不到 → 401 → 头像变色块。改成 fetch + blob
-        // URL,统一 authHeaders 注入,两环境一致。
-        const imgRes = await fetch(
-          `/api/identity/persons/${person.id}/sample/a/${filename}`,
-          { headers: authHeaders() },
-        );
         if (!imgRes.ok || cancelled) return;
         const blob = await imgRes.blob();
         if (cancelled) return;
@@ -81,7 +69,7 @@ export function PersonAvatar({ person, size = 28, badge = false }: Props) {
         URL.revokeObjectURL(url);
       }
     };
-  }, [person.id, enrolled]);
+  }, [person.id, hasAvatar, person.avatarExt]);
 
   return (
     <span

--- a/web/src/components/PersonDrawer.tsx
+++ b/web/src/components/PersonDrawer.tsx
@@ -1,16 +1,28 @@
 /**
  * 家人详情抽屉。
- * - 创建模式：新增家人（仅名字 + 家庭角色）
- * - 编辑模式：改名 / 删（二次确认）/ 让它认识她（启动 EnrollFlow）
+ * - 创建模式：新增家人（名字 + 家庭角色）
+ * - 编辑模式：从档案卡「编辑」进入即直接可改名字/家庭角色/头像，删除就在同屏
+ *   （无「查看→改名」中间态）；另可从档案头部入口直达身份录入。
+ *
+ * 头像：显式头像落 avatars/persons/<id>.<ext>（展示层，与识别数据分离）；上传经
+ * AvatarCropEditor 裁 256×256，随「保存」提交。「恢复默认头像」清显式头像→读取回落
+ * tier_a face[0]。
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { PerceptionCamera, Person } from "@/lib/types";
-import { createPerson, deletePerson, updatePerson } from "@/api";
+import {
+  createPerson,
+  deletePerson,
+  deletePersonAvatar,
+  updatePerson,
+  uploadPersonAvatar,
+} from "@/api";
 import { PersonAvatar } from "@/components/PersonAvatar";
 import { useEscClose } from "@/hooks/useEscClose";
-import { IconCheck, IconX } from "@/lib/icons";
+import { IconCamera, IconCheck, IconTrash, IconX } from "@/lib/icons";
+import { AvatarCropEditor } from "./AvatarCropEditor";
 import { EnrollFlow } from "./EnrollFlow";
 import { toast } from "./Toast";
 
@@ -35,27 +47,45 @@ export function PersonDrawer({
   const { t } = useTranslation();
   const [name, setName] = useState("");
   const [role, setRole] = useState("");
-  const [editing, setEditing] = useState(false);
   const [enrolling, setEnrolling] = useState(false);
   const [confirmingDel, setConfirmingDel] = useState(false);
   const [busy, setBusy] = useState(false);
+  // 头像暂存：avatarBlob=待上传新图；removeAvatar=待清显式头像（恢复默认）。二者互斥，随保存提交。
+  const [avatarBlob, setAvatarBlob] = useState<Blob | null>(null);
+  const [avatarPreview, setAvatarPreview] = useState<string | null>(null);
+  const [removeAvatar, setRemoveAvatar] = useState(false);
+  const [crop, setCrop] = useState<{ file: File } | null>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
   // submit/delete 跑期间挡关闭:scrim/ESC/X 都禁,避免 dialog 关掉但 await 还在跑
   // → 成功 reload 时住户已退出看到莫名刷新,失败 toast 又弹到无 dialog 上下文。
   const guardedClose = busy ? () => {} : onClose;
-  useEscClose(open && !busy, guardedClose);
+  useEscClose(open && !busy && !crop, guardedClose);
 
   useEffect(() => {
     if (open) {
       setName(person?.name ?? "");
       setRole(person?.role ?? "");
-      setEditing(person == null); // 新增模式默认编辑
       // 从档案头部「录入身份 / 补充身份样本」入口打开即进流程；新增模式不触发。
       setEnrolling(!!person && startEnrolling);
       setConfirmingDel(false);
+      setAvatarBlob(null);
+      setRemoveAvatar(false);
+      setCrop(null);
     } else {
       setConfirmingDel(false);
     }
   }, [open, person, startEnrolling]);
+
+  // 裁好的头像 blob → 预览 objectURL（随 blob 变化重建 + 清理）
+  useEffect(() => {
+    if (!avatarBlob) {
+      setAvatarPreview(null);
+      return;
+    }
+    const url = URL.createObjectURL(avatarBlob);
+    setAvatarPreview(url);
+    return () => URL.revokeObjectURL(url);
+  }, [avatarBlob]);
 
   if (!open) return null;
 
@@ -79,6 +109,17 @@ export function PersonDrawer({
 
   const isNew = person == null;
 
+  const pickAvatar = (file: File | undefined) => {
+    if (fileRef.current) fileRef.current.value = ""; // 允许再次选同一文件
+    if (!file) return;
+    setCrop({ file });
+  };
+
+  const restoreDefault = () => {
+    setAvatarBlob(null);
+    setRemoveAvatar(true);
+  };
+
   const submit = async () => {
     if (!name.trim()) return;
     setBusy(true);
@@ -91,6 +132,9 @@ export function PersonDrawer({
           // 发空串 = 显式清空家庭角色；后端按是否带 role 字段区分"未传(不改)"与"传空(清空)"
           role: role.trim(),
         });
+        // 头像变更随保存提交：新图上传，或恢复默认（清显式头像→回落 face[0]）。
+        if (avatarBlob) await uploadPersonAvatar(person.id, avatarBlob, "avatar.jpg");
+        else if (removeAvatar) await deletePersonAvatar(person.id);
       }
       onChanged();
       onClose();
@@ -115,45 +159,82 @@ export function PersonDrawer({
     }
   };
 
+  // 头像内容：待上传新图预览 > （恢复默认时按清空后状态预览）> 当前头像。
+  const avatarInner = avatarPreview ? (
+    <img src={avatarPreview} alt="" className="w-full h-full object-cover" />
+  ) : person ? (
+    <PersonAvatar
+      person={removeAvatar ? { ...person, avatarExt: null } : person}
+      size={96}
+    />
+  ) : null;
+
   return (
-    <div
-      className="fixed inset-0 z-[60] flex items-end md:items-center justify-center bg-black/40"
-      onClick={guardedClose}
-    >
+    <>
       <div
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="person-drawer-title"
-        className="w-full max-w-md bg-bg-secondary border border-border rounded-t-2xl md:rounded-xl shadow-sm p-6 anim-in"
-        onClick={(e) => e.stopPropagation()}
+        className="fixed inset-0 z-[60] flex items-end md:items-center justify-center bg-black/40"
+        onClick={guardedClose}
       >
-        <div className="flex items-center justify-between mb-4">
-          <h3
-            id="person-drawer-title"
-            className="text-title text-text-primary"
-          >
-            {isNew ? t("family.addPerson") : person.name}
-          </h3>
-          <button
-            type="button"
-            onClick={guardedClose}
-            disabled={busy}
-            className="rounded-full p-1 text-text-secondary hover:text-text-primary disabled:opacity-50"
-            aria-label={t("family.close")}
-          >
-            <IconX />
-          </button>
-        </div>
-
-        {/* 头像 */}
-        {!isNew && (
-          <div className="flex justify-center mb-4">
-            <PersonAvatar person={person} size={96} />
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="person-drawer-title"
+          className="w-full max-w-md bg-bg-secondary border border-border rounded-t-2xl md:rounded-xl shadow-sm p-6 anim-in"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="flex items-center justify-between mb-4">
+            <h3
+              id="person-drawer-title"
+              className="text-title text-text-primary"
+            >
+              {isNew ? t("family.addPerson") : person.name}
+            </h3>
+            <button
+              type="button"
+              onClick={guardedClose}
+              disabled={busy}
+              className="rounded-full p-1 text-text-secondary hover:text-text-primary disabled:opacity-50"
+              aria-label={t("family.close")}
+            >
+              <IconX />
+            </button>
           </div>
-        )}
 
-        {/* 基本信息 / 编辑 */}
-        {editing ? (
+          {/* 头像：hover 出相机蒙版点击上传（走裁剪）；有显式头像时可「恢复默认」 */}
+          {!isNew && person && (
+            <div className="flex flex-col items-center gap-2 mb-4">
+              <input
+                ref={fileRef}
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={(e) => pickAvatar(e.target.files?.[0])}
+              />
+              <button
+                type="button"
+                onClick={() => fileRef.current?.click()}
+                aria-label={t("family.changeAvatar")}
+                title={t("family.changeAvatar")}
+                className="relative group w-24 h-24 rounded-full overflow-hidden border border-border"
+              >
+                {avatarInner}
+                <span className="absolute inset-0 flex items-center justify-center bg-black/45 text-white opacity-0 group-hover:opacity-100 transition-opacity">
+                  <IconCamera width={22} height={22} />
+                </span>
+              </button>
+              {person.avatarExt && !avatarBlob && !removeAvatar && (
+                <button
+                  type="button"
+                  onClick={restoreDefault}
+                  className="text-caption text-text-secondary hover:text-text-primary"
+                >
+                  {t("family.restoreDefaultAvatar")}
+                </button>
+              )}
+            </div>
+          )}
+
+          {/* 基本信息（直接可编辑）：名字 / 家庭角色 */}
           <div className="space-y-3 mb-4">
             <Field label={t("family.drawerName")}>
               <input
@@ -173,65 +254,43 @@ export function PersonDrawer({
               />
             </Field>
           </div>
-        ) : (
-          person && (
-            <div className="text-center mb-4">
-              <div className="text-text-primary">{person.name}</div>
-              {person.role && (
-                <div className="text-caption text-text-secondary">
-                  {person.role}
-                </div>
-              )}
-            </div>
-          )
-        )}
 
-        {/* 删除二次确认态 */}
-        {confirmingDel && (
-          <div className="rounded-lg bg-error-bg border border-error p-3 mb-3">
-            <div className="text-error text-center mb-2.5">
-              {t("family.confirmDeletePerson", { name: person?.name })}
-            </div>
-            <div className="flex gap-2">
-              <button
-                type="button"
-                onClick={() => setConfirmingDel(false)}
-                disabled={busy}
-                className="flex-1 py-2 rounded-lg bg-bg-secondary border border-border text-text-primary disabled:opacity-60"
-              >
-                {t("family.cancel")}
-              </button>
-              <button
-                type="button"
-                onClick={doDelete}
-                disabled={busy}
-                className="flex-1 py-2 rounded-lg bg-error text-white hover:opacity-90 disabled:opacity-60"
-              >
-                {busy ? t("family.deleting") : t("family.confirmDelete")}
-              </button>
-            </div>
-          </div>
-        )}
-
-        {/* 动作按钮 */}
-        {!confirmingDel && (
-          <div className="flex flex-col gap-2">
-            {editing ? (
+          {/* 删除二次确认态 */}
+          {confirmingDel && (
+            <div className="rounded-lg bg-error-bg border border-error p-3 mb-3">
+              <div className="text-error text-center mb-2.5">
+                {t("family.confirmDeletePerson", { name: person?.name })}
+              </div>
               <div className="flex gap-2">
                 <button
                   type="button"
-                  onClick={() => {
-                    if (isNew) {
-                      onClose();
-                    } else {
-                      // 退出编辑态时把 name/role 回滚到 person 当前值，
-                      // 避免下次再点"改名"看到上次未保存的脏值
-                      setName(person?.name ?? "");
-                      setRole(person?.role ?? "");
-                      setEditing(false);
-                    }
-                  }}
-                  className="flex-1 py-2 rounded-lg bg-bg-primary border border-border text-text-secondary"
+                  onClick={() => setConfirmingDel(false)}
+                  disabled={busy}
+                  className="flex-1 py-2 rounded-lg bg-bg-secondary border border-border text-text-primary disabled:opacity-60"
+                >
+                  {t("family.cancel")}
+                </button>
+                <button
+                  type="button"
+                  onClick={doDelete}
+                  disabled={busy}
+                  className="flex-1 py-2 rounded-lg bg-error text-white hover:opacity-90 disabled:opacity-60"
+                >
+                  {busy ? t("family.deleting") : t("family.confirmDelete")}
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* 动作：取消 / 保存一行；存量成员的删除在分隔线下弱化呈现 */}
+          {!confirmingDel && (
+            <div className="flex flex-col">
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={guardedClose}
+                  disabled={busy}
+                  className="flex-1 py-2 rounded-lg bg-bg-primary border border-border text-text-secondary disabled:opacity-60"
                 >
                   {t("family.cancel")}
                 </button>
@@ -245,31 +304,37 @@ export function PersonDrawer({
                   {busy ? t("family.saving") : t("family.save")}
                 </button>
               </div>
-            ) : (
-              !isNew && (
-                <div className="flex gap-2">
-                  <button
-                    type="button"
-                    onClick={() => setEditing(true)}
-                    className="flex-1 py-2 rounded-lg bg-bg-primary border border-border text-text-secondary hover:text-text-primary"
-                  >
-                    {t("family.rename")}
-                  </button>
+              {!isNew && (
+                <div className="mt-4 pt-3 border-t border-border">
                   <button
                     type="button"
                     onClick={() => setConfirmingDel(true)}
-                    className="flex-1 py-2 rounded-lg bg-bg-primary border border-border text-error hover:bg-error-bg"
+                    disabled={busy}
+                    className="w-full py-2 rounded-lg text-error hover:bg-error-bg disabled:opacity-60 flex items-center justify-center gap-1.5"
                   >
+                    <IconTrash width={16} height={16} />
                     {t("family.delete")}
                   </button>
                 </div>
-              )
-            )}
-          </div>
-        )}
-
+              )}
+            </div>
+          )}
+        </div>
       </div>
-    </div>
+
+      {crop && (
+        <AvatarCropEditor
+          source={crop}
+          initialBox={null}
+          onCancel={() => setCrop(null)}
+          onConfirm={(blob) => {
+            setAvatarBlob(blob);
+            setRemoveAvatar(false);
+            setCrop(null);
+          }}
+        />
+      )}
+    </>
   );
 }
 

--- a/web/src/components/PersonDrawer.tsx
+++ b/web/src/components/PersonDrawer.tsx
@@ -72,7 +72,12 @@ export function PersonDrawer({
       setRemoveAvatar(false);
       setCrop(null);
     } else {
+      // 关闭即清暂存（趁抽屉渲染 null、屏幕不可见时清干净）——否则重开另一成员时
+      // 会先闪现上一次未保存的裁剪预览 / 恢复默认态一帧。
       setConfirmingDel(false);
+      setAvatarBlob(null);
+      setRemoveAvatar(false);
+      setCrop(null);
     }
   }, [open, person, startEnrolling]);
 
@@ -159,14 +164,14 @@ export function PersonDrawer({
     }
   };
 
-  // 头像内容：待上传新图预览 > （恢复默认时按清空后状态预览）> 当前头像。
+  // 头像内容：待上传新图预览 > 当前头像。「恢复默认」是暂存态，不改这里的预览——
+  // 显式头像文件要到「保存」才删、GET /avatar 在那之前仍会返回它，试图预览回落图
+  // 只会误导；改由下方「保存后恢复默认」提示告知。恒传稳定的 person 引用，避免
+  // PersonAvatar 收到每帧新建的对象字面量而反复拉图、闪占位。
   const avatarInner = avatarPreview ? (
     <img src={avatarPreview} alt="" className="w-full h-full object-cover" />
   ) : person ? (
-    <PersonAvatar
-      person={removeAvatar ? { ...person, avatarExt: null } : person}
-      size={96}
-    />
+    <PersonAvatar person={person} size={96} />
   ) : null;
 
   return (
@@ -230,6 +235,18 @@ export function PersonDrawer({
                 >
                   {t("family.restoreDefaultAvatar")}
                 </button>
+              )}
+              {removeAvatar && (
+                <div className="flex items-center gap-2 text-caption text-text-secondary">
+                  <span>{t("family.avatarWillReset")}</span>
+                  <button
+                    type="button"
+                    onClick={() => setRemoveAvatar(false)}
+                    className="text-brand-primary hover:text-brand-accent"
+                  >
+                    {t("family.undo")}
+                  </button>
+                </div>
               )}
             </div>
           )}

--- a/web/src/components/PersonDrawer.tsx
+++ b/web/src/components/PersonDrawer.tsx
@@ -144,6 +144,9 @@ export function PersonDrawer({
       onChanged();
       onClose();
     } catch (e) {
+      // 部分失败也刷新：updatePerson 成功但头像步骤抛错时，name/role 已存服务端，
+      // 先 reload 反映已保存的改动（不 onClose，留着让用户重试头像）；全失败时 reload 亦无害。
+      onChanged();
       toast(e instanceof Error ? e.message : t("family.saveFail"), "warn");
     } finally {
       setBusy(false);

--- a/web/src/i18n/locales/en/avatar.json
+++ b/web/src/i18n/locales/en/avatar.json
@@ -1,0 +1,9 @@
+{
+  "avatar": {
+    "cropTitle": "Adjust avatar",
+    "cropHint": "Drag to move · scroll or slider to zoom",
+    "cropZoom": "Zoom",
+    "cropConfirm": "Confirm",
+    "cancel": "Cancel"
+  }
+}

--- a/web/src/i18n/locales/en/family.json
+++ b/web/src/i18n/locales/en/family.json
@@ -26,6 +26,8 @@
     "save": "Save",
     "rename": "Rename",
     "delete": "Delete",
+    "changeAvatar": "Change avatar",
+    "restoreDefaultAvatar": "Restore default avatar",
 
     "enrollTitle": "Enroll identity · {{name}}",
     "analyzing": "Analyzing…",

--- a/web/src/i18n/locales/en/family.json
+++ b/web/src/i18n/locales/en/family.json
@@ -28,6 +28,8 @@
     "delete": "Delete",
     "changeAvatar": "Change avatar",
     "restoreDefaultAvatar": "Restore default avatar",
+    "avatarWillReset": "Reverts to default after saving",
+    "undo": "Undo",
 
     "enrollTitle": "Enroll identity · {{name}}",
     "analyzing": "Analyzing…",

--- a/web/src/i18n/locales/zh/avatar.json
+++ b/web/src/i18n/locales/zh/avatar.json
@@ -1,0 +1,9 @@
+{
+  "avatar": {
+    "cropTitle": "调整头像",
+    "cropHint": "拖动移动 · 滚轮或滑杆缩放",
+    "cropZoom": "缩放",
+    "cropConfirm": "确认",
+    "cancel": "取消"
+  }
+}

--- a/web/src/i18n/locales/zh/family.json
+++ b/web/src/i18n/locales/zh/family.json
@@ -28,6 +28,8 @@
     "delete": "删除",
     "changeAvatar": "更换头像",
     "restoreDefaultAvatar": "恢复默认头像",
+    "avatarWillReset": "保存后恢复默认",
+    "undo": "撤销",
 
     "enrollTitle": "录入身份 · {{name}}",
     "analyzing": "分析中…",

--- a/web/src/i18n/locales/zh/family.json
+++ b/web/src/i18n/locales/zh/family.json
@@ -26,6 +26,8 @@
     "save": "保存",
     "rename": "改名",
     "delete": "删除",
+    "changeAvatar": "更换头像",
+    "restoreDefaultAvatar": "恢复默认头像",
 
     "enrollTitle": "录入身份 · {{name}}",
     "analyzing": "分析中…",

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -45,6 +45,8 @@ export interface Person {
   voiceEnrolled: boolean;
   // 头像底色（personPalette 选）
   avatarHue: number; // 0..5
+  // 手动上传的显式头像后缀（avatars/persons/<id>.<ext>）；无则回落 tier_a face[0] / 占位
+  avatarExt?: string | null;
 }
 
 // ── 设备 ────────────────────────────────────────────────────


### PR DESCRIPTION
## 概述

让家人成员也能手动更换头像：在成员 [编辑] 抽屉悬停头像 → 裁剪 → 保存，或恢复默认。核心设计是把「展示头像」与「识别数据」分离——识别样本仍在 `persons/`，显式头像单独落到与之平级的新目录 `<lib_root>/avatars/persons/<id>.<ext>`；读取时按「显式头像 > 回落识别样本首张人脸 > 占位」解析。头像纯展示，不进 person 表 / ReID / gallery / 识别参照。共享头像存取层与裁剪组件按通用设计、为后期可能的扩展预留，本 PR 只接入家人成员。

术语：
- **显式头像**：用户手动上传的头像文件，与识别用的人脸样本无关。
- **回落人脸（face[0]）**：成员已录入身份时，取识别样本里字母序首张人脸作默认头像（旧行为）。
- **感知引擎快照**：识别引擎每窗口对成员列表做快照，快照一变即重置全屋识别——故头像不能放进 `persons/<id>/`（给没录入的人建目录会污染快照）。

## 1. 家人头像手动更换、显式头像独立存到 avatars/（展示与识别分离）· feat

**问题**：家人头像此前只能取自识别样本首张人脸、无法手动更换；而头像又不能与识别数据同目录——给没录入的成员建目录会扰动感知引擎快照、触发全屋识别重置。

**解决方案**：
- **展示头像与识别数据分离**：新增 `<lib_root>/avatars/` 平级目录（顶层无任何识别扫描者，安全），显式头像落 `avatars/persons/<id>.<ext>`；给没录入的人设头像也不新建 `persons/<id>/`，零引擎扰动。
- **共享头像存取层（按 subject 类型参数化、为后期扩展预留）**：纯文件存取——原子写（write-temp-fsync-rename）+ 清旧扩展名 + 格式白名单；当前仅接入家人成员。
- **三个端点 POST/GET/DELETE**：GET 读取优先级「显式头像 > 回落识别样本首张人脸 > 404（前端占位）」；成员列表附带头像后缀字段；删除成员时级联清其显式头像。
- **编辑抽屉可交互**：进入即直接可改名字/角色/头像（去掉「查看→改名」中间态）；悬停头像出相机 → 裁剪 256×256 → 随保存上传；有显式头像时可「恢复默认」。

<img width="920" height="562" alt="274585842ea27b09977852024421ebcb" src="https://github.com/user-attachments/assets/2040bd28-d06f-459c-a39f-7ca6503a40b0" />

## 2. 裁剪弹窗文案改用共用 avatar 域（修文案退化为原文 key）· fix

**问题**：共用的头像裁剪弹窗借用了另一功能域的 i18n 文案，在不含该域的构建里 key 解析不到，弹窗标题/提示/按钮直接显示原文。

**解决方案**：
- **共用 avatar 文案域**：新增 `avatar` i18n 域（标题/提示/缩放/确认/取消，中英各一份），裁剪弹窗改指 `avatar.*`，与具体功能域解耦。

<img width="658" height="533" alt="image" src="https://github.com/user-attachments/assets/bde103a9-e5fe-41da-a44f-cd20c848cb2f" />

## 3. 头像换/删后即时刷新 + 编辑抽屉显示细节 · fix

**问题**：换/删头像保存后头像位不自动刷新；另有几处编辑抽屉显示细节。

**解决方案**：
- **同扩展名替换也刷新**：头像组件改为依赖整个成员对象而非仅头像后缀值——同扩展名替换（jpg 换 jpg）后缀不变，原先只盯它会漏刷新、显示旧图。
- **恢复默认改暂存提示**：「保存后恢复默认 · 撤销」——显式头像要到保存才清、之前预览无法真实回落，原先点了像没反应。
- **关闭抽屉即清暂存**：否则重开另一成员会先闪现上一次未保存的裁剪预览一帧。
- **稳定引用防闪烁**：头像预览恒用稳定的成员对象引用，避免暂存态下每次 re-render 触发重复拉图。

## 测试与兼容性

- **backend**：头像库层 + 端点 + 级联单测全绿——set/path/clear/list、零引擎扰动不变量（设/删头像不建 `persons/<id>/`）、GET 解析优先级、删除级联、非法扩展名 400 / 无此人 404。
- **web**：`tsc --noEmit` + `vitest` 全绿（含 locale 中英一致性）。
- **兼容 / 回滚**：纯附加、零迁移——旧成员无显式头像时 GET 自动回落人脸首张，与改造前一致；识别路径（tier_a/tier_c/ReID/gallery）完全未碰。
- **风险提醒**：本组含「展示层新增」+「web 交互/反应性修复」两类，评审留意 web 反应性（刷新/闪烁）与 backend「零引擎扰动」两条主线；已在测试机端到端验证（上传/替换/恢复默认即时刷新、跨成员不串预览、弹窗文案正常）。


### 注
- **旧方案样例图**：移除旧方案的多一层"改名""删除"环节，减少冗余跳转，直接进入编辑页面
<img width="2274" height="1086" alt="image" src="https://github.com/user-attachments/assets/2b470186-0194-44c3-86eb-16850bc52b58" />
