### PR TITLE
feat: add audio format configuration support

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,16 @@
+# CodeGraph data files
+# These are local to each machine and should not be committed
+
+# Database
+*.db
+*.db-wal
+*.db-shm
+
+# Cache
+cache/
+
+# Logs
+*.log
+
+# Hook markers
+.dirty

--- a/backend/miloco/src/miloco/admin/feedback_pack.py
+++ b/backend/miloco/src/miloco/admin/feedback_pack.py
@@ -163,7 +163,7 @@ def build_feedback_pack(
         slug = region_slug(did)
         clip_dir = event_dir / slug
         found = False
-        for ext in ("mp4", "m4a"):
+        for ext in ("mp4", "m4a", "wav", "mp3"):
             if (clip_dir / f"clip.{ext}").exists():
                 components["clips_found"].append(f"{slug}/clip.{ext}")
                 found = True

--- a/backend/miloco/src/miloco/admin/router.py
+++ b/backend/miloco/src/miloco/admin/router.py
@@ -14,6 +14,7 @@ import subprocess
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as pkg_version
 from pathlib import Path
+from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field, StrictBool
@@ -574,7 +575,7 @@ class OmniConfigBody(BaseModel):
     api_key: str | None = None  # 留空 = 沿用该档案原 key(不被打码值覆盖)
     original_label: str | None = None  # 正在编辑的档案原名(支持改名/定位);None=新增
     activate: bool = True  # True=同时设为当前生效;False=只入列表(激活由 /activate 负责)
-    audio_format: str | None = None  # 音频编码格式:m4a/wav/mp3
+    audio_format: Literal["m4a", "wav", "mp3"] | None = None  # 音频编码格式
 
 
 class OmniSelectBody(BaseModel):
@@ -687,6 +688,7 @@ async def activate_omni_config(
                         "model": p.model,
                         "base_url": p.base_url,
                         "api_key": p.api_key,
+                        "audio_format": getattr(p, "audio_format", "m4a"),
                     }
                 }
             )

--- a/backend/miloco/src/miloco/admin/router.py
+++ b/backend/miloco/src/miloco/admin/router.py
@@ -522,6 +522,7 @@ def _full_omni_payload() -> dict:
             "api_key_masked": _mask_api_key(p.api_key),
             "has_key": bool(p.api_key),
             "active": p.label == active.label,
+            "audio_format": getattr(p, "audio_format", "m4a"),
         }
         for p in m.omni_profiles
     ]
@@ -535,6 +536,7 @@ def _full_omni_payload() -> dict:
                 "api_key_masked": _mask_api_key(active.api_key),
                 "has_key": True,
                 "active": True,
+                "audio_format": getattr(active, "audio_format", "m4a"),
             },
         )
     health = asdict(get_omni_circuit_breaker().snapshot())
@@ -546,6 +548,7 @@ def _full_omni_payload() -> dict:
             "api_key_masked": _mask_api_key(active.api_key),
             "has_key": bool(active.api_key),
             "health": health,
+            "audio_format": getattr(active, "audio_format", "m4a"),
         },
         "profiles": profiles,
     }
@@ -558,6 +561,7 @@ def _profiles_as_dicts() -> list[dict]:
             "model": p.model,
             "base_url": p.base_url,
             "api_key": p.api_key,
+            "audio_format": getattr(p, "audio_format", "m4a"),
         }
         for p in get_settings().model.omni_profiles
     ]
@@ -570,6 +574,7 @@ class OmniConfigBody(BaseModel):
     api_key: str | None = None  # 留空 = 沿用该档案原 key(不被打码值覆盖)
     original_label: str | None = None  # 正在编辑的档案原名(支持改名/定位);None=新增
     activate: bool = True  # True=同时设为当前生效;False=只入列表(激活由 /activate 负责)
+    audio_format: str | None = None  # 音频编码格式:m4a/wav/mp3
 
 
 class OmniSelectBody(BaseModel):
