### PR TITLE
fix: incremental_vacuum 漏 fetchall 致 SQLite 空闲页不回收

### DIFF
--- a/backend/miloco/src/miloco/database/connector.py
+++ b/backend/miloco/src/miloco/database/connector.py
@@ -23,6 +23,64 @@ logger = logging.getLogger(__name__)
 _DB_SCHEMA_VERSION = 2
 
 
+def incremental_vacuum(
+    conn: sqlite3.Connection,
+    max_pages: int | None = 10000,
+    chunk_pages: int = 500,
+) -> None:
+    """回收 auto_vacuum=INCREMENTAL 库里被 DELETE 标记为 free 的页，把空间还给 OS。
+
+    PRAGMA incremental_vacuum 靠消费结果集逐页驱动回收：不 fetch 时 Python sqlite3
+    只 step 一次、每轮仅回收 1 页，free page 会长期堆积；必须 fetchall 消费结果集才
+    真正逐页回收。max_pages 限单次回收上限（10000 页 ≈ 40MB），防清理尖峰。
+
+    单条 PRAGMA 的写事务是语句级的（pragma.c 在语句开头一次 sqlite3BeginWriteOperation、
+    循环到上限才提交），一条语句搬满上限会把写锁独占到搬完为止；同库其他 writer
+    （事件循环线程上的感知日志 INSERT、metrics worker）会整段卡在 busy_timeout 上，
+    抵掉 to_thread 的收益。注意这些 writer 的 busy 退避是在事件循环线程里同步跑的
+    （metrics_client._flush_buffer 是普通 def、直接跑阻塞 sqlite3），所以撞锁不只丢
+    observability 行，还会把事件循环冻住"对方持锁的剩余时长"（上限 5s/语句）。
+    所以按 chunk_pages 切成多条短语句，把一个覆盖全程的写事务
+    降级为多个各持锁数十毫秒的写事务。注意批间无主动 sleep、语句间写锁空窗仅几十微秒，
+    等待方（SQLite 默认 busy handler 退避轮询、最长 100ms 一轮）未必命中：默认 10000 页
+    整段亚秒级无妨，但 max_pages=None 追赶积压时整段窗口达秒级以上，可能耗尽 obs 连接的
+    5s busy timeout（撞锁即丢 trace 行），故只在维护窗口调。每批前查 freelist_count，
+    为 0 即返回，不为 no-op 白开写事务。
+
+    max_pages=None：不限页数、分批搬到清空整个 freelist，供上线时一次性追赶历史
+    积压（会持续占写锁较久，别在正常提供请求时调）。传 <=0 的整数下钳到 1：
+    SQLite 原生把 <=0 当"不限"，与防尖峰语义相反，不让它从数值路径漏进来。
+
+    仅在库的 auto_vacuum=INCREMENTAL(2) 时有效：其他模式下这条 PRAGMA 静默 no-op、
+    freelist 不下降，max_pages=None 会变成无终止循环（且每轮 no-op 仍开一次写事务、
+    持续抖写锁）。auto_vacuum 只能在空库上设，老库（fresh-build 路径之前建的）会永久
+    停在 NONE，故这里先校验模式、打日志留线索后直接返回。注意裸跑一次 VACUUM 只回收
+    当次空闲页、不改模式（明天这条 warning 照旧打）；要一次性切到增量回收，需停服后在
+    同一连接上按顺序跑 `PRAGMA auto_vacuum=INCREMENTAL;` 再 `VACUUM;`（SQLite 只允许
+    在建库时或 VACUUM 过程中改这个模式），或直接重建库。
+    """
+    mode = conn.execute("PRAGMA auto_vacuum").fetchone()[0]
+    if mode != 2:
+        logger.warning(
+            "Skip incremental_vacuum: auto_vacuum=%s (期望 2/INCREMENTAL)。该库建库时"
+            "未开增量回收。裸跑一次 VACUUM 只回收当次空闲页、模式仍留在 NONE(明天还会"
+            "打这条);要一次性切到增量回收,需停服后在同一连接上按顺序跑 "
+            "`PRAGMA auto_vacuum=INCREMENTAL;` 再 `VACUUM;`(SQLite 只允许在建库时或 "
+            "VACUUM 过程中改这个模式),或直接重建库。",
+            mode,
+        )
+        return
+    chunk = max(1, int(chunk_pages))
+    remaining = None if max_pages is None else max(1, int(max_pages))
+    while remaining is None or remaining > 0:
+        if conn.execute("PRAGMA freelist_count").fetchone()[0] == 0:
+            return
+        n = chunk if remaining is None else min(chunk, remaining)
+        conn.execute(f"PRAGMA incremental_vacuum({n})").fetchall()
+        if remaining is not None:
+            remaining -= n
+
+
 class SQLiteConnector:
     """SQLite database connector class"""
 

