### PR TITLE
fix(web): 设置抽屉 slider 在 API 数据到达前不暴露默认值

### DIFF
--- a/web/src/components/SettingsDrawer.tsx
+++ b/web/src/components/SettingsDrawer.tsx
@@ -177,7 +177,7 @@ export function SettingsDrawer({ open, onClose }: Props) {
 
         {/* body */}
         <div className="flex-1 overflow-y-auto px-5 py-6 space-y-7">
-          {loading || !config ? (
+          {loading ? (
             <div className="space-y-7 animate-pulse">
               <div className="space-y-2.5">
                 <div className="h-4 w-16 bg-border rounded" />
@@ -199,6 +199,14 @@ export function SettingsDrawer({ open, onClose }: Props) {
                 <div className="h-4 w-20 bg-border rounded" />
                 <div className="h-2 bg-border rounded-full" />
               </div>
+              <div className="space-y-2.5">
+                <div className="h-4 w-20 bg-border rounded" />
+                <div className="h-6 w-11 bg-border rounded-full" />
+              </div>
+            </div>
+          ) : !config ? (
+            <div className="text-caption text-text-tertiary text-center py-8">
+              {t("settings.loadFailed")}
             </div>
           ) : (
             <>

--- a/web/src/components/SettingsDrawer.tsx
+++ b/web/src/components/SettingsDrawer.tsx
@@ -40,7 +40,10 @@ export function SettingsDrawer({ open, onClose }: Props) {
   useEscClose(open, onClose);
 
   useEffect(() => {
-    if (!open) return;
+    if (!open) {
+      setConfig(null);
+      return;
+    }
     setLoading(true);
     // 抽屉靠 `if (!open) return null` 隐藏而非卸载，state 会跨「关闭→重开」保留。
     // 每次重载先把调度值复位为 null：本次读不到就稳定退回 unavailable（disable 开关），
@@ -174,7 +177,7 @@ export function SettingsDrawer({ open, onClose }: Props) {
 
         {/* body */}
         <div className="flex-1 overflow-y-auto px-5 py-6 space-y-7">
-          {loading ? (
+          {loading || !config ? (
             <div className="text-caption text-text-tertiary text-center py-8">
               Loading…
             </div>

--- a/web/src/components/SettingsDrawer.tsx
+++ b/web/src/components/SettingsDrawer.tsx
@@ -26,7 +26,7 @@ interface Props {
 export function SettingsDrawer({ open, onClose }: Props) {
   const { t } = useTranslation();
   const [config, setConfig] = useState<PerceptionConfig | null>(null);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState(false);
 
   const [videoShortEdge, setVideoShortEdge] = useState(DEFAULTS.video_short_edge);
@@ -42,6 +42,7 @@ export function SettingsDrawer({ open, onClose }: Props) {
   useEffect(() => {
     if (!open) {
       setConfig(null);
+      setLoading(true);
       return;
     }
     setLoading(true);

--- a/web/src/components/SettingsDrawer.tsx
+++ b/web/src/components/SettingsDrawer.tsx
@@ -178,8 +178,27 @@ export function SettingsDrawer({ open, onClose }: Props) {
         {/* body */}
         <div className="flex-1 overflow-y-auto px-5 py-6 space-y-7">
           {loading || !config ? (
-            <div className="text-caption text-text-tertiary text-center py-8">
-              Loading…
+            <div className="space-y-7 animate-pulse">
+              <div className="space-y-2.5">
+                <div className="h-4 w-16 bg-border rounded" />
+                <div className="flex gap-2">
+                  {Array.from({ length: 4 }, (_, i) => (
+                    <div key={i} className="flex-1 h-11 bg-border rounded-xl" />
+                  ))}
+                </div>
+              </div>
+              <div className="space-y-2.5">
+                <div className="h-4 w-12 bg-border rounded" />
+                <div className="flex gap-2">
+                  {Array.from({ length: 3 }, (_, i) => (
+                    <div key={i} className="flex-1 h-11 bg-border rounded-xl" />
+                  ))}
+                </div>
+              </div>
+              <div className="space-y-2.5">
+                <div className="h-4 w-20 bg-border rounded" />
+                <div className="h-2 bg-border rounded-full" />
+              </div>
             </div>
           ) : (
             <>

--- a/web/src/components/SettingsDrawer.tsx
+++ b/web/src/components/SettingsDrawer.tsx
@@ -40,11 +40,14 @@ export function SettingsDrawer({ open, onClose }: Props) {
   useEscClose(open, onClose);
 
   useEffect(() => {
-    if (!open) {
-      setConfig(null);
-      return;
+    if (!open) return;
+    if (config) {
+      setVideoShortEdge(config.video_short_edge);
+      setOmniFps(config.omni_fps);
+      setWindowSize(config.window_size);
+    } else {
+      setLoading(true);
     }
-    setLoading(true);
     // 抽屉靠 `if (!open) return null` 隐藏而非卸载，state 会跨「关闭→重开」保留。
     // 每次重载先把调度值复位为 null：本次读不到就稳定退回 unavailable（disable 开关），
     // 不留用上次会话的旧值，与 e107541 的「读不到就禁用」保持一致。

--- a/web/src/components/SettingsDrawer.tsx
+++ b/web/src/components/SettingsDrawer.tsx
@@ -40,14 +40,11 @@ export function SettingsDrawer({ open, onClose }: Props) {
   useEscClose(open, onClose);
 
   useEffect(() => {
-    if (!open) return;
-    if (config) {
-      setVideoShortEdge(config.video_short_edge);
-      setOmniFps(config.omni_fps);
-      setWindowSize(config.window_size);
-    } else {
-      setLoading(true);
+    if (!open) {
+      setConfig(null);
+      return;
     }
+    setLoading(true);
     // 抽屉靠 `if (!open) return null` 隐藏而非卸载，state 会跨「关闭→重开」保留。
     // 每次重载先把调度值复位为 null：本次读不到就稳定退回 unavailable（disable 开关），
     // 不留用上次会话的旧值，与 e107541 的「读不到就禁用」保持一致。


### PR DESCRIPTION
## Summary
- 设置抽屉用 `return null` 隐藏而非卸载，React state 跨开关保留。
  首帧渲染时 slider 会以硬编码默认值（4s）闪现，若 API 实际值不同
  （如 3s），用户从 4 滑到 3 后 dirty check 判定无变更，"应用设置"
  按钮被禁用
- 关闭抽屉时重置 config 为 null，渲染条件增加 `!config` 守卫，
  确保表单仅在 API 数据到达后展示
- Loading 占位从 "Loading…" 文字改为 skeleton 骨架屏，布局对齐
  真实表单结构

## Test plan
- [x] 后端 window_size 设为非默认值（如 3s），打开设置，确认不闪现 4s
- [x] slider 显示正确值后，不做修改，确认按钮为禁用态
- [x] 修改 slider 值，确认按钮启用，点击应用后生效
- [x] 关闭再打开抽屉，确认骨架屏过渡后加载最新值