@@ -623,6 +628,8 @@ async def put_omni_config(
     # 传 base_url 让 _key_by_label 校验"URL 未变才沿用旧 key",防跨 URL 复用凭证。
     key = _key_by_label(orig or label, body.api_key, base_url=base_url)
     entry = {"label": label, "base_url": base_url, "model": model, "api_key": key}
+    if body.audio_format:
+        entry["audio_format"] = body.audio_format
     tgt = orig or label
     will_activate = body.activate or _label_is_active(tgt)
     if will_activate:

--- a/backend/miloco/src/miloco/config/settings.py
+++ b/backend/miloco/src/miloco/config/settings.py
@@ -161,6 +161,13 @@ class OmniModelSettings(BaseModel):
         default="",
         description="多模态模型 API Key；为空时视为未配置，插件与后端启动前校验",
     )
+    audio_format: str = Field(
+        default="m4a",
+        description=(
+            "音频编码格式：m4a (AAC) / wav (PCM) / mp3。"
+            "MiMo/Qwen/Gemini 建议 m4a；智谱/OpenAI 建议 wav。"
+        ),
+    )
 
 
 class ModelSettings(BaseModel):

--- a/backend/miloco/src/miloco/config/settings.schema.json
+++ b/backend/miloco/src/miloco/config/settings.schema.json
@@ -97,6 +97,12 @@
               "type": "string",
               "default": "",
               "description": "多模态模型 API Key；为空时视为未配置，插件与后端启动前校验"
+            },
+            "audio_format": {
+              "type": "string",
+              "enum": ["m4a", "wav", "mp3"],
+              "default": "m4a",
+              "description": "音频编码格式：m4a (AAC) / wav (PCM) / mp3。MiMo/Qwen/Gemini 建议 m4a；智谱/OpenAI 建议 wav。"
             }
           },
           "required": ["model", "base_url", "api_key"]

--- a/backend/miloco/src/miloco/perception/engine/omni/omni_client.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/omni_client.py
@@ -363,7 +363,8 @@ def _build_messages(payload: dict, adapter: OmniProviderAdapter) -> list[dict]:
     if payload.get("video_base64"):
         content.append(adapter.build_video_block(payload["video_base64"], media_info))
     elif payload.get("audio_base64"):
-        content.append(adapter.build_audio_block(payload["audio_base64"], media_info))
+        audio_format = payload.get("audio_format", "m4a")
+        content.append(adapter.build_audio_block(payload["audio_base64"], media_info, audio_format))
 
     # Crop images (from tracker)
     for crop in payload.get("crops", []):