--- a/backend/miloco/src/miloco/main.py
+++ b/backend/miloco/src/miloco/main.py
@@ -109,32 +109,42 @@ async def _log_cleanup_loop() -> None:
         # perf.enabled=false 时跳过 observability cleanup — obs_init_schema 在
         # conn 上无条件建表,这里不门控会让关闭 perf 后 observability.db 仍被建出。
         if settings.perf.enabled:
-            try:
+            from miloco.database.connector import incremental_vacuum
+
+            def _cleanup_obs_db() -> tuple[int, int, int, int, int]:
+                # 整段(建表 + 5 条 DELETE + 回收)在工作线程内跑,连接线程内建、内关、
+                # 不跨线程共享:关服 cancel 时事件循环侧没有 conn.close() 会跑,不会关掉
+                # 本线程正在用的连接;顺带把 obs 这 5 条 DELETE 也移出事件循环(本 loop
+                # 其余几块清理仍同步跑在事件循环上,待后续统一处理)。
                 conn = obs_connect(obs_db_path)
                 try:
                     obs_init_schema(conn)
-                    dt = cleanup_traces_table(conn, settings.perf.retention.traces_days)
-                    dtd = cleanup_traces_device_table(conn, settings.perf.retention.traces_days)
-                    de = cleanup_events_table(conn, settings.perf.retention.events_days)
-                    da = cleanup_agent_runs_table(
-                        conn, settings.perf.retention.agent_runs_days
+                    counts = (
+                        cleanup_traces_table(conn, settings.perf.retention.traces_days),
+                        cleanup_traces_device_table(conn, settings.perf.retention.traces_days),
+                        cleanup_events_table(conn, settings.perf.retention.events_days),
+                        cleanup_agent_runs_table(conn, settings.perf.retention.agent_runs_days),
+                        cleanup_action_ledger_table(conn, settings.perf.retention.action_ledger_days),
                     )
-                    dal = cleanup_action_ledger_table(
-                        conn, settings.perf.retention.action_ledger_days
-                    )
-                    logger.info(
-                        "Observability cleanup: traces=%d, traces_device=%d, "
-                        "events=%d, agent_runs=%d, action_ledger=%d",
-                        dt, dtd, de, da, dal,
-                    )
-                    # auto_vacuum=INCREMENTAL 下,DELETE 把页标 free 但不还 OS。
-                    # 这里集中触发 incremental_vacuum,每页 4KB × 10000 ≈ 40MB 回收上限。
+                    # DELETE 把页标 free 但不还 OS,逐页回收(为何必须 fetchall、为何按
+                    # chunk 分批)见 connector.incremental_vacuum。
+                    # 单独 catch:DELETE 已在 autocommit 连接上提交,回收失败不该把行数
+                    # 统计一起吞掉、也不该报成「整段 cleanup 失败」误导排查方向。
                     try:
-                        conn.execute("PRAGMA incremental_vacuum(10000)")
+                        incremental_vacuum(conn)
                     except Exception as e:
                         logger.error("incremental_vacuum failed: %s", e)
+                    return counts
                 finally:
                     conn.close()
+
+            try:
+                dt, dtd, de, da, dal = await asyncio.to_thread(_cleanup_obs_db)
+                logger.info(
+                    "Observability cleanup: traces=%d, traces_device=%d, "
+                    "events=%d, agent_runs=%d, action_ledger=%d",
+                    dt, dtd, de, da, dal,
+                )
             except Exception as e:
                 logger.error("Observability DB cleanup failed: %s", e)
         # meaningful_events 行清理(按 event_ttl_days)
@@ -162,12 +172,17 @@ async def _log_cleanup_loop() -> None:
         except Exception as e:
             logger.error("Snapshots cleanup failed: %s", e)
         # miloco.db 已 DELETE 旧 perception_log / rule_log / meaningful_events,
-        # 走 incremental_vacuum 把 free pages 还 OS。
+        # 走 incremental_vacuum 把 free pages 还 OS。阻塞 I/O 移出事件循环。
         try:
-            from miloco.database.connector import get_db_connector
+            from miloco.database.connector import get_db_connector, incremental_vacuum
 
-            with get_db_connector().get_connection() as conn:
-                conn.execute("PRAGMA incremental_vacuum(10000)")
+            def _vacuum_miloco_db() -> None:
+                # 连接在工作线程内建、内关（get_connection 每次 sqlite3.connect
+                # 新建），不跨线程共享 conn。
+                with get_db_connector().get_connection() as conn:
+                    incremental_vacuum(conn)
+
+            await asyncio.to_thread(_vacuum_miloco_db)
         except Exception as e:
             logger.error("Miloco DB incremental_vacuum failed: %s", e)
         await asyncio.sleep(86400)

--- a/backend/miloco/tests/test_cleanup_loop_integration.py
+++ b/backend/miloco/tests/test_cleanup_loop_integration.py
@@ -154,3 +154,88 @@ class TestCleanupLoop:
         ):
             # 不应抛 OSError
             await _run_one_cycle()
