### PR TITLE
feat(on-demand-log): 主动查询日志持久化 + artifact 存储 + 前端展示

### DIFF
--- a/backend/miloco/src/miloco/admin/feedback_pack.py
+++ b/backend/miloco/src/miloco/admin/feedback_pack.py
@@ -23,7 +23,11 @@ from datetime import datetime
 from importlib.metadata import version as _get_pkg_version
 from pathlib import Path
 
-from miloco.perception.snapshot_writer import get_snapshot_root, region_slug
+from miloco.perception.snapshot_writer import (
+    CLIP_CANDIDATES,
+    get_snapshot_root,
+    region_slug,
+)
 from miloco.utils.paths import miloco_home
 from miloco.utils.time_utils import ms_to_iso_local, now_ms
 
@@ -163,9 +167,9 @@ def build_feedback_pack(
         slug = region_slug(did)
         clip_dir = event_dir / slug
         found = False
-        for ext in ("mp4", "m4a"):
-            if (clip_dir / f"clip.{ext}").exists():
-                components["clips_found"].append(f"{slug}/clip.{ext}")
+        for candidate in CLIP_CANDIDATES:
+            if (clip_dir / candidate).exists():
+                components["clips_found"].append(f"{slug}/{candidate}")
                 found = True
                 break
         if not found:
@@ -282,9 +286,9 @@ def build_on_demand_feedback_pack(
         slug = region_slug(did)
         clip_dir = event_dir / slug
         found = False
-        for ext in ("mp4", "m4a"):
-            if (clip_dir / f"clip.{ext}").exists():
-                components["clips_found"].append(f"{slug}/clip.{ext}")
+        for candidate in CLIP_CANDIDATES:
+            if (clip_dir / candidate).exists():
+                components["clips_found"].append(f"{slug}/{candidate}")
                 found = True
                 break
         if not found:
@@ -311,6 +315,7 @@ def build_on_demand_feedback_pack(
         "omni_trace_found": components["omni_trace_found"],
         "clips_found": components["clips_found"],
         "clips_missing": components["clips_missing"],
+        "clips_missing_basis": "clip_dids",
     }
 
     packs_dir = _packs_dir()

--- a/backend/miloco/src/miloco/admin/feedback_pack.py
+++ b/backend/miloco/src/miloco/admin/feedback_pack.py
@@ -243,3 +243,111 @@ def build_feedback_pack(
         "size_bytes": size_bytes,
         "components": components,
     }
+
+
+def build_on_demand_feedback_pack(
+    *,
+    log_id: str,
+    row: dict,
+    error_types: list[str],
+    feedback_text: str,
+    uid: str = "",
+) -> tuple[Path, int, dict]:
+    """打包 on-demand query 反馈数据 -> tar.gz.
+
+    与 build_feedback_pack 结构一致,但数据来源是 on_demand_log 而非 meaningful_events;
+    查询路径不产画廊,故 components 无 gallery_included 键.
+
+    Returns:
+        (pack_path, size_bytes, components) — components 是完整性记录
+        {omni_trace_found, clips_found, clips_missing},端点需原样回给前端.
+    """
+    snapshot_root = get_snapshot_root()
+    event_dir = snapshot_root / log_id
+
+    components: dict = {
+        "omni_trace_found": False,
+        "clips_found": [],
+        "clips_missing": [],
+    }
+
+    trace_path = event_dir / "omni_trace.json.gz"
+    sanitized_trace: bytes | None = None
+    if trace_path.exists():
+        sanitized_trace = _sanitize_trace(trace_path.read_bytes())
+    components["omni_trace_found"] = sanitized_trace is not None
+
+    device_ids: list[str] = row.get("sources", [])
+    for did in device_ids:
+        slug = region_slug(did)
+        clip_dir = event_dir / slug
+        found = False
+        for ext in ("mp4", "m4a"):
+            if (clip_dir / f"clip.{ext}").exists():
+                components["clips_found"].append(f"{slug}/clip.{ext}")
+                found = True
+                break
+        if not found:
+            components["clips_missing"].append(slug)
+
+    try:
+        miloco_version = _get_pkg_version("miloco")
+    except Exception:
+        miloco_version = "unknown"
+
+    metadata = {
+        "log_id": log_id,
+        "type": "on_demand",
+        "uid": uid,
+        "timestamp": row.get("timestamp"),
+        "query": _sanitize_pii(row.get("query", "")),
+        "answer": _sanitize_pii(row.get("answer", "")),
+        "sources": device_ids,
+        "latency_ms": row.get("latency_ms"),
+        "error_types": [_ERROR_TYPE_LABELS.get(k, k) for k in error_types],
+        "user_feedback": _sanitize_pii(feedback_text),
+        "created_at": ms_to_iso_local(now_ms()),
+        "miloco_version": miloco_version,
+        "omni_trace_found": components["omni_trace_found"],
+        "clips_found": components["clips_found"],
+        "clips_missing": components["clips_missing"],
+    }
+
+    packs_dir = _packs_dir()
+    packs_dir.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    short_id = _uuid.uuid4().hex[:6]
+    pack_dir = packs_dir / f"{stamp}-{short_id}"
+    pack_dir.mkdir(parents=True, exist_ok=True)
+    uid_slug = uid if uid else "anonymous"
+    final_path = pack_dir / f"{_PACK_PREFIX}{uid_slug}-od-{log_id}-{stamp}{_PACK_SUFFIX}"
+
+    with tempfile.TemporaryDirectory() as tmp_root:
+        tmp_root_p = Path(tmp_root)
+        with tempfile.NamedTemporaryFile(
+            suffix=_PACK_SUFFIX, dir=tmp_root_p, delete=False
+        ) as tf:
+            tar_tmp = Path(tf.name)
+
+        with tarfile.open(tar_tmp, "w:gz") as tar:
+            meta_bytes = json.dumps(metadata, ensure_ascii=False, indent=2).encode()
+            info = tarfile.TarInfo(name="metadata.json")
+            info.size = len(meta_bytes)
+            tar.addfile(info, io.BytesIO(meta_bytes))
+
+            if sanitized_trace is not None:
+                info = tarfile.TarInfo(name="omni_trace.json.gz")
+                info.size = len(sanitized_trace)
+                tar.addfile(info, io.BytesIO(sanitized_trace))
+
+            for clip_rel in components["clips_found"]:
+                clip_path = event_dir / clip_rel
+                if clip_path.exists():
+                    tar.add(clip_path, arcname=f"clips/{clip_rel}")
+
+        shutil.move(str(tar_tmp), final_path)
+
+    size_bytes = final_path.stat().st_size
+    _cleanup_by_total_size(packs_dir)
+
+    return final_path, size_bytes, components

--- a/backend/miloco/src/miloco/admin/feedback_pack.py
+++ b/backend/miloco/src/miloco/admin/feedback_pack.py
@@ -263,8 +263,9 @@ def build_on_demand_feedback_pack(
     查询路径不产画廊,故 components 无 gallery_included 键.
 
     Returns:
-        {path, size_bytes, components}
-        {omni_trace_found, clips_found, clips_missing},端点需原样回给前端.
+        {path, size_bytes, components} — 与 build_feedback_pack 同形状;
+        components 是完整性记录 {omni_trace_found, clips_found, clips_missing},
+        端点(perception/router.py::submit_on_demand_feedback)需原样回给前端.
     """
     snapshot_root = get_snapshot_root()
     event_dir = snapshot_root / log_id

--- a/backend/miloco/src/miloco/admin/feedback_pack.py
+++ b/backend/miloco/src/miloco/admin/feedback_pack.py
@@ -277,8 +277,8 @@ def build_on_demand_feedback_pack(
         sanitized_trace = _sanitize_trace(trace_path.read_bytes())
     components["omni_trace_found"] = sanitized_trace is not None
 
-    device_ids: list[str] = row.get("sources", [])
-    for did in device_ids:
+    clip_dids: list[str] = row.get("clip_dids", [])
+    for did in clip_dids:
         slug = region_slug(did)
         clip_dir = event_dir / slug
         found = False
@@ -302,7 +302,7 @@ def build_on_demand_feedback_pack(
         "timestamp": row.get("timestamp"),
         "query": _sanitize_pii(row.get("query", "")),
         "answer": _sanitize_pii(row.get("answer", "")),
-        "sources": device_ids,
+        "sources": row.get("sources", []),
         "latency_ms": row.get("latency_ms"),
         "error_types": [_ERROR_TYPE_LABELS.get(k, k) for k in error_types],
         "user_feedback": _sanitize_pii(feedback_text),

--- a/backend/miloco/src/miloco/admin/feedback_pack.py
+++ b/backend/miloco/src/miloco/admin/feedback_pack.py
@@ -256,14 +256,14 @@ def build_on_demand_feedback_pack(
     error_types: list[str],
     feedback_text: str,
     uid: str = "",
-) -> tuple[Path, int, dict]:
+) -> dict:
     """打包 on-demand query 反馈数据 -> tar.gz.
 
     与 build_feedback_pack 结构一致,但数据来源是 on_demand_log 而非 meaningful_events;
     查询路径不产画廊,故 components 无 gallery_included 键.
 
     Returns:
-        (pack_path, size_bytes, components) — components 是完整性记录
+        {path, size_bytes, components}
         {omni_trace_found, clips_found, clips_missing},端点需原样回给前端.
     """
     snapshot_root = get_snapshot_root()
@@ -355,4 +355,8 @@ def build_on_demand_feedback_pack(
     size_bytes = final_path.stat().st_size
     _cleanup_by_total_size(packs_dir)
 
-    return final_path, size_bytes, components
+    return {
+        "path": final_path.as_posix(),
+        "size_bytes": size_bytes,
+        "components": components,
+    }

--- a/backend/miloco/src/miloco/config/settings.py
+++ b/backend/miloco/src/miloco/config/settings.py
@@ -322,7 +322,11 @@ class PerceptionSettings(BaseModel):
     )
     snapshot_max_disk_mb: int = Field(
         default=5000,
-        description="截图磁盘配额上限(MB);超出按 mtime 升序 LRU 删",
+        description=(
+            "snapshot 目录总大小上限(MB),超限按 mtime LRU 淘汰最旧事件目录。"
+            "注意实时事件 clip 与主动查询 clip 共享这一份配额:主动查询目录总是最新的,"
+            "永远排在存活侧,高频查询会把历史事件 clip 提前挤出配额"
+        ),
     )
     snapshot_min_free_disk_mb: int = Field(
         default=500,

--- a/backend/miloco/src/miloco/database/connector.py
+++ b/backend/miloco/src/miloco/database/connector.py
@@ -168,11 +168,35 @@ class SQLiteConnector:
                             "task_terminate_log",
                             self._create_task_terminate_log_table,
                         ),
+                        (
+                            "on_demand_log",
+                            self._create_on_demand_log_table,
+                        ),
                     ):
                         if tbl not in existing_tables:
                             logger.info("%s table not found, creating...", tbl)
                             create_fn(conn)
                             tables_created.append(tbl)
+
+                    # on_demand_log: ensure new columns exist (for DBs created before artifact support)
+                    if "on_demand_log" in existing_tables:
+                        cols = {
+                            r["name"]
+                            for r in conn.execute(
+                                "PRAGMA table_info(on_demand_log)"
+                            ).fetchall()
+                        }
+                        for col, defn in [
+                            ("snapshot_count", "INTEGER NOT NULL DEFAULT 0"),
+                            ("clip_dids", "TEXT NOT NULL DEFAULT '[]'"),
+                            ("clip_kinds", "TEXT NOT NULL DEFAULT '{}'"),
+                            ("has_trace", "INTEGER NOT NULL DEFAULT 0"),
+                        ]:
+                            if col not in cols:
+                                conn.execute(
+                                    f"ALTER TABLE on_demand_log ADD COLUMN {col} {defn}"
+                                )
+                                logger.info("on_demand_log: added column %s", col)
 
                     # If new tables were created, commit transaction
                     if tables_created:
@@ -255,6 +279,7 @@ class SQLiteConnector:
         self._create_task_record_event_table(conn)
         self._create_task_record_event_entry_table(conn)
         self._create_task_terminate_log_table(conn)
+        self._create_on_demand_log_table(conn)
         conn.execute(f"PRAGMA user_version = {_DB_SCHEMA_VERSION}")
         conn.commit()
         logger.info("Database table structure created successfully")
@@ -342,6 +367,31 @@ class SQLiteConnector:
             "CREATE INDEX IF NOT EXISTS idx_perception_log_timestamp ON perception_log(timestamp)"
         )
         logger.info("Perception log table created successfully")
+
+    def _create_on_demand_log_table(self, conn: sqlite3.Connection) -> None:
+        """Create on-demand perception query log table."""
+        cursor = conn.cursor()
+
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS on_demand_log (
+                id              TEXT PRIMARY KEY,
+                timestamp       INTEGER NOT NULL,
+                query           TEXT NOT NULL,
+                answer          TEXT NOT NULL,
+                sources         TEXT NOT NULL,
+                latency_ms      INTEGER,
+                snapshot_count  INTEGER NOT NULL DEFAULT 0,
+                clip_dids       TEXT NOT NULL DEFAULT '[]',
+                clip_kinds      TEXT NOT NULL DEFAULT '{}',
+                has_trace       INTEGER NOT NULL DEFAULT 0,
+                created_at      INTEGER NOT NULL
+            )
+        """)
+
+        cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_on_demand_log_timestamp ON on_demand_log(timestamp)"
+        )
+        logger.info("On-demand log table created successfully")
 
     def _create_meaningful_events_table(self, conn: sqlite3.Connection) -> None:
         """Create meaningful_events table.

--- a/backend/miloco/src/miloco/database/on_demand_log_repo.py
+++ b/backend/miloco/src/miloco/database/on_demand_log_repo.py
@@ -1,0 +1,183 @@
+"""
+On-demand perception query log repo — SQLite persistence.
+
+Stores every on-demand perception query (question + answer + metadata)
+for later retrieval via the web dashboard.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from miloco.database.connector import get_db_connector
+from miloco.utils.time_utils import now_ms
+
+if TYPE_CHECKING:
+    from miloco.perception.schema import OnDemandLogEntry
+
+logger = logging.getLogger(__name__)
+
+
+class OnDemandLogRepo:
+    """Data access object for the on_demand_log table."""
+
+    def __init__(self):
+        self.db_connector = get_db_connector()
+
+    @staticmethod
+    def _row_to_dict(row: dict[str, Any]) -> dict[str, Any]:
+        sources = row["sources"]
+        if isinstance(sources, str):
+            sources = json.loads(sources)
+        clip_dids = row.get("clip_dids", "[]")
+        if isinstance(clip_dids, str):
+            clip_dids = json.loads(clip_dids)
+        return {
+            "id": row["id"],
+            "timestamp": row["timestamp"],
+            "query": row["query"],
+            "answer": row["answer"],
+            "sources": sources,
+            "latency_ms": row["latency_ms"],
+            "snapshot_count": row.get("snapshot_count", 0),
+            "clip_dids": clip_dids,
+            "clip_kinds": json.loads(row.get("clip_kinds", "{}")),
+            "has_trace": bool(row.get("has_trace", 0)),
+        }
+
+    def append(self, entry: OnDemandLogEntry) -> bool:
+        """Insert an on-demand query log entry.
+
+        Returns:
+            True if inserted, False on error.
+        """
+        try:
+            sql = """
+                INSERT INTO on_demand_log
+                (id, timestamp, query, answer, sources, latency_ms,
+                 snapshot_count, clip_dids, clip_kinds, has_trace, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """
+            params = (
+                entry.id or str(uuid.uuid4()),
+                entry.timestamp,
+                entry.query,
+                entry.answer,
+                json.dumps(entry.sources, ensure_ascii=False),
+                entry.latency_ms,
+                entry.snapshot_count,
+                json.dumps(entry.clip_dids, ensure_ascii=False),
+                json.dumps(entry.clip_kinds, ensure_ascii=False),
+                1 if entry.has_trace else 0,
+                now_ms(),
+            )
+            with self.db_connector.get_connection() as conn:
+                cursor = conn.cursor()
+                cursor.execute(sql, params)
+                conn.commit()
+
+            logger.debug("On-demand log inserted: %s", entry.id)
+            return True
+
+        except Exception as e:
+            logger.error("Failed to insert on-demand log: %s", e)
+            return False
+
+    def query(
+        self,
+        after_ms: int | None = None,
+        before_ms: int | None = None,
+        before_id: str | None = None,
+        since_ms: int | None = None,
+        limit: int | None = None,
+    ) -> tuple[list[dict[str, Any]], int]:
+        """Query on-demand logs with time filters.
+
+        Returns:
+            (logs, count) where logs are dicts ready for API serialization.
+        """
+        try:
+            conditions: list[str] = []
+            params: list[Any] = []
+
+            if after_ms is not None:
+                conditions.append("timestamp > ?")
+                params.append(after_ms)
+            elif since_ms is not None:
+                conditions.append("timestamp >= ?")
+                params.append(since_ms)
+
+            if before_ms is not None:
+                if before_id is not None:
+                    conditions.append("(timestamp < ? OR (timestamp = ? AND id < ?))")
+                    params.extend([before_ms, before_ms, before_id])
+                else:
+                    conditions.append("timestamp < ?")
+                    params.append(before_ms)
+
+            where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+            limit_clause = "LIMIT ?" if limit is not None else ""
+            sql = f"""
+                SELECT id, timestamp, query, answer, sources, latency_ms,
+                       snapshot_count, clip_dids, clip_kinds, has_trace
+                FROM on_demand_log
+                {where}
+                ORDER BY timestamp DESC, id DESC
+                {limit_clause}
+            """
+            if limit is not None:
+                params.append(limit)
+
+            results = self.db_connector.execute_query(sql, tuple(params))
+
+            logs = [self._row_to_dict(row) for row in results]
+
+            return logs, len(logs)
+
+        except Exception as e:
+            logger.error("Failed to query on-demand logs: %s", e)
+            return [], 0
+
+    def get_by_id(self, log_id: str) -> dict[str, Any] | None:
+        """Get a single on-demand log entry by ID."""
+        try:
+            sql = """
+                SELECT id, timestamp, query, answer, sources, latency_ms,
+                       snapshot_count, clip_dids, clip_kinds, has_trace
+                FROM on_demand_log WHERE id = ?
+            """
+            results = self.db_connector.execute_query(sql, (log_id,))
+            if not results:
+                return None
+            return self._row_to_dict(results[0])
+        except Exception as e:
+            logger.error("Failed to get on-demand log by id: %s", e)
+            return None
+
+    def count_all(self) -> int:
+        """Get total count of on-demand log entries."""
+        try:
+            sql = "SELECT COUNT(*) as count FROM on_demand_log"
+            results = self.db_connector.execute_query(sql)
+            return results[0]["count"] if results else 0
+        except Exception as e:
+            logger.error("Failed to count on-demand logs: %s", e)
+            return 0
+
+    def delete_before_days(self, days: int) -> int:
+        """Delete on-demand logs older than N days.
+
+        Returns:
+            Number of deleted rows.
+        """
+        try:
+            cutoff_ms = int((datetime.now().timestamp() - days * 86400) * 1000)
+            sql = "DELETE FROM on_demand_log WHERE timestamp < ?"
+            return self.db_connector.execute_update(sql, (cutoff_ms,))
+        except Exception as e:
+            logger.error("Failed to delete old on-demand logs: %s", e)
+            return 0

--- a/backend/miloco/src/miloco/database/on_demand_log_repo.py
+++ b/backend/miloco/src/miloco/database/on_demand_log_repo.py
@@ -36,6 +36,9 @@ class OnDemandLogRepo:
         clip_dids = row.get("clip_dids", "[]")
         if isinstance(clip_dids, str):
             clip_dids = json.loads(clip_dids)
+        clip_kinds = row.get("clip_kinds", "{}")
+        if isinstance(clip_kinds, str):
+            clip_kinds = json.loads(clip_kinds)
         return {
             "id": row["id"],
             "timestamp": row["timestamp"],
@@ -45,7 +48,7 @@ class OnDemandLogRepo:
             "latency_ms": row["latency_ms"],
             "snapshot_count": row.get("snapshot_count", 0),
             "clip_dids": clip_dids,
-            "clip_kinds": json.loads(row.get("clip_kinds", "{}")),
+            "clip_kinds": clip_kinds,
             "has_trace": bool(row.get("has_trace", 0)),
         }
 

--- a/backend/miloco/src/miloco/main.py
+++ b/backend/miloco/src/miloco/main.py
@@ -94,6 +94,11 @@ async def _log_cleanup_loop() -> None:
         except Exception as e:
             logger.error("Perception log cleanup failed: %s", e)
         try:
+            deleted_od = mgr.perception_service.cleanup_on_demand_logs(settings.perception.event_ttl_days)
+            logger.info("On-demand log cleanup: deleted %d entries", deleted_od)
+        except Exception as e:
+            logger.error("On-demand log cleanup failed: %s", e)
+        try:
             deleted_r = await mgr.rule_service.cleanup_logs(settings.rule.log_ttl)
             logger.info("Rule log cleanup: deleted %d entries", deleted_r)
         except Exception as e:

--- a/backend/miloco/src/miloco/perception/__init__.py
+++ b/backend/miloco/src/miloco/perception/__init__.py
@@ -5,6 +5,7 @@ Perception module — multimodal smart home perception engine.
 import asyncio
 import logging
 
+from miloco.database.on_demand_log_repo import OnDemandLogRepo
 from miloco.database.perception_repo import PerceptionLogRepo
 from miloco.perception.client import PerceptionEngineProxy
 from miloco.perception.collect.camera_adapter import CameraDeviceAdapter
@@ -25,6 +26,7 @@ async def init_perception_module(miot_proxy, kv_repo):
 
     # 1. 初始化基础依赖实例
     perception_log_repo = PerceptionLogRepo()
+    on_demand_log_repo = OnDemandLogRepo()
     perception_engine_proxy = PerceptionEngineProxy()
 
     # 2. 创建窗口就绪事件（回调从流线程触发，需 threadsafe 调度到事件循环）
@@ -61,6 +63,7 @@ async def init_perception_module(miot_proxy, kv_repo):
         pipeline=pipeline_processor,
         perception_runner=perception_runner,
         log_repo=perception_log_repo,
+        on_demand_log_repo=on_demand_log_repo,
     )
 
     # 7.1 把 omni 熔断器的状态变化桥接到 SSE(通过 PipelineProcessor._publish),