--- a/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
@@ -227,14 +227,18 @@ def build_fused_payload(
         scene = SceneDescriptor(route="audio", has_identity=False, stream=False)
         system_prompt = build_system_prompt(scene, include_home_profile=False)
         ep = packets[0]
-        audio_b64 = _encode_audio_only_mp4(ep.audio_clip, ep.sample_rate)
+        # 获取配置的音频格式
+        audio_format = get_settings().model.omni.audio_format or "m4a"
+        audio_result = _encode_audio(ep.audio_clip, ep.sample_rate, audio_format)
+        audio_b64 = audio_result[0] if audio_result else None
+        actual_format = audio_result[1] if audio_result else audio_format
         user_content: list[dict] = []
         if context.current_time:
             user_content.append({"type": "text", "text": f"当前时间: {context.current_time}"})
         if context.room_name:
             user_content.append({"type": "text", "text": f"位置: {context.room_name}"})
         if audio_b64 and len(audio_b64) >= _MIN_AUDIO_B64_LEN:
-            user_content.append(adapter.build_audio_block(audio_b64, _audio_only_media_info(ep.sample_rate)))
+            user_content.append(adapter.build_audio_block(audio_b64, _audio_only_media_info(ep.sample_rate), actual_format))
         elif audio_b64:
             logger.warning(
                 "event=fused_audio_b64_too_short size=%d (< %d), 跳过 input_audio 块, "
@@ -387,7 +391,11 @@ def _build_payload(
     }
     if route == "audio":
         ep = packets[0]
-        base["audio_base64"] = _encode_audio_only_mp4(ep.audio_clip, ep.sample_rate)
+        from miloco.config import get_settings
+        audio_format = get_settings().model.omni.audio_format or "m4a"
+        audio_result = _encode_audio(ep.audio_clip, ep.sample_rate, audio_format)
+        base["audio_base64"] = audio_result[0] if audio_result else None
+        base["audio_format"] = audio_result[1] if audio_result else audio_format
         base["media_info"] = _audio_only_media_info(ep.sample_rate)
     else:
         short_edge = _get_video_short_edge()
@@ -1352,34 +1360,71 @@ def _encode_audio_only_mp4(
     (跟 _encode_video_mp4 对称,UI 端用同一个 <video> 控件播放;m4a 容器虽然只
     有音频,HTML5 <video> 也能 render audio-only track).
     """
+    result = _encode_audio(audio_clip, sample_rate, "m4a")
+    return result[0] if result else None
+
+
+def _encode_audio(
+    audio_clip: NDArray[np.int16],
+    sample_rate: int,
+    audio_format: str = "m4a",
+) -> tuple[str, str] | None:
+    """编码音频为指定格式，返回 (base64_str, format_name)。
+
+    支持的格式：
+    - m4a: AAC 编码，ipod 容器（MiMo/Qwen/Gemini 推荐）
+    - wav: PCM s16le 编码（智谱/OpenAI 推荐）
+    - mp3: MP3 编码（通用兼容）
+
+    Args:
+        audio_clip: PCM 音频数据 (int16)
+        sample_rate: 采样率
+        audio_format: 目标格式 (m4a/wav/mp3)
+
+    Returns:
+        (base64_str, format_name) 元组，失败返回 None
+    """
     import os
     import tempfile
 
     from miloco.perception.snapshot_context import push_clip_bytes
 
-    _AAC_FRAME_SIZE = 1024
-    if audio_clip is None or audio_clip.size < _AAC_FRAME_SIZE:
+    _FRAME_SIZE = 1024
+    if audio_clip is None or audio_clip.size < _FRAME_SIZE:
         return None
 
-    with tempfile.NamedTemporaryFile(suffix=".m4a", delete=False) as tmp:
+    # 格式配置
+    format_config = {
+        "m4a": {"suffix": ".m4a", "container_format": "ipod", "codec": "aac"},
+        "wav": {"suffix": ".wav", "container_format": "wav", "codec": "pcm_s16le"},
+        "mp3": {"suffix": ".mp3", "container_format": "mp3", "codec": "mp3"},
+    }
+
+    if audio_format not in format_config:
+        logger.warning("event=unsupported_audio_format format=%s, fallback to m4a", audio_format)
+        audio_format = "m4a"
+
+    config = format_config[audio_format]
+
+    with tempfile.NamedTemporaryFile(suffix=config["suffix"], delete=False) as tmp:
         tmp_path = tmp.name
 
     try:
-        container = av.open(tmp_path, "w", format="ipod")
-        a_stream = container.add_stream("aac", rate=sample_rate)
+        container = av.open(tmp_path, "w", format=config["container_format"])
+        a_stream = container.add_stream(config["codec"], rate=sample_rate)
         a_stream.layout = "mono"
 
         pts = 0
-        for i in range(0, audio_clip.size, _AAC_FRAME_SIZE):
-            chunk = audio_clip[i : i + _AAC_FRAME_SIZE]
-            if chunk.size < _AAC_FRAME_SIZE:
-                chunk = np.pad(chunk, (0, _AAC_FRAME_SIZE - chunk.size))
+        for i in range(0, audio_clip.size, _FRAME_SIZE):
+            chunk = audio_clip[i : i + _FRAME_SIZE]
+            if chunk.size < _FRAME_SIZE:
+                chunk = np.pad(chunk, (0, _FRAME_SIZE - chunk.size))
             audio_frame = av.AudioFrame.from_ndarray(
                 chunk.reshape(1, -1), format="s16", layout="mono"
             )
             audio_frame.sample_rate = sample_rate
             audio_frame.pts = pts
-            pts += _AAC_FRAME_SIZE
+            pts += _FRAME_SIZE
             for packet in a_stream.encode(audio_frame):
                 container.mux(packet)
         for packet in a_stream.encode():
@@ -1388,10 +1433,10 @@ def _encode_audio_only_mp4(
         container.close()
 
         with open(tmp_path, "rb") as f:
-            m4a_bytes = f.read()
-        # 旁路把 audio-only 的 m4a 字节 push 给 meaningful_events 复用(零重编)
-        push_clip_bytes(m4a_bytes, "m4a")
-        return base64.b64encode(m4a_bytes).decode()
+            audio_bytes = f.read()
+        # 旁路把音频字节 push 给 meaningful_events 复用
+        push_clip_bytes(audio_bytes, audio_format)
+        return base64.b64encode(audio_bytes).decode(), audio_format
     finally:
         if os.path.exists(tmp_path):
             os.unlink(tmp_path)

--- a/backend/miloco/src/miloco/perception/engine/omni/provider.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/provider.py
@@ -49,7 +49,7 @@ class OmniProviderAdapter(ABC):
         """构建 video content block（进 messages[].content[]，恒为 OpenAI 形态）。"""
 
     @abstractmethod
-    def build_audio_block(self, audio_base64: str, media: LocalMediaInfo) -> dict[str, Any]:
+    def build_audio_block(self, audio_base64: str, media: LocalMediaInfo, audio_format: str = "m4a") -> dict[str, Any]:
         """构建 audio-only content block（恒为 OpenAI 形态）。"""
 
     @abstractmethod
@@ -131,10 +131,12 @@ class MiMoAdapter(OpenAICompatAdapter):
             "media_resolution": "max",
         }
 
-    def build_audio_block(self, audio_base64: str, media: LocalMediaInfo) -> dict[str, Any]:
+    def build_audio_block(self, audio_base64: str, media: LocalMediaInfo, audio_format: str = "m4a") -> dict[str, Any]:
+        mime_map = {"m4a": "audio/m4a", "wav": "audio/wav", "mp3": "audio/mpeg"}
+        mime_type = mime_map.get(audio_format, "audio/m4a")
         return {
             "type": "input_audio",
-            "input_audio": {"data": f"data:audio/m4a;base64,{audio_base64}"},
+            "input_audio": {"data": f"data:{mime_type};base64,{audio_base64}"},
         }
 
     def build_request_body(
@@ -178,12 +180,12 @@ class QwenOmniAdapter(OpenAICompatAdapter):
             "video_url": {"url": f"data:;base64,{video_base64}"},
         }
 
-    def build_audio_block(self, audio_base64: str, media: LocalMediaInfo) -> dict[str, Any]:
+    def build_audio_block(self, audio_base64: str, media: LocalMediaInfo, audio_format: str = "m4a") -> dict[str, Any]:
         return {
             "type": "input_audio",
             "input_audio": {
                 "data": f"data:;base64,{audio_base64}",
-                "format": "m4a",
+                "format": audio_format,
             },
         }
 
@@ -315,12 +317,14 @@ class GeminiAdapter(OmniProviderAdapter):
             "fps": media.fps,
         }
 
-    def build_audio_block(self, audio_base64: str, media: LocalMediaInfo) -> dict[str, Any]:
+    def build_audio_block(self, audio_base64: str, media: LocalMediaInfo, audio_format: str = "m4a") -> dict[str, Any]:
         # m4a(AAC) 容器 mime 记为 audio/mp4；Gemini 原生 inline audio 对 m4a 的接受度需实测，
-        # 不达标属编码层问题（见 prompt_builder._encode_audio_only_mp4），不在 adapter 范围。
+        # 不达标属编码层问题（见 prompt_builder._encode_audio），不在 adapter 范围。
+        mime_map = {"m4a": "audio/mp4", "wav": "audio/wav", "mp3": "audio/mpeg"}
+        mime_type = mime_map.get(audio_format, "audio/mp4")
         return {
             "type": "input_audio",
-            "input_audio": {"data": f"data:audio/mp4;base64,{audio_base64}"},
+            "input_audio": {"data": f"data:{mime_type};base64,{audio_base64}"},
         }
 
     def _content_to_parts(self, content: str | list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/backend/miloco/src/miloco/perception/events_service.py
+++ b/backend/miloco/src/miloco/perception/events_service.py
@@ -29,9 +29,15 @@ logger = logging.getLogger(__name__)
 SnapshotStatus = Literal["found", "gone", "not_found"]
 
 # 视频路径产物 clip.mp4 (H264+AAC);audio-only 路径产物 clip.m4a (仅 AAC,ipod muxer).
-# 探测顺序:先 mp4 后 m4a,先找到的优先返回。
-_CLIP_CANDIDATES = ("clip.mp4", "clip.m4a")
-_MEDIA_TYPE_BY_SUFFIX = {".mp4": "video/mp4", ".m4a": "audio/mp4"}
+# 音频格式支持: m4a (AAC), wav (PCM), mp3 (MP3).
+# 探测顺序:先 mp4 后 m4a/wav/mp3,先找到的优先返回。
+_CLIP_CANDIDATES = ("clip.mp4", "clip.m4a", "clip.wav", "clip.mp3")
+_MEDIA_TYPE_BY_SUFFIX = {
+    ".mp4": "video/mp4",
+    ".m4a": "audio/mp4",
+    ".wav": "audio/wav",
+    ".mp3": "audio/mpeg",
+}
 
 
 class EventsService:
@@ -119,13 +125,18 @@ class EventsService:
         共识 — 见 prompt_builder._is_audio_only;所以多 device 间 kind 一致,
         取第一个有效结果即可).
 
-        Returns: "mp4" / "m4a" / None(未落盘 / 已被 cleanup 清掉).
+        Returns: "mp4" / "m4a" / "wav" / "mp3" / None(未落盘 / 已被 cleanup 清掉).
         """
         if not device_ids:
             return None
         for did in device_ids:
             device_dir = snapshot_root / event_id / region_slug(did)
-            for filename, kind in (("clip.mp4", "mp4"), ("clip.m4a", "m4a")):
+            for filename, kind in (
+                ("clip.mp4", "mp4"),
+                ("clip.m4a", "m4a"),
+                ("clip.wav", "wav"),
+                ("clip.mp3", "mp3"),
+            ):
                 if (device_dir / filename).exists():
                     return kind
         return None

--- a/backend/miloco/src/miloco/perception/schema.py
+++ b/backend/miloco/src/miloco/perception/schema.py
@@ -521,12 +521,14 @@ class MeaningfulEvent(BaseModel):
         default=None,
         description="最近一次反馈包的大小(bytes)",
     )
-    clip_kind: Literal["mp4", "m4a"] | None = Field(
+    clip_kind: Literal["mp4", "m4a", "wav", "mp3"] | None = Field(
         default=None,
         description=(
             "Container of the persisted clip,服务端 stat 落盘文件后缀计算:"
             "'mp4' = H264+AAC video container(omni video 路径产物);"
             "'m4a' = AAC-only audio container(omni audio-only 路径产物);"
+            "'wav' = PCM audio container(omni audio-only 路径产物);"
+            "'mp3' = MP3 audio container(omni audio-only 路径产物);"
             "None = no clip on disk(metadata-only / cleanup 已清).多 device 共识下"
             "全 device kind 一致(见 prompt_builder._is_audio_only),取第一个 device 即可."
         ),

--- a/backend/miloco/src/miloco/perception/snapshot_context.py
+++ b/backend/miloco/src/miloco/perception/snapshot_context.py
@@ -67,7 +67,7 @@ logger = logging.getLogger(__name__)
 # clip 字节的容器/codec 类型,持久化层据此选 filename 与 Content-Type.
 # 主流 UI <video> 控件对两者都能渲染,但浏览器 / 一些播放器靠扩展名 sniff 容器,
 # 所以扩展名要跟实际容器一致(M4A 不能伪装成 .mp4).
-ClipKind = Literal["mp4", "m4a"]
+ClipKind = Literal["mp4", "m4a", "wav", "mp3"]
 
 
 @dataclass

--- a/backend/miloco/src/miloco/perception/snapshot_writer.py
+++ b/backend/miloco/src/miloco/perception/snapshot_writer.py
@@ -137,7 +137,7 @@ def _save_clips(
     for device_id, (clip_bytes, kind) in clips.items():
         if not clip_bytes:
             continue
-        if kind not in ("mp4", "m4a"):
+        if kind not in ("mp4", "m4a", "wav", "mp3"):
             logger.error("Unknown clip kind %r for %s; skipping", kind, device_id)
             continue
         device_dir = event_dir / region_slug(device_id)

--- a/backend/miloco/tests/perception/engine/omni/test_provider.py
+++ b/backend/miloco/tests/perception/engine/omni/test_provider.py
@@ -68,10 +68,20 @@ class TestMiMoAdapter:
         assert block["media_resolution"] == "max"
         assert block["video_url"]["url"].startswith("data:video/mp4;base64,")
 
-    def test_audio_block(self):
+    def test_audio_block_default_m4a(self):
         block = self.adapter.build_audio_block("BBBB", _AUDIO_MEDIA)
         assert block["type"] == "input_audio"
         assert block["input_audio"]["data"].startswith("data:audio/m4a;base64,")
+
+    def test_audio_block_wav(self):
+        block = self.adapter.build_audio_block("BBBB", _AUDIO_MEDIA, "wav")
+        assert block["type"] == "input_audio"
+        assert block["input_audio"]["data"].startswith("data:audio/wav;base64,")
+
+    def test_audio_block_mp3(self):
+        block = self.adapter.build_audio_block("BBBB", _AUDIO_MEDIA, "mp3")
+        assert block["type"] == "input_audio"
+        assert block["input_audio"]["data"].startswith("data:audio/mpeg;base64,")
 
     def test_request_body_non_stream(self):
         body = self.adapter.build_request_body(
@@ -102,10 +112,22 @@ class TestQwenOmniAdapter:
         assert "media_resolution" not in block
         assert block["video_url"]["url"].startswith("data:;base64,")
 
-    def test_audio_block_has_format(self):
+    def test_audio_block_default_m4a(self):
         block = self.adapter.build_audio_block("BBBB", _AUDIO_MEDIA)
         assert block["type"] == "input_audio"
         assert block["input_audio"]["format"] == "m4a"
+        assert block["input_audio"]["data"].startswith("data:;base64,")
+
+    def test_audio_block_wav(self):
+        block = self.adapter.build_audio_block("BBBB", _AUDIO_MEDIA, "wav")
+        assert block["type"] == "input_audio"
+        assert block["input_audio"]["format"] == "wav"
+        assert block["input_audio"]["data"].startswith("data:;base64,")
+
+    def test_audio_block_mp3(self):
+        block = self.adapter.build_audio_block("BBBB", _AUDIO_MEDIA, "mp3")
+        assert block["type"] == "input_audio"
+        assert block["input_audio"]["format"] == "mp3"
         assert block["input_audio"]["data"].startswith("data:;base64,")
 
     def test_request_body_forces_stream(self):
@@ -253,6 +275,21 @@ class TestGeminiAdapter:
         parts = body["contents"][0]["parts"]
         assert parts[0]["inline_data"] == {"mime_type": "image/png", "data": "IMG"}
         assert parts[1]["inline_data"] == {"mime_type": "audio/mp4", "data": "AUD"}
+
+    def test_audio_block_default_m4a(self):
+        block = self.adapter.build_audio_block("AUD", _AUDIO_MEDIA)
+        assert block["type"] == "input_audio"
+        assert block["input_audio"]["data"].startswith("data:audio/mp4;base64,")
+
+    def test_audio_block_wav(self):
+        block = self.adapter.build_audio_block("AUD", _AUDIO_MEDIA, "wav")
+        assert block["type"] == "input_audio"
+        assert block["input_audio"]["data"].startswith("data:audio/wav;base64,")
+
+    def test_audio_block_mp3(self):
+        block = self.adapter.build_audio_block("AUD", _AUDIO_MEDIA, "mp3")
+        assert block["type"] == "input_audio"
+        assert block["input_audio"]["data"].startswith("data:audio/mpeg;base64,")
 
     def test_parse_response_to_openai_shape(self):
         raw = {

--- a/web/src/api/real.ts
+++ b/web/src/api/real.ts
@@ -1438,6 +1438,7 @@ export async function realUpdateOmniConfig(
   if (input.api_key) body.api_key = input.api_key;
   if (input.original_label !== undefined) body.original_label = input.original_label;
   if (input.activate !== undefined) body.activate = input.activate;
+  if (input.audio_format) body.audio_format = input.audio_format;
   const r = await apiFetch<Normal<OmniConfigState>>("/api/admin/omni-config", {
     method: "PUT",
     body: JSON.stringify(body),

--- a/web/src/api/real.ts
+++ b/web/src/api/real.ts
@@ -1014,8 +1014,8 @@ interface BackendMeaningfulEvent {
   snapshot_count: number;
   device_ids: string[];
   rule_names?: Record<string, string>;
-  /** 服务端根据落盘文件后缀计算:"mp4" 视频路径 / "m4a" audio-only / null 未落盘. */
-  clip_kind?: "mp4" | "m4a" | null;
+  /** 服务端根据落盘文件后缀计算:"mp4" 视频路径 / "m4a"|"wav"|"mp3" audio-only / null 未落盘. */
+  clip_kind?: "mp4" | "m4a" | "wav" | "mp3" | null;
   has_trace?: boolean;
   has_feedback?: boolean;
   feedback_pack_path?: string | null;

--- a/web/src/components/ActivityFeed.tsx
+++ b/web/src/components/ActivityFeed.tsx
@@ -514,8 +514,10 @@ function ActivityRow({
   // 区分音频事件 vs 视频事件 — backend stat 落盘文件后缀计算 clip_kind:
   //   "mp4" → 视频路径 (H264+AAC),UI 🎬
   //   "m4a" → audio-only 路径(纯 AAC,画面静止),UI 🎤 音频
+  //   "wav" → audio-only 路径(PCM,画面静止),UI 🎤 音频
+  //   "mp3" → audio-only 路径(MP3,画面静止),UI 🎤 音频
   //   null/undefined → 未落盘(磁盘满预检失败 / 老库 event),UI 🎤
-  const isAudioOnly = event.clip_kind === "m4a";
+  const isAudioOnly = event.clip_kind === "m4a" || event.clip_kind === "wav" || event.clip_kind === "mp3";
 
   // humanize 后按 \n\n 分章节渲染.每章节自成一段(line-clamp-2 折叠模式).
   const humanized = useMemo(

--- a/web/src/components/UsageOmniConfig.tsx
+++ b/web/src/components/UsageOmniConfig.tsx
@@ -183,6 +183,7 @@ export function UsageOmniConfig() {
   const [apiKey, setApiKey] = useState("");
   const [showKey, setShowKey] = useState(false); // API Key 明文/密文切换(末端眼睛图标)
   const [model, setModel] = useState("");
+  const [audioFormat, setAudioFormat] = useState("m4a"); // 音频编码格式
   const [models, setModels] = useState<string[]>([]);
   const [modelsLoading, setModelsLoading] = useState(false);
   const [modelsMsg, setModelsMsg] = useState<string | null>(null);
@@ -235,6 +236,7 @@ export function UsageOmniConfig() {
     setApiKey("");
     setShowKey(false);
     setModel("");
+    setAudioFormat("m4a");
     setModels([]);
     setModelsMsg(null);
     setModelsErr(false);
@@ -250,6 +252,7 @@ export function UsageOmniConfig() {
     setApiKey("");
     setShowKey(false);
     setModel(p.model);
+    setAudioFormat(p.audio_format || "m4a");
     setModels([]);
     setModelsMsg(null);
     setModelsErr(false);
@@ -315,6 +318,7 @@ export function UsageOmniConfig() {
         api_key: apiKey.trim() || undefined,
         original_label: target,
         activate: false, // 只入列表;启用由模型列表的「启用」负责
+        audio_format: audioFormat,
       });
       setState(s);
       setAdding(false);
@@ -750,6 +754,20 @@ export function UsageOmniConfig() {
                             : models.length
                               ? t("usage.modelsCount", { n: models.length })
                               : t("usage.modelsHint")}
+                    </span>
+                  </Field>
+                  <Field label={t("usage.audioFormatLabel")}>
+                    <select
+                      value={audioFormat}
+                      onChange={(e) => setAudioFormat(e.target.value)}
+                      className={INPUT_CLS}
+                    >
+                      <option value="m4a">m4a (AAC) — MiMo/Qwen/Gemini</option>
+                      <option value="wav">wav — 智谱/OpenAI</option>
+                      <option value="mp3">mp3 — 通用兼容</option>
+                    </select>
+                    <span className="text-caption mt-1 block text-text-tertiary">
+                      {t("usage.audioFormatHint")}
                     </span>
                   </Field>
                   <div className="md:col-span-2 pt-1 flex items-center gap-3 flex-wrap">

--- a/web/src/i18n/locales/en/usage.json
+++ b/web/src/i18n/locales/en/usage.json
@@ -77,6 +77,8 @@
     "modelsFetching": "Fetching model list…",
     "modelsCount": "{{n}} available, search or type directly; please pick a multimodal (omni) model supporting video/audio",
     "modelsHint": "Auto-fetched after filling Base URL and API Key, or type a model id directly",
+    "audioFormatLabel": "Audio format",
+    "audioFormatHint": "m4a for MiMo/Qwen/Gemini; wav for 智谱/OpenAI; mp3 for general compatibility",
     "saving": "Saving…",
     "save": "Save",
     "testing": "Testing…",

--- a/web/src/i18n/locales/zh/usage.json
+++ b/web/src/i18n/locales/zh/usage.json
@@ -77,6 +77,8 @@
     "modelsFetching": "正在拉取模型列表…",
     "modelsCount": "共 {{n}} 个可选,可搜索或直接输入;请选支持视频/音频的多模态(omni)模型",
     "modelsHint": "填好 Base URL 和 API Key 后自动拉取,也可直接输入模型 id",
+    "audioFormatLabel": "音频格式",
+    "audioFormatHint": "m4a 适用于 MiMo/Qwen/Gemini；wav 适用于智谱/OpenAI；mp3 通用兼容",
     "saving": "保存中…",
     "save": "保存",
     "testing": "测试中…",

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -119,8 +119,10 @@ export interface ActivityEvent {
   /** clip 容器类型,服务端 stat 落盘文件后缀计算:
    *   "mp4" = 视频路径(H264+AAC,UI 显 🎬)
    *   "m4a" = audio-only 路径(纯 AAC,UI 显 🎤 音频)
+   *   "wav" = audio-only 路径(PCM,UI 显 🎤 音频)
+   *   "mp3" = audio-only 路径(MP3,UI 显 🎤 音频)
    *   undefined / null = 未落盘(老 event / metadata-only / 已被 cleanup 清掉) */
-  clip_kind?: "mp4" | "m4a" | null;
+  clip_kind?: "mp4" | "m4a" | "wav" | "mp3" | null;
   /** omni_trace.json.gz 是否存在;前端据此决定是否显示反馈按钮 */
   has_trace?: boolean;
   /** 该事件是否已有反馈打包 */

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -309,6 +309,8 @@ export interface OmniModelConfig {
   api_key_masked: string;
   /** 是否已配置 api_key。 */
   has_key: boolean;
+  /** 音频编码格式：m4a / wav / mp3，默认 m4a。 */
+  audio_format?: string;
 }
 
 /** 已保存的配置档案（label 为唯一标识），active 标记是否为当前生效。 */
@@ -386,6 +388,8 @@ export interface OmniConfigUpdate {
   original_label?: string;
   /** 是否同时设为当前生效；省略=后端默认 true。「保存」传 false（激活走列表的「启用」）。 */
   activate?: boolean;
+  /** 音频编码格式：m4a / wav / mp3，默认 m4a。 */
+  audio_format?: string;
 }
 
 /** 测试连接结果：ok=true 即连通；否则 message 给出原因（Key 无效 / 不可达 / 模型不存在等）。 */


### PR DESCRIPTION
## Description

This PR adds configurable audio encoding format support (m4a/wav/mp3) for different API providers.

### Problem

The original implementation hardcoded m4a (AAC) audio format, which caused compatibility issues with some API providers like Zhipu (智谱) and OpenAI that only support wav/mp3 formats. Users encountered HTTP 400 errors:
```
messages[2].content[2].input_audio.format不能为空
```

### Solution

Added a new `audio_format` configuration option that allows users to select the audio encoding format through the web interface. The encoding layer dynamically generates audio in the selected format.

### Changes

**Backend:**
- Added `audio_format` field to `OmniModelSettings` (default: "m4a")
- New `_encode_audio()` function supporting m4a/wav/mp3 formats
- Updated all adapters (`MiMoAdapter`, `QwenOmniAdapter`, `GeminiAdapter`) to support dynamic audio format
- Updated API endpoints to handle `audio_format` parameter

**Frontend:**
- Added audio format dropdown in model configuration UI
- Added i18n translations (English/Chinese)
- Updated TypeScript types

**Tests:**
- Added 9 new test cases for audio format support
- All existing tests pass

### Audio Format Recommendations

| Provider | Recommended Format |
|----------|-------------------|
| MiMo | m4a |
| QwenOmni | m4a |
| Gemini | m4a |
| 智谱 (Zhipu) | wav |
| OpenAI | wav |
| General | mp3 |

### Testing

1. Tested with Zhipu API using wav format - works correctly
2. Tested with MiMo API using m4a format - maintains compatibility
3. All unit tests pass

### Breaking Changes

None. The default format is "m4a", maintaining backward compatibility.

Co-Authored-By: Claude <noreply@anthropic.com>