+
+    @pytest.mark.asyncio
+    async def test_obs_cleanup_owned_by_worker_thread(self, isolated_env):
+        """回归护栏:obs 连接必须在工作线程内建、内关,回收也在工作线程跑。
+
+        这是一条纯时序不变量,helper 的护栏一条都覆盖不到它(五条单测全跑在 miloco.db
+        上,碰不到 _cleanup_obs_db 的时序)。三种回归都能全绿逃过 CI,只有这条能 red:
+        - 把 obs_connect 挪回线程函数外(建在事件循环线程、只把语句放进 to_thread):
+          关服 cancel 撞上工作线程还在 fetch 搬页的窗口时,事件循环线程会 close 掉正
+          在用的连接,抛 "Cannot operate on a closed database"。
+        - 把 incremental_vacuum 挪回 await 之后:把最多 40MB 的阻塞 I/O 压回事件循环。
+        - 把 obs 那次 incremental_vacuum 整块删掉(它外面裹着一层 try/except,看起来
+          像可选的):obs.db 从此只 DELETE 不回收,退回本 PR 要修的 bug,而且是在两个
+          库里空闲页更多的那个上。
+        """
+        import threading
+
+        import miloco.database.connector as connector_module
+        import miloco.main as main_module
+        from miloco.observability.metrics_db import connect as real_connect
+
+        loop_tid = threading.get_ident()
+        connect_tids: list[int] = []
+        close_tids: list[int] = []
+        obs_vacuum_tids: list[int] = []
+        miloco_vacuum_tids: list[int] = []
+
+        # sqlite3.Connection 是 C 类型、无 __dict__,不能直接给实例赋 close,
+        # 用薄代理转发、只在 close 上挂记录。
+        class _TrackingConn:
+            def __init__(self, conn):
+                self._conn = conn
+
+            def __getattr__(self, name):
+                return getattr(self._conn, name)
+
+            def close(self):
+                close_tids.append(threading.get_ident())
+                self._conn.close()
+
+        def _tracking_connect(path):
+            connect_tids.append(threading.get_ident())
+            return _TrackingConn(real_connect(path))
+
+        real_vacuum = connector_module.incremental_vacuum
+
+        def _tracking_vacuum(conn, *args, **kwargs):
+            # 一轮 loop body 里 incremental_vacuum 被调两次(obs 一次、miloco.db 一次)。
+            # 共用一个桶时,obs 那次被整块删掉后 miloco 那次仍能让断言全绿,护栏形同
+            # 虚设 —— obs 连接是 _TrackingConn、miloco 的是裸 sqlite3.Connection,
+            # 按这个天然判别标记分桶,两个调用点各断各的。
+            bucket = (
+                obs_vacuum_tids
+                if isinstance(conn, _TrackingConn)
+                else miloco_vacuum_tids
+            )
+            bucket.append(threading.get_ident())
+            return real_vacuum(conn, *args, **kwargs)
+
+        # incremental_vacuum 在 main.py 是函数内 import,patch 到 connector 模块属性上。
+        with (
+            patch.object(main_module, "obs_connect", side_effect=_tracking_connect),
+            patch.object(
+                connector_module, "incremental_vacuum", side_effect=_tracking_vacuum
+            ),
+        ):
+            await _run_one_cycle()
+
+        assert connect_tids, "obs cleanup 整段没跑到(perf.enabled 被关?)"
+        assert loop_tid not in connect_tids, (
+            f"obs 连接建在事件循环线程上了: {connect_tids} vs loop {loop_tid}"
+        )
+        assert connect_tids == close_tids, (
+            f"建连/关连不在同一线程: connect={connect_tids} close={close_tids}"
+        )
+        assert obs_vacuum_tids, "obs 回收没跑到(incremental_vacuum 调用被删?)"
+        assert loop_tid not in obs_vacuum_tids, (
+            f"obs 回收跑在事件循环线程上了: {obs_vacuum_tids} vs loop {loop_tid}"
+        )
+        assert obs_vacuum_tids == connect_tids, (
+            f"obs 回收不在建连的那个线程上: vacuum={obs_vacuum_tids} connect={connect_tids}"
+        )
+        assert miloco_vacuum_tids and loop_tid not in miloco_vacuum_tids, (
+            f"miloco.db 回收跑在事件循环线程上了: {miloco_vacuum_tids} vs loop {loop_tid}"
+        )