--- a/backend/miloco/src/miloco/perception/client.py
+++ b/backend/miloco/src/miloco/perception/client.py
@@ -681,9 +681,14 @@ class PerceptionEngineProxy:
             )
 
     async def on_demand_perceive(
-        self, batch: PerceptionBatch, query: str
+        self, batch: PerceptionBatch, query: str,
+        artifacts: OmniEventArtifacts | None = None,
     ) -> OnDemandPerceptionResult | None:
-        """Run on-demand query pipeline — offloaded to inference thread."""
+        """Run on-demand query pipeline — offloaded to inference thread.
+
+        artifacts: 若非 None, omni 内部产出的 clip 字节和 trace 会写入
+        artifacts.clips / artifacts.trace（同 realtime_perceive 语义）。
+        """
         async with get_monitor().track_async(NodeName.ENGINE, "on_demand") as _eng_h, self._engine_lock:
             if not self.ready:
                 _eng_h.skip_rolling()
@@ -705,9 +710,13 @@ class PerceptionEngineProxy:
                     _run_with_trace_id(
                         trace_id,
                         self._on_demand_perceive_impl(batched_snapshot, query),
+                        artifacts=artifacts,
                     )
                 )
 
+            if artifacts is not None:
+                with event_artifacts_scope(artifacts):
+                    return await self._on_demand_perceive_impl(batched_snapshot, query)
             return await self._on_demand_perceive_impl(batched_snapshot, query)
 
     async def handle_realtime_perception_result(
@@ -1005,7 +1014,8 @@ async def _persist_meaningful_event(
                 )
                 # count 留 0,继续走 publish
             else:
-                count = save_event_artifacts(event_id, artifacts)
+                clip_dids = save_event_artifacts(event_id, artifacts)
+                count = len(clip_dids)
                 if count > 0:
                     dao.update_snapshot_count(event_id, count)
         else:

--- a/backend/miloco/src/miloco/perception/client.py
+++ b/backend/miloco/src/miloco/perception/client.py
@@ -970,8 +970,8 @@ async def _persist_meaningful_event(
         # relevant 为空(如老测试数据未标 source_device_ids)时保持原有全量列表不收窄;
         # 否则 device_ids 和 artifacts.clips 必须同步收窄——两者分别驱动"日志展示哪些
         # 摄像头"和"落盘哪些摄像头的 clip",不同步会导致不相关摄像头的 clip 被落盘、
-        # snapshot_count 与 device_ids 长度对不上(save_event_artifacts 文档的
-        # "0 ~ len(artifacts.clips)"不变量)。trace / gallery 不是按事件相关性归属的
+        # snapshot_count 与 device_ids 长度对不上(save_event_artifacts 返回的
+        # clip_dids 必是 artifacts.clips 的子集,见 snapshot_writer.py 的 Returns)。trace / gallery 不是按事件相关性归属的
         # 产物,不参与收窄。
         relevant_device_ids = _collect_relevant_device_ids(result)
         if relevant_device_ids:

--- a/backend/miloco/src/miloco/perception/engine/pipeline.py
+++ b/backend/miloco/src/miloco/perception/engine/pipeline.py
@@ -853,15 +853,37 @@ async def run_query_pipeline(
         if not room_identity_packets:
             return None
 
-        # Build query prompt from IdentityPackets and call Omni
-        payload = build_query_prompt(
-            identity_packets=room_identity_packets,
-            query=query,
-            last_caption=captions.get(room_name),
+        # Resolve the device whose video will be encoded by build_query_prompt.
+        # _encode_batch_video picks the first packet with all_frames; align here
+        # so push_clip_bytes falls under the correct device_id.
+        # Edge: if this packet's PyAV encode fails and a later one succeeds,
+        # clip bytes land under the wrong device_id — extremely rare.
+        primary_idx = next(
+            (i for i, ep in enumerate(room_identity_packets) if ep.all_frames),
+            0,
         )
-        raw_response = await call_omni(
-            payload, resolve_live_omni_config(config.omni), type="on_demand"
-        )
+        primary_did = snapshots[primary_idx].device.did if snapshots else "unknown"
+
+        # Set device context before build_query_prompt — push_clip_bytes is
+        # called during video encoding inside build_query_prompt, and
+        # push_omni_trace is called inside call_omni's finally block.
+        device_ctx_token = set_device_context(DeviceContext(
+            device_trace_id=str(uuid.uuid4()),
+            device_id=primary_did,
+            room_name=room_name,
+        ))
+        try:
+            payload = build_query_prompt(
+                identity_packets=room_identity_packets,
+                query=query,
+                last_caption=captions.get(room_name),
+            )
+            raw_response = await call_omni(
+                payload, resolve_live_omni_config(config.omni), type="on_demand"
+            )
+        finally:
+            reset_device_context(device_ctx_token)
+
         answer = parse_query_response(raw_response)
         if not answer:
             return None
@@ -870,7 +892,8 @@ async def run_query_pipeline(
     # 各 room 并发（与 run_batch_pipeline 同源：per-room omni 墙钟 Σ→max）。单房间查询
     # 无变化；多房间/全屋查询省 Σ。return_exceptions=True + _reraise_first 保持原"任一
     # room 失败即整体失败"语义（上层 on_demand_perceive 捕获→空答案）。query 路径不走
-    # fused、无 set_device_context，并发面比主路径更窄（run_identity 池写仍是原子同步段）。
+    # fused；set_device_context 在 _run_room_query 内部 per-room 设/重置，gather 的
+    # per-Task context copy 保证各 room 的 ContextVar 互不干扰。
     room_results = await asyncio.gather(
         *(_run_room_query(rn, snaps) for rn, snaps in batch.by_room().items()),
         return_exceptions=True,

--- a/backend/miloco/src/miloco/perception/engine/pipeline.py
+++ b/backend/miloco/src/miloco/perception/engine/pipeline.py
@@ -854,12 +854,15 @@ async def run_query_pipeline(
             return None
 
         # Resolve the device whose video will be encoded by build_query_prompt.
-        # _encode_batch_video picks the first packet with all_frames (prompt_builder.py:1418)
-        # and push_clip_bytes fires only after a successful encode (:1287), so this is the
-        # same predicate evaluated twice — attribution is exact, not best-effort.
-        # Note: _encode_batch_video has no try/except, so a PyAV failure on THIS packet
-        # propagates out of build_query_prompt → room task raises → _reraise_first
-        # (:901) → the whole (possibly multi-room) query degrades to answer="".
+        # _encode_batch_video loops edge_packets and returns the first one _encode_video
+        # can encode — and _encode_video bails with (None, None) only when all_frames is
+        # empty, while push_clip_bytes fires at the tail of _encode_video_mp4 after a
+        # successful encode. So this is the same predicate evaluated twice: attribution
+        # is exact, not best-effort.
+        # Note: neither _encode_batch_video nor _encode_video_mp4 has an except clause
+        # (only try/finally to unlink the temp file), so a PyAV failure on THIS packet
+        # propagates out of build_query_prompt → room task raises → _reraise_first below
+        # → the whole (possibly multi-room) query degrades to answer="".
         primary_idx = next(
             (i for i, ep in enumerate(room_identity_packets) if ep.all_frames),
             0,

--- a/backend/miloco/src/miloco/perception/engine/pipeline.py
+++ b/backend/miloco/src/miloco/perception/engine/pipeline.py
@@ -854,10 +854,12 @@ async def run_query_pipeline(
             return None
 
         # Resolve the device whose video will be encoded by build_query_prompt.
-        # _encode_batch_video picks the first packet with all_frames; align here
-        # so push_clip_bytes falls under the correct device_id.
-        # Edge: if this packet's PyAV encode fails and a later one succeeds,
-        # clip bytes land under the wrong device_id — extremely rare.
+        # _encode_batch_video picks the first packet with all_frames (prompt_builder.py:1418)
+        # and push_clip_bytes fires only after a successful encode (:1287), so this is the
+        # same predicate evaluated twice — attribution is exact, not best-effort.
+        # Note: _encode_batch_video has no try/except, so a PyAV failure on THIS packet
+        # propagates out of build_query_prompt → room task raises → _reraise_first
+        # (:901) → the whole (possibly multi-room) query degrades to answer="".
         primary_idx = next(
             (i for i, ep in enumerate(room_identity_packets) if ep.all_frames),
             0,

--- a/backend/miloco/src/miloco/perception/events_service.py
+++ b/backend/miloco/src/miloco/perception/events_service.py
@@ -125,20 +125,24 @@ class EventsService:
             return None
         for did in device_ids:
             device_dir = snapshot_root / event_id / region_slug(did)
-            for filename, kind in (("clip.mp4", "mp4"), ("clip.m4a", "m4a")):
-                if (device_dir / filename).exists():
-                    return kind
+            for filename in CLIP_CANDIDATES:
+                path = device_dir / filename
+                if path.exists():
+                    return path.suffix[1:]
         return None
 
     _UUID_RE = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
 
     @staticmethod
     def _build_feedback_index() -> dict[str, tuple[str, int]]:
-        """一次扫描 packs 目录,建 event_id → (path, size) 索引.
+        """一次扫描 packs 目录,建 event_id / log_id → (path, size) 索引.
 
-        文件名格式: feedback-{uid}-{event_id}-{YYYYMMDD-HHMMSS}.tar.gz
-        通过 UUID 正则匹配 event_id,兼容有无 uid 前缀.
-        同一 event_id 有多个 pack 时取最新(mtime 最大).
+        两种包名共用本索引:
+        - 事件包     feedback-{uid}-{event_id}-{YYYYMMDD-HHMMSS}.tar.gz
+        - 主动查询包 feedback-{uid}-od-{log_id}-{YYYYMMDD-HHMMSS}.tar.gz
+        取 UUID 正则 findall 的最后一个匹配,故 uid/字面量 od/时间戳都不会被误命中.
+        调用方: EventsService.list_events 与 PerceptionService.query_on_demand_logs.
+        同一 id 有多个 pack 时取最新(mtime 最大).
         """
         packs_dir = miloco_home() / "packs"
         if not packs_dir.exists():

--- a/backend/miloco/src/miloco/perception/events_service.py
+++ b/backend/miloco/src/miloco/perception/events_service.py
@@ -18,7 +18,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 from miloco.perception.schema import MeaningfulEvent
-from miloco.perception.snapshot_writer import get_snapshot_root, region_slug
+from miloco.perception.snapshot_writer import (
+    CLIP_CANDIDATES,
+    MEDIA_TYPE_BY_SUFFIX,
+    get_snapshot_root,
+    region_slug,
+)
 from miloco.utils.paths import miloco_home
 
 if TYPE_CHECKING:
@@ -27,11 +32,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 SnapshotStatus = Literal["found", "gone", "not_found"]
-
-# 视频路径产物 clip.mp4 (H264+AAC);audio-only 路径产物 clip.m4a (仅 AAC,ipod muxer).
-# 探测顺序:先 mp4 后 m4a,先找到的优先返回。
-_CLIP_CANDIDATES = ("clip.mp4", "clip.m4a")
-_MEDIA_TYPE_BY_SUFFIX = {".mp4": "video/mp4", ".m4a": "audio/mp4"}
 
 
 class EventsService:
@@ -83,7 +83,7 @@ class EventsService:
         scrubber 的 seek.
 
         探测顺序:先 clip.mp4 (视频路径产物),后 clip.m4a (audio-only 路径产物).
-        对应 media_type 由 _MEDIA_TYPE_BY_SUFFIX 决定.
+        对应 media_type 由 MEDIA_TYPE_BY_SUFFIX 决定.
 
         Args:
             event_id: UUID
@@ -103,10 +103,10 @@ class EventsService:
             return ("not_found", None, None, None)
 
         device_dir = get_snapshot_root() / event_id / region_slug(device_id)
-        for filename in _CLIP_CANDIDATES:
+        for filename in CLIP_CANDIDATES:
             path = device_dir / filename
             if path.exists():
-                return ("found", path, _MEDIA_TYPE_BY_SUFFIX[path.suffix], row["timestamp"])
+                return ("found", path, MEDIA_TYPE_BY_SUFFIX[path.suffix], row["timestamp"])
         # event metadata 在表里,但文件已被 cleanup 清掉(或写前预检跳过没落)
         return ("gone", None, None, None)
 

--- a/backend/miloco/src/miloco/perception/events_service.py
+++ b/backend/miloco/src/miloco/perception/events_service.py
@@ -70,7 +70,7 @@ class EventsService:
             since_ms=since, before_ms=before, limit=limit, offset=offset
         )
         snapshot_root = get_snapshot_root()
-        feedback_index = self._build_feedback_index()
+        feedback_index = self.build_feedback_index()
         return [self._row_to_event(row, snapshot_root, feedback_index) for row in rows]
 
     async def locate_clip(
@@ -134,7 +134,7 @@ class EventsService:
     _UUID_RE = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
 
     @staticmethod
-    def _build_feedback_index() -> dict[str, tuple[str, int]]:
+    def build_feedback_index() -> dict[str, tuple[str, int]]:
         """一次扫描 packs 目录,建 event_id / log_id → (path, size) 索引.
 
         两种包名共用本索引:

--- a/backend/miloco/src/miloco/perception/processor.py
+++ b/backend/miloco/src/miloco/perception/processor.py
@@ -789,13 +789,15 @@ class PipelineProcessor:
 
     async def process_on_demand(
         self, dids: list[str] | None, query: str
-    ) -> OnDemandPerceptionResult | None:
+    ) -> "tuple[OnDemandPerceptionResult, OmniEventArtifacts] | None":
         """Active perception pipeline — multi-device batch query.
 
         1. Batch-collect specified devices via collector.collect_batch(dids)
         2. Run perception_engine_proxy.on_demand_perceive(batch, query) for fusion inference
-        3. Return answer dict mapping source key to answer string
+        3. Return (result, artifacts) — artifacts contain clips + omni trace
         """
+        from miloco.perception.snapshot_context import OmniEventArtifacts
+
         async with get_monitor().track_async(NodeName.PROCESSOR, "on_demand") as _proc_h:
             # Peek without consuming — realtime pipeline still needs this data
             batch = self._collector.collect_batch(dids, drain=False)
@@ -808,8 +810,24 @@ class PipelineProcessor:
             if batch.end_timestamp and batch.start_timestamp:
                 _proc_h.add_window_ms(batch.end_timestamp - batch.start_timestamp)
 
+            artifacts = OmniEventArtifacts()
+
             try:
-                return await self._perception_engine_proxy.on_demand_perceive(batch, query)
+                result = await self._perception_engine_proxy.on_demand_perceive(
+                    batch, query, artifacts=artifacts,
+                )
             except Exception as e:
                 logger.error("[processor] 主动查询感知失败 | %s", e, exc_info=True)
                 return None
+
+            if result is None:
+                return None
+
+            # Filter out empty clips (same as realtime path)
+            artifacts.clips = {
+                did: (clip_bytes, kind)
+                for did, (clip_bytes, kind) in artifacts.clips.items()
+                if clip_bytes
+            }
+
+            return result, artifacts

--- a/backend/miloco/src/miloco/perception/processor.py
+++ b/backend/miloco/src/miloco/perception/processor.py
@@ -41,6 +41,7 @@ from miloco.perception.schema import (
     PerceptionLatency,
     PerceptionLogEntry,
 )
+from miloco.perception.snapshot_context import OmniEventArtifacts
 from miloco.perception.types import OnDemandPerceptionResult
 
 logger = logging.getLogger("perf")
@@ -789,15 +790,13 @@ class PipelineProcessor:
 
     async def process_on_demand(
         self, dids: list[str] | None, query: str
-    ) -> "tuple[OnDemandPerceptionResult, OmniEventArtifacts] | None":
+    ) -> tuple[OnDemandPerceptionResult, OmniEventArtifacts] | None:
         """Active perception pipeline — multi-device batch query.
 
         1. Batch-collect specified devices via collector.collect_batch(dids)
         2. Run perception_engine_proxy.on_demand_perceive(batch, query) for fusion inference
         3. Return (result, artifacts) — artifacts contain clips + omni trace
         """
-        from miloco.perception.snapshot_context import OmniEventArtifacts
-
         async with get_monitor().track_async(NodeName.PROCESSOR, "on_demand") as _proc_h:
             # Peek without consuming — realtime pipeline still needs this data
             batch = self._collector.collect_batch(dids, drain=False)

--- a/backend/miloco/src/miloco/perception/router.py
+++ b/backend/miloco/src/miloco/perception/router.py
@@ -145,7 +145,12 @@ async def query_on_demand_logs(
 )
 async def get_on_demand_clip(log_id: str, device_id: str) -> FileResponse:
     """Serve the clip file for an on-demand query log entry."""
-    from miloco.perception.snapshot_writer import get_snapshot_root, region_slug
+    from miloco.perception.snapshot_writer import (
+        CLIP_CANDIDATES,
+        MEDIA_TYPE_BY_SUFFIX,
+        get_snapshot_root,
+        region_slug,
+    )
 
     row = manager.perception_service.get_on_demand_log(log_id)
     if row is None:
@@ -154,7 +159,7 @@ async def get_on_demand_clip(log_id: str, device_id: str) -> FileResponse:
         raise HTTPException(message="not found", status_code=404)
 
     device_dir = get_snapshot_root() / log_id / region_slug(device_id)
-    for filename, media_type in [("clip.mp4", "video/mp4"), ("clip.m4a", "audio/mp4")]:
+    for filename in CLIP_CANDIDATES:
         path = device_dir / filename
         if path.exists():
             from datetime import datetime
@@ -164,7 +169,7 @@ async def get_on_demand_clip(log_id: str, device_id: str) -> FileResponse:
             local_dt = datetime.fromtimestamp(row["timestamp"] / 1000, tz=deploy_timezone())
             download_name = f"clip-{local_dt.strftime('%Y-%m-%d-%H-%M-%S')}.{filename.split('.')[1]}"
             return FileResponse(
-                path=path, media_type=media_type,
+                path=path, media_type=MEDIA_TYPE_BY_SUFFIX[path.suffix],
                 filename=download_name, content_disposition_type="inline",
             )
     raise HTTPException(message="clip expired", status_code=410)

--- a/backend/miloco/src/miloco/perception/router.py
+++ b/backend/miloco/src/miloco/perception/router.py
@@ -9,9 +9,11 @@ import logging
 from dataclasses import asdict
 
 from fastapi import APIRouter, Depends, Query
+from fastapi.responses import FileResponse
+from pydantic import BaseModel, Field
 
 from miloco.manager import get_manager
-from miloco.middleware import verify_token
+from miloco.middleware import verify_token, verify_token_query_fallback
 from miloco.middleware.exceptions import HTTPException
 from miloco.perception.engine_state import set_perception_enabled
 from miloco.perception.schema import OnDemandPerceptionRequest
@@ -117,6 +119,107 @@ async def query_logs(
         after=after, before=before, since=since, limit=limit
     )
     return NormalResponse(code=0, message="ok", data=data)
+
+
+@router.get(
+    "/on-demand-logs",
+    summary="Query on-demand perception query logs",
+    dependencies=[Depends(verify_token)],
+)
+async def query_on_demand_logs(
+    limit: int | None = Query(None, ge=1, le=1000, description="Max entries; omit for unlimited"),
+    since: int | None = Query(None, description="Unix ms lower bound (inclusive)"),
+    before: int | None = Query(None, description="Unix ms upper bound (exclusive)"),
+    before_id: str | None = Query(None, description="Compound cursor tiebreaker (used with before)"),
+):
+    data = manager.perception_service.query_on_demand_logs(
+        since_ms=since, before_ms=before, before_id=before_id, limit=limit
+    )
+    return NormalResponse(code=0, message="ok", data=data)
+
+
+@router.get(
+    "/on-demand-logs/{log_id}/clip/{device_id}",
+    summary="Get on-demand query clip (omni 看到的字节级 mp4/m4a)",
+    dependencies=[Depends(verify_token_query_fallback)],
+)
+async def get_on_demand_clip(log_id: str, device_id: str) -> FileResponse:
+    """Serve the clip file for an on-demand query log entry."""
+    from miloco.perception.snapshot_writer import get_snapshot_root, region_slug
+
+    row = manager.perception_service.get_on_demand_log(log_id)
+    if row is None:
+        raise HTTPException(message="not found", status_code=404)
+    if device_id not in row["sources"]:
+        raise HTTPException(message="not found", status_code=404)
+
+    device_dir = get_snapshot_root() / log_id / region_slug(device_id)
+    for filename, media_type in [("clip.mp4", "video/mp4"), ("clip.m4a", "audio/mp4")]:
+        path = device_dir / filename
+        if path.exists():
+            from datetime import datetime
+
+            from miloco.utils.time_utils import deploy_timezone
+
+            local_dt = datetime.fromtimestamp(row["timestamp"] / 1000, tz=deploy_timezone())
+            download_name = f"clip-{local_dt.strftime('%Y-%m-%d-%H-%M-%S')}.{filename.split('.')[1]}"
+            return FileResponse(
+                path=path, media_type=media_type,
+                filename=download_name, content_disposition_type="inline",
+            )
+    raise HTTPException(message="clip expired", status_code=410)
+
+
+class OnDemandFeedbackBody(BaseModel):
+    error_types: list[str] = Field(default_factory=list)
+    feedback_text: str = Field(default="")
+
+
+@router.post(
+    "/on-demand-logs/{log_id}/feedback",
+    summary="Submit feedback for an on-demand query",
+    dependencies=[Depends(verify_token)],
+)
+async def submit_on_demand_feedback(log_id: str, body: OnDemandFeedbackBody):
+    """Build a feedback pack for an on-demand query (trace + clips + user annotation)."""
+    import asyncio
+
+    from miloco.admin.feedback_pack import build_on_demand_feedback_pack
+
+    row = manager.perception_service.get_on_demand_log(log_id)
+    if row is None:
+        raise HTTPException(message="not found", status_code=404)
+
+    uid = ""
+    try:
+        user_info = await manager.miot_proxy.get_user_info()
+        if user_info:
+            uid = user_info.uid
+    except Exception:
+        logger.exception(
+            "Failed to resolve miot uid for on-demand feedback pack; "
+            "falling back to anonymous"
+        )
+
+    pack_path, pack_size, components = await asyncio.to_thread(
+        build_on_demand_feedback_pack,
+        log_id=log_id,
+        row=row,
+        error_types=body.error_types,
+        feedback_text=body.feedback_text,
+        uid=uid,
+    )
+    return NormalResponse(
+        code=0, message="ok",
+        data={
+            "log_id": log_id,
+            "pack_path": str(pack_path),
+            "pack_size_bytes": pack_size,
+            "uploaded": False,
+            "upload_key": None,
+            "components": components,
+        },
+    )
 
 
 @router.get(

--- a/backend/miloco/src/miloco/perception/router.py
+++ b/backend/miloco/src/miloco/perception/router.py
@@ -127,7 +127,7 @@ async def query_logs(
     dependencies=[Depends(verify_token)],
 )
 async def query_on_demand_logs(
-    limit: int | None = Query(None, ge=1, le=1000, description="Max entries; omit for unlimited"),
+    limit: int = Query(50, ge=1, le=200, description="每页条数,上限 200"),
     since: int | None = Query(None, description="Unix ms lower bound (inclusive)"),
     before: int | None = Query(None, description="Unix ms upper bound (exclusive)"),
     before_id: str | None = Query(None, description="Compound cursor tiebreaker (used with before)"),

--- a/backend/miloco/src/miloco/perception/router.py
+++ b/backend/miloco/src/miloco/perception/router.py
@@ -206,7 +206,7 @@ async def submit_on_demand_feedback(log_id: str, body: OnDemandFeedbackBody):
             "falling back to anonymous"
         )
 
-    pack_path, pack_size, components = await asyncio.to_thread(
+    result = await asyncio.to_thread(
         build_on_demand_feedback_pack,
         log_id=log_id,
         row=row,
@@ -218,11 +218,11 @@ async def submit_on_demand_feedback(log_id: str, body: OnDemandFeedbackBody):
         code=0, message="ok",
         data={
             "log_id": log_id,
-            "pack_path": str(pack_path),
-            "pack_size_bytes": pack_size,
+            "pack_path": result["path"],
+            "pack_size_bytes": result["size_bytes"],
             "uploaded": False,
             "upload_key": None,
-            "components": components,
+            "components": result["components"],
         },
     )
 

--- a/backend/miloco/src/miloco/perception/router.py
+++ b/backend/miloco/src/miloco/perception/router.py
@@ -155,7 +155,7 @@ async def get_on_demand_clip(log_id: str, device_id: str) -> FileResponse:
     row = manager.perception_service.get_on_demand_log(log_id)
     if row is None:
         raise HTTPException(message="not found", status_code=404)
-    if device_id not in row["sources"]:
+    if device_id not in row.get("clip_dids", []):
         raise HTTPException(message="not found", status_code=404)
 
     device_dir = get_snapshot_root() / log_id / region_slug(device_id)

--- a/backend/miloco/src/miloco/perception/schema.py
+++ b/backend/miloco/src/miloco/perception/schema.py
@@ -476,7 +476,13 @@ class PerceptionLogEntry(BaseModel):
 
 
 class OnDemandLogEntry(BaseModel):
-    """On-demand perception query log entry stored in DB."""
+    """On-demand perception query log — 写库入参 DTO,不是列表 API 的响应模型.
+
+    列表响应形状由 OnDemandLogRepo._row_to_dict + PerceptionService.
+    query_on_demand_logs 就地注入的 has_feedback / feedback_pack_path /
+    feedback_pack_size 决定;加对外字段要同时改那两处与
+    web/src/lib/types.ts::OnDemandLogEntry.
+    """
 
     id: str = Field(..., description="UUID")
     timestamp: int = Field(..., description="Query time, millisecond Unix timestamp")
@@ -491,9 +497,6 @@ class OnDemandLogEntry(BaseModel):
         default=False,
         description="omni_trace.json.gz on disk (list API overrides DB column with live stat)",
     )
-    has_feedback: bool = Field(default=False, description="Derived from packs dir scan, not a DB column")
-    feedback_pack_path: str | None = Field(default=None, description="Latest feedback pack local path")
-    feedback_pack_size: int | None = Field(default=None, description="Latest feedback pack bytes")
 
 
 class MeaningfulEvent(BaseModel):

--- a/backend/miloco/src/miloco/perception/schema.py
+++ b/backend/miloco/src/miloco/perception/schema.py
@@ -475,6 +475,27 @@ class PerceptionLogEntry(BaseModel):
     )
 
 
+class OnDemandLogEntry(BaseModel):
+    """On-demand perception query log entry stored in DB."""
+
+    id: str = Field(..., description="UUID")
+    timestamp: int = Field(..., description="Query time, millisecond Unix timestamp")
+    query: str = Field(..., description="User's natural language question")
+    answer: str = Field(..., description="VLM answer")
+    sources: list[str] = Field(default_factory=list, description="Device did list")
+    latency_ms: int | None = Field(default=None, description="Inference latency in ms")
+    snapshot_count: int = Field(default=0, description="Number of devices with clips on disk")
+    clip_dids: list[str] = Field(default_factory=list, description="Device IDs that have clips on disk")
+    clip_kinds: dict[str, Literal["mp4", "m4a"]] = Field(default_factory=dict, description="Per-device clip kind: {did: 'mp4'|'m4a'}")
+    has_trace: bool = Field(
+        default=False,
+        description="omni_trace.json.gz on disk (list API overrides DB column with live stat)",
+    )
+    has_feedback: bool = Field(default=False, description="Derived from packs dir scan, not a DB column")
+    feedback_pack_path: str | None = Field(default=None, description="Latest feedback pack local path")
+    feedback_pack_size: int | None = Field(default=None, description="Latest feedback pack bytes")
+
+
 class MeaningfulEvent(BaseModel):
     """有意义事件(family-ui Activity tab 展示用).
 

--- a/backend/miloco/src/miloco/perception/service.py
+++ b/backend/miloco/src/miloco/perception/service.py
@@ -213,6 +213,9 @@ class PerceptionService:
         clip_kinds: dict[str, str] = {}
         has_trace = False
 
+        if not result.answer:
+            artifacts.clips = {}
+
         if artifacts.clips or artifacts.trace:
             from miloco.config.settings import get_settings
             from miloco.perception.snapshot_writer import (

--- a/backend/miloco/src/miloco/perception/service.py
+++ b/backend/miloco/src/miloco/perception/service.py
@@ -11,6 +11,7 @@ ensuring a unified data path.
 
 import asyncio
 import logging
+import shutil
 
 from miloco.database.on_demand_log_repo import OnDemandLogRepo
 from miloco.database.perception_repo import PerceptionLogRepo
@@ -240,8 +241,10 @@ class PerceptionService:
                 }
                 has_trace = (snapshot_root / log_id / "omni_trace.json.gz").exists()
 
-        # Persist on-demand query log (with artifact metadata)
-        self._od_log_repo.append(
+        # Persist on-demand query log (with artifact metadata).
+        # 行写失败必须回滚已落盘的产物:读端点都先过库(router.py:155/194),
+        # 行不在 → clip 永远不可达,而 mtime 最新、LRU 最后淘汰,白占共享配额。
+        inserted = self._od_log_repo.append(
             OnDemandLogEntry(
                 id=log_id,
                 timestamp=t_start,
@@ -255,6 +258,13 @@ class PerceptionService:
                 has_trace=has_trace,
             )
         )
+        if not inserted:
+            logger.error(
+                "on_demand_log insert failed for %s; discarding orphaned artifacts",
+                log_id,
+            )
+            if clip_dids or has_trace:
+                shutil.rmtree(get_snapshot_root() / log_id, ignore_errors=True)
 
         # Map inference results back to API response items
         return OnDemandPerceptionResultItem(
@@ -331,6 +341,8 @@ class PerceptionService:
         logs, count = self._od_log_repo.query(
             since_ms=since_ms, before_ms=before_ms, before_id=before_id, limit=limit
         )
+        if not logs:
+            return {"logs": logs, "count": count}
 
         from miloco.perception.events_service import EventsService
         from miloco.perception.snapshot_writer import get_snapshot_root

--- a/backend/miloco/src/miloco/perception/service.py
+++ b/backend/miloco/src/miloco/perception/service.py
@@ -348,7 +348,7 @@ class PerceptionService:
         from miloco.perception.snapshot_writer import get_snapshot_root
 
         snapshot_root = get_snapshot_root()
-        fb_index = EventsService._build_feedback_index()
+        fb_index = EventsService.build_feedback_index()
         for row in logs:
             row["has_trace"] = (
                 snapshot_root / row["id"] / "omni_trace.json.gz"

--- a/backend/miloco/src/miloco/perception/service.py
+++ b/backend/miloco/src/miloco/perception/service.py
@@ -214,7 +214,12 @@ class PerceptionService:
         has_trace = False
 
         if not result.answer:
-            artifacts.clips = {}
+            omni_responded = any(
+                call.get("error") is None
+                for call in (artifacts.trace or {}).get("calls", [])
+            )
+            if not omni_responded:
+                artifacts.clips = {}
 
         if artifacts.clips or artifacts.trace:
             from miloco.config.settings import get_settings

--- a/backend/miloco/src/miloco/perception/service.py
+++ b/backend/miloco/src/miloco/perception/service.py
@@ -175,6 +175,7 @@ class PerceptionService:
         import uuid
 
         from miloco.perception.schema import OnDemandLogEntry
+        from miloco.perception.snapshot_writer import get_snapshot_root
 
         active_sources = self._collector.get_all_active_sources()
 
@@ -226,7 +227,6 @@ class PerceptionService:
             from miloco.config.settings import get_settings
             from miloco.perception.snapshot_writer import (
                 check_disk_space,
-                get_snapshot_root,
                 save_event_artifacts,
             )
 

--- a/backend/miloco/src/miloco/perception/service.py
+++ b/backend/miloco/src/miloco/perception/service.py
@@ -12,6 +12,7 @@ ensuring a unified data path.
 import asyncio
 import logging
 
+from miloco.database.on_demand_log_repo import OnDemandLogRepo
 from miloco.database.perception_repo import PerceptionLogRepo
 from miloco.middleware.exceptions import BusinessException
 from miloco.perception.collect.collector import MultimodalCollector
@@ -37,11 +38,13 @@ class PerceptionService:
         pipeline: PipelineProcessor,
         perception_runner: PerceptionRunner,
         log_repo: PerceptionLogRepo,
+        on_demand_log_repo: OnDemandLogRepo | None = None,
     ):
         self._collector = collector
         self._pipeline = pipeline
         self._engine = perception_runner
         self._log_repo = log_repo
+        self._od_log_repo = on_demand_log_repo or OnDemandLogRepo()
         # 串行化引擎生命周期操作(start/stop/重建/降级)。这些操作都含多个 await
         # 让出点且改 runner._is_running,不加锁会在「应用设置重启」与用户手动
         # 启停/删模型交错时出现 executor 未重挂、孤儿 task 等状态错乱。
@@ -168,6 +171,10 @@ class PerceptionService:
         If the realtime engine is running, data comes from its existing stream
         subscriptions. If not running, the collector may have no data.
         """
+        import uuid
+
+        from miloco.perception.schema import OnDemandLogEntry
+
         active_sources = self._collector.get_all_active_sources()
 
         valid_dids: list[str] = []
@@ -186,19 +193,65 @@ class PerceptionService:
                 code=2011,
             )
 
-        # Single batch inference call — collector assembles batch, processor infers
-        result = await self._pipeline.process_on_demand(valid_dids, request.query)
+        t_start = now_ms()
 
-        if not result:
+        # Single batch inference call — collector assembles batch, processor infers
+        pipeline_result = await self._pipeline.process_on_demand(valid_dids, request.query)
+
+        if not pipeline_result:
             raise BusinessException(
                 "Failed to perform on-demand perception.",
                 code=2012,
             )
 
+        result, artifacts = pipeline_result
+        t_end = now_ms()
+        log_id = str(uuid.uuid4())
+
+        # Save artifacts (clips + trace) to disk
+        clip_dids: list[str] = []
+        clip_kinds: dict[str, str] = {}
+        has_trace = False
+
+        if artifacts.clips or artifacts.trace:
+            from miloco.config.settings import get_settings
+            from miloco.perception.snapshot_writer import (
+                check_disk_space,
+                get_snapshot_root,
+                save_event_artifacts,
+            )
+
+            settings = get_settings()
+            snapshot_root = get_snapshot_root()
+            if check_disk_space(snapshot_root, settings.perception.snapshot_min_free_disk_mb):
+                clip_dids = save_event_artifacts(log_id, artifacts)
+                clip_kinds = {
+                    did: artifacts.clips[did][1]
+                    for did in clip_dids
+                    if did in artifacts.clips
+                }
+                has_trace = (snapshot_root / log_id / "omni_trace.json.gz").exists()
+
+        # Persist on-demand query log (with artifact metadata)
+        self._od_log_repo.append(
+            OnDemandLogEntry(
+                id=log_id,
+                timestamp=t_start,
+                query=request.query,
+                answer=result.answer,
+                sources=valid_dids,
+                latency_ms=t_end - t_start,
+                snapshot_count=len(clip_dids),
+                clip_dids=clip_dids,
+                clip_kinds=clip_kinds,
+                has_trace=has_trace,
+            )
+        )
+
         # Map inference results back to API response items
         return OnDemandPerceptionResultItem(
             answer=result.answer,
-            timestamp=ms_to_iso_local(now_ms()),
+            timestamp=ms_to_iso_local(t_end),
         )
 
     # ---- Perception logs ----
@@ -249,6 +302,51 @@ class PerceptionService:
     def cleanup_logs(self, keep_days: int) -> int:
         """清理过期感知日志。"""
         return self._log_repo.delete_before_days(keep_days)
+
+    # ---- On-demand logs ----
+
+    def query_on_demand_logs(
+        self,
+        since_ms: int | None = None,
+        before_ms: int | None = None,
+        before_id: str | None = None,
+        limit: int | None = None,
+    ) -> dict:
+        """Query on-demand perception query logs.
+
+        Args:
+            since_ms: Unix ms lower bound (inclusive).
+            before_ms: Unix ms upper bound (exclusive).
+            before_id: Compound cursor tiebreaker (used with before_ms).
+            limit: Max entries to return.
+        """
+        logs, count = self._od_log_repo.query(
+            since_ms=since_ms, before_ms=before_ms, before_id=before_id, limit=limit
+        )
+
+        from miloco.perception.events_service import EventsService
+        from miloco.perception.snapshot_writer import get_snapshot_root
+
+        snapshot_root = get_snapshot_root()
+        fb_index = EventsService._build_feedback_index()
+        for row in logs:
+            row["has_trace"] = (
+                snapshot_root / row["id"] / "omni_trace.json.gz"
+            ).exists()
+            fb = fb_index.get(row["id"])
+            row["has_feedback"] = fb is not None
+            row["feedback_pack_path"] = fb[0] if fb else None
+            row["feedback_pack_size"] = fb[1] if fb else None
+
+        return {"logs": logs, "count": count}
+
+    def get_on_demand_log(self, log_id: str) -> dict | None:
+        """Get a single on-demand log entry by ID."""
+        return self._od_log_repo.get_by_id(log_id)
+
+    def cleanup_on_demand_logs(self, keep_days: int) -> int:
+        """清理过期主动查询日志。"""
+        return self._od_log_repo.delete_before_days(keep_days)
 
     # ---- Device management ----
 

--- a/backend/miloco/src/miloco/perception/snapshot_writer.py
+++ b/backend/miloco/src/miloco/perception/snapshot_writer.py
@@ -92,7 +92,7 @@ def check_disk_space(root: Path, min_free_mb: int) -> bool:
         return True
 
 
-def save_event_artifacts(event_id: str, artifacts: OmniEventArtifacts) -> int:
+def save_event_artifacts(event_id: str, artifacts: OmniEventArtifacts) -> list[str]:
     """落盘一次 omni 触发事件的所有产物(clip 字节 + omni trace).
 
     路径:
@@ -101,16 +101,16 @@ def save_event_artifacts(event_id: str, artifacts: OmniEventArtifacts) -> int:
 
     Args:
         event_id: 事件 UUID
-        artifacts: 含 clips dict 和 trace dict 的容器.两者都空时返 0 不落任何文件.
+        artifacts: 含 clips dict 和 trace dict 的容器.两者都空时返空列表.
 
     Returns:
-        成功落盘的 device clip 个数(0 ~ len(artifacts.clips));trace 不计入.
-        保持 MeaningfulEvent.snapshot_count 字段含义.
+        成功落盘的 device_id 列表;trace 不计入.
+        len(result) 等价于原 snapshot_count.
 
     Caller 责任:调用前已 check_disk_space 确认有空间;本函数遇 OSError 静默跳过.
     """
     if not artifacts.clips and artifacts.trace is None and not artifacts.gallery:
-        return 0
+        return []
 
     snapshot_root = get_snapshot_root()
     event_dir = snapshot_root / event_id
@@ -118,22 +118,26 @@ def save_event_artifacts(event_id: str, artifacts: OmniEventArtifacts) -> int:
         event_dir.mkdir(parents=True, exist_ok=True)
     except OSError as e:
         logger.error("Failed to create event dir %s: %s", event_dir, e)
-        return 0
+        return []
 
-    clip_count = _save_clips(event_dir, artifacts.clips)
+    clip_dids = _save_clips(event_dir, artifacts.clips)
     if artifacts.trace is not None:
         _save_trace(event_dir, artifacts.trace)
     if artifacts.gallery:
         _save_gallery(event_dir, artifacts.gallery)
-    return clip_count
+    return clip_dids
 
 
 def _save_clips(
     event_dir: Path,
     clips: dict[str, tuple[bytes, ClipKind]],
-) -> int:
-    """落 per-device clip 字节到 event_dir.kind 非法 / 空字节 → 跳过该 device."""
-    count = 0
+) -> list[str]:
+    """落 per-device clip 字节到 event_dir.kind 非法 / 空字节 → 跳过该 device.
+
+    Returns:
+        成功落盘的 device_id 列表.
+    """
+    saved: list[str] = []
     for device_id, (clip_bytes, kind) in clips.items():
         if not clip_bytes:
             continue
@@ -149,11 +153,11 @@ def _save_clips(
         path = device_dir / f"clip.{kind}"
         try:
             path.write_bytes(clip_bytes)
-            count += 1
+            saved.append(device_id)
         except OSError as e:
             logger.error("Failed to write %s: %s", path, e)
             continue
-    return count
+    return saved
 
 
 def _save_trace(event_dir: Path, trace: dict[str, Any]) -> None:

--- a/backend/miloco/src/miloco/perception/snapshot_writer.py
+++ b/backend/miloco/src/miloco/perception/snapshot_writer.py
@@ -57,6 +57,10 @@ def region_slug(s: str) -> str:
     return slug or "_"
 
 
+CLIP_CANDIDATES: tuple[str, ...] = ("clip.mp4", "clip.m4a")
+MEDIA_TYPE_BY_SUFFIX: dict[str, str] = {".mp4": "video/mp4", ".m4a": "audio/mp4"}
+
+
 def get_snapshot_root() -> Path:
     """返回截图根目录绝对路径.
 

--- a/backend/miloco/src/miloco/perception/snapshot_writer.py
+++ b/backend/miloco/src/miloco/perception/snapshot_writer.py
@@ -57,6 +57,9 @@ def region_slug(s: str) -> str:
     return slug or "_"
 
 
+# 视频路径产物 clip.mp4 (H264+AAC);audio-only 路径产物 clip.m4a (仅 AAC,ipod muxer).
+# 探测顺序:先 mp4 后 m4a,先找到的优先返回。
+# 落盘/事件 clip 端点/主动查询 clip 端点/反馈打包四处同源;加新容器改这里 + ClipKind。
 CLIP_CANDIDATES: tuple[str, ...] = ("clip.mp4", "clip.m4a")
 MEDIA_TYPE_BY_SUFFIX: dict[str, str] = {".mp4": "video/mp4", ".m4a": "audio/mp4"}
 
@@ -145,7 +148,7 @@ def _save_clips(
     for device_id, (clip_bytes, kind) in clips.items():
         if not clip_bytes:
             continue
-        if kind not in ("mp4", "m4a"):
+        if f"clip.{kind}" not in CLIP_CANDIDATES:
             logger.error("Unknown clip kind %r for %s; skipping", kind, device_id)
             continue
         device_dir = event_dir / region_slug(device_id)

--- a/backend/miloco/tests/test_events_service.py
+++ b/backend/miloco/tests/test_events_service.py
@@ -280,7 +280,7 @@ class TestBuildFeedbackIndex:
         (packs / f"feedback-user123-{eid}-20260701-143025.tar.gz").write_bytes(b"x")
         monkeypatch.setattr("miloco.perception.events_service.miloco_home", lambda: tmp_path)
         from miloco.perception.events_service import EventsService
-        idx = EventsService._build_feedback_index()
+        idx = EventsService.build_feedback_index()
         assert eid in idx
         assert idx[eid][0].endswith(".tar.gz")
 
@@ -291,7 +291,7 @@ class TestBuildFeedbackIndex:
         (packs / f"feedback-{eid}-20260701-143025.tar.gz").write_bytes(b"x")
         monkeypatch.setattr("miloco.perception.events_service.miloco_home", lambda: tmp_path)
         from miloco.perception.events_service import EventsService
-        idx = EventsService._build_feedback_index()
+        idx = EventsService.build_feedback_index()
         assert eid in idx
 
     def test_picks_latest_by_mtime(self, tmp_path, monkeypatch):
@@ -307,7 +307,7 @@ class TestBuildFeedbackIndex:
         os.utime(new, (2000, 2000))
         monkeypatch.setattr("miloco.perception.events_service.miloco_home", lambda: tmp_path)
         from miloco.perception.events_service import EventsService
-        idx = EventsService._build_feedback_index()
+        idx = EventsService.build_feedback_index()
         assert idx[eid][0] == new.as_posix()
 
     def test_empty_packs_dir(self, tmp_path, monkeypatch):
@@ -315,13 +315,13 @@ class TestBuildFeedbackIndex:
         packs.mkdir()
         monkeypatch.setattr("miloco.perception.events_service.miloco_home", lambda: tmp_path)
         from miloco.perception.events_service import EventsService
-        idx = EventsService._build_feedback_index()
+        idx = EventsService.build_feedback_index()
         assert idx == {}
 
     def test_no_packs_dir(self, tmp_path, monkeypatch):
         monkeypatch.setattr("miloco.perception.events_service.miloco_home", lambda: tmp_path)
         from miloco.perception.events_service import EventsService
-        idx = EventsService._build_feedback_index()
+        idx = EventsService.build_feedback_index()
         assert idx == {}
 
     def test_finds_pack_in_timestamp_subdir(self, tmp_path, monkeypatch):
@@ -332,9 +332,20 @@ class TestBuildFeedbackIndex:
         (subdir / f"feedback-user123-{eid}-20260701-143025.tar.gz").write_bytes(b"x")
         monkeypatch.setattr("miloco.perception.events_service.miloco_home", lambda: tmp_path)
         from miloco.perception.events_service import EventsService
-        idx = EventsService._build_feedback_index()
+        idx = EventsService.build_feedback_index()
         assert eid in idx
         assert "20260701-143025" in idx[eid][0]
+
+    def test_parses_on_demand_pack_name(self, tmp_path, monkeypatch):
+        """主动查询包多一个字面量 od 段,findall 取最后一个匹配才不会误命中。"""
+        log_id = "aaaaaaaa-1111-2222-3333-444444444444"
+        packs = tmp_path / "packs"
+        packs.mkdir()
+        (packs / f"feedback-user123-od-{log_id}-20260701-143025.tar.gz").write_bytes(b"x")
+        monkeypatch.setattr("miloco.perception.events_service.miloco_home", lambda: tmp_path)
+        from miloco.perception.events_service import EventsService
+        idx = EventsService.build_feedback_index()
+        assert log_id in idx
 
 
 class TestManagerSingleton:

--- a/backend/miloco/tests/test_on_demand_log_repo.py
+++ b/backend/miloco/tests/test_on_demand_log_repo.py
@@ -1,0 +1,228 @@
+# Copyright (C) 2025 Xiaomi Corporation
+# This software may be used and distributed according to the terms of the Xiaomi Miloco License Agreement.
+
+"""Integration tests for OnDemandLogRepo against a real SQLite file."""
+
+import time
+import uuid
+
+import pytest
+
+
+@pytest.fixture
+def real_db(tmp_path, monkeypatch):
+    """Each test case gets a fresh SQLite DB."""
+    db_file = tmp_path / "test.db"
+    monkeypatch.setenv("MILOCO_DATABASE__PATH", str(db_file))
+
+    from miloco.config import reset_settings
+
+    reset_settings()
+
+    import miloco.database.connector as connector_module
+
+    monkeypatch.setattr(connector_module, "db_connector", None)
+    connector_module.init_database()
+
+    yield db_file
+
+    reset_settings()
+
+
+@pytest.fixture
+def repo(real_db):
+    from miloco.database.on_demand_log_repo import OnDemandLogRepo
+
+    return OnDemandLogRepo()
+
+
+def _make_entry(
+    ts_ms: int,
+    *,
+    query: str = "谁在客厅？",
+    answer: str = "没有人",
+    sources: list[str] | None = None,
+    clip_dids: list[str] | None = None,
+    clip_kinds: dict[str, str] | None = None,
+    has_trace: bool = False,
+    entry_id: str | None = None,
+):
+    from miloco.perception.schema import OnDemandLogEntry
+
+    return OnDemandLogEntry(
+        id=entry_id or str(uuid.uuid4()),
+        timestamp=ts_ms,
+        query=query,
+        answer=answer,
+        sources=sources or ["lumi.camera.v1"],
+        latency_ms=120,
+        snapshot_count=len(clip_dids) if clip_dids else 0,
+        clip_dids=clip_dids or [],
+        clip_kinds=clip_kinds or {},
+        has_trace=has_trace,
+    )
+
+
+class TestAppendAndQuery:
+    def test_roundtrip(self, repo):
+        now_ms = int(time.time() * 1000)
+        entry = _make_entry(
+            now_ms,
+            sources=["dev_a", "dev_b"],
+            clip_dids=["dev_a"],
+            clip_kinds={"dev_a": "mp4"},
+            has_trace=True,
+        )
+        assert repo.append(entry) is True
+
+        logs, count = repo.query()
+        assert count == 1
+        row = logs[0]
+        assert row["id"] == entry.id
+        assert row["timestamp"] == now_ms
+        assert row["query"] == "谁在客厅？"
+        assert row["answer"] == "没有人"
+        assert row["sources"] == ["dev_a", "dev_b"]
+        assert row["clip_dids"] == ["dev_a"]
+        assert row["clip_kinds"] == {"dev_a": "mp4"}
+        assert row["has_trace"] is True
+
+    def test_empty_query(self, repo):
+        logs, count = repo.query()
+        assert logs == []
+        assert count == 0
+
+
+class TestGetById:
+    def test_hit(self, repo):
+        now_ms = int(time.time() * 1000)
+        entry = _make_entry(now_ms, entry_id="test-uuid-123")
+        repo.append(entry)
+
+        row = repo.get_by_id("test-uuid-123")
+        assert row is not None
+        assert row["id"] == "test-uuid-123"
+
+    def test_miss(self, repo):
+        assert repo.get_by_id("nonexistent") is None
+
+
+class TestCompoundCursorPagination:
+    """Compound cursor (timestamp, id) prevents data loss at page boundaries
+    when multiple entries share the same millisecond timestamp."""
+
+    def test_same_ms_no_duplicates_no_loss(self, repo):
+        ts = int(time.time() * 1000)
+        ids = [f"id-{chr(ord('a') + i)}" for i in range(5)]
+        for eid in ids:
+            repo.append(_make_entry(ts, entry_id=eid))
+
+        page1, _ = repo.query(limit=3)
+        assert len(page1) == 3
+
+        oldest = page1[-1]
+        page2, _ = repo.query(
+            before_ms=oldest["timestamp"],
+            before_id=oldest["id"],
+            limit=3,
+        )
+        assert len(page2) == 2
+
+        all_ids = {r["id"] for r in page1} | {r["id"] for r in page2}
+        assert all_ids == set(ids)
+
+    def test_cursor_without_before_id_falls_back_to_timestamp_only(self, repo):
+        base = int(time.time() * 1000)
+        repo.append(_make_entry(base, entry_id="older"))
+        repo.append(_make_entry(base + 1000, entry_id="newer"))
+
+        logs, _ = repo.query(before_ms=base + 1000)
+        assert len(logs) == 1
+        assert logs[0]["id"] == "older"
+
+    def test_pagination_order_is_desc(self, repo):
+        base = int(time.time() * 1000)
+        for i in range(5):
+            repo.append(_make_entry(base + i * 1000, entry_id=f"entry-{i}"))
+
+        logs, _ = repo.query()
+        timestamps = [r["timestamp"] for r in logs]
+        assert timestamps == sorted(timestamps, reverse=True)
+
+
+class TestQueryFilters:
+    def test_after_ms_exclusive(self, repo):
+        base = int(time.time() * 1000)
+        repo.append(_make_entry(base, entry_id="at"))
+        repo.append(_make_entry(base + 1000, entry_id="after"))
+
+        logs, _ = repo.query(after_ms=base)
+        assert len(logs) == 1
+        assert logs[0]["id"] == "after"
+
+    def test_since_ms_inclusive(self, repo):
+        base = int(time.time() * 1000)
+        repo.append(_make_entry(base - 1000, entry_id="before"))
+        repo.append(_make_entry(base, entry_id="at"))
+        repo.append(_make_entry(base + 1000, entry_id="after"))
+
+        logs, _ = repo.query(since_ms=base)
+        assert len(logs) == 2
+        assert {r["id"] for r in logs} == {"at", "after"}
+
+
+class TestDeleteBeforeDays:
+    def test_deletes_old_keeps_recent(self, repo):
+        now_ms = int(time.time() * 1000)
+        old_ms = now_ms - 8 * 86400 * 1000  # 8 days ago
+        repo.append(_make_entry(old_ms, entry_id="old"))
+        repo.append(_make_entry(now_ms, entry_id="recent"))
+
+        deleted = repo.delete_before_days(7)
+        assert deleted == 1
+
+        logs, count = repo.query()
+        assert count == 1
+        assert logs[0]["id"] == "recent"
+
+    def test_within_window_not_deleted(self, repo):
+        now_ms = int(time.time() * 1000)
+        just_within = now_ms - 6 * 86400 * 1000  # 6 days ago (within 7-day window)
+        repo.append(_make_entry(just_within, entry_id="within"))
+
+        deleted = repo.delete_before_days(7)
+        assert deleted == 0
+        assert repo.count_all() == 1
+
+
+class TestDuplicateId:
+    def test_duplicate_id_returns_false(self, repo):
+        entry = _make_entry(int(time.time() * 1000), entry_id="dup")
+        assert repo.append(entry) is True
+        assert repo.append(entry) is False
+
+
+class TestRowToDict:
+    """Verify JSON deserialization and defaults for optional columns."""
+
+    def test_clip_kinds_dict_roundtrip(self, repo):
+        now_ms = int(time.time() * 1000)
+        repo.append(_make_entry(
+            now_ms,
+            clip_dids=["cam1", "cam2"],
+            clip_kinds={"cam1": "mp4", "cam2": "m4a"},
+        ))
+
+        row = repo.query()[0][0]
+        assert row["clip_kinds"] == {"cam1": "mp4", "cam2": "m4a"}
+        assert row["clip_dids"] == ["cam1", "cam2"]
+
+    def test_defaults_for_no_artifacts(self, repo):
+        now_ms = int(time.time() * 1000)
+        repo.append(_make_entry(now_ms))
+
+        row = repo.query()[0][0]
+        assert row["snapshot_count"] == 0
+        assert row["clip_dids"] == []
+        assert row["clip_kinds"] == {}
+        assert row["has_trace"] is False

--- a/backend/miloco/tests/test_on_demand_service.py
+++ b/backend/miloco/tests/test_on_demand_service.py
@@ -1,0 +1,154 @@
+# Copyright (C) 2025 Xiaomi Corporation
+# This software may be used and distributed according to the terms of the Xiaomi Miloco License Agreement.
+
+"""Unit tests for PerceptionService.on_demand_perceive artifact orchestration.
+
+Covers:
+- DB insert failure → orphan artifact rollback (shutil.rmtree)
+- Empty answer + omni not responded → clips discarded, trace kept
+- Empty answer + omni responded → clips kept
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from miloco.perception.schema import OnDemandPerceptionRequest
+from miloco.perception.snapshot_context import OmniEventArtifacts
+
+
+@pytest.fixture
+def isolated_settings(tmp_path, monkeypatch):
+    monkeypatch.setenv("MILOCO_HOME", str(tmp_path))
+    from miloco.config import reset_settings
+
+    reset_settings()
+    yield tmp_path
+    reset_settings()
+
+
+def _make_artifacts(*, clips=None, trace=None):
+    a = OmniEventArtifacts()
+    if clips is not None:
+        a.clips = clips
+    if trace is not None:
+        a.trace = trace
+    return a
+
+
+def _make_result(answer="有一个人在客厅"):
+    r = MagicMock()
+    r.answer = answer
+    return r
+
+
+def _build_service(*, od_log_repo=None):
+    from miloco.perception.service import PerceptionService
+
+    collector = MagicMock()
+    collector.get_all_active_sources.return_value = {"cam1": object()}
+    pipeline = AsyncMock()
+    runner = MagicMock()
+    runner.is_running = False
+    log_repo = MagicMock()
+    service = PerceptionService(
+        collector=collector,
+        pipeline=pipeline,
+        perception_runner=runner,
+        log_repo=log_repo,
+        on_demand_log_repo=od_log_repo,
+    )
+    return service, pipeline
+
+
+REQUEST = OnDemandPerceptionRequest(sources=["cam1"], query="谁在客厅？")
+
+
+class TestOnDemandPerceiveArtifacts:
+    """service.on_demand_perceive artifact orchestration."""
+
+    @pytest.mark.asyncio
+    async def test_db_insert_fail_rolls_back_artifacts(self, isolated_settings):
+        """DB append returns False → snapshots/{log_id}/ cleaned up."""
+        from miloco.database.on_demand_log_repo import OnDemandLogRepo
+        from miloco.perception.snapshot_writer import get_snapshot_root
+
+        od_repo = MagicMock(spec=OnDemandLogRepo)
+        od_repo.append.return_value = False
+
+        service, pipeline = _build_service(od_log_repo=od_repo)
+
+        result = _make_result()
+        artifacts = _make_artifacts(
+            clips={"cam1": (b"\x00" * 100, "mp4")},
+            trace={"calls": [{"error": None}]},
+        )
+        pipeline.process_on_demand.return_value = (result, artifacts)
+
+        with patch(
+            "miloco.perception.snapshot_writer.check_disk_space",
+            return_value=True,
+        ):
+            await service.on_demand_perceive(REQUEST)
+
+        od_repo.append.assert_called_once()
+        log_id = od_repo.append.call_args[0][0].id
+        snapshot_root = get_snapshot_root()
+        assert not (snapshot_root / log_id).exists(), (
+            "orphan artifact dir should be cleaned up after DB insert failure"
+        )
+
+    @pytest.mark.asyncio
+    async def test_empty_answer_omni_not_responded_discards_clips(
+        self, isolated_settings
+    ):
+        """omni all calls errored + empty answer → clips discarded."""
+        from miloco.database.on_demand_log_repo import OnDemandLogRepo
+
+        od_repo = MagicMock(spec=OnDemandLogRepo)
+        od_repo.append.return_value = True
+
+        service, pipeline = _build_service(od_log_repo=od_repo)
+
+        result = _make_result(answer="")
+        artifacts = _make_artifacts(
+            clips={"cam1": (b"\x00" * 100, "mp4")},
+            trace={"calls": [{"error": "timeout"}]},
+        )
+        pipeline.process_on_demand.return_value = (result, artifacts)
+
+        with patch(
+            "miloco.perception.snapshot_writer.check_disk_space",
+            return_value=True,
+        ):
+            await service.on_demand_perceive(REQUEST)
+
+        entry = od_repo.append.call_args[0][0]
+        assert entry.clip_dids == [], "clips should be discarded when omni not responded"
+        assert entry.snapshot_count == 0
+
+    @pytest.mark.asyncio
+    async def test_empty_answer_omni_responded_keeps_clips(self, isolated_settings):
+        """omni responded (no error) but empty answer → clips kept."""
+        from miloco.database.on_demand_log_repo import OnDemandLogRepo
+
+        od_repo = MagicMock(spec=OnDemandLogRepo)
+        od_repo.append.return_value = True
+
+        service, pipeline = _build_service(od_log_repo=od_repo)
+
+        result = _make_result(answer="")
+        artifacts = _make_artifacts(
+            clips={"cam1": (b"\x00" * 100, "mp4")},
+            trace={"calls": [{"error": None}]},
+        )
+        pipeline.process_on_demand.return_value = (result, artifacts)
+
+        with patch(
+            "miloco.perception.snapshot_writer.check_disk_space",
+            return_value=True,
+        ):
+            await service.on_demand_perceive(REQUEST)
+
+        entry = od_repo.append.call_args[0][0]
+        assert len(entry.clip_dids) > 0, "clips should be kept when omni responded"
+        assert entry.snapshot_count > 0

--- a/backend/miloco/tests/test_snapshot_writer.py
+++ b/backend/miloco/tests/test_snapshot_writer.py
@@ -131,16 +131,16 @@ class TestSaveEventArtifacts:
         self.root = tmp_path
 
     def test_empty_artifacts_returns_zero(self):
-        """clips 和 trace 都空 → 不创建任何文件,返 0."""
-        assert save_event_artifacts("event-1", OmniEventArtifacts()) == 0
+        """clips 和 trace 都空 → 不创建任何文件,返空列表."""
+        assert save_event_artifacts("event-1", OmniEventArtifacts()) == []
         assert not (self.root / "event-1").exists()
 
     def test_single_device_one_clip(self):
         """喂 1 个 device 的 mp4 字节 → 落 1 个 clip.mp4 文件."""
         clip_bytes = b"\x00\x00\x00\x20ftypisom" + b"\x00" * 100
         artifacts = OmniEventArtifacts(clips={"cam_living_01": (clip_bytes, "mp4")})
-        count = save_event_artifacts("event-1", artifacts)
-        assert count == 1
+        clip_dids = save_event_artifacts("event-1", artifacts)
+        assert clip_dids == ["cam_living_01"]
         path = self.root / "event-1" / "cam_living_01" / "clip.mp4"
         assert path.read_bytes() == clip_bytes
 
@@ -152,22 +152,21 @@ class TestSaveEventArtifacts:
                 "cam_kitchen_01": (b"video-bytes-B", "mp4"),
             }
         )
-        count = save_event_artifacts("event-multi", artifacts)
-        assert count == 2
+        clip_dids = save_event_artifacts("event-multi", artifacts)
+        assert set(clip_dids) == {"cam_living_01", "cam_kitchen_01"}
         assert (self.root / "event-multi" / "cam_living_01" / "clip.mp4").exists()
         assert (self.root / "event-multi" / "cam_kitchen_01" / "clip.mp4").exists()
 
     def test_empty_bytes_skipped(self):
         """某 device 字节为空 → 跳过."""
         artifacts = OmniEventArtifacts(clips={"cam_a": (b"", "mp4")})
-        count = save_event_artifacts("event-empty", artifacts)
-        assert count == 0
+        assert save_event_artifacts("event-empty", artifacts) == []
 
     def test_device_id_slug_applied(self):
         """device_id 含 '/' → slug 化为 '_',目录路径合法."""
         artifacts = OmniEventArtifacts(clips={"cam/living/01": (b"x" * 100, "mp4")})
-        count = save_event_artifacts("event-slug", artifacts)
-        assert count == 1
+        clip_dids = save_event_artifacts("event-slug", artifacts)
+        assert clip_dids == ["cam/living/01"]
         assert (self.root / "event-slug" / "cam_living_01" / "clip.mp4").exists()
 
     def test_kind_decides_extension(self):
@@ -178,8 +177,8 @@ class TestSaveEventArtifacts:
                 "cam_video": (b"video-bytes", "mp4"),
             }
         )
-        count = save_event_artifacts("event-tuple", artifacts)
-        assert count == 2
+        clip_dids = save_event_artifacts("event-tuple", artifacts)
+        assert set(clip_dids) == {"cam_audio", "cam_video"}
         assert (self.root / "event-tuple" / "cam_audio" / "clip.m4a").read_bytes() == b"audio-bytes"
         assert (self.root / "event-tuple" / "cam_video" / "clip.mp4").read_bytes() == b"video-bytes"
 
@@ -188,16 +187,15 @@ class TestSaveEventArtifacts:
         artifacts = OmniEventArtifacts(
             clips={"cam_a": (b"x", "webm")},  # type: ignore[dict-item]
         )
-        count = save_event_artifacts("event-bad-kind", artifacts)
-        assert count == 0
+        assert save_event_artifacts("event-bad-kind", artifacts) == []
         assert not (self.root / "event-bad-kind" / "cam_a").exists()
 
     def test_trace_only_writes_gz(self):
-        """只有 trace → 落 omni_trace.json.gz,不创建 device 子目录,返 0."""
+        """只有 trace → 落 omni_trace.json.gz,不创建 device 子目录,返空列表."""
         trace = {"schema_version": 1, "calls": [{"model": "mimo"}]}
         artifacts = OmniEventArtifacts(trace=trace)
-        count = save_event_artifacts("event-trace", artifacts)
-        assert count == 0
+        clip_dids = save_event_artifacts("event-trace", artifacts)
+        assert clip_dids == []
         gz_path = self.root / "event-trace" / "omni_trace.json.gz"
         assert gz_path.exists()
         # device 子目录不存在
@@ -208,13 +206,13 @@ class TestSaveEventArtifacts:
         assert decoded == trace
 
     def test_clips_and_trace_both(self):
-        """同时 clips + trace → 两类文件都落,count 只计 clip."""
+        """同时 clips + trace → 两类文件都落,clip_dids 只含 clip 设备."""
         artifacts = OmniEventArtifacts(
             clips={"cam_a": (b"v", "mp4"), "cam_b": (b"a", "m4a")},
             trace={"schema_version": 1, "calls": []},
         )
-        count = save_event_artifacts("event-both", artifacts)
-        assert count == 2
+        clip_dids = save_event_artifacts("event-both", artifacts)
+        assert set(clip_dids) == {"cam_a", "cam_b"}
         assert (self.root / "event-both" / "cam_a" / "clip.mp4").exists()
         assert (self.root / "event-both" / "cam_b" / "clip.m4a").exists()
         assert (self.root / "event-both" / "omni_trace.json.gz").exists()

--- a/backend/miloco/tests/test_snapshot_writer.py
+++ b/backend/miloco/tests/test_snapshot_writer.py
@@ -130,7 +130,7 @@ class TestSaveEventArtifacts:
         monkeypatch.setattr(snapshot_writer, "get_snapshot_root", lambda: tmp_path)
         self.root = tmp_path
 
-    def test_empty_artifacts_returns_zero(self):
+    def test_empty_artifacts_returns_empty_list(self):
         """clips 和 trace 都空 → 不创建任何文件,返空列表."""
         assert save_event_artifacts("event-1", OmniEventArtifacts()) == []
         assert not (self.root / "event-1").exists()

--- a/knowledge/03-features/event-feedback.md
+++ b/knowledge/03-features/event-feedback.md
@@ -51,13 +51,17 @@
       → PII 脱敏（trace 文本 + 事件 text + 用户补充）
       → 写 metadata.json + omni_trace + clips(+可选 gallery) 到
         $MILOCO_HOME/packs/{时间戳子目录}/feedback-{uid}-{event_id(完整 UUID)}-{时间戳}.tar.gz
+        主动查询包同目录、多一个 od 段:feedback-{uid}-od-{log_id(完整 UUID)}-{时间戳}.tar.gz
+        _build_feedback_index 的 UUID 正则取 findall 的最后一个匹配,故两种格式共用一份索引
       → 按总大小清理旧包
       → 返回 {path, size_bytes, components}
 
-已反馈态（列表侧,与打包解耦）：
+已反馈态（列表侧,与打包解耦；两条链路共用一份索引）：
   GET 事件列表 → EventsService.list_events（perception/events_service.py）
-      _build_feedback_index 扫 packs 目录,UUID 正则回捞 event_id → (path,size)
-      → MeaningfulEvent.has_feedback / feedback_pack_path / feedback_pack_size
+  GET 主动查询列表 → PerceptionService.query_on_demand_logs（perception/service.py，
+      跨模块直调 EventsService._build_feedback_index）
+      → 扫 packs 目录,UUID 正则回捞 event_id / log_id → (path,size)
+      → MeaningfulEvent / OnDemandLogEntry 的 has_feedback / feedback_pack_path / feedback_pack_size
 
 打开文件夹：
   已反馈态点「打开所在文件夹」→ revealDir → POST /api/admin/reveal-dir
@@ -66,17 +70,17 @@
 
 ### 核心模块
 
-| 类 / 符号                                     | 文件                                                    | 职责                                                                                                              |
-| --------------------------------------------- | ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `build_feedback_pack`                         | `admin/feedback_pack.py`                                | 打包核心：取事件 → 读事件目录 artifacts → PII 脱敏 → 写 tar.gz → 总大小清理；返回 path/size/components 完整性记录 |
-| `submit_event_feedback` / `reveal_dir`        | `admin/router.py`                                       | 反馈提交端点（解析 uid、线程化打包、映射 404/500）；打开文件夹端点（限 packs 根，跨平台 open）                    |
-| `EventsService._build_feedback_index`         | `perception/events_service.py`                          | 扫 packs 目录建 `event_id → (path,size)` 索引，把「已反馈态」注入事件列表（同一事件多包取最新）                   |
-| `MeaningfulEvent`（反馈相关字段）             | `perception/schema.py`                                  | 事件对外模型新增 `has_feedback` / `feedback_pack_path` / `feedback_pack_size`；`has_trace` 决定前端是否显示入口   |
-| `OmniEventArtifacts` / `save_event_artifacts` | `perception/snapshot_context.py` / `snapshot_writer.py` | 推理侧旁路收集 clip/trace/gallery 并落到事件目录——本模块打包的原料源（属感知流水线，非本模块产出）                |
-| `FeedbackSection`                             | `web/src/components/ActivityFeed.tsx`                   | 反馈面板 UI：错误类别多选、补充文本、画廊开关、已反馈态、飞书问卷链接、打开文件夹                                 |
+| 类 / 符号                                     | 文件                                                    | 职责                                                                                                                              |
+| --------------------------------------------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `build_feedback_pack`                         | `admin/feedback_pack.py`                                | 打包核心：取事件 → 读事件目录 artifacts → PII 脱敏 → 写 tar.gz → 总大小清理；返回 path/size/components 完整性记录                 |
+| `submit_event_feedback` / `reveal_dir`        | `admin/router.py`                                       | 反馈提交端点（解析 uid、线程化打包、映射 404/500）；打开文件夹端点（限 packs 根，跨平台 open）                                    |
+| `EventsService._build_feedback_index`         | `perception/events_service.py`                          | 扫 packs 目录建 `event_id → (path,size)` 索引，把「已反馈态」注入事件列表（同一事件多包取最新）                                   |
+| `MeaningfulEvent`（反馈相关字段）             | `perception/schema.py`                                  | 事件对外模型新增 `has_feedback` / `feedback_pack_path` / `feedback_pack_size`；`has_trace` 决定前端是否显示入口                   |
+| `OmniEventArtifacts` / `save_event_artifacts` | `perception/snapshot_context.py` / `snapshot_writer.py` | 推理侧旁路收集 clip/trace/gallery 并落到事件目录——本模块打包的原料源（属感知流水线，非本模块产出）                                |
+| `FeedbackSection`                             | `web/src/components/ActivityFeed.tsx`                   | 反馈面板 UI：错误类别多选、补充文本、画廊开关、已反馈态、飞书问卷链接、打开文件夹                                                 |
 | `build_on_demand_feedback_pack`               | `admin/feedback_pack.py`                                | on-demand 查询反馈打包：取日志行 → 读 `snapshots/{log_id}/` artifacts → PII 脱敏 → tar.gz；`clips_missing_basis` 基于 `clip_dids` |
-| `submit_on_demand_feedback`                   | `perception/router.py`                                  | on-demand 反馈端点（POST `/api/perception/on-demand-logs/{log_id}/feedback`）；返回 path/size/components                        |
-| `OnDemandFeedback`                            | `web/src/components/ActivityFeed.tsx`                   | on-demand 查询反馈面板 UI，镜像 `FeedbackSection` 行为（含 `confirmedResubmit` 修改门控）                                       |
+| `submit_on_demand_feedback`                   | `perception/router.py`                                  | on-demand 反馈端点（POST `/api/perception/on-demand-logs/{log_id}/feedback`）；返回 path/size/components                          |
+| `OnDemandFeedback`                            | `web/src/components/ActivityFeed.tsx`                   | on-demand 查询反馈面板 UI，镜像 `FeedbackSection` 行为（含 `confirmedResubmit` 修改门控）                                         |
 
 ### 关键设计决策
 
@@ -98,6 +102,7 @@
 
 - **`POST /api/admin/events/feedback`**：入参 `event_id` + 错误类别 + 补充文本 + 是否含画廊；返回 `pack_path` / `pack_size_bytes` / `uploaded`(当前恒 false) / `upload_key`(当前 null) / `components`。`components` 逐项标注 trace 是否找到、哪些 device 的 clip 找到 / 缺失、画廊是否含入——即使部分缺失也成功返回。事件不存在返回 404。
 - **`POST /api/admin/reveal-dir`**：入参 `path`（须在 packs 根内），在系统文件管理器打开该目录；越界 403、不存在 404。
+- **`POST /api/perception/on-demand-logs/{log_id}/feedback`**：主动查询版，入参 `error_types` + `feedback_text`（无画廊开关——查询路径不产画廊）；返回形状与事件版一致，但 `components` 只有 `omni_trace_found` / `clips_found` / `clips_missing` 三键，没有 `gallery_included`。`clips_missing` 的基准是 `on_demand_log.clip_dids`（真正落过 clip 的设备），与事件版按 `device_ids` 遍历不同，故包内 `metadata.json` 额外带 `clips_missing_basis` 字段标注基准。日志行不存在返回 404。
 - **事件模型的反馈字段**：`has_feedback`（是否已有包）、`feedback_pack_path` / `feedback_pack_size`（最近一次包的本地路径与大小）；`has_trace` 供前端决定是否显示反馈入口。字段定义见 `perception/schema.py::MeaningfulEvent`。
 
 ### 如果我要改事件反馈相关功能

--- a/knowledge/03-features/event-feedback.md
+++ b/knowledge/03-features/event-feedback.md
@@ -50,7 +50,7 @@
       读事件目录 snapshots/{event_id}/：omni_trace.json.gz、{device_slug}/clip.*、gallery/
       → PII 脱敏（trace 文本 + 事件 text + 用户补充）
       → 写 metadata.json + omni_trace + clips(+可选 gallery) 到
-        $MILOCO_HOME/packs/{时间戳子目录}/feedback-{uid}-{event_id}-{时间戳}.tar.gz
+        $MILOCO_HOME/packs/{时间戳子目录}/feedback-{uid}-{event_id(完整 UUID)}-{时间戳}.tar.gz
       → 按总大小清理旧包
       → 返回 {path, size_bytes, components}
 
@@ -74,6 +74,9 @@
 | `MeaningfulEvent`（反馈相关字段）             | `perception/schema.py`                                  | 事件对外模型新增 `has_feedback` / `feedback_pack_path` / `feedback_pack_size`；`has_trace` 决定前端是否显示入口   |
 | `OmniEventArtifacts` / `save_event_artifacts` | `perception/snapshot_context.py` / `snapshot_writer.py` | 推理侧旁路收集 clip/trace/gallery 并落到事件目录——本模块打包的原料源（属感知流水线，非本模块产出）                |
 | `FeedbackSection`                             | `web/src/components/ActivityFeed.tsx`                   | 反馈面板 UI：错误类别多选、补充文本、画廊开关、已反馈态、飞书问卷链接、打开文件夹                                 |
+| `build_on_demand_feedback_pack`               | `admin/feedback_pack.py`                                | on-demand 查询反馈打包：取日志行 → 读 `snapshots/{log_id}/` artifacts → PII 脱敏 → tar.gz；`clips_missing_basis` 基于 `clip_dids` |
+| `submit_on_demand_feedback`                   | `perception/router.py`                                  | on-demand 反馈端点（POST `/api/perception/on-demand-logs/{log_id}/feedback`）；返回 path/size/components                        |
+| `OnDemandFeedback`                            | `web/src/components/ActivityFeed.tsx`                   | on-demand 查询反馈面板 UI，镜像 `FeedbackSection` 行为（含 `confirmedResubmit` 修改门控）                                       |
 
 ### 关键设计决策
 

--- a/knowledge/03-features/event-feedback.md
+++ b/knowledge/03-features/event-feedback.md
@@ -74,7 +74,7 @@
 | --------------------------------------------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | `build_feedback_pack`                         | `admin/feedback_pack.py`                                | 打包核心：取事件 → 读事件目录 artifacts → PII 脱敏 → 写 tar.gz → 总大小清理；返回 path/size/components 完整性记录                 |
 | `submit_event_feedback` / `reveal_dir`        | `admin/router.py`                                       | 反馈提交端点（解析 uid、线程化打包、映射 404/500）；打开文件夹端点（限 packs 根，跨平台 open）                                    |
-| `EventsService.build_feedback_index`         | `perception/events_service.py`                          | 扫 packs 目录建 `event_id → (path,size)` 索引，把「已反馈态」注入事件列表（同一事件多包取最新）                                   |
+| `EventsService.build_feedback_index`          | `perception/events_service.py`                          | 扫 packs 目录建 `event_id → (path,size)` 索引，把「已反馈态」注入事件列表（同一事件多包取最新）                                   |
 | `MeaningfulEvent`（反馈相关字段）             | `perception/schema.py`                                  | 事件对外模型新增 `has_feedback` / `feedback_pack_path` / `feedback_pack_size`；`has_trace` 决定前端是否显示入口                   |
 | `OmniEventArtifacts` / `save_event_artifacts` | `perception/snapshot_context.py` / `snapshot_writer.py` | 推理侧旁路收集 clip/trace/gallery 并落到事件目录——本模块打包的原料源（属感知流水线，非本模块产出）                                |
 | `FeedbackSection`                             | `web/src/components/ActivityFeed.tsx`                   | 反馈面板 UI：错误类别多选、补充文本、画廊开关、已反馈态、飞书问卷链接、打开文件夹                                                 |
@@ -113,7 +113,7 @@
 | 打包目录总大小上限 / 清理策略      | `admin/feedback_pack.py`（`_cleanup_by_total_size`）                   |
 | 提交端点入参 / 上传通道接入        | `admin/router.py`（`submit_event_feedback`）                           |
 | 打开文件夹的路径限制 / 平台命令    | `admin/router.py`（`reveal_dir`）                                      |
-| 已反馈态如何算出 / 多包取哪个      | `perception/events_service.py`（`build_feedback_index`）              |
+| 已反馈态如何算出 / 多包取哪个      | `perception/events_service.py`（`build_feedback_index`）               |
 | 事件模型的反馈字段                 | `perception/schema.py`（`MeaningfulEvent`）                            |
 | clip / trace / 画廊的产生与落盘    | `perception/snapshot_context.py`、`snapshot_writer.py`（属感知流水线） |
 | 反馈面板 UI / 错误类别 / 问卷链接  | `web/src/components/ActivityFeed.tsx`（`FeedbackSection`）             |

--- a/knowledge/03-features/event-feedback.md
+++ b/knowledge/03-features/event-feedback.md
@@ -52,14 +52,14 @@
       → 写 metadata.json + omni_trace + clips(+可选 gallery) 到
         $MILOCO_HOME/packs/{时间戳子目录}/feedback-{uid}-{event_id(完整 UUID)}-{时间戳}.tar.gz
         主动查询包同目录、多一个 od 段:feedback-{uid}-od-{log_id(完整 UUID)}-{时间戳}.tar.gz
-        _build_feedback_index 的 UUID 正则取 findall 的最后一个匹配,故两种格式共用一份索引
+        build_feedback_index 的 UUID 正则取 findall 的最后一个匹配,故两种格式共用一份索引
       → 按总大小清理旧包
       → 返回 {path, size_bytes, components}
 
 已反馈态（列表侧,与打包解耦；两条链路共用一份索引）：
   GET 事件列表 → EventsService.list_events（perception/events_service.py）
   GET 主动查询列表 → PerceptionService.query_on_demand_logs（perception/service.py，
-      跨模块直调 EventsService._build_feedback_index）
+      跨模块直调 EventsService.build_feedback_index）
       → 扫 packs 目录,UUID 正则回捞 event_id / log_id → (path,size)
       → MeaningfulEvent / OnDemandLogEntry 的 has_feedback / feedback_pack_path / feedback_pack_size
 
@@ -74,7 +74,7 @@
 | --------------------------------------------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | `build_feedback_pack`                         | `admin/feedback_pack.py`                                | 打包核心：取事件 → 读事件目录 artifacts → PII 脱敏 → 写 tar.gz → 总大小清理；返回 path/size/components 完整性记录                 |
 | `submit_event_feedback` / `reveal_dir`        | `admin/router.py`                                       | 反馈提交端点（解析 uid、线程化打包、映射 404/500）；打开文件夹端点（限 packs 根，跨平台 open）                                    |
-| `EventsService._build_feedback_index`         | `perception/events_service.py`                          | 扫 packs 目录建 `event_id → (path,size)` 索引，把「已反馈态」注入事件列表（同一事件多包取最新）                                   |
+| `EventsService.build_feedback_index`         | `perception/events_service.py`                          | 扫 packs 目录建 `event_id → (path,size)` 索引，把「已反馈态」注入事件列表（同一事件多包取最新）                                   |
 | `MeaningfulEvent`（反馈相关字段）             | `perception/schema.py`                                  | 事件对外模型新增 `has_feedback` / `feedback_pack_path` / `feedback_pack_size`；`has_trace` 决定前端是否显示入口                   |
 | `OmniEventArtifacts` / `save_event_artifacts` | `perception/snapshot_context.py` / `snapshot_writer.py` | 推理侧旁路收集 clip/trace/gallery 并落到事件目录——本模块打包的原料源（属感知流水线，非本模块产出）                                |
 | `FeedbackSection`                             | `web/src/components/ActivityFeed.tsx`                   | 反馈面板 UI：错误类别多选、补充文本、画廊开关、已反馈态、飞书问卷链接、打开文件夹                                                 |
@@ -86,7 +86,7 @@
 
 **打包只消费、不产生 artifacts**：clip 与 omni_trace 由 omni 推理链路在编码/调用现场「旁路」收集（`OmniEventArtifacts` + ContextVar，见 `perception/snapshot_context.py`），随事件一次性落到 `snapshots/{event_id}/`——字节级即 omni 当时看到的、零重编。反馈打包只是事后按 `event_id` 把这些已落盘文件读出来重新封装，故本模块无需触碰深层 omni 调用栈，也保证包内 clip 与推理输入完全一致。
 
-**已反馈态从文件系统派生，不加 DB 列**：`_build_feedback_index` 每次列事件时扫一遍 packs 目录、用 UUID 正则从包文件名回捞 `event_id`，即时算出 `has_feedback`。事实源就是包文件本身，避免为一个可从磁盘推导的状态做 schema migration，也天然容忍用户手动删包。
+**已反馈态从文件系统派生，不加 DB 列**：`build_feedback_index` 每次列事件时扫一遍 packs 目录、用 UUID 正则从包文件名回捞 `event_id`，即时算出 `has_feedback`。事实源就是包文件本身，避免为一个可从磁盘推导的状态做 schema migration，也天然容忍用户手动删包。
 
 **PII 脱敏且失败即弃（fail-closed）**：打包前对 trace 文本、事件 text、用户补充说明统一做个人信息正则替换；trace 脱敏一旦异常，宁可整段丢弃 trace 也不把未脱敏内容打进包（"宁可缺 trace 也不泄 PII"）。脱敏规则与替换目标见 `admin/feedback_pack.py`，属实现细节不在此展开。
 
@@ -113,7 +113,7 @@
 | 打包目录总大小上限 / 清理策略      | `admin/feedback_pack.py`（`_cleanup_by_total_size`）                   |
 | 提交端点入参 / 上传通道接入        | `admin/router.py`（`submit_event_feedback`）                           |
 | 打开文件夹的路径限制 / 平台命令    | `admin/router.py`（`reveal_dir`）                                      |
-| 已反馈态如何算出 / 多包取哪个      | `perception/events_service.py`（`_build_feedback_index`）              |
+| 已反馈态如何算出 / 多包取哪个      | `perception/events_service.py`（`build_feedback_index`）              |
 | 事件模型的反馈字段                 | `perception/schema.py`（`MeaningfulEvent`）                            |
 | clip / trace / 画廊的产生与落盘    | `perception/snapshot_context.py`、`snapshot_writer.py`（属感知流水线） |
 | 反馈面板 UI / 错误类别 / 问卷链接  | `web/src/components/ActivityFeed.tsx`（`FeedbackSection`）             |
@@ -122,7 +122,7 @@
 
 **上游（数据来源）**：[感知流水线](perception-pipeline.md) 在每次 omni 推理后把 clip / omni_trace / gallery 收敛进 `OmniEventArtifacts` 并落到事件目录，是反馈包的原料源；打包只读不写这些文件。
 
-**主体（事件身份）**：以 `meaningful_events` 的 `event_id` 为主键——`build_feedback_pack` 经 `meaningful_events_dao` 取事件元数据，`_build_feedback_index` 用 `event_id` 关联包文件。有价值事件的定义见 [感知流水线](perception-pipeline.md)。
+**主体（事件身份）**：以 `meaningful_events` 的 `event_id` 为主键——`build_feedback_pack` 经 `meaningful_events_dao` 取事件元数据，`build_feedback_index` 用 `event_id` 关联包文件。有价值事件的定义见 [感知流水线](perception-pipeline.md)。
 
 **入口（Web）**：日志页 `ActivityFeed` 是唯一交互入口，反馈面板与视频回放共处一条事件流；已反馈态、打开文件夹、飞书问卷链接均在此渲染，前端 API 封装在 `web/src/api/index.ts` / `real.ts`、类型在 `web/src/lib/types.ts`。
 

--- a/knowledge/03-features/perception-pipeline.md
+++ b/knowledge/03-features/perception-pipeline.md
@@ -126,7 +126,7 @@ Omni 层（`engine/omni/omni.py`）调用视觉语言模型（MiMo API，OpenAI 
 
 **Fused 模式**：将身份识别合并到主 Omni 调用中，省掉额外的识别请求。gallery 采用"全或无"语义：任一候选成员的图像合成失败，整 gallery 放弃，避免少一个人时 Omni 错认。
 
-**主动查询路径（on-demand）**：主动查询入口从实时流缓冲 peek 数据后跳过 Gate 直接走 Identity + Omni，不影响实时流水线。
+**主动查询路径（on-demand）**：主动查询入口从实时流缓冲 peek 数据后跳过 Gate 直接走 Identity + Omni，不影响实时流水线。每次查询自动写入 `on_demand_log` 表（query/answer/sources/latency），并复用 `OmniEventArtifacts` + `save_event_artifacts` 把 clip 和 omni_trace 落到 `snapshots/{log_id}/`；omni 未响应时只落 trace、跳过 clip。clip 始终为 mp4（`build_query_prompt` 不走 audio-only 路径）。前端 Activity 页通过子 Tab 浏览查询日志、播放 clip、提交反馈（反馈打包见 [事件反馈](event-feedback.md)）。
 
 **Suggestion 去重**：`PerceptionEngine` 对建议做去重抑制，同类建议短期内只报一次，避免 Agent 被重复触发。去重用句向量语义相似度（`EventEmbedder`，`engine/omni/dedup_embedder.py`，bge-small-zh）而非精确文本匹配——措辞略有差异的同类建议也能识别为重复；embedder 初始化失败时降级为精确文本匹配。
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from "react";
 import {
   getHomeStatus,
   listActivity,
+  listOnDemandLogs,
   listCameras,
   listDevices,
   listHomeEntries,
@@ -149,6 +150,9 @@ function MainApp() {
   });
   const activity = useAsync(() => listActivity(homeId), [homeId], {
     errorLabel: t("app.loadActivityFail"),
+  });
+  const onDemandLogs = useAsync(() => listOnDemandLogs(homeId), [homeId], {
+    errorLabel: t("app.loadOnDemandLogsFail", "Failed to load on-demand logs"),
   });
   // 家庭档案（候选区 + 正式区记忆）——家庭 tab 用，成员抽屉与非人面板共享。
   const home = useAsync(() => listHomeEntries(homeId), [homeId], {
@@ -398,6 +402,10 @@ function MainApp() {
               eventsLoading={activity.loading}
               eventsError={activity.error}
               onRetryEvents={() => activity.reload()}
+              onDemandLogs={onDemandLogs.data}
+              deviceNames={Object.fromEntries(
+                (devices.data ?? []).map((d) => [d.did, d.name]),
+              )}
             />
           </div>
         );

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,7 +2,7 @@
  * 主框架：左 Sidebar + 主区按 tab 切换。mobile 下 Sidebar 折叠为底部 nav。
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   getHomeStatus,
   listActivity,
@@ -154,6 +154,10 @@ function MainApp() {
   const onDemandLogs = useAsync(() => listOnDemandLogs(homeId), [homeId], {
     errorLabel: t("app.loadOnDemandLogsFail", "Failed to load on-demand logs"),
   });
+  const deviceNames = useMemo(
+    () => Object.fromEntries((devices.data ?? []).map((d) => [d.did, d.name])),
+    [devices.data],
+  );
   // 家庭档案（候选区 + 正式区记忆）——家庭 tab 用，成员抽屉与非人面板共享。
   const home = useAsync(() => listHomeEntries(homeId), [homeId], {
     errorLabel: t("app.loadHomeEntriesFail"),
@@ -406,9 +410,7 @@ function MainApp() {
               onDemandLoading={onDemandLogs.loading}
               onDemandError={onDemandLogs.error}
               onRetryOnDemand={() => onDemandLogs.reload()}
-              deviceNames={Object.fromEntries(
-                (devices.data ?? []).map((d) => [d.did, d.name]),
-              )}
+              deviceNames={deviceNames}
             />
           </div>
         );

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -403,6 +403,8 @@ function MainApp() {
               eventsError={activity.error}
               onRetryEvents={() => activity.reload()}
               onDemandLogs={onDemandLogs.data}
+              onDemandLoading={onDemandLogs.loading}
+              onDemandError={onDemandLogs.error}
               deviceNames={Object.fromEntries(
                 (devices.data ?? []).map((d) => [d.did, d.name]),
               )}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -405,6 +405,7 @@ function MainApp() {
               onDemandLogs={onDemandLogs.data}
               onDemandLoading={onDemandLogs.loading}
               onDemandError={onDemandLogs.error}
+              onRetryOnDemand={() => onDemandLogs.reload()}
               deviceNames={Object.fromEntries(
                 (devices.data ?? []).map((d) => [d.did, d.name]),
               )}

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -280,6 +280,27 @@ export function subscribeEvents(
   return impl.realSubscribeEvents(onEvent, onOpen);
 }
 
+// ── 主动查询日志 ──────────────────────────────────────────
+export async function listOnDemandLogs(
+  homeId?: HomeId,
+  opts?: { since?: number; before?: number; before_id?: string; limit?: number },
+): Promise<import("@/lib/types").OnDemandLogEntry[]> {
+  if (!isPrimary(homeId)) return [];
+  return impl.realListOnDemandLogs(opts);
+}
+
+export function onDemandClipUrl(logId: string, deviceId: string): string {
+  return impl.realOnDemandClipUrl(logId, deviceId);
+}
+
+export async function submitOnDemandFeedback(
+  logId: string,
+  errorTypes: string[],
+  feedbackText: string,
+): Promise<{ pack_path: string; pack_size_bytes: number }> {
+  return impl.realSubmitOnDemandFeedback(logId, errorTypes, feedbackText);
+}
+
 // ── 摄像头 ────────────────────────────────────────────────
 // ── 米家多家庭 ────────────────────────────────────────────
 export async function listScopeHomes(homeId?: HomeId): Promise<ScopeHome[]> {

--- a/web/src/api/real.ts
+++ b/web/src/api/real.ts
@@ -1137,6 +1137,50 @@ export async function realListActivity(opts?: {
   );
 }
 
+// ── On-demand logs ──────────────────────────────────────────
+
+export async function realListOnDemandLogs(opts?: {
+  since?: number;
+  before?: number;
+  before_id?: string;
+  limit?: number;
+}): Promise<import("@/lib/types").OnDemandLogEntry[]> {
+  const params = new URLSearchParams();
+  if (opts?.since !== undefined) params.set("since", String(opts.since));
+  if (opts?.before !== undefined) params.set("before", String(opts.before));
+  if (opts?.before_id !== undefined) params.set("before_id", opts.before_id);
+  params.set("limit", String(opts?.limit ?? 50));
+  const qs = params.toString();
+  const resp = await apiFetch<
+    Normal<{ logs: import("@/lib/types").OnDemandLogEntry[]; count: number }>
+  >(qs ? `/api/perception/on-demand-logs?${qs}` : "/api/perception/on-demand-logs");
+  return resp.data.logs;
+}
+
+export function realOnDemandClipUrl(logId: string, deviceId: string): string {
+  const token = resolveToken();
+  const base = `/api/perception/on-demand-logs/${encodeURIComponent(logId)}/clip/${encodeURIComponent(deviceId)}`;
+  return token ? `${base}?token=${encodeURIComponent(token)}` : base;
+}
+
+export async function realSubmitOnDemandFeedback(
+  logId: string,
+  errorTypes: string[],
+  feedbackText: string,
+): Promise<{ pack_path: string; pack_size_bytes: number }> {
+  const resp = await apiFetch<
+    Normal<{ log_id: string; pack_path: string; pack_size_bytes: number }>
+  >(`/api/perception/on-demand-logs/${encodeURIComponent(logId)}/feedback`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      error_types: errorTypes,
+      feedback_text: feedbackText,
+    }),
+  });
+  return { pack_path: resp.data.pack_path, pack_size_bytes: resp.data.pack_size_bytes };
+}
+
 /**
  * 拼事件 clip mp4 URL,带 `?token=...` query 鉴权(<video> 无法设 Authorization header).
  * 后端 `verify_token_query_fallback` 支持 query token.

--- a/web/src/components/ActivityFeed.tsx
+++ b/web/src/components/ActivityFeed.tsx
@@ -1294,7 +1294,7 @@ function OnDemandRow({ log, onOpenLightbox, deviceNames }: {
   const packPath = feedbackPack?.path ?? log.feedback_pack_path ?? null;
   const packSize = feedbackPack?.size ?? log.feedback_pack_size ?? null;
   const hasClips = log.snapshot_count > 0;
-  const clipDids = log.clip_dids ?? log.sources.slice(0, log.snapshot_count);
+  const clipDids = log.clip_dids ?? [];
   const allAudioOnly = hasClips && clipDids.every((did) => (log.clip_kinds?.[did] ?? "mp4") === "m4a");
 
   const trailing = expanded

--- a/web/src/components/ActivityFeed.tsx
+++ b/web/src/components/ActivityFeed.tsx
@@ -1198,7 +1198,15 @@ function OnDemandLogList({ initial, homeId, deviceNames, onCountChange }: {
   if (logs.length === 0) {
     return (
       <div className="text-body text-center py-10 text-text-secondary">
-        {t("activity.odEmpty")}
+        <div>{t("activity.odEmpty")}</div>
+        <button
+          type="button"
+          onClick={refresh}
+          disabled={refreshing}
+          className="mt-3 text-caption text-text-tertiary hover:text-text-primary transition-colors disabled:opacity-50"
+        >
+          {refreshing ? t("activity.odLoading") : t("activity.odRefresh")}
+        </button>
       </div>
     );
   }
@@ -1356,19 +1364,28 @@ function OnDemandFeedback({ logId, feedbackDone, feedbackPack, onSubmitted }: {
 }) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
+  const [confirmedResubmit, setConfirmedResubmit] = useState(false);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [text, setText] = useState("");
   const [status, setStatus] = useState<"idle" | "submitting" | "error">("idle");
 
   if (!open && status === "idle") {
-    if (feedbackDone && feedbackPack) {
+    if (feedbackDone && !confirmedResubmit) {
       return (
         <div className="mt-2.5 sm:ml-[82px] px-3.5 py-2.5 rounded-lg bg-info-bg text-caption" onClick={(e) => e.stopPropagation()}>
-          <span className="text-info">
-            ✓ {t("activity.feedbackSaved")}
-            {feedbackPack.path && <>，<button type="button" onClick={() => { const i = feedbackPack.path.lastIndexOf("/"); if (i > 0) revealDir(feedbackPack.path.substring(0, i)).catch(() => {}); }} className="text-info underline hover:opacity-80">{t("activity.feedbackReveal")}</button></>}
-            ，<a href={FEEDBACK_FORM_URL} target="_blank" rel="noopener noreferrer" className="text-info underline hover:opacity-80">{t("activity.feedbackSubmitLink")}</a>
-          </span>
+          <div className="flex items-baseline justify-between">
+            <span className="text-info">
+              ✓ {t("activity.feedbackSaved")}
+              {feedbackPack?.path && <>，<button type="button" onClick={() => { const i = feedbackPack.path.lastIndexOf("/"); if (i > 0) revealDir(feedbackPack.path.substring(0, i)).catch(() => {}); }} className="text-info underline hover:opacity-80">{t("activity.feedbackReveal")}</button></>}
+              ，<a href={FEEDBACK_FORM_URL} target="_blank" rel="noopener noreferrer" className="text-info underline hover:opacity-80">{t("activity.feedbackSubmitLink")}</a>
+            </span>
+            <button type="button" onClick={() => { setConfirmedResubmit(true); setOpen(true); }} className="flex-shrink-0 ml-3 text-[11px] text-text-tertiary hover:text-brand-primary transition-colors">
+              {t("activity.feedbackModify", "修改反馈信息")}
+            </button>
+          </div>
+          {feedbackPack?.path && (
+            <div className="mt-1.5 text-[10px] text-text-tertiary font-mono truncate" title={feedbackPack.path}>{feedbackPack.path}</div>
+          )}
         </div>
       );
     }
@@ -1409,8 +1426,11 @@ function OnDemandFeedback({ logId, feedbackDone, feedbackPack, onSubmitted }: {
     try {
       const result = await submitOnDemandFeedback(logId, [...selected], text);
       onSubmitted(result.pack_path, result.pack_size_bytes);
+      setConfirmedResubmit(false);
       setStatus("idle");
       setOpen(false);
+      setSelected(new Set());
+      setText("");
     } catch {
       setStatus("error");
     }
@@ -1436,7 +1456,7 @@ function OnDemandFeedback({ logId, feedbackDone, feedbackPack, onSubmitted }: {
         ⚠ {t("activity.feedbackPrivacy")}
       </div>
       <div className="flex justify-end items-center gap-1.5 mt-2.5">
-        <button type="button" onClick={() => { setOpen(false); setSelected(new Set()); setText(""); }}
+        <button type="button" onClick={() => { setOpen(false); setConfirmedResubmit(false); setSelected(new Set()); setText(""); }}
           className="px-3.5 py-[5px] text-caption text-text-secondary rounded-md hover:bg-bg-tertiary transition-colors">
           {t("activity.feedbackCancel")}
         </button>

--- a/web/src/components/ActivityFeed.tsx
+++ b/web/src/components/ActivityFeed.tsx
@@ -40,6 +40,8 @@ interface Props {
   eventsError?: Error | null;
   onRetryEvents?: () => void;
   onDemandLogs?: OnDemandLogEntry[];
+  onDemandLoading?: boolean;
+  onDemandError?: Error | null;
   deviceNames?: Record<string, string>;
 }
 
@@ -135,6 +137,8 @@ export function ActivityFeed({
   eventsError,
   onRetryEvents,
   onDemandLogs: initialOdLogs,
+  onDemandLoading,
+  onDemandError,
   deviceNames = {},
 }: Props) {
   const { t } = useTranslation();
@@ -536,7 +540,7 @@ export function ActivityFeed({
 
       {/* On-demand queries panel */}
       <div hidden={activeTab !== "queries"}>
-        <OnDemandLogList initial={initialOdLogs ?? EMPTY_OD_LOGS} homeId={homeId} deviceNames={deviceNames} onCountChange={handleOdCount} />
+        <OnDemandLogList initial={initialOdLogs ?? EMPTY_OD_LOGS} initialLoading={onDemandLoading ?? false} initialError={onDemandError ?? null} homeId={homeId} deviceNames={deviceNames} onCountChange={handleOdCount} />
       </div>
 
       </div>{/* end tab panels */}
@@ -1150,8 +1154,10 @@ function SubTab({ active, onClick, label }: {
 
 const OD_PAGE_SIZE = 50;
 
-function OnDemandLogList({ initial, homeId, deviceNames, onCountChange }: {
+function OnDemandLogList({ initial, initialLoading, initialError, homeId, deviceNames, onCountChange }: {
   initial: OnDemandLogEntry[];
+  initialLoading: boolean;
+  initialError: Error | null;
   homeId: HomeId;
   deviceNames: Record<string, string>;
   onCountChange: (n: number, hasMore: boolean) => void;
@@ -1197,6 +1203,28 @@ function OnDemandLogList({ initial, homeId, deviceNames, onCountChange }: {
       .finally(() => setLoading(false));
   };
 
+  if (logs.length === 0 && initialLoading) {
+    return (
+      <div className="text-body text-center py-10 text-text-secondary">
+        {t("activity.odLoading")}
+      </div>
+    );
+  }
+  if (logs.length === 0 && initialError) {
+    return (
+      <div className="text-body text-center py-10 text-text-secondary">
+        <div>{t("activity.odLoadFailed", { msg: initialError.message })}</div>
+        <button
+          type="button"
+          onClick={refresh}
+          disabled={refreshing}
+          className="mt-3 text-caption text-text-tertiary hover:text-text-primary transition-colors disabled:opacity-50"
+        >
+          {refreshing ? t("activity.odLoading") : t("activity.retry")}
+        </button>
+      </div>
+    );
+  }
   if (logs.length === 0) {
     return (
       <div className="text-body text-center py-10 text-text-secondary">

--- a/web/src/components/ActivityFeed.tsx
+++ b/web/src/components/ActivityFeed.tsx
@@ -1323,14 +1323,16 @@ function OnDemandClipPlayer({ logId, deviceId, onOpenLightbox }: {
   const src = onDemandClipUrl(logId, deviceId);
   if (failed) {
     return (
-      <div onClick={(e) => e.stopPropagation()} className="flex-shrink-0 w-48 h-48 rounded bg-bg-primary border border-border flex items-center justify-center text-caption-mono text-text-tertiary">
+      <div onClick={(e) => e.stopPropagation()} className="flex-shrink-0 w-48 h-48 rounded bg-bg-primary border border-border flex items-center justify-center text-caption-mono text-text-tertiary"
+        aria-label={t("activity.clipExpiredAria")}>
         {t("activity.clipExpired")}
       </div>
     );
   }
   return (
     <div onClick={(e) => e.stopPropagation()} className="flex-shrink-0 relative group">
-      <video src={src} controls preload="metadata" onError={() => setFailed(true)} onClick={(e) => e.stopPropagation()} className="w-48 h-48 rounded bg-black border border-border object-contain" />
+      <video src={src} controls preload="metadata" onError={() => setFailed(true)} onClick={(e) => e.stopPropagation()} className="w-48 h-48 rounded bg-black border border-border object-contain"
+        aria-label={`${deviceId} clip`} />
       <button type="button" onClick={(e) => { e.stopPropagation(); onOpenLightbox(src); }} aria-label={t("activity.zoomPlay")}
         className="absolute top-1 right-1 w-7 h-7 rounded-full bg-black/60 hover:bg-black/80 text-white text-xs flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
         ⛶
@@ -1345,7 +1347,8 @@ function OnDemandAudioPlayer({ logId, deviceId }: { logId: string; deviceId: str
   const src = onDemandClipUrl(logId, deviceId);
   if (failed) {
     return (
-      <div onClick={(e) => e.stopPropagation()} className="flex-shrink-0 w-full px-4 py-3 rounded bg-bg-primary border border-border text-caption-mono text-text-tertiary">
+      <div onClick={(e) => e.stopPropagation()} className="flex-shrink-0 w-full px-4 py-3 rounded bg-bg-primary border border-border text-caption-mono text-text-tertiary"
+        aria-label={t("activity.audioExpiredAria")}>
         {t("activity.audioExpired")}
       </div>
     );
@@ -1353,7 +1356,8 @@ function OnDemandAudioPlayer({ logId, deviceId }: { logId: string; deviceId: str
   return (
     <div onClick={(e) => e.stopPropagation()} className="flex-shrink-0 w-full px-4 py-3 rounded bg-bg-primary border border-border flex items-center gap-3">
       <span className="text-caption-mono text-text-secondary whitespace-nowrap">{t("activity.audioOnly")}</span>
-      <audio src={src} controls preload="metadata" onError={() => setFailed(true)} className="flex-1 min-w-0 h-9" />
+      <audio src={src} controls preload="metadata" onError={() => setFailed(true)} className="flex-1 min-w-0 h-9"
+        aria-label={`${deviceId} audio clip`} />
     </div>
   );
 }

--- a/web/src/components/ActivityFeed.tsx
+++ b/web/src/components/ActivityFeed.tsx
@@ -857,6 +857,9 @@ const ERROR_TYPE_KEYS = [
   "other",
 ] as const;
 
+// 主动查询不经过规则匹配/建议生成,排除 ruleFalse;其余类别与事件侧同源。
+const OD_ERROR_TYPE_KEYS = ERROR_TYPE_KEYS.filter((k) => k !== "ruleFalse");
+
 function FeedbackSection({ eventId, hasFeedback, packPath, onSubmitted }: {
   eventId: string;
   hasFeedback?: boolean;
@@ -1438,7 +1441,7 @@ function OnDemandFeedback({ logId, feedbackDone, feedbackPack, onSubmitted }: {
       <div className="text-[13px] font-semibold text-text-primary mb-2.5">{t("activity.feedbackTitle")}</div>
       <div className="text-caption text-text-tertiary mb-1">{t("activity.feedbackErrorType")}</div>
       <div className="flex flex-wrap gap-1.5 mb-3">
-        {(["person","pet","action","envDevice","voice","other"] as const).map((k) => (
+        {OD_ERROR_TYPE_KEYS.map((k) => (
           <button key={k} type="button"
             onClick={() => setSelected((prev) => { const n = new Set(prev); if (n.has(k)) n.delete(k); else n.add(k); return n; })}
             className={`px-2.5 py-1 text-caption rounded-full border transition-colors ${selected.has(k) ? "text-brand-primary bg-brand-soft border-brand-primary" : "text-text-secondary bg-bg-secondary border-border hover:border-border-strong"}`}>

--- a/web/src/components/ActivityFeed.tsx
+++ b/web/src/components/ActivityFeed.tsx
@@ -446,7 +446,7 @@ export function ActivityFeed({
       </div>
 
       {/* Sub-tabs */}
-      <div className="flex gap-0 px-5 border-b border-border">
+      <div className="flex gap-0 px-5 border-b border-border" role="tablist" aria-label={t("activity.title")}>
         <SubTab active={activeTab === "events"} onClick={() => setActiveTab("events")} label={t("activity.tabEvents")} />
         <SubTab active={activeTab === "queries"} onClick={() => setActiveTab("queries")} label={t("activity.tabOnDemand")} />
       </div>
@@ -1131,6 +1131,8 @@ function SubTab({ active, onClick, label }: {
   return (
     <button
       type="button"
+      role="tab"
+      aria-selected={active}
       onClick={onClick}
       className={
         "px-4 py-2 text-body font-medium border-b-2 -mb-px transition-colors " +

--- a/web/src/components/ActivityFeed.tsx
+++ b/web/src/components/ActivityFeed.tsx
@@ -140,6 +140,11 @@ export function ActivityFeed({
   const { t } = useTranslation();
   const [activeTab, setActiveTab] = useState<ActivityTab>("events");
   const [odCount, setOdCount] = useState((initialOdLogs ?? EMPTY_OD_LOGS).length);
+  const [odHasMore, setOdHasMore] = useState((initialOdLogs ?? EMPTY_OD_LOGS).length === OD_PAGE_SIZE);
+  const handleOdCount = useCallback((n: number, hasMore: boolean) => {
+    setOdCount(n);
+    setOdHasMore(hasMore);
+  }, []);
   // 初始为空:App 层 useAsync 不带 since 参数,拿到的是全时段事件;本组件默认
   // since=todayStartMs(),若直接用 initial 初始化会在首帧闪现历史日志,随后被
   // fetchPage(带 since)替换——即 "切 tab 闪一下旧日志再变空" 的 bug。
@@ -402,7 +407,7 @@ export function ActivityFeed({
           <span className="text-caption-mono text-text-tertiary font-normal">
             {activeTab === "events"
               ? t("activity.loadedCount", { n: feedRows.length, more: showLoadMore ? "+" : "" })
-              : t("activity.odLoaded", { n: odCount, more: "" })}
+              : t("activity.odLoaded", { n: odCount, more: odHasMore ? "+" : "" })}
           </span>
         </h2>
         <div className="inline-flex items-center gap-3 flex-wrap" style={{ visibility: activeTab === "events" ? "visible" : "hidden" }}>
@@ -531,7 +536,7 @@ export function ActivityFeed({
 
       {/* On-demand queries panel */}
       <div hidden={activeTab !== "queries"}>
-        <OnDemandLogList initial={initialOdLogs ?? EMPTY_OD_LOGS} homeId={homeId} deviceNames={deviceNames} onCountChange={setOdCount} />
+        <OnDemandLogList initial={initialOdLogs ?? EMPTY_OD_LOGS} homeId={homeId} deviceNames={deviceNames} onCountChange={handleOdCount} />
       </div>
 
       </div>{/* end tab panels */}
@@ -1144,7 +1149,7 @@ function OnDemandLogList({ initial, homeId, deviceNames, onCountChange }: {
   initial: OnDemandLogEntry[];
   homeId: HomeId;
   deviceNames: Record<string, string>;
-  onCountChange: (n: number) => void;
+  onCountChange: (n: number, hasMore: boolean) => void;
 }) {
   const { t } = useTranslation();
   const [logs, setLogs] = useState<OnDemandLogEntry[]>(initial);
@@ -1156,7 +1161,7 @@ function OnDemandLogList({ initial, homeId, deviceNames, onCountChange }: {
   useEffect(() => {
     setLogs(initial);
     setHasMore(initial.length === OD_PAGE_SIZE);
-    onCountChange(initial.length);
+    onCountChange(initial.length, initial.length === OD_PAGE_SIZE);
   }, [initial, homeId, onCountChange]);
 
   const refresh = () => {
@@ -1166,7 +1171,7 @@ function OnDemandLogList({ initial, homeId, deviceNames, onCountChange }: {
       .then((fresh) => {
         setLogs(fresh);
         setHasMore(fresh.length === OD_PAGE_SIZE);
-        onCountChange(fresh.length);
+        onCountChange(fresh.length, fresh.length === OD_PAGE_SIZE);
       })
       .catch(() => {})
       .finally(() => setRefreshing(false));
@@ -1181,19 +1186,11 @@ function OnDemandLogList({ initial, homeId, deviceNames, onCountChange }: {
         const next = [...logs, ...older];
         setLogs(next);
         setHasMore(older.length === OD_PAGE_SIZE);
-        onCountChange(next.length);
+        onCountChange(next.length, older.length === OD_PAGE_SIZE);
       })
       .catch(() => setHasMore(false))
       .finally(() => setLoading(false));
   };
-
-  if (loading && logs.length === 0) {
-    return (
-      <div className="text-body text-center py-10 text-text-secondary">
-        {t("activity.odLoading")}
-      </div>
-    );
-  }
 
   if (logs.length === 0) {
     return (
@@ -1282,8 +1279,8 @@ function OnDemandRow({ log, onOpenLightbox, deviceNames }: {
           <div className="text-caption-mono text-text-tertiary whitespace-nowrap sm:text-center">{time}</div>
         </div>
         <div className="min-w-0 sm:order-2">
-          <div className="text-body text-text-primary font-semibold break-words">Q: {log.query}</div>
-          <div className="text-body text-text-secondary break-words mt-0.5">A: {log.answer}</div>
+          <div className="text-body text-text-primary font-semibold break-words whitespace-pre-line">Q: {log.query}</div>
+          <div className="text-body text-text-secondary break-words whitespace-pre-line mt-0.5">A: {log.answer || <span className="text-text-tertiary italic">{t("activity.odNoAnswer", "推理失败，无答案")}</span>}</div>
           <div className="text-caption-mono text-text-tertiary mt-1">
             {log.sources.map((did) => deviceNames[did] ? `${deviceNames[did]}(${did})` : did).join(", ")}
           </div>

--- a/web/src/components/ActivityFeed.tsx
+++ b/web/src/components/ActivityFeed.tsx
@@ -11,9 +11,10 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { eventClipUrl, listActivity, revealDir, submitEventFeedback, subscribeEvents } from "@/api";
+import { eventClipUrl, listActivity, listOnDemandLogs, onDemandClipUrl, revealDir, submitEventFeedback, submitOnDemandFeedback, subscribeEvents } from "@/api";
 import { humanizeRulesInText } from "@/lib/eventText";
-import type { ActivityEvent, HomeId } from "@/lib/types";
+import { smartTimeParts } from "@/lib/relativeTime";
+import type { ActivityEvent, HomeId, OnDemandLogEntry } from "@/lib/types";
 import {
   ACTIONS_LIMIT,
   ActionRow,
@@ -21,6 +22,8 @@ import {
   type BackendActionRow,
 } from "./ActionsFeed";
 import { TimeLabel } from "./TimeLabel";
+
+type ActivityTab = "events" | "queries";
 
 interface Props {
   events: ActivityEvent[];
@@ -36,10 +39,14 @@ interface Props {
   /** 事件初始页加载失败——内联提示 + 重试,同样不阻断动作流。 */
   eventsError?: Error | null;
   onRetryEvents?: () => void;
+  onDemandLogs?: OnDemandLogEntry[];
+  deviceNames?: Record<string, string>;
 }
 
 const PAGE_SIZE = 50;
 const FILTER_DEBOUNCE_MS = 300;
+const FEEDBACK_FORM_URL = "https://mi.feishu.cn/share/base/form/shrcnUmo9ez8NwkcpvpJsKSOdgd";
+const EMPTY_OD_LOGS: OnDemandLogEntry[] = [];
 // SSE 事件常成串到达(一次 agent 控制伴随多条事件),每条都全量重拉 500 行动作太重。
 // 合并突发:末条到达后 ~1.5s 才拉一次(trailing debounce)。mount / homeId 切换仍即时拉。
 const SSE_ACTIONS_DEBOUNCE_MS = 1500;
@@ -127,8 +134,12 @@ export function ActivityFeed({
   eventsLoading,
   eventsError,
   onRetryEvents,
+  onDemandLogs: initialOdLogs,
+  deviceNames = {},
 }: Props) {
   const { t } = useTranslation();
+  const [activeTab, setActiveTab] = useState<ActivityTab>("events");
+  const [odCount, setOdCount] = useState((initialOdLogs ?? EMPTY_OD_LOGS).length);
   // 初始为空:App 层 useAsync 不带 since 参数,拿到的是全时段事件;本组件默认
   // since=todayStartMs(),若直接用 initial 初始化会在首帧闪现历史日志,随后被
   // fetchPage(带 since)替换——即 "切 tab 闪一下旧日志再变空" 的 bug。
@@ -389,15 +400,12 @@ export function ActivityFeed({
         >
           {t("activity.title")}
           <span className="text-caption-mono text-text-tertiary font-normal">
-            {/* 已加载 N 条 — 单流合并后的行数(事件 + 窗内动作);showEvents 且 hasMore
-                时后端还有更早事件可拉,N 不等于"总数" */}
-            {t("activity.loadedCount", {
-              n: feedRows.length,
-              more: showLoadMore ? "+" : "",
-            })}
+            {activeTab === "events"
+              ? t("activity.loadedCount", { n: feedRows.length, more: showLoadMore ? "+" : "" })
+              : t("activity.odLoaded", { n: odCount, more: "" })}
           </span>
         </h2>
-        <div className="inline-flex items-center gap-3 flex-wrap">
+        <div className="inline-flex items-center gap-3 flex-wrap" style={{ visibility: activeTab === "events" ? "visible" : "hidden" }}>
           {/* 事件 / 动作 checkbox — 都默认勾选,仅组件内 state 不持久化 */}
           <label className="inline-flex items-center gap-1.5 text-caption text-text-secondary cursor-pointer select-none">
             <input
@@ -431,6 +439,18 @@ export function ActivityFeed({
           />
         </div>
       </div>
+
+      {/* Sub-tabs */}
+      <div className="flex gap-0 px-5 border-b border-border">
+        <SubTab active={activeTab === "events"} onClick={() => setActiveTab("events")} label={t("activity.tabEvents")} />
+        <SubTab active={activeTab === "queries"} onClick={() => setActiveTab("queries")} label={t("activity.tabOnDemand")} />
+      </div>
+
+      {/* Tab panels */}
+      <div className="min-h-[240px]">
+
+      {/* Events panel */}
+      <div hidden={activeTab !== "events"}>
 
       {/* 事件初始页加载中 / 失败:内联提示,不阻断下方合流(动作已独立加载)。 */}
       {(eventsError || eventsLoading) && (
@@ -506,6 +526,15 @@ export function ActivityFeed({
           </button>
         </div>
       )}
+
+      </div>{/* end events panel */}
+
+      {/* On-demand queries panel */}
+      <div hidden={activeTab !== "queries"}>
+        <OnDemandLogList initial={initialOdLogs ?? EMPTY_OD_LOGS} homeId={homeId} deviceNames={deviceNames} onCountChange={setOdCount} />
+      </div>
+
+      </div>{/* end tab panels */}
 
       {lightboxSrc && (
         <Lightbox src={lightboxSrc} onClose={() => setLightboxSrc(null)} />
@@ -871,7 +900,7 @@ function FeedbackSection({ eventId, hasFeedback, packPath, onSubmitted }: {
             <span className="text-info">
               ✓ {t("activity.feedbackSaved", "反馈已记录，数据已保存到本地")}
               {packPath && <>，<button type="button" onClick={() => { const i = packPath.lastIndexOf("/"); if (i > 0) revealDir(packPath.substring(0, i)).catch(() => {}); }} className="text-info underline hover:opacity-80">{t("activity.feedbackReveal", "点击打开所在文件夹")}</button></>}
-              ，<a href="https://mi.feishu.cn/share/base/form/shrcnUmo9ez8NwkcpvpJsKSOdgd" target="_blank" rel="noopener noreferrer" className="text-info underline hover:opacity-80">{t("activity.feedbackSubmitLink", "前往提交")}</a>
+              ，<a href={FEEDBACK_FORM_URL} target="_blank" rel="noopener noreferrer" className="text-info underline hover:opacity-80">{t("activity.feedbackSubmitLink", "前往提交")}</a>
             </span>
             <button type="button" onClick={() => { setConfirmedResubmit(true); setOpen(true); }} className="flex-shrink-0 ml-3 text-[11px] text-text-tertiary hover:text-brand-primary transition-colors">
               {t("activity.feedbackModify", "修改反馈信息")}
@@ -1080,6 +1109,342 @@ function AudioClipPlayer({
         className="flex-1 min-w-0 h-9"
         aria-label={`${device_id} audio clip`}
       />
+    </div>
+  );
+}
+
+/* ── Sub-tab button ── */
+
+function SubTab({ active, onClick, label }: {
+  active: boolean;
+  onClick: () => void;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={
+        "px-4 py-2 text-body font-medium border-b-2 -mb-px transition-colors " +
+        (active
+          ? "text-brand-primary border-brand-primary font-semibold"
+          : "text-text-tertiary border-transparent hover:text-text-secondary")
+      }
+    >
+      {label}
+    </button>
+  );
+}
+
+/* ── On-demand log list ── */
+
+const OD_PAGE_SIZE = 50;
+
+function OnDemandLogList({ initial, homeId, deviceNames, onCountChange }: {
+  initial: OnDemandLogEntry[];
+  homeId: HomeId;
+  deviceNames: Record<string, string>;
+  onCountChange: (n: number) => void;
+}) {
+  const { t } = useTranslation();
+  const [logs, setLogs] = useState<OnDemandLogEntry[]>(initial);
+  const [loading, setLoading] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [hasMore, setHasMore] = useState(initial.length === OD_PAGE_SIZE);
+  const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLogs(initial);
+    setHasMore(initial.length === OD_PAGE_SIZE);
+    onCountChange(initial.length);
+  }, [initial, homeId, onCountChange]);
+
+  const refresh = () => {
+    if (refreshing) return;
+    setRefreshing(true);
+    listOnDemandLogs(homeId, { limit: OD_PAGE_SIZE })
+      .then((fresh) => {
+        setLogs(fresh);
+        setHasMore(fresh.length === OD_PAGE_SIZE);
+        onCountChange(fresh.length);
+      })
+      .catch(() => {})
+      .finally(() => setRefreshing(false));
+  };
+
+  const loadMore = () => {
+    if (loading || !hasMore || logs.length === 0) return;
+    const oldest = logs[logs.length - 1];
+    setLoading(true);
+    listOnDemandLogs(homeId, { before: oldest.timestamp, before_id: oldest.id, limit: OD_PAGE_SIZE })
+      .then((older) => {
+        const next = [...logs, ...older];
+        setLogs(next);
+        setHasMore(older.length === OD_PAGE_SIZE);
+        onCountChange(next.length);
+      })
+      .catch(() => setHasMore(false))
+      .finally(() => setLoading(false));
+  };
+
+  if (loading && logs.length === 0) {
+    return (
+      <div className="text-body text-center py-10 text-text-secondary">
+        {t("activity.odLoading")}
+      </div>
+    );
+  }
+
+  if (logs.length === 0) {
+    return (
+      <div className="text-body text-center py-10 text-text-secondary">
+        {t("activity.odEmpty")}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="px-5 py-2 flex justify-end">
+        <button
+          type="button"
+          onClick={refresh}
+          disabled={refreshing}
+          className="text-caption text-text-tertiary hover:text-text-primary transition-colors disabled:opacity-50"
+        >
+          {refreshing ? t("activity.odLoading") : t("activity.odRefresh")}
+        </button>
+      </div>
+      <ul className="divide-y divide-border">
+        {logs.map((log) => (
+          <OnDemandRow key={log.id} log={log} onOpenLightbox={setLightboxSrc} deviceNames={deviceNames} />
+        ))}
+      </ul>
+      {lightboxSrc && (
+        <Lightbox src={lightboxSrc} onClose={() => setLightboxSrc(null)} />
+      )}
+      {hasMore && (
+        <div className="px-5 py-3 border-t border-border flex justify-center">
+          <button
+            type="button"
+            onClick={loadMore}
+            disabled={loading}
+            className="text-caption text-text-secondary hover:text-text-primary underline-offset-4 hover:underline transition-colors disabled:opacity-50"
+          >
+            {loading ? t("activity.odLoading") : t("activity.loadMore")}
+          </button>
+        </div>
+      )}
+    </>
+  );
+}
+
+function OnDemandRow({ log, onOpenLightbox, deviceNames }: {
+  log: OnDemandLogEntry;
+  onOpenLightbox: (src: string) => void;
+  deviceNames: Record<string, string>;
+}) {
+  const { t } = useTranslation();
+  const { time, date } = smartTimeParts(log.timestamp);
+  const [expanded, setExpanded] = useState(false);
+  const [feedbackDone, setFeedbackDone] = useState(false);
+  const [feedbackPack, setFeedbackPack] = useState<{ path: string; size: number } | null>(null);
+  const hasFeedback = log.has_feedback || feedbackDone;
+  const packPath = feedbackPack?.path ?? log.feedback_pack_path ?? null;
+  const packSize = feedbackPack?.size ?? log.feedback_pack_size ?? null;
+  const hasClips = log.snapshot_count > 0;
+  const clipDids = log.clip_dids ?? log.sources.slice(0, log.snapshot_count);
+  const allAudioOnly = hasClips && clipDids.every((did) => (log.clip_kinds?.[did] ?? "mp4") === "m4a");
+
+  const trailing = expanded
+    ? t("activity.collapse")
+    : hasClips && !allAudioOnly
+      ? "🎬"
+      : "💬";
+
+  return (
+    <li
+      onClick={() => { if (!window.getSelection()?.toString()) setExpanded((x) => !x); }}
+      aria-expanded={expanded}
+      className="px-5 py-2.5 hover:bg-bg-tertiary transition-colors cursor-pointer list-none"
+    >
+      <div className="flex flex-col gap-1 sm:grid sm:grid-cols-[70px_1fr_auto] sm:gap-x-3 sm:gap-y-1 sm:items-baseline">
+        <div className="sm:justify-self-stretch leading-tight">
+          <div className="text-caption-mono text-text-secondary whitespace-nowrap sm:text-center">{date}</div>
+          <div className="text-caption-mono text-text-tertiary whitespace-nowrap sm:text-center">{time}</div>
+        </div>
+        <div className="min-w-0 sm:order-2">
+          <div className="text-body text-text-primary font-semibold break-words">Q: {log.query}</div>
+          <div className="text-body text-text-secondary break-words mt-0.5">A: {log.answer}</div>
+          <div className="text-caption-mono text-text-tertiary mt-1">
+            {log.sources.map((did) => deviceNames[did] ? `${deviceNames[did]}(${did})` : did).join(", ")}
+          </div>
+        </div>
+        <span className="text-caption-mono text-text-tertiary whitespace-nowrap sm:order-last sm:justify-self-end" aria-hidden="true">
+          {trailing}
+        </span>
+      </div>
+
+      {expanded && hasClips && (
+        <div className="mt-3 flex gap-2 overflow-x-auto pb-2 sm:ml-[82px]">
+          {clipDids.map((did) =>
+            (log.clip_kinds?.[did] ?? "mp4") === "m4a"
+              ? <OnDemandAudioPlayer key={did} logId={log.id} deviceId={did} />
+              : <OnDemandClipPlayer key={did} logId={log.id} deviceId={did} onOpenLightbox={onOpenLightbox} />,
+          )}
+        </div>
+      )}
+
+      {expanded && log.has_trace && (
+        <OnDemandFeedback
+          logId={log.id}
+          feedbackDone={hasFeedback}
+          feedbackPack={packPath && packSize ? { path: packPath, size: packSize } : null}
+          onSubmitted={(path, size) => { setFeedbackDone(true); setFeedbackPack({ path, size }); }}
+        />
+      )}
+    </li>
+  );
+}
+
+function OnDemandClipPlayer({ logId, deviceId, onOpenLightbox }: {
+  logId: string; deviceId: string; onOpenLightbox: (src: string) => void;
+}) {
+  const { t } = useTranslation();
+  const [failed, setFailed] = useState(false);
+  const src = onDemandClipUrl(logId, deviceId);
+  if (failed) {
+    return (
+      <div onClick={(e) => e.stopPropagation()} className="flex-shrink-0 w-48 h-48 rounded bg-bg-primary border border-border flex items-center justify-center text-caption-mono text-text-tertiary">
+        {t("activity.clipExpired")}
+      </div>
+    );
+  }
+  return (
+    <div onClick={(e) => e.stopPropagation()} className="flex-shrink-0 relative group">
+      <video src={src} controls preload="metadata" onError={() => setFailed(true)} onClick={(e) => e.stopPropagation()} className="w-48 h-48 rounded bg-black border border-border object-contain" />
+      <button type="button" onClick={(e) => { e.stopPropagation(); onOpenLightbox(src); }} aria-label={t("activity.zoomPlay")}
+        className="absolute top-1 right-1 w-7 h-7 rounded-full bg-black/60 hover:bg-black/80 text-white text-xs flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
+        ⛶
+      </button>
+    </div>
+  );
+}
+
+function OnDemandAudioPlayer({ logId, deviceId }: { logId: string; deviceId: string }) {
+  const { t } = useTranslation();
+  const [failed, setFailed] = useState(false);
+  const src = onDemandClipUrl(logId, deviceId);
+  if (failed) {
+    return (
+      <div onClick={(e) => e.stopPropagation()} className="flex-shrink-0 w-full px-4 py-3 rounded bg-bg-primary border border-border text-caption-mono text-text-tertiary">
+        {t("activity.audioExpired")}
+      </div>
+    );
+  }
+  return (
+    <div onClick={(e) => e.stopPropagation()} className="flex-shrink-0 w-full px-4 py-3 rounded bg-bg-primary border border-border flex items-center gap-3">
+      <span className="text-caption-mono text-text-secondary whitespace-nowrap">{t("activity.audioOnly")}</span>
+      <audio src={src} controls preload="metadata" onError={() => setFailed(true)} className="flex-1 min-w-0 h-9" />
+    </div>
+  );
+}
+
+function OnDemandFeedback({ logId, feedbackDone, feedbackPack, onSubmitted }: {
+  logId: string; feedbackDone: boolean; feedbackPack: { path: string; size: number } | null;
+  onSubmitted: (path: string, size: number) => void;
+}) {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [text, setText] = useState("");
+  const [status, setStatus] = useState<"idle" | "submitting" | "error">("idle");
+
+  if (!open && status === "idle") {
+    if (feedbackDone && feedbackPack) {
+      return (
+        <div className="mt-2.5 sm:ml-[82px] px-3.5 py-2.5 rounded-lg bg-info-bg text-caption" onClick={(e) => e.stopPropagation()}>
+          <span className="text-info">
+            ✓ {t("activity.feedbackSaved")}
+            {feedbackPack.path && <>，<button type="button" onClick={() => { const i = feedbackPack.path.lastIndexOf("/"); if (i > 0) revealDir(feedbackPack.path.substring(0, i)).catch(() => {}); }} className="text-info underline hover:opacity-80">{t("activity.feedbackReveal")}</button></>}
+            ，<a href={FEEDBACK_FORM_URL} target="_blank" rel="noopener noreferrer" className="text-info underline hover:opacity-80">{t("activity.feedbackSubmitLink")}</a>
+          </span>
+        </div>
+      );
+    }
+    return (
+      <div className="mt-2 sm:ml-[82px]">
+        <button type="button" onClick={(e) => { e.stopPropagation(); setOpen(true); }}
+          className="inline-flex items-center gap-1 px-3 py-[5px] text-caption text-text-tertiary bg-transparent border border-border rounded-md hover:text-brand-primary hover:border-brand-primary hover:bg-brand-soft transition-colors">
+          <span className="text-[11px]">⚑</span> {t("activity.feedbackButton")}
+        </button>
+      </div>
+    );
+  }
+
+  if (status === "submitting") {
+    return (
+      <div className="mt-2.5 sm:ml-[82px] flex items-center gap-2 px-3.5 py-2.5 rounded-lg bg-bg-tertiary text-caption text-text-secondary" onClick={(e) => e.stopPropagation()}>
+        <span className="inline-block w-3 h-3 border-2 border-border border-t-brand-primary rounded-full animate-spin" />
+        {t("activity.feedbackSubmitting")}
+      </div>
+    );
+  }
+
+  if (status === "error") {
+    return (
+      <div className="mt-2.5 sm:ml-[82px]" onClick={(e) => e.stopPropagation()}>
+        <div className="px-3.5 py-2.5 rounded-lg text-caption" style={{ background: "rgba(220,38,38,.06)", color: "#DC2626" }}>
+          ✗ {t("activity.feedbackError")}
+        </div>
+        <button type="button" onClick={() => setStatus("idle")} className="mt-1.5 text-caption text-text-tertiary hover:text-text-secondary">
+          {t("activity.feedbackRetry")}
+        </button>
+      </div>
+    );
+  }
+
+  const handleSubmit = async () => {
+    setStatus("submitting");
+    try {
+      const result = await submitOnDemandFeedback(logId, [...selected], text);
+      onSubmitted(result.pack_path, result.pack_size_bytes);
+      setStatus("idle");
+      setOpen(false);
+    } catch {
+      setStatus("error");
+    }
+  };
+
+  return (
+    <div className="mt-2.5 sm:ml-[82px] p-3.5 rounded-[10px] bg-bg-primary border border-border" onClick={(e) => e.stopPropagation()}>
+      <div className="text-[13px] font-semibold text-text-primary mb-2.5">{t("activity.feedbackTitle")}</div>
+      <div className="text-caption text-text-tertiary mb-1">{t("activity.feedbackErrorType")}</div>
+      <div className="flex flex-wrap gap-1.5 mb-3">
+        {(["person","pet","action","envDevice","voice","other"] as const).map((k) => (
+          <button key={k} type="button"
+            onClick={() => setSelected((prev) => { const n = new Set(prev); if (n.has(k)) n.delete(k); else n.add(k); return n; })}
+            className={`px-2.5 py-1 text-caption rounded-full border transition-colors ${selected.has(k) ? "text-brand-primary bg-brand-soft border-brand-primary" : "text-text-secondary bg-bg-secondary border-border hover:border-border-strong"}`}>
+            {t(`activity.errorType.${k}`)}
+          </button>
+        ))}
+      </div>
+      <div className="text-caption text-text-tertiary mb-1">{t("activity.feedbackText")}</div>
+      <textarea value={text} onChange={(e) => setText(e.target.value)} placeholder={t("activity.feedbackPlaceholder")}
+        className="w-full h-[52px] px-2.5 py-2 border border-border rounded-lg text-[13px] bg-bg-secondary text-text-primary resize-none focus:outline-none focus:border-brand-primary transition-colors" />
+      <div className="mt-2 px-2.5 py-1.5 rounded-md text-[11px] text-text-tertiary" style={{ background: "rgba(217,119,6,.06)" }}>
+        ⚠ {t("activity.feedbackPrivacy")}
+      </div>
+      <div className="flex justify-end items-center gap-1.5 mt-2.5">
+        <button type="button" onClick={() => { setOpen(false); setSelected(new Set()); setText(""); }}
+          className="px-3.5 py-[5px] text-caption text-text-secondary rounded-md hover:bg-bg-tertiary transition-colors">
+          {t("activity.feedbackCancel")}
+        </button>
+        <button type="button" onClick={handleSubmit}
+          className="px-4 py-[5px] text-caption font-medium text-white bg-brand-primary rounded-md hover:bg-brand-accent transition-colors">
+          {t("activity.feedbackSubmit")}
+        </button>
+      </div>
     </div>
   );
 }

--- a/web/src/components/ActivityFeed.tsx
+++ b/web/src/components/ActivityFeed.tsx
@@ -42,6 +42,7 @@ interface Props {
   onDemandLogs?: OnDemandLogEntry[];
   onDemandLoading?: boolean;
   onDemandError?: Error | null;
+  onRetryOnDemand: () => void;
   deviceNames?: Record<string, string>;
 }
 
@@ -139,6 +140,7 @@ export function ActivityFeed({
   onDemandLogs: initialOdLogs,
   onDemandLoading,
   onDemandError,
+  onRetryOnDemand,
   deviceNames = {},
 }: Props) {
   const { t } = useTranslation();
@@ -540,7 +542,7 @@ export function ActivityFeed({
 
       {/* On-demand queries panel */}
       <div hidden={activeTab !== "queries"}>
-        <OnDemandLogList initial={initialOdLogs ?? EMPTY_OD_LOGS} initialLoading={onDemandLoading ?? false} initialError={onDemandError ?? null} homeId={homeId} deviceNames={deviceNames} onCountChange={handleOdCount} />
+        <OnDemandLogList initial={initialOdLogs ?? EMPTY_OD_LOGS} initialLoading={onDemandLoading ?? false} initialError={onDemandError ?? null} onRetryInitial={onRetryOnDemand} homeId={homeId} deviceNames={deviceNames} onCountChange={handleOdCount} />
       </div>
 
       </div>{/* end tab panels */}
@@ -1154,10 +1156,11 @@ function SubTab({ active, onClick, label }: {
 
 const OD_PAGE_SIZE = 50;
 
-function OnDemandLogList({ initial, initialLoading, initialError, homeId, deviceNames, onCountChange }: {
+function OnDemandLogList({ initial, initialLoading, initialError, onRetryInitial, homeId, deviceNames, onCountChange }: {
   initial: OnDemandLogEntry[];
   initialLoading: boolean;
   initialError: Error | null;
+  onRetryInitial: () => void;
   homeId: HomeId;
   deviceNames: Record<string, string>;
   onCountChange: (n: number, hasMore: boolean) => void;
@@ -1216,11 +1219,11 @@ function OnDemandLogList({ initial, initialLoading, initialError, homeId, device
         <div>{t("activity.odLoadFailed", { msg: initialError.message })}</div>
         <button
           type="button"
-          onClick={refresh}
-          disabled={refreshing}
+          onClick={onRetryInitial}
+          disabled={initialLoading}
           className="mt-3 text-caption text-text-tertiary hover:text-text-primary transition-colors disabled:opacity-50"
         >
-          {refreshing ? t("activity.odLoading") : t("activity.retry")}
+          {initialLoading ? t("activity.odLoading") : t("activity.retry")}
         </button>
       </div>
     );

--- a/web/src/i18n/locales/en/activity.json
+++ b/web/src/i18n/locales/en/activity.json
@@ -45,6 +45,12 @@
     "feedbackReveal": "Open containing folder",
     "feedbackSubmitLink": "Go to submit",
     "feedbackModify": "Modify feedback",
+    "tabEvents": "Events",
+    "tabOnDemand": "Queries",
+    "odLoaded": "{{n}} loaded{{more}}",
+    "odEmpty": "No on-demand queries yet",
+    "odLoading": "Loading…",
+    "odRefresh": "Refresh",
     "errorType": {
       "person": "Person identification error",
       "pet": "Pet identification error",

--- a/web/src/i18n/locales/en/activity.json
+++ b/web/src/i18n/locales/en/activity.json
@@ -49,6 +49,7 @@
     "tabOnDemand": "Queries",
     "odLoaded": "{{n}} loaded{{more}}",
     "odEmpty": "No on-demand queries yet",
+    "odLoadFailed": "Failed to load on-demand queries: {{msg}}",
     "odLoading": "Loading…",
     "odRefresh": "Refresh",
     "odNoAnswer": "Inference failed, no answer",

--- a/web/src/i18n/locales/en/activity.json
+++ b/web/src/i18n/locales/en/activity.json
@@ -51,6 +51,7 @@
     "odEmpty": "No on-demand queries yet",
     "odLoading": "Loading…",
     "odRefresh": "Refresh",
+    "odNoAnswer": "Inference failed, no answer",
     "errorType": {
       "person": "Person identification error",
       "pet": "Pet identification error",

--- a/web/src/i18n/locales/en/app.json
+++ b/web/src/i18n/locales/en/app.json
@@ -29,6 +29,7 @@
     "engineStoppedWakeManually": "Engine stopped, wake it manually: {{msg}}",
     "engineStoppedWakeManuallyNoMsg": "Engine stopped, wake it manually",
     "stopFail": "Couldn't stop, try again later",
-    "miotBound": "Xiaomi Home connected"
+    "miotBound": "Xiaomi Home connected",
+    "loadOnDemandLogsFail": "Failed to load on-demand logs"
   }
 }

--- a/web/src/i18n/locales/zh/activity.json
+++ b/web/src/i18n/locales/zh/activity.json
@@ -45,6 +45,12 @@
     "feedbackReveal": "点击打开所在文件夹",
     "feedbackSubmitLink": "前往提交",
     "feedbackModify": "修改反馈信息",
+    "tabEvents": "事件",
+    "tabOnDemand": "主动查询",
+    "odLoaded": "已加载 {{n}} 条{{more}}",
+    "odEmpty": "还没有主动查询记录",
+    "odLoading": "加载中…",
+    "odRefresh": "刷新",
     "errorType": {
       "person": "人物识别错误",
       "pet": "宠物识别错误",

--- a/web/src/i18n/locales/zh/activity.json
+++ b/web/src/i18n/locales/zh/activity.json
@@ -51,6 +51,7 @@
     "odEmpty": "还没有主动查询记录",
     "odLoading": "加载中…",
     "odRefresh": "刷新",
+    "odNoAnswer": "推理失败，无答案",
     "errorType": {
       "person": "人物识别错误",
       "pet": "宠物识别错误",

--- a/web/src/i18n/locales/zh/activity.json
+++ b/web/src/i18n/locales/zh/activity.json
@@ -49,6 +49,7 @@
     "tabOnDemand": "主动查询",
     "odLoaded": "已加载 {{n}} 条{{more}}",
     "odEmpty": "还没有主动查询记录",
+    "odLoadFailed": "加载主动查询失败：{{msg}}",
     "odLoading": "加载中…",
     "odRefresh": "刷新",
     "odNoAnswer": "推理失败，无答案",

--- a/web/src/i18n/locales/zh/app.json
+++ b/web/src/i18n/locales/zh/app.json
@@ -29,6 +29,7 @@
     "engineStoppedWakeManually": "引擎已停下，请手动唤醒：{{msg}}",
     "engineStoppedWakeManuallyNoMsg": "引擎已停下，请手动唤醒",
     "stopFail": "停止失败，稍后再试",
-    "miotBound": "米家已绑定"
+    "miotBound": "米家已绑定",
+    "loadOnDemandLogsFail": "加载主动查询日志失败"
   }
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -133,6 +133,23 @@ export interface ActivityEvent {
   feedback_pack_size?: number | null;
 }
 
+// ── 主动查询日志(on_demand_log)─────────────────────────────
+export interface OnDemandLogEntry {
+  id: string;
+  timestamp: number; // Unix ms
+  query: string;
+  answer: string;
+  sources: string[]; // device dids
+  latency_ms: number | null;
+  snapshot_count: number;
+  clip_dids: string[];
+  clip_kinds: Record<string, "mp4" | "m4a">;
+  has_trace: boolean;
+  has_feedback: boolean;
+  feedback_pack_path: string | null;
+  feedback_pack_size: number | null;
+}
+
 // ── 家庭档案（home_profile：候选区 / 正式区记忆）─────────────────
 // 与 backend miloco/home_profile/schema.py::Entry 对齐。member_* 是与人绑定的
 // 个人记忆（按 subject_id 归到成员），family/space/device 是与人无关的家庭信息。


### PR DESCRIPTION
## Summary
- 新增 `on_demand_log` 表，每次 on-demand perception 查询自动写入 query/answer/sources/latency + omni trace + 视频 clip 落盘（omni 未返回时只落 trace、跳过 clip）
- 新增 `GET /api/perception/on-demand-logs` 查询端点、clip 服务端点、反馈打包端点
- 前端 Activity 页增加"事件 / 主动查询"子 Tab，支持列表浏览、视频播放（Lightbox 放大）、反馈提交
- query pipeline 激活 `OmniEventArtifacts` + `set_device_context`，使 clip 和 trace 自动落盘到 `snapshots/{log_id}/`

## 数据流

### 记录时机

推理过程中，编码器内部通过 ContextVar 旁路机制自动收集：

| 阶段 | 时机 | 记录内容 |
|---|---|---|
| 推理中 | `_encode_video_mp4` 编码成功后 | clip 字节 → `push_clip_bytes` → `artifacts.clips[device_id]` |
| 推理中 | `call_omni` finally 块 | prompt + response → `push_omni_trace` → `artifacts.trace["calls"]` |
| 推理后 | `save_event_artifacts(log_id, artifacts)` | 内存 → 磁盘（clip 文件 + trace 压缩包；omni 未返回时只落 trace） |
| 推理后 | `od_log_repo.append(OnDemandLogEntry)` | 元数据 → SQLite |

### 各信息来源

| 字段 | 来源 |
|---|---|
| `query` | 用户 HTTP 请求 `request.query` |
| `answer` | omni 推理结果 `result.answer` |
| `sources` | 经校验的在线设备 ID 列表 |
| `latency_ms` | 推理前后 `t_end - t_start` |
| clip 字节 | 编码器 `_encode_video_mp4` 内部，经 `push_clip_bytes` 旁路写入 ContextVar 绑定的 artifacts 容器 |
| trace | `call_omni` 经 `push_omni_trace` 旁路写入 |
| `clip_dids` | `save_event_artifacts` 返回值（成功落盘的设备 ID 列表） |
| `clip_kinds` | `artifacts.clips[did][1]`（编码器决定：on-demand 路径始终 `"mp4"`；`"m4a"` 仅 realtime audio-only 路径产生，本 PR 不涉及） |
| `has_trace` | 写入时检查 `omni_trace.json.gz` 是否存在（DB 列）；list API 用 live `Path.exists()` 覆盖 DB 值，确保 clip 过期后准确反映 |

### 存储位置

**磁盘**（`snapshot_root`，与 realtime 事件共用目录，`cleanup_snapshots` 按 mtime TTL/LRU 统一清理）：

```
snapshots/{log_id}/
  ├── {region_slug(device_A)}/clip.mp4
  ├── {region_slug(device_B)}/clip.mp4
  └── omni_trace.json.gz
```

> **Note:** on-demand query 路径经由 `build_query_prompt`，不走 `_build_payload` 的 audio-only 分支，因此 clip 始终为 mp4。服务端点仍探测 mp4/m4a 以保持 forward-compatible。

**SQLite**（`on_demand_log` 表，`delete_before_days` 按 TTL 清理）：

```
id, timestamp, query, answer, sources, latency_ms,
snapshot_count, clip_dids, clip_kinds, has_trace, created_at
```

### 产物收集数据流

```
service.on_demand_perceive
  └─ processor.process_on_demand  (new OmniEventArtifacts 容器)
       └─ client.on_demand_perceive(batch, query, artifacts)
            └─ event_artifacts_scope(artifacts)         ← ContextVar 置位
                 └─ pipeline: gather(per-room)
                      ├─ room A: set_device_context(首帧镜头) → omni → push_clip_bytes[A]
                      └─ room B: set_device_context(首帧镜头) → omni → push_clip_bytes[B]
  ↓ (artifacts.clips / trace 已填好)
check_disk_space → clip_dids = save_event_artifacts(log_id, artifacts)
                 → snapshots/{log_id}/{slug}/clip.*  +  omni_trace.json.gz
od_log_repo.append(OnDemandLogEntry(snapshot_count, clip_dids, clip_kinds, has_trace))
```

## Test plan
- [x] 启动后端，确认 `on_demand_log` 表自动创建（含 snapshot_count/clip_dids/clip_kinds/has_trace 列）
- [x] CLI 发起 `miloco-cli perceive query`，确认 `snapshots/{log_id}/` 下有 `omni_trace.json.gz` + `clip.mp4`
- [x] `GET /api/perception/on-demand-logs` 返回 `snapshot_count > 0, has_trace: true`
- [x] 前端"主动查询" tab 点击行展开能播放视频，hover 放大按钮可全屏
- [x] 展开后点击反馈按钮，打包数据成功，飞书提交链接显示
- [x] 同毫秒复合游标翻页不漏不重（`test_on_demand_log_repo.py` 14 个用例全过）

## Known limitations
- **磁盘配额共用**：on-demand clip 与 realtime event snapshot 共用 `snapshot_root` 目录和 `cleanup_snapshots` 的 5 GB LRU 配额。高频 on-demand 查询会加速淘汰旧 realtime clip。后续可按来源分别限额，当前单池足够覆盖典型用量。
- **audio-only 不支持**：`build_query_prompt` 不经过 `_build_payload` 的 audio-only 路径，on-demand clip 始终为 mp4。如需 audio-only 查询需单独适配。

## 前端
<img width="1348" height="980" alt="20260721-191349" src="https://github.com/user-attachments/assets/8424c984-fc36-4971-a504-8e36a0a3f648" />