--- a/backend/miloco/tests/test_connector_wal_pragmas.py
+++ b/backend/miloco/tests/test_connector_wal_pragmas.py
@@ -83,6 +83,161 @@ def test_incremental_vacuum_callable(fresh_db):
         conn.execute("PRAGMA incremental_vacuum(100)")
 
 
+def test_incremental_vacuum_helper_reclaims_all_free_pages(fresh_db):
+    """incremental_vacuum helper 必须消费结果集逐页回收，把 freelist 清零。
+
+    回归护栏：helper 里的 .fetchall() 一旦被删回去，只 step 一次、每轮仅回收 1 页，
+    freelist_count 会停在 before-1，本测试的 after==0 断言即失败。
+    """
+    from miloco.database.connector import get_db_connector, incremental_vacuum
+
+    with get_db_connector().get_connection() as conn:
+        conn.execute("CREATE TABLE t(x BLOB)")
+        conn.executemany(
+            "INSERT INTO t VALUES(?)", [(b"0" * 4096,) for _ in range(2000)]
+        )
+        conn.execute("DELETE FROM t")
+        before = conn.execute("PRAGMA freelist_count").fetchone()[0]
+        assert before > 1, f"预置 free page 不足以区分逐页/单页回收: {before}"
+        # 预置量必须落在 helper 默认上限内，否则 after==0 失败的真因是撞上限、
+        # 不是漏 fetchall，会把排查方向带偏。
+        assert before < 10000, f"预置 free page 超过默认上限，用例失去判别力: {before}"
+
+        incremental_vacuum(conn)
+
+        after = conn.execute("PRAGMA freelist_count").fetchone()[0]
+        assert after == 0, f"free page 未回收干净，剩 {after}（漏 fetchall 会停在 before-1）"
+
+
+def test_incremental_vacuum_clamps_non_positive_max_pages(fresh_db):
+    """max_pages<=0 必须下钳到 1，不能落到 SQLite 原生的"不限页数"语义。
+
+    回归护栏：helper 里 max(1, ...) 一旦被删回 int(max_pages)，0 会被 SQLite 当
+    "不限"、一次清空整个 freelist，after 变 0，本测试的 after==before-1 断言即失败。
+    """
+    from miloco.database.connector import get_db_connector, incremental_vacuum
+
+    with get_db_connector().get_connection() as conn:
+        conn.execute("CREATE TABLE t(x BLOB)")
+        conn.executemany(
+            "INSERT INTO t VALUES(?)", [(b"0" * 4096,) for _ in range(500)]
+        )
+        conn.execute("DELETE FROM t")
+        before = conn.execute("PRAGMA freelist_count").fetchone()[0]
+        assert before > 1, f"预置 free page 不足以区分下钳/不限: {before}"
+
+        incremental_vacuum(conn, 0)
+
+        after = conn.execute("PRAGMA freelist_count").fetchone()[0]
+        assert after == before - 1, (
+            f"0 被当成不限页数了: {before} → {after}（下钳 max(1, ...) 被删？）"
+        )
+
+
+def test_incremental_vacuum_unlimited_when_none(fresh_db):
+    """max_pages=None 不限页数、分批搬到清空整个 freelist（供上线追赶积压）。
+
+    预置量（~4200 页）远超单批 chunk_pages(500)，验证 while 分批循环能搬完清零。
+    """
+    from miloco.database.connector import get_db_connector, incremental_vacuum
+
+    with get_db_connector().get_connection() as conn:
+        conn.execute("CREATE TABLE t(x BLOB)")
+        conn.executemany(
+            "INSERT INTO t VALUES(?)", [(b"0" * 4096,) for _ in range(2000)]
+        )
+        conn.execute("DELETE FROM t")
+        before = conn.execute("PRAGMA freelist_count").fetchone()[0]
+        assert before > 500, f"预置量需超过单批 chunk 才能验证分批: {before}"
+
+        incremental_vacuum(conn, None)
+
+        after = conn.execute("PRAGMA freelist_count").fetchone()[0]
+        assert after == 0, f"None 应清空整个 freelist，剩 {after}"
+
+
+def test_incremental_vacuum_splits_into_chunk_sized_statements(fresh_db):
+    """回归护栏：必须按 chunk_pages 切成多条短语句，每条一个独立写事务。
+
+    合回单条语句时 freelist 最终值不变、其它用例照样绿，只有这条能 red：
+    它数的是"跑了几条 PRAGMA、每条多少页"。
+    """
+    from miloco.database.connector import get_db_connector, incremental_vacuum
+
+    class _CountingConn:
+        def __init__(self, conn):
+            self._conn = conn
+            self.vacuum_stmts: list[str] = []
+
+        def execute(self, sql, *args):
+            if "incremental_vacuum" in sql:
+                self.vacuum_stmts.append(sql)
+            return self._conn.execute(sql, *args)
+
+    with get_db_connector().get_connection() as conn:
+        conn.execute("CREATE TABLE t(x BLOB)")
+        conn.executemany(
+            "INSERT INTO t VALUES(?)", [(b"0" * 4096,) for _ in range(500)]
+        )
+        conn.execute("DELETE FROM t")
+        before = conn.execute("PRAGMA freelist_count").fetchone()[0]
+        assert before > 100, f"预置量需超过单批 chunk 才能验证分批: {before}"
+
+        spy = _CountingConn(conn)
+        incremental_vacuum(spy, max_pages=None, chunk_pages=100)
+
+        assert len(spy.vacuum_stmts) > 1, (
+            f"只跑了 {len(spy.vacuum_stmts)} 条 PRAGMA，分批被合回单条语句？"
+        )
+        assert all(s == "PRAGMA incremental_vacuum(100)" for s in spy.vacuum_stmts), (
+            f"单条语句超出 chunk_pages 上限: {spy.vacuum_stmts}"
+        )
+        assert conn.execute("PRAGMA freelist_count").fetchone()[0] == 0
+
+
+def test_incremental_vacuum_skips_non_incremental_db(tmp_path, caplog):
+    """回归护栏：auto_vacuum!=INCREMENTAL 的库必须打 warning 后直接返回、不发回收 PRAGMA。
+
+    这是模式前置校验唯一的护栏：一旦校验被删，这条 PRAGMA 在 NONE 库上静默 no-op、
+    freelist 永不归零，max_pages=None 会无终止循环挂死整个测试 job。用薄代理数
+    incremental_vacuum 语句数、断言"一条都没发"，直接锁住"命中校验、零回收"这个
+    不变量，不依赖"默认上限空转多少轮后返回"的隐含前提。
+    """
+    import logging
+    import sqlite3
+
+    from miloco.database.connector import incremental_vacuum
+
+    # 默认建库 auto_vacuum=NONE(0),模拟 fresh-build 路径之前建的老库
+    db_file = tmp_path / "none_mode.db"
+    conn = sqlite3.connect(db_file)
+    try:
+        assert conn.execute("PRAGMA auto_vacuum").fetchone()[0] == 0
+        conn.execute("CREATE TABLE t(x BLOB)")
+        conn.executemany("INSERT INTO t VALUES(?)", [(b"0" * 4096,) for _ in range(500)])
+        conn.execute("DELETE FROM t")
+        before = conn.execute("PRAGMA freelist_count").fetchone()[0]
+        assert before > 0, f"预置 free page 不足: {before}"
+
+        vacuum_stmts: list[str] = []
+
+        class _RecordingConn:
+            def execute(self, sql, *args):
+                if "incremental_vacuum" in sql:
+                    vacuum_stmts.append(sql)
+                return conn.execute(sql, *args)
+
+        with caplog.at_level(logging.WARNING):
+            incremental_vacuum(_RecordingConn())
+
+        assert vacuum_stmts == [], f"NONE 模式下仍发了回收 PRAGMA: {vacuum_stmts}(模式校验被删?)"
+        assert "Skip incremental_vacuum" in caplog.text, "模式校验分支未走到(warning 未打)"
+        after = conn.execute("PRAGMA freelist_count").fetchone()[0]
+        assert after == before, f"NONE 库不该回收任何页: {before} → {after}"
+    finally:
+        conn.close()
+
+
 def test_pre_created_empty_file_runs_fresh_path(tmp_path, monkeypatch):
     """预创建空文件场景:db_file.touch() 后启动,应走 fresh 路径设 auto_vacuum。
 


### PR DESCRIPTION
## 背景

排查「运行多日后 SQLite 库文件只涨不缩」时挖到一个确证问题。

## 问题：`incremental_vacuum` 漏 `.fetchall()`，SQLite 空闲页不回收（两处）

`PRAGMA incremental_vacuum` 靠**返回结果集逐页驱动**回收——每 fetch 一行才回收一页。`conn.execute(...)` 不消费结果集，SQLite 只 step 一次，**每次 cleanup 只回收 1 页**，DELETE 产生的空闲页持续堆积、文件只涨不缩。

`main.py` 两处 cleanup 都中招：

| 库 | 大小 | 空闲页 | 位置 |
|---|---|---|---|
| observability.db | 222.8MB | 142.5MB (**63%**) | `main.py::_log_cleanup_loop`（清 traces 等 5 表） |
| miloco.db | 72.8MB | 18.1MB (**24%**) | `main.py::_log_cleanup_loop`（清 perception_log / rule_log / meaningful_events 后回收） |

副本对照实测（生产 observability.db，freelist=36497）：

```
execute 不 fetchall            : 36497 → 36496   只回收 1 页  ← 现状 bug
incremental_vacuum + fetchall  : 36497 → 0       回收全部 36497 页
incremental_vacuum(10000)+fetch: 36497 → 26497   正好回收 10000 页
```

`PRAGMA auto_vacuum` 报 2 是正常工作的，工具没选错、是漏了消费结果集。

## 修复

把回收逻辑抽成公共函数 `miloco.database.connector.incremental_vacuum(conn, max_pages=10000, chunk_pages=500)`，`main.py` 两处 cleanup 均改调它，消除「两处各自记得补 fetchall」的隐性约定。函数内：

1. **消费结果集**：`.fetchall()` 逐页驱动回收（修复本 bug）。
2. **模式前置校验**：只在库 `auto_vacuum=INCREMENTAL(2)` 时有效——其他模式下 PRAGMA 静默 no-op、freelist 不降，`max_pages=None` 会变成无终止循环（且每轮 no-op 仍开写事务抖锁）。老库（fresh-build 路径之前建的）会永久停在 NONE，故循环前先校验、打 warning 留线索后返回。**注意裸跑 `VACUUM` 只回收当次空闲页、不改模式**（明天这条 warning 照旧打）；要切到增量回收需停服后在同一连接上按顺序跑 `PRAGMA auto_vacuum=INCREMENTAL;` 再 `VACUUM;`（SQLite 只允许在建库时或 VACUUM 过程中改该模式），或直接重建库。
3. **参数语义**：`max_pages` 默认 10000 页（≈40MB）防尖峰；`max_pages=None` 不限页数、分批清空整个 freelist，供上线追赶历史积压；`<=0` 整数下钳到 1（SQLite 原生把 `<=0` 当「不限」，与防尖峰意图相反）。

## 线程模型与写锁

回收量从「1 页」放大到「最多 40MB」后成为真实阻塞 I/O，两处均改到工作线程（`asyncio.to_thread`，与同文件 `_rollover_daily_loop` 既有约定一致）：

- **分批切写事务**：单条 `PRAGMA incremental_vacuum` 的写事务是**语句级**的（搬满上限才提交），一条语句搬满会把写锁独占到搬完。只挪线程不够——同库其他 writer（事件循环上的感知日志 INSERT、metrics flush）会从「天然串行」变成并发抢写锁、整段卡 busy_timeout（observability 5s 超时还会静默丢 trace 行）。故按 `chunk_pages=500` 切成多条短写事务、间隙让锁；每批前查 `freelist_count`、为 0 提前返回。
- **连接归属**：observability.db 把整段 cleanup（建表 + 5 条 DELETE + 回收）一次性放进线程函数、连接线程内建内关——既顺带把 5 条 DELETE 移出事件循环，又消除「连接建在循环线程、语句跑在工作线程」的跨线程持有（否则关服 `cancel()` 时 `CancelledError`（BaseException 子类、`except Exception` 接不住）会让循环线程在工作线程还在 fetch 时 `conn.close()`，抛 `Cannot operate on a closed database`）。miloco.db 同样连接放线程内建内关。

## 测试

- `test_incremental_vacuum_helper_reclaims_all_free_pages`：整表 DELETE 后断言 `freelist_count == 0`；漏 fetchall 停在 `before-1` 即 red（并加 `before<10000` 余量断言，防撞上限误导排查）。
- `test_incremental_vacuum_clamps_non_positive_max_pages`：`incremental_vacuum(conn, 0)` 必须只回收 1 页（`after==before-1`）；下钳被删即 red。
- `test_incremental_vacuum_unlimited_when_none`：`max_pages=None` 分批搬完清零。
- `test_incremental_vacuum_splits_into_chunk_sized_statements`：`_CountingConn` 代理数 PRAGMA 语句数，分批被合回单条语句即 red（锁住「切写事务」这个并发行为，仅看 freelist 的其它用例锁不住）。
- `test_incremental_vacuum_skips_non_incremental_db`：手建 `auto_vacuum=NONE` 的库，用薄代理断言打 warning 后直接返回、一条回收 PRAGMA 都没发；模式前置校验被删即 red。
- `test_obs_cleanup_owned_by_worker_thread`：复用既有 `_run_one_cycle` 集成 fixture，薄代理记录 obs 连接建/关、两处回收各自所在线程。一轮 loop body 里 `incremental_vacuum` 被调两次（obs 一次、miloco.db 一次），**按连接身份分桶**（obs 连接是薄代理、miloco 的是裸 `sqlite3.Connection`）后各自断言，三种回归都能 red：把建连挪回事件循环线程、把回收挪回 `await` 之后、以及把 obs 那次回收整块删掉（共用一个桶时这条会被 miloco 那次顶成绿）。obs 侧另断言 `obs_vacuum_tids == connect_tids`，即回收就跑在建连的那个线程上。

## 影响 / 上线注意

- 代码修复只让**今后**的 cleanup 正常回收。两个生产库现有积压（observability 140MB / miloco 18MB）会在几天 cleanup 周期里逐步回收；想立即清完就在维护窗口内跑一次 `incremental_vacuum(conn, None)`（仍按 500 页分批让锁，但会持续较久，别在高峰调）。**注意**：若目标库 `auto_vacuum` 不是 INCREMENTAL（老库），helper 会打 warning 直接返回、不回收。这类库**不能只跑一次 `VACUUM`**（那只回收当次空闲页、模式仍留在 NONE，下个周期照旧不回收），需在维护窗口内于同一连接上按顺序跑 `PRAGMA auto_vacuum=INCREMENTAL;` 再 `VACUUM;`，或直接重建库。
- **行为变更（写锁竞争面）**：observability.db 的**整段** cleanup（建表 + 5 条 DELETE + 回收）与 miloco.db 的回收都改为在工作线程（`asyncio.to_thread`）执行。回收按 500 页分批放锁；但**5 条 DELETE 仍是单条无 `LIMIT` 的写事务、未分批**，且从此与事件循环上的 metrics worker flush 真并发（此前同在事件循环、结构上不可能重叠）。稳态下每天只删一天量、大概率远低于 obs 连接的 5s busy timeout；但在**下调 retention 天数**（如 `traces_days` 7→2 一次删 5 天）或**长时间停服后重启补删**时，这条 DELETE 是最可能突破 5s 的写事务。届时 metrics worker 撞锁会丢 trace 行（不重试）；且它的 busy 退避跑在事件循环线程上（`_flush_buffer` 是同步 `def`、直接跑阻塞 sqlite3），事件循环会跟着冻结「DELETE 持锁的剩余时长」，外部表现是服务假死、而不只是 observability 缺行。改前这条 DELETE 本身就跑在事件循环上、冻结时长相同且确定发生，故**不是相对 main 的回归**；但这是给 DELETE 上分批的优先级依据。DELETE 分批留作后续单独 PR，此前若要大批删建议在维护窗口手动分批。
- 回收失败单独 `try/except`：DELETE 已在 autocommit 连接上提交，回收报错不再吞掉 retention 行数统计、也不再粗化成「整段 cleanup 失败」。
- 无用户可见的接口变更；新增一个内部导出函数 `miloco.database.connector.incremental_vacuum`（observability.db 与 miloco.db cleanup 共用）。

---

> 分支名里的 `-and-astype` 是历史遗留（早期版本一度改过解码链路，已完全撤回）。本 PR 只改 SQLite 回收，`backend/miot/` 零改动。
