### PR TITLE
feat: auto-stop/resume perception engine on omni failure + decoder pause

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,16 @@
+# CodeGraph data files
+# These are local to each machine and should not be committed
+
+# Database
+*.db
+*.db-wal
+*.db-shm
+
+# Cache
+cache/
+
+# Logs
+*.log
+
+# Hook markers
+.dirty

--- a/backend/miloco/src/miloco/admin/feedback_pack.py
+++ b/backend/miloco/src/miloco/admin/feedback_pack.py
@@ -163,7 +163,7 @@ def build_feedback_pack(
         slug = region_slug(did)
         clip_dir = event_dir / slug
         found = False
-        for ext in ("mp4", "m4a"):
+        for ext in ("mp4", "m4a", "wav", "mp3"):
             if (clip_dir / f"clip.{ext}").exists():
                 components["clips_found"].append(f"{slug}/clip.{ext}")
                 found = True

--- a/backend/miloco/src/miloco/admin/router.py
+++ b/backend/miloco/src/miloco/admin/router.py
@@ -1020,6 +1020,89 @@ async def omni_health_stream():
 
 
 # =============================================================================
+# 截图模式双模型配置（vision_model / audio_model）
+# =============================================================================
+
+
+class SplitModelItem(BaseModel):
+    """单个 split model 配置项（model + base_url + api_key）。
+
+    与 OmniModelSettings 对齐；为 None 的字段在 PUT 时不更新（保留旧值）。
+    """
+    model: str | None = None
+    base_url: str | None = None
+    api_key: str | None = None
+
+
+class SplitModelConfigBody(BaseModel):
+    """双模型配置请求体。传哪个改哪个，不传则不动。"""
+    vision_model: SplitModelItem | None = None
+    audio_model: SplitModelItem | None = None
+
+
+def _split_model_payload() -> dict:
+    """构造返回给前端的 split model 配置（api_key 打码）。"""
+    s = get_settings()
+
+    def _mask(item):
+        if item is None:
+            return None
+        key = item.api_key or ""
+        return {
+            "model": item.model or "",
+            "base_url": item.base_url or "",
+            "has_key": bool(key),
+            "api_key_masked": (key[:4] + "****" + key[-4:]) if len(key) > 8 else ("****" if key else ""),
+        }
+
+    return {
+        "vision_model": _mask(s.model.vision_model),
+        "audio_model": _mask(s.model.audio_model),
+    }
+
+
+@router.get(
+    "/split-model-config",
+    summary="获取截图模式双模型配置",
+    response_model=NormalResponse,
+)
+def get_split_model_config(current_user: str = Depends(verify_token)):
+    return NormalResponse(code=0, message="ok", data=_split_model_payload())
+
+
+@router.put(
+    "/split-model-config",
+    summary="修改截图模式双模型配置（写 config.json，下个推理窗口自动生效）",
+    response_model=NormalResponse,
+)
+def put_split_model_config(body: SplitModelConfigBody, current_user: str = Depends(verify_token)):
+    update: dict = {}
+    if body.vision_model is not None:
+        vm: dict = {}
+        if body.vision_model.model is not None:
+            vm["model"] = body.vision_model.model
+        if body.vision_model.base_url is not None:
+            vm["base_url"] = body.vision_model.base_url
+        if body.vision_model.api_key is not None:
+            vm["api_key"] = body.vision_model.api_key
+        if vm:
+            update["vision_model"] = vm
+    if body.audio_model is not None:
+        am: dict = {}
+        if body.audio_model.model is not None:
+            am["model"] = body.audio_model.model
+        if body.audio_model.base_url is not None:
+            am["base_url"] = body.audio_model.base_url
+        if body.audio_model.api_key is not None:
+            am["api_key"] = body.audio_model.api_key
+        if am:
+            update["audio_model"] = am
+    if update:
+        update_shared_config(model=update)
+    return NormalResponse(code=0, message="ok", data=_split_model_payload())
+
+
+# =============================================================================
 # 感知参数配置
 # =============================================================================
 
@@ -1028,6 +1111,7 @@ class PerceptionConfigBody(BaseModel):
     video_short_edge: int | None = Field(default=None, ge=64, le=2160)
     omni_fps: int | None = Field(default=None, ge=1, le=30)
     window_size: int | None = Field(default=None, ge=1, le=60)
+    transmission_mode: str | None = Field(default=None, pattern="^(video|screenshot)$")
 
 
 def _perception_config_payload() -> dict:
@@ -1037,6 +1121,7 @@ def _perception_config_payload() -> dict:
         "video_short_edge": inp.get("video_short_edge", 512),
         "omni_fps": inp.get("omni_fps", 1),
         "window_size": s.perception.collect.window_size,
+        "transmission_mode": inp.get("transmission_mode", "video"),
     }
 
 
@@ -1062,6 +1147,8 @@ async def put_perception_config(body: PerceptionConfigBody, current_user: str = 
         update.setdefault("perception", {}).setdefault("engine", {}).setdefault("input", {})["omni_fps"] = body.omni_fps
     if body.window_size is not None:
         update.setdefault("perception", {}).setdefault("collect", {})["window_size"] = body.window_size
+    if body.transmission_mode is not None:
+        update.setdefault("perception", {}).setdefault("engine", {}).setdefault("input", {})["transmission_mode"] = body.transmission_mode
     payload = _perception_config_payload()
     if update:
         # 三个参数生效路径各不同，按「新值 != 旧值」判断（前端 drawer 三字段一起 PUT）：
@@ -1072,6 +1159,7 @@ async def put_perception_config(body: PerceptionConfigBody, current_user: str = 
         #   - window_size：runner 构造时 cache，需 stop→start 重读（apply_config_restart）。
         omni_fps_changed = body.omni_fps is not None and body.omni_fps != payload["omni_fps"]
         window_changed = body.window_size is not None and body.window_size != payload["window_size"]
+        # transmission_mode 每帧实时读 settings（_get_transmission_mode），写盘即生效，无需重启
         update_shared_config(**update)
         payload = _perception_config_payload()
         # config 已写盘(不可回滚)；热更/重启失败仅带 restart_ok=False，不冒泡成 500——

--- a/backend/miloco/src/miloco/admin/router.py
+++ b/backend/miloco/src/miloco/admin/router.py
@@ -14,6 +14,7 @@ import subprocess
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as pkg_version
 from pathlib import Path
+from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field, StrictBool
@@ -574,7 +575,7 @@ class OmniConfigBody(BaseModel):
     api_key: str | None = None  # 留空 = 沿用该档案原 key(不被打码值覆盖)
     original_label: str | None = None  # 正在编辑的档案原名(支持改名/定位);None=新增
     activate: bool = True  # True=同时设为当前生效;False=只入列表(激活由 /activate 负责)
-    audio_format: str | None = None  # 音频编码格式:m4a/wav/mp3
+    audio_format: Literal["m4a", "wav", "mp3"] | None = None  # 音频编码格式
 
 
 class OmniSelectBody(BaseModel):
@@ -687,6 +688,7 @@ async def activate_omni_config(
                         "model": p.model,
                         "base_url": p.base_url,
                         "api_key": p.api_key,
+                        "audio_format": getattr(p, "audio_format", "m4a"),
                     }
                 }
             )

--- a/backend/miloco/src/miloco/admin/router.py
+++ b/backend/miloco/src/miloco/admin/router.py
@@ -522,6 +522,7 @@ def _full_omni_payload() -> dict:
             "api_key_masked": _mask_api_key(p.api_key),
             "has_key": bool(p.api_key),
             "active": p.label == active.label,
+            "audio_format": getattr(p, "audio_format", "m4a"),
         }
         for p in m.omni_profiles
     ]
@@ -535,6 +536,7 @@ def _full_omni_payload() -> dict:
                 "api_key_masked": _mask_api_key(active.api_key),
                 "has_key": True,
                 "active": True,
+                "audio_format": getattr(active, "audio_format", "m4a"),
             },
         )
     health = asdict(get_omni_circuit_breaker().snapshot())
@@ -546,6 +548,7 @@ def _full_omni_payload() -> dict:
             "api_key_masked": _mask_api_key(active.api_key),
             "has_key": bool(active.api_key),
             "health": health,
+            "audio_format": getattr(active, "audio_format", "m4a"),
         },
         "profiles": profiles,
     }
@@ -558,6 +561,7 @@ def _profiles_as_dicts() -> list[dict]:
             "model": p.model,
             "base_url": p.base_url,
             "api_key": p.api_key,
+            "audio_format": getattr(p, "audio_format", "m4a"),
         }
         for p in get_settings().model.omni_profiles
     ]
@@ -570,6 +574,7 @@ class OmniConfigBody(BaseModel):
     api_key: str | None = None  # 留空 = 沿用该档案原 key(不被打码值覆盖)
     original_label: str | None = None  # 正在编辑的档案原名(支持改名/定位);None=新增
     activate: bool = True  # True=同时设为当前生效;False=只入列表(激活由 /activate 负责)
+    audio_format: str | None = None  # 音频编码格式:m4a/wav/mp3
 
 
 class OmniSelectBody(BaseModel):
@@ -623,6 +628,8 @@ async def put_omni_config(
     # 传 base_url 让 _key_by_label 校验"URL 未变才沿用旧 key",防跨 URL 复用凭证。
     key = _key_by_label(orig or label, body.api_key, base_url=base_url)
     entry = {"label": label, "base_url": base_url, "model": model, "api_key": key}
+    if body.audio_format:
+        entry["audio_format"] = body.audio_format
     tgt = orig or label
     will_activate = body.activate or _label_is_active(tgt)
     if will_activate:

--- a/backend/miloco/src/miloco/config/settings.py
+++ b/backend/miloco/src/miloco/config/settings.py
@@ -161,6 +161,13 @@ class OmniModelSettings(BaseModel):
         default="",
         description="多模态模型 API Key；为空时视为未配置，插件与后端启动前校验",
     )
+    audio_format: str = Field(
+        default="m4a",
+        description=(
+            "音频编码格式：m4a (AAC) / wav (PCM) / mp3。"
+            "MiMo/Qwen/Gemini 建议 m4a；智谱/OpenAI 建议 wav。"
+        ),
+    )
 
 
 class ModelSettings(BaseModel):

--- a/backend/miloco/src/miloco/config/settings.py
+++ b/backend/miloco/src/miloco/config/settings.py
@@ -308,6 +308,14 @@ class PerceptionCollectSettings(BaseModel):
     full_action: str = Field(
         default="clear", description="窗口满载处理策略（drop/clear/keep）"
     )
+    auto_stop_on_omni_failure: bool = Field(
+        default=True,
+        description="omni 熔断器持续 OPEN 超过阈值时自动停止整个感知引擎(gate+identity+omni)，释放 ONNX 模型内存和 CPU",
+    )
+    auto_stop_threshold_sec: float = Field(
+        default=60.0,
+        description="熔断器持续 OPEN 多少秒后触发自动停止（需 auto_stop_on_omni_failure=true）",
+    )
 
 
 class PerceptionSettings(BaseModel):

--- a/backend/miloco/src/miloco/config/settings.py
+++ b/backend/miloco/src/miloco/config/settings.py
@@ -185,6 +185,22 @@ class ModelSettings(BaseModel):
             "当前生效的那套即 omni（按 label 匹配）。"
         ),
     )
+    vision_model: OmniModelSettings | None = Field(
+        default=None,
+        description=(
+            "截图模式专用视觉模型（可选）。仅 transmission_mode=screenshot 时生效；"
+            "配了 vision_model + audio_model 时自动拆分为双模型并发调用。"
+            "未配置的字段（base_url/api_key）回退到 omni 的值。"
+        ),
+    )
+    audio_model: OmniModelSettings | None = Field(
+        default=None,
+        description=(
+            "截图模式专用音频/ASR 模型（可选）。仅 transmission_mode=screenshot 时生效；"
+            "配了 vision_model + audio_model 时自动拆分为双模型并发调用。"
+            "未配置的字段（base_url/api_key）回退到 omni 的值。"
+        ),
+    )
 
 
 class DatabaseSettings(BaseModel):
@@ -315,6 +331,17 @@ class PerceptionCollectSettings(BaseModel):
     auto_stop_threshold_sec: float = Field(
         default=60.0,
         description="熔断器持续 OPEN 多少秒后触发自动停止（需 auto_stop_on_omni_failure=true）",
+    )
+    raw_stream_save_dir: str | None = Field(
+        default=None,
+        description=(
+            "原始视频流保存目录（感知引擎未就绪时录制 H.265 流）。"
+            "null=不录制；路径支持 ~ 展开。按 {did}/{日期}/ 分目录，文件名=时间.hevc"
+        ),
+    )
+    raw_stream_segment_minutes: int = Field(
+        default=60,
+        description="原始视频流分片时长（分钟），每段时间生成一个 .hevc 文件",
     )
 
 

--- a/backend/miloco/src/miloco/config/settings.schema.json
+++ b/backend/miloco/src/miloco/config/settings.schema.json
@@ -97,6 +97,12 @@
               "type": "string",
               "default": "",
               "description": "多模态模型 API Key；为空时视为未配置，插件与后端启动前校验"
+            },
+            "audio_format": {
+              "type": "string",
+              "enum": ["m4a", "wav", "mp3"],
+              "default": "m4a",
+              "description": "音频编码格式：m4a (AAC) / wav (PCM) / mp3。MiMo/Qwen/Gemini 建议 m4a；智谱/OpenAI 建议 wav。"
             }
           },
           "required": ["model", "base_url", "api_key"]

--- a/backend/miloco/src/miloco/config/settings.yaml
+++ b/backend/miloco/src/miloco/config/settings.yaml
@@ -78,12 +78,14 @@ perception:
     max_windows: 3           # 最大待处理窗口数
     settle_ms: 500           # 等待慢轨道的宽限期（毫秒）
     full_action: "clear"     # 窗口满载处理策略：drop | clear | keep
+    auto_stop_on_omni_failure: true   # omni 持续失败时自动停止整个感知引擎
+    auto_stop_threshold_sec: 60       # 熔断器 OPEN 多少秒后触发自动停止
   engine:
     input:
       # 帧率旋钮集中在此一处(对应 InputConfig):
       #   fps      —— 下发/pipeline 帧率 = tracker 帧率(下采后 tracker 逐帧消费全部)
       #   omni_fps —— 送 omni 的视频帧率, 与 fps 解耦; omni 已是瓶颈, 不随 tracker 提频涨
-      fps: 3
+      fps: 2
       omni_fps: 1
       video_short_edge: 512
     gate:
@@ -91,7 +93,7 @@ perception:
       # 也强制生成 packet 并打 hold 标志,保住 video 路由不被纯音频短路。
       # 0 = 关闭 hold。过长在画面间歇有变化的场景会持续续命窗口、期间静默窗也被
       # 拉起跑下游 omni,浪费调用;过短则人短暂静止时 video 路由会切走。
-      hold_duration_sec: 90
+      hold_duration_sec: 30
     identity:
       # mock | real | deep_sort —— v1.2 主动注册默认 deep_sort,DeepSORT 内置
       # ReID 关联,跟踪更稳;额外暴露 Track.features deque 给陌生人池零额外推理

--- a/backend/miloco/src/miloco/config/settings.yaml
+++ b/backend/miloco/src/miloco/config/settings.yaml
@@ -80,6 +80,8 @@ perception:
     full_action: "clear"     # 窗口满载处理策略：drop | clear | keep
     auto_stop_on_omni_failure: true   # omni 持续失败时自动停止整个感知引擎
     auto_stop_threshold_sec: 60       # 熔断器 OPEN 多少秒后触发自动停止
+    raw_stream_save_dir: null         # 原始视频流保存目录（null=不录制）
+    raw_stream_segment_minutes: 60    # 分片时长（分钟）
   engine:
     input:
       # 帧率旋钮集中在此一处(对应 InputConfig):
@@ -88,6 +90,8 @@ perception:
       fps: 2
       omni_fps: 1
       video_short_edge: 512
+      # 传输模式: "video" = mp4(H.264+AAC)(默认); "screenshot" = JPEG 图片序列 + 独立音频(省 CPU/内存)
+      transmission_mode: "video"
     gate:
       # visual 滞回时长(秒)。visual 最近通过过、距今 <= 此值时,本窗 visual 不通过
       # 也强制生成 packet 并打 hold 标志,保住 video 路由不被纯音频短路。

--- a/backend/miloco/src/miloco/miot/client.py
+++ b/backend/miloco/src/miloco/miot/client.py
@@ -583,6 +583,26 @@ class MiotProxy:
             logger.error("Failed to stop decode audio frame stream: %s", e)
             raise
 
+    def pause_all_decoders(self) -> None:
+        """暂停所有摄像头的解码器：P2P 连接保持，帧直接丢弃不走 H.264 解码。"""
+        try:
+            camera_client = self._miot_client._camera_client
+            for did, instance in camera_client.camera_map.items():
+                instance.pause_decoders()
+            logger.info("Paused all camera decoders (%d cameras)", len(camera_client.camera_map))
+        except Exception as e:
+            logger.error("Failed to pause decoders: %s", e)
+
+    def resume_all_decoders(self) -> None:
+        """恢复所有摄像头的解码器。"""
+        try:
+            camera_client = self._miot_client._camera_client
+            for did, instance in camera_client.camera_map.items():
+                instance.resume_decoders()
+            logger.info("Resumed all camera decoders (%d cameras)", len(camera_client.camera_map))
+        except Exception as e:
+            logger.error("Failed to resume decoders: %s", e)
+
     async def _create_camera_img_manager(
         self,
         camera_info: MIoTCameraInfo,

--- a/backend/miloco/src/miloco/miot/client.py
+++ b/backend/miloco/src/miloco/miot/client.py
@@ -603,6 +603,40 @@ class MiotProxy:
         except Exception as e:
             logger.error("Failed to resume decoders: %s", e)
 
+    async def register_raw_video_stream(
+        self,
+        camera_id: str,
+        channel: int,
+        callback,
+    ) -> int:
+        """注册原始视频流回调（不解码，直接收 H.265 编码数据）。"""
+        if camera_id not in self._camera_img_managers:
+            logger.warning("Camera %s not found in managers", camera_id)
+            return -1
+        instance = self._camera_img_managers[camera_id]
+        try:
+            await instance.register_raw_stream(callback, channel)
+            logger.info("Registered raw video stream for %s channel %d", camera_id, channel)
+            return 0
+        except Exception as e:
+            logger.error("Failed to register raw video stream: %s", e)
+            return -1
+
+    async def unregister_raw_video_stream(
+        self,
+        camera_id: str,
+        channel: int,
+    ) -> None:
+        """取消注册原始视频流回调。"""
+        if camera_id not in self._camera_img_managers:
+            return
+        instance = self._camera_img_managers[camera_id]
+        try:
+            await instance.unregister_raw_stream(channel)
+            logger.info("Unregistered raw video stream for %s channel %d", camera_id, channel)
+        except Exception as e:
+            logger.error("Failed to unregister raw video stream: %s", e)
+
     async def _create_camera_img_manager(
         self,
         camera_info: MIoTCameraInfo,

--- a/backend/miloco/src/miloco/perception/__init__.py
+++ b/backend/miloco/src/miloco/perception/__init__.py
@@ -47,6 +47,9 @@ async def init_perception_module(miot_proxy, kv_repo):
         log_repo=perception_log_repo,
     )
 
+    # 5.1 将引擎就绪检查注入 camera_adapter（用于原始流录制模式判断）
+    camera_adapter.set_engine_ready_fn(lambda: pipeline_processor.engine_ready)
+
     # 6. 初始化实时感知引擎
     perception_runner = PerceptionRunner(
         collector=multimodal_collector,

--- a/backend/miloco/src/miloco/perception/client.py
+++ b/backend/miloco/src/miloco/perception/client.py
@@ -198,6 +198,31 @@ async def _run_with_trace_id(
         reset_trace_id(token)
 
 
+def _build_split_model_config(
+    omni_kwargs: dict,
+    split_settings: "OmniModelSettings | None",
+) -> "OmniConfig | None":
+    """从 omni 基础 kwargs + split model settings 构造独立 OmniConfig。
+
+    split_settings 中未配的字段回退到 omni 的值；split_settings 为 None 时返回 None
+    （不启用拆分）。
+    """
+    if split_settings is None:
+        return None
+    from miloco.perception.engine.config import OmniConfig
+    from miloco.perception.engine.omni.omni_client import resolve_omni_api_key
+
+    merged = dict(omni_kwargs)
+    if split_settings.model:
+        merged["model"] = split_settings.model
+    if split_settings.base_url:
+        merged["base_url"] = split_settings.base_url
+    if split_settings.api_key:
+        merged["api_key"] = split_settings.api_key
+    merged["api_key"] = resolve_omni_api_key(merged.get("api_key", ""))
+    return OmniConfig(**merged)
+
+
 class PerceptionEngineProxy:
     """Real perception proxy backed by perception-engine pipeline.
 
@@ -341,11 +366,22 @@ class PerceptionEngineProxy:
             override=engine_cfg.get("identity_engine"),
         )
 
+        # 截图模式双模型拆分：从 settings.model.vision_model / audio_model 构造
+        # 独立 OmniConfig，未配的字段回退到 omni 值。
+        vision_omni_cfg = _build_split_model_config(
+            omni_kwargs, settings.model.vision_model
+        )
+        audio_omni_cfg = _build_split_model_config(
+            omni_kwargs, settings.model.audio_model
+        )
+
         config = PerceptionConfig(
             input=InputConfig(**engine_cfg.get("input", {})),
             gate=GateConfig(**engine_cfg.get("gate", {})),
             identity=IdentityConfig(**identity_kwargs),
             omni=OmniConfig(**omni_kwargs),
+            vision_omni=vision_omni_cfg,
+            audio_omni=audio_omni_cfg,
             identity_engine=identity_engine_cfg,
         )
 

--- a/backend/miloco/src/miloco/perception/collect/adapter_base.py
+++ b/backend/miloco/src/miloco/perception/collect/adapter_base.py
@@ -162,3 +162,9 @@ class BaseDeviceAdapter(ABC):
                     did,
                     e,
                 )
+
+    def pause_streams(self) -> None:
+        """暂停设备数据流（解码器等）。默认 no-op，子类按需覆写。"""
+
+    def resume_streams(self) -> None:
+        """恢复设备数据流。默认 no-op，子类按需覆写。"""

--- a/backend/miloco/src/miloco/perception/collect/camera_adapter.py
+++ b/backend/miloco/src/miloco/perception/collect/camera_adapter.py
@@ -310,6 +310,14 @@ class CameraDeviceAdapter(BaseDeviceAdapter):
 
         state.sync_buffer.clear()
 
+    def pause_streams(self) -> None:
+        """暂停摄像头解码器：P2P 连接保持，帧直接丢弃不走 H.264 解码。"""
+        self._miot_proxy.pause_all_decoders()
+
+    def resume_streams(self) -> None:
+        """恢复摄像头解码器。"""
+        self._miot_proxy.resume_all_decoders()
+
     def collect(self, did: str, *, drain: bool = True) -> DeviceData | None:
         """Collect multimodal data from the device's sync buffer.
 

--- a/backend/miloco/src/miloco/perception/collect/camera_adapter.py
+++ b/backend/miloco/src/miloco/perception/collect/camera_adapter.py
@@ -30,6 +30,7 @@ from miloco.miot.client import MiotProxy
 from miloco.miot.schema import CameraInfo
 from miloco.node_monitor import NodeName, get_monitor
 from miloco.perception.collect.adapter_base import BaseDeviceAdapter
+from miloco.perception.collect.raw_stream_writer import RawStreamWriterManager
 from miloco.perception.collect.stream_buffer import (
     MultiTrackSyncBuffer,
     StreamFragment,
@@ -100,6 +101,8 @@ class _CameraDeviceState:
     # Registration IDs for multi-reg decoded frame callbacks
     decoded_video_reg_id: int = -1
     decoded_audio_reg_id: int = -1
+    # Raw stream mode: True when recording raw H.265 (no decode)
+    raw_stream_active: bool = False
     # Clock calibration: epoch_delta = unix_ms - monotonic_ms (locked on first frame)
     # Used to convert monotonic wall_ms to unix timestamps for display.
     epoch_delta: int | None = None
@@ -115,11 +118,23 @@ class CameraDeviceAdapter(BaseDeviceAdapter):
         self,
         miot_proxy: MiotProxy,
         on_window_ready: Callable[[], None] | None = None,
+        engine_ready_fn: Callable[[], bool] | None = None,
     ):
         self._miot_proxy = miot_proxy
         self._on_window_ready = on_window_ready
+        self._engine_ready_fn = engine_ready_fn
         self._devices: dict[str, _CameraDeviceState] = {}
+
+    def set_engine_ready_fn(self, fn: Callable[[], bool]) -> None:
+        """Set the engine readiness check function (called after pipeline init)."""
+        self._engine_ready_fn = fn
         self._last_ondemand_refresh_ms = 0
+        # Raw stream writer manager — saves H.265 when perception engine not ready
+        collect_cfg = get_settings().perception.collect
+        self._raw_writers = RawStreamWriterManager(
+            save_dir=collect_cfg.raw_stream_save_dir,
+            segment_minutes=collect_cfg.raw_stream_segment_minutes,
+        )
 
     async def discover_devices(
         self,
@@ -253,30 +268,58 @@ class CameraDeviceAdapter(BaseDeviceAdapter):
         )
         self._devices[did] = state
 
-        # Subscribe decoded video frame stream (multi-reg)
-        try:
-            reg_id = await self._miot_proxy.start_camera_decode_video_stream(
-                physical_did, channel, self._make_decoded_video_callback(did)
-            )
-            state.decoded_video_reg_id = reg_id
-        except Exception as e:
-            logger.error("Failed to subscribe decoded video for %s: %s", did, e)
+        # 判断是否使用原始流录制模式（感知引擎未就绪 + 配置了录制目录）
+        use_raw_mode = (
+            self._raw_writers.enabled
+            and self._engine_ready_fn is not None
+            and not self._engine_ready_fn()
+        )
 
-        # Subscribe decoded audio frame stream (multi-reg)
-        try:
-            reg_id = await self._miot_proxy.start_camera_decode_audio_stream(
-                physical_did, channel, self._make_decoded_audio_callback(did)
-            )
-            state.decoded_audio_reg_id = reg_id
-        except Exception as e:
-            logger.error("Failed to subscribe decoded audio for %s: %s", did, e)
+        if use_raw_mode:
+            # 原始流模式：注册 raw_video 回调，直接保存 H.265 数据，不解码
+            try:
+                device_name = source.name if source else did
+                writer = self._raw_writers.get_or_create(did, device_name)
+                if writer:
+                    def _raw_video_cb(did_str, data, ts, seq, ch):
+                        writer.write_frame(data, ts, seq)
 
-        # 两路流都没订上 = camera_img_manager 缺失（典型：登录时相机 LAN 未就绪，
-        # refresh_cameras 没建成 manager，start_*_stream 返回 -1 静默失败）。保留该
-        # device 只会让 active_sources 报「已连」假象，且 did 留在 _devices 使后续
-        # sync 早退、永不重试。剔除它，交给 sync_devices 的按需补建在下轮重连。
-        if state.decoded_video_reg_id < 0 and state.decoded_audio_reg_id < 0:
+                    await self._miot_proxy.register_raw_video_stream(
+                        physical_did, channel, _raw_video_cb
+                    )
+                    state.raw_stream_active = True
+                    logger.info(
+                        "[camera] %s connected in raw stream mode (saving H.265, no decode)",
+                        did,
+                    )
+            except Exception as e:
+                logger.error("Failed to register raw video stream for %s: %s", did, e)
+        else:
+            # 正常模式：订阅解码后的视频/音频帧
+            try:
+                reg_id = await self._miot_proxy.start_camera_decode_video_stream(
+                    physical_did, channel, self._make_decoded_video_callback(did)
+                )
+                state.decoded_video_reg_id = reg_id
+            except Exception as e:
+                logger.error("Failed to subscribe decoded video for %s: %s", did, e)
+
+            try:
+                reg_id = await self._miot_proxy.start_camera_decode_audio_stream(
+                    physical_did, channel, self._make_decoded_audio_callback(did)
+                )
+                state.decoded_audio_reg_id = reg_id
+            except Exception as e:
+                logger.error("Failed to subscribe decoded audio for %s: %s", did, e)
+
+        # 两路流都没订上 = camera_img_manager 缺失
+        if (
+            not state.raw_stream_active
+            and state.decoded_video_reg_id < 0
+            and state.decoded_audio_reg_id < 0
+        ):
             self._devices.pop(did, None)
+            self._raw_writers.close_writer(did)
             logger.warning(
                 "Camera %s stream subscribe failed (manager missing?), "
                 "will retry on next sync",
@@ -292,21 +335,30 @@ class CameraDeviceAdapter(BaseDeviceAdapter):
         # did 是合成 did（多通道带 ``:ch{n}``）；SDK 停流用物理 did + 通道号。
         physical_did, channel = split_channel_did(did)
 
-        if state.decoded_video_reg_id >= 0:
+        if state.raw_stream_active:
+            # 原始流模式：取消 raw_video 回调 + 关闭 writer
             try:
-                await self._miot_proxy.stop_camera_decode_video_stream(
-                    physical_did, channel, state.decoded_video_reg_id
-                )
+                await self._miot_proxy.unregister_raw_video_stream(physical_did, channel)
             except Exception as e:
-                logger.error("Failed to unsubscribe decoded video for %s: %s", did, e)
+                logger.error("Failed to unregister raw video stream for %s: %s", did, e)
+            self._raw_writers.close_writer(did)
+        else:
+            # 正常模式：取消解码回调
+            if state.decoded_video_reg_id >= 0:
+                try:
+                    await self._miot_proxy.stop_camera_decode_video_stream(
+                        physical_did, channel, state.decoded_video_reg_id
+                    )
+                except Exception as e:
+                    logger.error("Failed to unsubscribe decoded video for %s: %s", did, e)
 
-        if state.decoded_audio_reg_id >= 0:
-            try:
-                await self._miot_proxy.stop_camera_decode_audio_stream(
-                    physical_did, channel, state.decoded_audio_reg_id
-                )
-            except Exception as e:
-                logger.error("Failed to unsubscribe decoded audio for %s: %s", did, e)
+            if state.decoded_audio_reg_id >= 0:
+                try:
+                    await self._miot_proxy.stop_camera_decode_audio_stream(
+                        physical_did, channel, state.decoded_audio_reg_id
+                    )
+                except Exception as e:
+                    logger.error("Failed to unsubscribe decoded audio for %s: %s", did, e)
 
         state.sync_buffer.clear()
 
@@ -317,6 +369,24 @@ class CameraDeviceAdapter(BaseDeviceAdapter):
     def resume_streams(self) -> None:
         """恢复摄像头解码器。"""
         self._miot_proxy.resume_all_decoders()
+
+    async def switch_to_decode_mode(self) -> None:
+        """感知引擎就绪后，从原始流模式切换到解码模式。
+
+        断开所有 raw_stream 设备，下一轮 sync_devices 会以解码模式重连。
+        """
+        raw_dids = [
+            did for did, state in self._devices.items() if state.raw_stream_active
+        ]
+        if not raw_dids:
+            return
+        logger.info(
+            "[camera] Switching %d cameras from raw mode to decode mode",
+            len(raw_dids),
+        )
+        for did in raw_dids:
+            await self.disconnect_device(did)
+        # 下一轮 sync_devices 会自动重连（此时 engine 已就绪 → 解码模式）
 
     def collect(self, did: str, *, drain: bool = True) -> DeviceData | None:
         """Collect multimodal data from the device's sync buffer.

--- a/backend/miloco/src/miloco/perception/collect/collector.py
+++ b/backend/miloco/src/miloco/perception/collect/collector.py
@@ -169,6 +169,16 @@ class MultimodalCollector:
         """Get adapter for a specific device type."""
         return self._adapters.get(device_type)
 
+    def pause_streams(self) -> None:
+        """暂停所有设备的数据流（解码器等）。设备保持连接，数据直接丢弃。"""
+        for adapter in self._adapters.values():
+            adapter.pause_streams()
+
+    def resume_streams(self) -> None:
+        """恢复所有设备的数据流。"""
+        for adapter in self._adapters.values():
+            adapter.resume_streams()
+
     async def shutdown(self) -> None:
         """Shutdown all adapters — disconnect all devices."""
         for adapter in self._adapters.values():

--- a/backend/miloco/src/miloco/perception/collect/collector.py
+++ b/backend/miloco/src/miloco/perception/collect/collector.py
@@ -179,6 +179,12 @@ class MultimodalCollector:
         for adapter in self._adapters.values():
             adapter.resume_streams()
 
+    async def switch_to_decode_mode(self) -> None:
+        """感知引擎就绪后，切换所有设备到解码模式。"""
+        for adapter in self._adapters.values():
+            if hasattr(adapter, "switch_to_decode_mode"):
+                await adapter.switch_to_decode_mode()
+
     async def shutdown(self) -> None:
         """Shutdown all adapters — disconnect all devices."""
         for adapter in self._adapters.values():

--- a/backend/miloco/src/miloco/perception/collect/raw_stream_writer.py
+++ b/backend/miloco/src/miloco/perception/collect/raw_stream_writer.py
@@ -1,0 +1,210 @@
+# -*- coding: utf-8 -*-
+"""Raw H.265 stream writer — saves camera video to .hevc files.
+
+When the perception engine is not ready (no API key, omni down, etc.),
+the camera P2P connection stays alive but decoded frames are wasted.
+This module captures the raw encoded stream (before decoding) and saves
+it to disk, organized by camera DID and date.
+
+File layout:
+    {save_dir}/{did}/{YYYY-MM-DD}/{HH-MM-SS}.hevc
+
+Each .hevc file contains Annex-B H.265 NAL units, playable with:
+    ffplay -f hevc 11-00-00.hevc
+    ffmpeg -i 11-00-00.hevc -c copy output.mp4
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+class RawStreamWriter:
+    """Writes raw H.265 stream to segmented .hevc files.
+
+    Thread-safe: the miot raw_data callback runs on the native P2P thread,
+    so all file I/O is serialized via a lock.
+    """
+
+    def __init__(
+        self,
+        did: str,
+        device_name: str,
+        save_dir: str,
+        segment_minutes: int = 60,
+    ):
+        self._did = did
+        self._device_name = device_name
+        self._save_dir = Path(os.path.expanduser(save_dir))
+        self._segment_minutes = segment_minutes
+        self._lock = threading.Lock()
+        self._current_file = None
+        self._current_segment_start = 0  # monotonic time when segment started
+        self._bytes_written = 0
+        self._frames_written = 0
+        self._segment_path: Path | None = None
+
+    def write_frame(self, data: bytes, timestamp: int, sequence: int) -> None:
+        """Write one raw video frame to the current segment file.
+
+        Called from the miot native thread (via __on_raw_data → raw_video callback).
+        """
+        with self._lock:
+            try:
+                self._maybe_rotate_segment(timestamp)
+                if self._current_file is not None:
+                    self._current_file.write(data)
+                    self._bytes_written += len(data)
+                    self._frames_written += 1
+            except Exception as e:
+                logger.error(
+                    "[raw-writer] Failed to write frame for %s: %s",
+                    self._did, e,
+                )
+
+    def close(self) -> None:
+        """Close the current segment file."""
+        with self._lock:
+            self._close_current_file()
+
+    @property
+    def is_active(self) -> bool:
+        with self._lock:
+            return self._current_file is not None
+
+    @property
+    def stats(self) -> dict:
+        with self._lock:
+            return {
+                "did": self._did,
+                "bytes_written": self._bytes_written,
+                "frames_written": self._frames_written,
+                "current_segment": str(self._segment_path) if self._segment_path else None,
+            }
+
+    def _maybe_rotate_segment(self, timestamp: int) -> None:
+        """Rotate to a new segment file if needed."""
+        now = time.monotonic()
+        need_rotate = (
+            self._current_file is None
+            or (now - self._current_segment_start) >= self._segment_minutes * 60
+        )
+
+        if not need_rotate:
+            return
+
+        self._close_current_file()
+        self._open_new_segment(timestamp)
+
+    def _open_new_segment(self, timestamp: int) -> None:
+        """Open a new segment file based on current time."""
+        now = datetime.now()
+        date_str = now.strftime("%Y-%m-%d")
+        time_str = now.strftime("%H-%M-%S")
+
+        # {save_dir}/{did}-{device_name}/{date}/{time}.hevc
+        dir_name = f"{self._did}-{self._sanitize_name(self._device_name)}"
+        segment_dir = self._save_dir / dir_name / date_str
+        segment_dir.mkdir(parents=True, exist_ok=True)
+
+        segment_path = segment_dir / f"{time_str}.hevc"
+
+        try:
+            self._current_file = open(segment_path, "ab")  # append mode
+            self._segment_path = segment_path
+            self._current_segment_start = time.monotonic()
+            logger.info(
+                "[raw-writer] Opened segment: %s (camera=%s)",
+                segment_path, self._did,
+            )
+        except Exception as e:
+            logger.error(
+                "[raw-writer] Failed to open segment %s: %s",
+                segment_path, e,
+            )
+            self._current_file = None
+
+    def _close_current_file(self) -> None:
+        """Close the current file handle."""
+        if self._current_file is not None:
+            try:
+                self._current_file.close()
+                if self._segment_path:
+                    size_mb = self._segment_path.stat().st_size / (1024 * 1024)
+                    logger.info(
+                        "[raw-writer] Closed segment: %s (%.1fMB, %d frames)",
+                        self._segment_path, size_mb, self._frames_written,
+                    )
+            except Exception as e:
+                logger.error("[raw-writer] Error closing file: %s", e)
+            finally:
+                self._current_file = None
+                self._segment_path = None
+
+    @staticmethod
+    def _sanitize_name(name: str) -> str:
+        """Sanitize device name for use in file paths."""
+        return "".join(c if c.isalnum() or c in "-_" else "_" for c in name)[:30]
+
+
+class RawStreamWriterManager:
+    """Manages RawStreamWriter instances for multiple cameras."""
+
+    def __init__(self, save_dir: str | None, segment_minutes: int = 60):
+        self._save_dir = save_dir
+        self._segment_minutes = segment_minutes
+        self._writers: dict[str, RawStreamWriter] = {}
+        self._lock = threading.Lock()
+
+    @property
+    def enabled(self) -> bool:
+        return self._save_dir is not None
+
+    def get_or_create(
+        self, did: str, device_name: str
+    ) -> RawStreamWriter | None:
+        """Get or create a writer for the given camera."""
+        if not self.enabled:
+            return None
+
+        with self._lock:
+            if did not in self._writers:
+                self._writers[did] = RawStreamWriter(
+                    did=did,
+                    device_name=device_name,
+                    save_dir=self._save_dir,
+                    segment_minutes=self._segment_minutes,
+                )
+                logger.info(
+                    "[raw-writer] Created writer for camera %s (%s)",
+                    did, device_name,
+                )
+            return self._writers[did]
+
+    def close_writer(self, did: str) -> None:
+        """Close and remove a writer."""
+        with self._lock:
+            writer = self._writers.pop(did, None)
+            if writer:
+                writer.close()
+                logger.info("[raw-writer] Closed writer for camera %s", did)
+
+    def close_all(self) -> None:
+        """Close all writers."""
+        with self._lock:
+            for did, writer in self._writers.items():
+                writer.close()
+            self._writers.clear()
+            logger.info("[raw-writer] Closed all writers")
+
+    def get_stats(self) -> list[dict]:
+        """Get stats for all active writers."""
+        with self._lock:
+            return [w.stats for w in self._writers.values()]

--- a/backend/miloco/src/miloco/perception/engine/config.py
+++ b/backend/miloco/src/miloco/perception/engine/config.py
@@ -28,6 +28,10 @@ class InputConfig:
     # 实测:小目标清晰度主要由输入像素分辨率(video_short_edge)决定,本档位只控每帧 token 预算,
     # 故默认 low;identity 等细节敏感场景可经 CLI 切 high。运行时由 GeminiAdapter 实时读 settings。
     media_resolution: str = ""
+    # 传输模式: "video" = 编码为 mp4(H.264+AAC) 发送(默认,兼容性最好);
+    # "screenshot" = 编码为 JPEG 图片序列 + 独立音频发送(跳过 H.264 编码, CPU/内存占用显著降低)。
+    # 截图模式复用 omni_fps 控制帧率。音频始终独立编码为 m4a/wav/mp3。
+    transmission_mode: str = "video"
 
 
 @dataclass
@@ -356,6 +360,10 @@ class PerceptionConfig:
     gate: GateConfig = field(default_factory=GateConfig)
     identity: IdentityConfig = field(default_factory=IdentityConfig)
     omni: OmniConfig = field(default_factory=OmniConfig)
+    # 截图模式双模型拆分（可选）：配了则 screenshot 模式下并发调用两个专用模型。
+    # 未配时 screenshot 模式仍用单 omni 模型发图片+音频。
+    vision_omni: OmniConfig | None = None
+    audio_omni: OmniConfig | None = None
     identity_engine: IdentityEngineConfig = field(default_factory=IdentityEngineConfig)
 
 

--- a/backend/miloco/src/miloco/perception/engine/identity/default_config.yaml
+++ b/backend/miloco/src/miloco/perception/engine/identity/default_config.yaml
@@ -46,7 +46,7 @@ deep_sort:
   track_human_only: true
   # fast 模式(静止 track 跳过 ReID 推理,降 CPU)
   mode: "fast"                       # "normal" / "fast"
-  human_reid_skip_windows: 4         # CPU 紧张时调高(降 ReID 抽取频次)
+  human_reid_skip_windows: 8         # CPU 紧张时调高(降 ReID 抽取频次)
 
 # Pending State 置信度感知 commit + recheck hysteresis
 # 单次 omni 识别可能误判，按 best_conf 决定需要几次同答才 commit；

--- a/backend/miloco/src/miloco/perception/engine/omni/circuit_breaker.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/circuit_breaker.py
@@ -329,6 +329,12 @@ class OmniCircuitBreaker:
                 retry_available_in_seconds=retry_avail_s,
             )
 
+    @property
+    def current_state(self) -> CircuitState:
+        """公共只读属性：当前熔断器状态。线程安全。"""
+        with self._lock:
+            return self._state
+
     def state_for_test(self) -> CircuitState:
         with self._lock:
             return self._state

--- a/backend/miloco/src/miloco/perception/engine/omni/omni.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/omni.py
@@ -93,6 +93,12 @@ async def run_omni(
     edge_packet: IdentityPacket, context: OmniContext, config: OmniConfig
 ) -> OmniOutput:
     """Run Omni layer: build prompt → call model → parse response."""
+    # 截图模式双模型拆分
+    vision_cfg, audio_cfg = resolve_split_model_configs(config)
+    if vision_cfg and audio_cfg:
+        return await run_omni_split(
+            [edge_packet], context, vision_cfg, audio_cfg,
+        )
     payload = build_prompt(edge_packet, context)
     raw_response = await call_omni(payload, config)
     output = parse_omni_response(raw_response, _rule_name_to_id(context))
@@ -104,11 +110,177 @@ async def run_omni_batch(
     edge_packets: list[IdentityPacket], context: OmniContext, config: OmniConfig
 ) -> OmniOutput:
     """Run Omni layer for multiple devices in the same room."""
+    # 截图模式双模型拆分
+    vision_cfg, audio_cfg = resolve_split_model_configs(config)
+    if vision_cfg and audio_cfg:
+        return await run_omni_split(
+            edge_packets, context, vision_cfg, audio_cfg,
+        )
     payload = build_batch_prompt(edge_packets, context)
     raw_response = await call_omni(payload, config)
     output = parse_omni_response(raw_response, _rule_name_to_id(context))
     output.usage = extract_usage(raw_response)
     return output
+
+
+# =============================================================================
+# 截图模式双模型拆分 —— vision + audio 并发调用
+# =============================================================================
+
+
+def resolve_split_model_configs(
+    base_config: OmniConfig,
+) -> tuple[OmniConfig | None, OmniConfig | None]:
+    """从当前 settings 解析 vision/audio 模型配置。
+
+    返回 ``(vision_config, audio_config)``；任一为 None 表示不启用拆分。
+    仅当 transmission_mode=screenshot 且两个 split model 都已配置时才返回非 None。
+    """
+    from dataclasses import replace
+
+    from miloco.config import get_settings
+    from miloco.perception.engine.config import OmniConfig
+
+    settings = get_settings()
+    engine_input = settings.perception.engine.get("input", {})
+    if engine_input.get("transmission_mode") != "screenshot":
+        return None, None
+
+    vision_s = settings.model.vision_model
+    audio_s = settings.model.audio_model
+    if vision_s is None or audio_s is None:
+        return None, None
+
+    # 构造 vision config：未配字段回退到 base_config（omni）
+    vision_cfg = replace(
+        base_config,
+        model=vision_s.model or base_config.model,
+        base_url=vision_s.base_url or base_config.base_url,
+        api_key=vision_s.api_key or base_config.api_key,
+    )
+    # 构造 audio config
+    audio_cfg = replace(
+        base_config,
+        model=audio_s.model or base_config.model,
+        base_url=audio_s.base_url or base_config.base_url,
+        api_key=audio_s.api_key or base_config.api_key,
+    )
+    return vision_cfg, audio_cfg
+
+
+def _merge_split_outputs(vision_out: OmniOutput, audio_out: OmniOutput) -> OmniOutput:
+    """合并 vision 和 audio 模型的输出。
+
+    规则：vision 取 caption/identities/matched_rules/suggestions，
+    audio 取 speeches/env_sounds。usage 合并。
+    """
+    merged = vision_out.model_copy()
+    merged.speeches = audio_out.speeches
+    merged.env_sounds = audio_out.env_sounds
+    # 合并 usage
+    if vision_out.usage or audio_out.usage:
+        v = vision_out.usage or {}
+        a = audio_out.usage or {}
+        merged.usage = {
+            "input_tokens": v.get("input_tokens", 0) + a.get("input_tokens", 0),
+            "output_tokens": v.get("output_tokens", 0) + a.get("output_tokens", 0),
+            "cached_tokens": v.get("cached_tokens", 0) + a.get("cached_tokens", 0),
+        }
+    return merged
+
+
+def _build_vision_only_payload(
+    edge_packets: list[IdentityPacket],
+    context: OmniContext,
+    stream: bool = False,
+    label_lookup: "dict[str, str] | None" = None,
+) -> dict:
+    """构建仅含视觉信息的 payload（剥离音频 schema 字段）。
+
+    与 _build_payload 的区别：SceneDescriptor 的 has_audio=False，
+    使 schema 剥离 speeches/env_sounds 字段（视觉模型不需要输出这些）。
+    """
+    from miloco.perception.engine.omni.field_registry import SceneDescriptor
+    from miloco.perception.engine.omni.prompt_builder import (
+        _build_user_content,
+        _encode_batch_screenshots,
+        _get_video_short_edge,
+        build_system_prompt,
+    )
+
+    short_edge = _get_video_short_edge()
+    screenshots_b64, media_info = _encode_batch_screenshots(edge_packets, short_edge=short_edge)
+    # 视觉专用：has_audio=False → schema 剥掉 speeches/env_sounds
+    scene = SceneDescriptor(
+        route="video", has_identity=False, stream=stream,
+        has_audio=False, has_speech=False,
+    )
+    return {
+        "system_prompt": build_system_prompt(scene, include_home_profile=True),
+        "user_content": _build_user_content(edge_packets, context, stream=stream, label_lookup=label_lookup),
+        "screenshots_b64": screenshots_b64,
+        "media_info": media_info,
+        "crops": [],
+    }
+
+
+def _build_audio_only_payload(
+    edge_packets: list[IdentityPacket],
+    context: OmniContext,
+) -> dict:
+    """构建仅含音频信息的 payload（复用 audio route 逻辑）。
+
+    与 audio route 完全一致：has_audio=True，schema 只含 speeches/env_sounds/suggestions。
+    """
+    from miloco.perception.engine.omni.field_registry import SceneDescriptor
+    from miloco.perception.engine.omni.prompt_builder import (
+        _build_user_content,
+        _encode_audio,
+        _audio_only_media_info,
+        build_system_prompt,
+    )
+    from miloco.config import get_settings
+
+    scene = SceneDescriptor(
+        route="audio", has_identity=False, stream=False,
+        has_audio=True, has_speech=True,
+    )
+    ep = edge_packets[0]
+    audio_format = get_settings().model.omni.audio_format or "m4a"
+    audio_result = _encode_audio(ep.audio_clip, ep.sample_rate, audio_format)
+    return {
+        "system_prompt": build_system_prompt(scene, include_home_profile=True),
+        "user_content": _build_user_content(edge_packets, context, stream=False),
+        "audio_base64": audio_result[0] if audio_result else None,
+        "audio_format": audio_result[1] if audio_result else audio_format,
+        "media_info": _audio_only_media_info(ep.sample_rate),
+        "crops": [],
+    }
+
+
+async def run_omni_split(
+    edge_packets: list[IdentityPacket],
+    context: OmniContext,
+    vision_config: OmniConfig,
+    audio_config: OmniConfig,
+    label_lookup: "dict[str, str] | None" = None,
+) -> OmniOutput:
+    """截图模式双模型拆分：并发调用 vision 和 audio 模型，合并结果。"""
+    vision_payload = _build_vision_only_payload(edge_packets, context, label_lookup=label_lookup)
+    audio_payload = _build_audio_only_payload(edge_packets, context)
+
+    vision_task = call_omni(vision_payload, vision_config)
+    audio_task = call_omni(audio_payload, audio_config)
+
+    vision_raw, audio_raw = await asyncio.gather(vision_task, audio_task)
+
+    vision_out = parse_omni_response(vision_raw, _rule_name_to_id(context))
+    vision_out.usage = extract_usage(vision_raw)
+
+    audio_out = parse_omni_response(audio_raw, _rule_name_to_id(context))
+    audio_out.usage = extract_usage(audio_raw)
+
+    return _merge_split_outputs(vision_out, audio_out)
 
 
 # =============================================================================
@@ -179,18 +351,42 @@ async def run_omni_fused(
     # 永远不会被 GC（_gc_dead_tracks 跳过 inflight）也不会被重新派发
     # （needs_omni_call 返回 False）。
     adapter = get_adapter(config.model)
+
+    # 截图模式双模型拆分检测
+    vision_cfg, audio_cfg = resolve_split_model_configs(config)
+    use_split = vision_cfg is not None and audio_cfg is not None
+
     try:
-        payload = build_fused_payload(
-            packets=edge_packets,
-            context=context,
-            candidates=candidates,
-            gallery_snapshot=gallery_snapshot,
-            config=fused_prompt_config,
-            label_lookup=name_lookup,
-            adapter=adapter,
-            matching_moot=person_lib_empty,
-        )
-        raw_response = await _call_omni_messages(payload["messages"], config, adapter=adapter)
+        if use_split:
+            # 双模型拆分：vision（fused，无音频 schema）+ audio（audio-only）并发
+            vision_payload = build_fused_payload(
+                packets=edge_packets,
+                context=context,
+                candidates=candidates,
+                gallery_snapshot=gallery_snapshot,
+                config=fused_prompt_config,
+                label_lookup=name_lookup,
+                adapter=adapter,
+                matching_moot=person_lib_empty,
+                force_no_audio=True,
+            )
+            audio_payload = _build_audio_only_payload(edge_packets, context)
+            vision_task = _call_omni_messages(vision_payload["messages"], config, adapter=adapter)
+            audio_task = call_omni(audio_payload, audio_cfg)
+            raw_response, audio_raw_response = await asyncio.gather(vision_task, audio_task)
+        else:
+            payload = build_fused_payload(
+                packets=edge_packets,
+                context=context,
+                candidates=candidates,
+                gallery_snapshot=gallery_snapshot,
+                config=fused_prompt_config,
+                label_lookup=name_lookup,
+                adapter=adapter,
+                matching_moot=person_lib_empty,
+            )
+            raw_response = await _call_omni_messages(payload["messages"], config, adapter=adapter)
+            audio_raw_response = None
     except OmniError as e:
         # omni API / 网络错:_call_omni_messages 已在源头打日志(omni API 调用失败),
         # 这里只做 inflight track 清理 + 上抛,不重复打。
@@ -210,6 +406,21 @@ async def run_omni_fused(
     try:
         omni_output = parse_omni_response(raw_response, _rule_name_to_id(context))
         omni_output.usage = extract_usage(raw_response)
+
+        # 双模型拆分：合并 audio 模型的 speeches/env_sounds
+        if use_split and audio_raw_response is not None:
+            audio_output = parse_omni_response(audio_raw_response, _rule_name_to_id(context))
+            omni_output.speeches = audio_output.speeches
+            omni_output.env_sounds = audio_output.env_sounds
+            audio_usage = extract_usage(audio_raw_response)
+            if omni_output.usage or audio_usage:
+                v = omni_output.usage or {}
+                a = audio_usage or {}
+                omni_output.usage = {
+                    "input_tokens": v.get("input_tokens", 0) + a.get("input_tokens", 0),
+                    "output_tokens": v.get("output_tokens", 0) + a.get("output_tokens", 0),
+                    "cached_tokens": v.get("cached_tokens", 0) + a.get("cached_tokens", 0),
+                }
 
         # 抽 identity_assignments 并写回 state（仅当有 candidate 才有意义）
         if candidates:

--- a/backend/miloco/src/miloco/perception/engine/omni/omni_client.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/omni_client.py
@@ -360,7 +360,17 @@ def _build_messages(payload: dict, adapter: OmniProviderAdapter) -> list[dict]:
 
     media_info = payload.get("media_info")
 
-    if payload.get("video_base64"):
+    if payload.get("screenshots_b64"):
+        # 截图模式：每张 JPEG 作为独立 image_url 块 + 独立音频块
+        for img_b64 in payload["screenshots_b64"]:
+            content.append({
+                "type": "image_url",
+                "image_url": {"url": f"data:image/jpeg;base64,{img_b64}"},
+            })
+        if payload.get("audio_base64"):
+            audio_format = payload.get("audio_format", "m4a")
+            content.append(adapter.build_audio_block(payload["audio_base64"], media_info, audio_format))
+    elif payload.get("video_base64"):
         content.append(adapter.build_video_block(payload["video_base64"], media_info))
     elif payload.get("audio_base64"):
         audio_format = payload.get("audio_format", "m4a")

--- a/backend/miloco/src/miloco/perception/engine/omni/omni_client.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/omni_client.py
@@ -363,7 +363,8 @@ def _build_messages(payload: dict, adapter: OmniProviderAdapter) -> list[dict]:
     if payload.get("video_base64"):
         content.append(adapter.build_video_block(payload["video_base64"], media_info))
     elif payload.get("audio_base64"):
-        content.append(adapter.build_audio_block(payload["audio_base64"], media_info))
+        audio_format = payload.get("audio_format", "m4a")
+        content.append(adapter.build_audio_block(payload["audio_base64"], media_info, audio_format))
 
     # Crop images (from tracker)
     for crop in payload.get("crops", []):

--- a/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
@@ -56,7 +56,7 @@ from .field_registry import SceneDescriptor, render_field_spec, render_schema
 from .home_profile_loader import get_home_profile_prefix
 from .provider import LocalMediaInfo, OmniProviderAdapter
 
-RouteType = Literal["video", "audio"]
+RouteType = Literal["video", "audio", "screenshot"]
 
 if TYPE_CHECKING:
     from miloco.perception.engine.identity.dispatcher import IdentityQueryItem
@@ -156,14 +156,33 @@ def build_query_prompt(
     if home_profile:
         parts.append(home_profile)
     short_edge = _get_video_short_edge()
-    video_b64, media_info = _encode_batch_video(identity_packets, short_edge=short_edge)
-    return {
-        "system_prompt": "\n\n".join(parts),
-        "user_content": _build_query_user_content(identity_packets, query, last_caption, label_lookup),
-        "video_base64": video_b64,
-        "media_info": media_info,
-        "crops": [],
-    }
+    if _get_transmission_mode() == "screenshot":
+        screenshots_b64, media_info = _encode_batch_screenshots(identity_packets, short_edge=short_edge)
+        result: dict = {
+            "system_prompt": "\n\n".join(parts),
+            "user_content": _build_query_user_content(identity_packets, query, last_caption, label_lookup),
+            "screenshots_b64": screenshots_b64,
+            "media_info": media_info,
+            "crops": [],
+        }
+        # 音频独立编码
+        ep = next((p for p in identity_packets if p.all_frames), identity_packets[0])
+        if _packet_audio_included(ep):
+            from miloco.config import get_settings
+            audio_format = get_settings().model.omni.audio_format or "m4a"
+            audio_result = _encode_audio(ep.audio_clip, ep.sample_rate, audio_format)
+            result["audio_base64"] = audio_result[0] if audio_result else None
+            result["audio_format"] = audio_result[1] if audio_result else audio_format
+        return result
+    else:
+        video_b64, media_info = _encode_batch_video(identity_packets, short_edge=short_edge)
+        return {
+            "system_prompt": "\n\n".join(parts),
+            "user_content": _build_query_user_content(identity_packets, query, last_caption, label_lookup),
+            "video_base64": video_b64,
+            "media_info": media_info,
+            "crops": [],
+        }
 
 
 def build_fused_payload(
@@ -175,6 +194,7 @@ def build_fused_payload(
     label_lookup: "dict[str, str] | None" = None,
     adapter: OmniProviderAdapter | None = None,
     matching_moot: bool = False,
+    force_no_audio: bool = False,
 ) -> dict:
     """构造 fused 主调用的 payload（身份识别和场景理解合并到同一次 omni 调用）。
 
@@ -257,16 +277,38 @@ def build_fused_payload(
             "candidate_track_ids": [],
         }
 
+    route = _resolve_route(packets)
     short_edge = _get_video_short_edge()
-    video_b64, media_info = _encode_batch_video(packets, short_edge=short_edge)
+
+    # 截图模式：编码 JPEG 列表 + 独立音频；视频模式：编码 mp4（含音频）
+    if route == "screenshot":
+        screenshots_b64, media_info = _encode_batch_screenshots(packets, short_edge=short_edge)
+        video_b64 = None
+        # 音频独立编码（force_no_audio 时跳过——双模型拆分 vision-only 调用）
+        ep = next((p for p in packets if p.all_frames), packets[0])
+        screenshot_audio_b64 = None
+        screenshot_audio_format = "m4a"
+        if not force_no_audio and _packet_audio_included(ep):
+            from miloco.config import get_settings
+            audio_format = get_settings().model.omni.audio_format or "m4a"
+            audio_result = _encode_audio(ep.audio_clip, ep.sample_rate, audio_format)
+            screenshot_audio_b64 = audio_result[0] if audio_result else None
+            screenshot_audio_format = audio_result[1] if audio_result else audio_format
+    else:
+        screenshots_b64 = None
+        screenshot_audio_b64 = None
+        screenshot_audio_format = "m4a"
+        video_b64, media_info = _encode_batch_video(packets, short_edge=short_edge)
 
     # has_speech 只由本轮 VAD 决定：本轮真有人声（含 pending 的延续语音）→ VAD 自然过、
     # 保留 speeches、模型把 <pending_speech> 拼成完整句；本轮无人声 → 剥 speeches，挂着的
     # pending 半句不强行补全（否则模型会就着噪声脑补出一个完成句，正是要根除的幻觉）。
+    # force_no_audio 时 has_audio/has_speech 强制 False（双模型拆分 vision-only 用）。
+    scene_has_audio = False if force_no_audio else _batch_video_has_audio(packets)
+    scene_has_speech = False if force_no_audio else _batch_video_has_speech(packets)
     scene = SceneDescriptor(
         route="video", has_identity=bool(candidates), stream=False,
-        has_audio=_batch_video_has_audio(packets),
-        has_speech=_batch_video_has_speech(packets),
+        has_audio=scene_has_audio, has_speech=scene_has_speech,
         identity_match_disabled=matching_moot,
     )
     system_prompt = build_system_prompt(scene, include_home_profile=False)
@@ -281,6 +323,10 @@ def build_fused_payload(
         cfg=cfg,
         label_lookup=label_lookup,
         matching_moot=matching_moot,
+        screenshots_b64=screenshots_b64,
+        screenshot_audio_b64=screenshot_audio_b64,
+        screenshot_audio_format=screenshot_audio_format,
+        force_no_audio=force_no_audio,
     )
 
     messages = _assemble_fused_messages(
@@ -379,8 +425,11 @@ def _build_payload(
     # 拼接照常；本轮无人声 → 剥 speeches，挂着的 pending 半句不强行补全（否则模型会就着
     # 噪声脑补出完成句，正是要根除的幻觉）。
     has_speech = True if route == "audio" else _batch_video_has_speech(packets)
+    # SceneDescriptor.route 只有 "video" / "audio"（决定 prompt/schema）；
+    # screenshot 对 prompt/schema 等价于 video（有视觉信息）。
+    prompt_route: Literal["video", "audio"] = "audio" if route == "audio" else "video"
     scene = SceneDescriptor(
-        route=route, has_identity=False, stream=stream,
+        route=prompt_route, has_identity=False, stream=stream,
         has_audio=has_audio, has_speech=has_speech,
     )
     base: dict = {
@@ -398,6 +447,19 @@ def _build_payload(
         base["audio_base64"] = audio_result[0] if audio_result else None
         base["audio_format"] = audio_result[1] if audio_result else audio_format
         base["media_info"] = _audio_only_media_info(ep.sample_rate)
+    elif route == "screenshot":
+        short_edge = _get_video_short_edge()
+        screenshots_b64, media_info = _encode_batch_screenshots(packets, short_edge=short_edge)
+        base["screenshots_b64"] = screenshots_b64
+        base["media_info"] = media_info
+        # 截图模式下音频独立编码
+        ep = next((p for p in packets if p.all_frames), packets[0])
+        if _packet_audio_included(ep):
+            from miloco.config import get_settings
+            audio_format = get_settings().model.omni.audio_format or "m4a"
+            audio_result = _encode_audio(ep.audio_clip, ep.sample_rate, audio_format)
+            base["audio_base64"] = audio_result[0] if audio_result else None
+            base["audio_format"] = audio_result[1] if audio_result else audio_format
     else:
         short_edge = _get_video_short_edge()
         video_b64, media_info = _encode_batch_video(packets, short_edge=short_edge)
@@ -565,7 +627,8 @@ def _build_user_content(
     # 非 fused 兜底路径：单条 user 文本，规则 + 历史 + 本轮事实内联（fused 路径才把它们
     # 拆成独立 message）。规则用新「# 待判断规则」格式，与 fused 一致。
     parts: list[str] = []
-    is_video = _resolve_route(packets) == "video"
+    route = _resolve_route(packets)
+    is_video = route in ("video", "screenshot")
     # matched_rules 仅 video 路由有（audio-only 剥离）→ audio 不下发「# 待判断规则」段
     if is_video:
         rule_conditions = _render_rule_conditions(context)
@@ -596,6 +659,10 @@ def _build_fused_user_content(
     cfg: FusedPromptConfig,
     label_lookup: "dict[str, str] | None" = None,
     matching_moot: bool = False,
+    screenshots_b64: list[str] | None = None,
+    screenshot_audio_b64: str | None = None,
+    screenshot_audio_format: str = "m4a",
+    force_no_audio: bool = False,
 ) -> list[dict]:
     """构建 user 消息的 content 列表（text/image_url/video_url 块交错）。
 
@@ -605,6 +672,8 @@ def _build_fused_user_content(
     ``matching_moot=True``（身份库为空）时整个 gallery 段不渲染——库空无成员可比对，
     identities 已由精简版 spec 指示"只判 unknown/no_person"（见 build_fused_payload），
     此处不再塞"<gallery>库为空…"这类无用文本。待识别 track 列表仍照常渲染（no_person 判定按 track 给结论）。
+
+    ``force_no_audio=True`` 时跳过音频块构建（双模型拆分的 vision-only 调用用）。
     """
     gallery_content: list[dict] = []
 
@@ -720,11 +789,28 @@ def _build_fused_user_content(
     # 4. gallery（候选成员参考图，紧邻 video 便于视觉比对）
     content.extend(gallery_content)
 
-    # 5. 主 video
-    # video_b64 size sanity check — PyAV 编码异常情况下可能返回非空但损坏的极短
-    # base64 串, 入 payload 会让 omni 服务端 400 Multimodal data is corrupted。
-    # 太短 → 跳过 video_url 块, 退化为"无视频窗口"(text + gallery 仍能识别)。
-    if video_b64 and len(video_b64) >= _MIN_VIDEO_B64_LEN:
+    # 5. 主视觉（video 或 screenshot）+ 音频
+    if screenshots_b64:
+        # 截图模式：每张 JPEG 作为独立 image_url 块
+        for i, img_b64 in enumerate(screenshots_b64):
+            if len(img_b64) >= _MIN_JPEG_BYTES:
+                content.append(_jpeg_block(base64.b64decode(img_b64)))
+            else:
+                logger.warning(
+                    "event=fused_screenshot_b64_too_short idx=%d size=%d (< %d), 跳过",
+                    i, len(img_b64), _MIN_JPEG_BYTES,
+                )
+        # 音频独立发送（force_no_audio 时跳过——双模型拆分的 vision-only 调用）
+        if not force_no_audio and screenshot_audio_b64 and len(screenshot_audio_b64) >= _MIN_AUDIO_B64_LEN:
+            content.append(adapter.build_audio_block(
+                screenshot_audio_b64, media_info, screenshot_audio_format,
+            ))
+        elif screenshot_audio_b64:
+            logger.warning(
+                "event=fused_screenshot_audio_b64_too_short size=%d (< %d), 跳过",
+                len(screenshot_audio_b64), _MIN_AUDIO_B64_LEN,
+            )
+    elif video_b64 and len(video_b64) >= _MIN_VIDEO_B64_LEN:
         content.append(adapter.build_video_block(video_b64, media_info))
     elif video_b64:
         logger.warning(
@@ -1119,6 +1205,15 @@ def _get_video_short_edge() -> int:
         return get_settings().perception.engine.get("input", {}).get("video_short_edge", _VIDEO_SHORT_EDGE)
     except Exception:
         return _VIDEO_SHORT_EDGE
+
+
+def _get_transmission_mode() -> str:
+    """读取传输模式配置: "video"(默认) 或 "screenshot"。"""
+    try:
+        from miloco.config import get_settings
+        return get_settings().perception.engine.get("input", {}).get("transmission_mode", "video")
+    except Exception:
+        return "video"
 _CROP_SIZE = (512, 512)
 
 # 多模态 payload sanity check 下限 — 防"非 None 但实际损坏"的 bytes 入 payload
@@ -1295,6 +1390,63 @@ def _encode_video_mp4(
             os.unlink(tmp_path)
 
 
+def _encode_frames_jpeg(
+    frames: list[NDArray[np.uint8]],
+    short_edge: int = _VIDEO_SHORT_EDGE,
+    jpeg_quality: int = 80,
+) -> tuple[list[str], LocalMediaInfo]:
+    """将 BGR 帧编码为 JPEG base64 字符串列表（截图模式专用）。
+
+    与 _encode_video_mp4 的区别：跳过 H.264 编码，每帧独立编码为 JPEG，
+    无临时文件 I/O，CPU/内存占用显著降低。
+
+    Returns ``(list[base64_str], media_info)``。
+    """
+    if not frames:
+        return [], LocalMediaInfo(
+            video_width=0, video_height=0, fps=0, frame_count=0,
+            has_audio=False, audio_sample_rate=0,
+        )
+
+    h0, w0 = frames[0].shape[:2]
+    scale = short_edge / min(h0, w0)
+    target_w = int(w0 * scale) // 2 * 2
+    target_h = int(h0 * scale) // 2 * 2
+
+    encode_params = [cv2.IMWRITE_JPEG_QUALITY, jpeg_quality]
+    result: list[str] = []
+    for frame_data in frames:
+        resized = cv2.resize(frame_data, (target_w, target_h), interpolation=cv2.INTER_AREA)
+        ok, buf = cv2.imencode(".jpg", resized, encode_params)
+        if ok:
+            result.append(base64.b64encode(buf.tobytes()).decode())
+
+    media_info = LocalMediaInfo(
+        video_width=target_w,
+        video_height=target_h,
+        fps=0,  # 截图模式无连续帧率概念
+        frame_count=len(result),
+        has_audio=False,
+        audio_sample_rate=0,
+    )
+    return result, media_info
+
+
+def _encode_batch_screenshots(
+    edge_packets: list[IdentityPacket],
+    short_edge: int = _VIDEO_SHORT_EDGE,
+) -> tuple[list[str], LocalMediaInfo]:
+    """从首个有 frames 的 device 编码截图列表。与 _encode_batch_video 口径一致。"""
+    for ep in edge_packets:
+        b64_list, media_info = _encode_frames_jpeg(ep.all_frames, short_edge=short_edge)
+        if b64_list:
+            return b64_list, media_info
+    return [], LocalMediaInfo(
+        video_width=0, video_height=0, fps=0, frame_count=0,
+        has_audio=False, audio_sample_rate=0,
+    )
+
+
 # =============================================================================
 # Crop encoding (tracker crop images)
 # =============================================================================
@@ -1339,12 +1491,17 @@ def _is_audio_only(packets: list[IdentityPacket]) -> bool:
 
 
 def _resolve_route(packets: list[IdentityPacket]) -> RouteType:
-    """决定本次调用走 video route 还是 audio route。
+    """决定本次调用走 video / audio / screenshot route。
 
     - audio：所有 packet 都满足 audio_active=True 且 visual_changed=False
+    - screenshot：配置为 screenshot 传输模式且非 audio-only
     - video：其他所有情况（含 batch 混合、trigger=None 兼容旧路径）
     """
-    return "audio" if _is_audio_only(packets) else "video"
+    if _is_audio_only(packets):
+        return "audio"
+    if _get_transmission_mode() == "screenshot":
+        return "screenshot"
+    return "video"
 
 
 def _encode_audio_only_mp4(

--- a/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
@@ -228,6 +228,7 @@ def build_fused_payload(
         system_prompt = build_system_prompt(scene, include_home_profile=False)
         ep = packets[0]
         # 获取配置的音频格式
+        from miloco.config import get_settings
         audio_format = get_settings().model.omni.audio_format or "m4a"
         audio_result = _encode_audio(ep.audio_clip, ep.sample_rate, audio_format)
         audio_b64 = audio_result[0] if audio_result else None

--- a/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
@@ -227,14 +227,18 @@ def build_fused_payload(
         scene = SceneDescriptor(route="audio", has_identity=False, stream=False)
         system_prompt = build_system_prompt(scene, include_home_profile=False)
         ep = packets[0]
-        audio_b64 = _encode_audio_only_mp4(ep.audio_clip, ep.sample_rate)
+        # 获取配置的音频格式
+        audio_format = get_settings().model.omni.audio_format or "m4a"
+        audio_result = _encode_audio(ep.audio_clip, ep.sample_rate, audio_format)
+        audio_b64 = audio_result[0] if audio_result else None
+        actual_format = audio_result[1] if audio_result else audio_format
         user_content: list[dict] = []
         if context.current_time:
             user_content.append({"type": "text", "text": f"当前时间: {context.current_time}"})
         if context.room_name:
             user_content.append({"type": "text", "text": f"位置: {context.room_name}"})
         if audio_b64 and len(audio_b64) >= _MIN_AUDIO_B64_LEN:
-            user_content.append(adapter.build_audio_block(audio_b64, _audio_only_media_info(ep.sample_rate)))
+            user_content.append(adapter.build_audio_block(audio_b64, _audio_only_media_info(ep.sample_rate), actual_format))
         elif audio_b64:
             logger.warning(
                 "event=fused_audio_b64_too_short size=%d (< %d), 跳过 input_audio 块, "
@@ -387,7 +391,11 @@ def _build_payload(
     }
     if route == "audio":
         ep = packets[0]
-        base["audio_base64"] = _encode_audio_only_mp4(ep.audio_clip, ep.sample_rate)
+        from miloco.config import get_settings
+        audio_format = get_settings().model.omni.audio_format or "m4a"
+        audio_result = _encode_audio(ep.audio_clip, ep.sample_rate, audio_format)
+        base["audio_base64"] = audio_result[0] if audio_result else None
+        base["audio_format"] = audio_result[1] if audio_result else audio_format
         base["media_info"] = _audio_only_media_info(ep.sample_rate)
     else:
         short_edge = _get_video_short_edge()
@@ -1352,34 +1360,71 @@ def _encode_audio_only_mp4(
     (跟 _encode_video_mp4 对称,UI 端用同一个 <video> 控件播放;m4a 容器虽然只
     有音频,HTML5 <video> 也能 render audio-only track).
     """
+    result = _encode_audio(audio_clip, sample_rate, "m4a")
+    return result[0] if result else None
+
+
+def _encode_audio(
+    audio_clip: NDArray[np.int16],
+    sample_rate: int,
+    audio_format: str = "m4a",
+) -> tuple[str, str] | None:
+    """编码音频为指定格式，返回 (base64_str, format_name)。
+
+    支持的格式：
+    - m4a: AAC 编码，ipod 容器（MiMo/Qwen/Gemini 推荐）
+    - wav: PCM s16le 编码（智谱/OpenAI 推荐）
+    - mp3: MP3 编码（通用兼容）
+
+    Args:
+        audio_clip: PCM 音频数据 (int16)
+        sample_rate: 采样率
+        audio_format: 目标格式 (m4a/wav/mp3)
+
+    Returns:
+        (base64_str, format_name) 元组，失败返回 None
+    """
     import os
     import tempfile
 
     from miloco.perception.snapshot_context import push_clip_bytes
 
-    _AAC_FRAME_SIZE = 1024
-    if audio_clip is None or audio_clip.size < _AAC_FRAME_SIZE:
+    _FRAME_SIZE = 1024
+    if audio_clip is None or audio_clip.size < _FRAME_SIZE:
         return None
 
-    with tempfile.NamedTemporaryFile(suffix=".m4a", delete=False) as tmp:
+    # 格式配置
+    format_config = {
+        "m4a": {"suffix": ".m4a", "container_format": "ipod", "codec": "aac"},
+        "wav": {"suffix": ".wav", "container_format": "wav", "codec": "pcm_s16le"},
+        "mp3": {"suffix": ".mp3", "container_format": "mp3", "codec": "mp3"},
+    }
+
+    if audio_format not in format_config:
+        logger.warning("event=unsupported_audio_format format=%s, fallback to m4a", audio_format)
+        audio_format = "m4a"
+
+    config = format_config[audio_format]
+
+    with tempfile.NamedTemporaryFile(suffix=config["suffix"], delete=False) as tmp:
         tmp_path = tmp.name
 
     try:
-        container = av.open(tmp_path, "w", format="ipod")
-        a_stream = container.add_stream("aac", rate=sample_rate)
+        container = av.open(tmp_path, "w", format=config["container_format"])
+        a_stream = container.add_stream(config["codec"], rate=sample_rate)
         a_stream.layout = "mono"
 
         pts = 0
-        for i in range(0, audio_clip.size, _AAC_FRAME_SIZE):
-            chunk = audio_clip[i : i + _AAC_FRAME_SIZE]
-            if chunk.size < _AAC_FRAME_SIZE:
-                chunk = np.pad(chunk, (0, _AAC_FRAME_SIZE - chunk.size))
+        for i in range(0, audio_clip.size, _FRAME_SIZE):
+            chunk = audio_clip[i : i + _FRAME_SIZE]
+            if chunk.size < _FRAME_SIZE:
+                chunk = np.pad(chunk, (0, _FRAME_SIZE - chunk.size))
             audio_frame = av.AudioFrame.from_ndarray(
                 chunk.reshape(1, -1), format="s16", layout="mono"
             )
             audio_frame.sample_rate = sample_rate
             audio_frame.pts = pts
-            pts += _AAC_FRAME_SIZE
+            pts += _FRAME_SIZE
             for packet in a_stream.encode(audio_frame):
                 container.mux(packet)
         for packet in a_stream.encode():
@@ -1388,10 +1433,10 @@ def _encode_audio_only_mp4(
         container.close()
 
         with open(tmp_path, "rb") as f:
-            m4a_bytes = f.read()
-        # 旁路把 audio-only 的 m4a 字节 push 给 meaningful_events 复用(零重编)
-        push_clip_bytes(m4a_bytes, "m4a")
-        return base64.b64encode(m4a_bytes).decode()
+            audio_bytes = f.read()
+        # 旁路把音频字节 push 给 meaningful_events 复用
+        push_clip_bytes(audio_bytes, audio_format)
+        return base64.b64encode(audio_bytes).decode(), audio_format
     finally:
         if os.path.exists(tmp_path):
             os.unlink(tmp_path)

--- a/backend/miloco/src/miloco/perception/engine/omni/provider.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/provider.py
@@ -49,7 +49,7 @@ class OmniProviderAdapter(ABC):
         """构建 video content block（进 messages[].content[]，恒为 OpenAI 形态）。"""
 
     @abstractmethod
-    def build_audio_block(self, audio_base64: str, media: LocalMediaInfo) -> dict[str, Any]:
+    def build_audio_block(self, audio_base64: str, media: LocalMediaInfo, audio_format: str = "m4a") -> dict[str, Any]:
         """构建 audio-only content block（恒为 OpenAI 形态）。"""
 
     @abstractmethod
@@ -131,10 +131,12 @@ class MiMoAdapter(OpenAICompatAdapter):
             "media_resolution": "max",
         }
 
-    def build_audio_block(self, audio_base64: str, media: LocalMediaInfo) -> dict[str, Any]:
+    def build_audio_block(self, audio_base64: str, media: LocalMediaInfo, audio_format: str = "m4a") -> dict[str, Any]:
+        mime_map = {"m4a": "audio/m4a", "wav": "audio/wav", "mp3": "audio/mpeg"}
+        mime_type = mime_map.get(audio_format, "audio/m4a")
         return {
             "type": "input_audio",
-            "input_audio": {"data": f"data:audio/m4a;base64,{audio_base64}"},
+            "input_audio": {"data": f"data:{mime_type};base64,{audio_base64}"},
         }
 
     def build_request_body(
@@ -178,12 +180,12 @@ class QwenOmniAdapter(OpenAICompatAdapter):
             "video_url": {"url": f"data:;base64,{video_base64}"},
         }
 
-    def build_audio_block(self, audio_base64: str, media: LocalMediaInfo) -> dict[str, Any]:
+    def build_audio_block(self, audio_base64: str, media: LocalMediaInfo, audio_format: str = "m4a") -> dict[str, Any]:
         return {
             "type": "input_audio",
             "input_audio": {
                 "data": f"data:;base64,{audio_base64}",
-                "format": "m4a",
+                "format": audio_format,
             },
         }
 
@@ -315,12 +317,14 @@ class GeminiAdapter(OmniProviderAdapter):
             "fps": media.fps,
         }
 
-    def build_audio_block(self, audio_base64: str, media: LocalMediaInfo) -> dict[str, Any]:
+    def build_audio_block(self, audio_base64: str, media: LocalMediaInfo, audio_format: str = "m4a") -> dict[str, Any]:
         # m4a(AAC) 容器 mime 记为 audio/mp4；Gemini 原生 inline audio 对 m4a 的接受度需实测，
-        # 不达标属编码层问题（见 prompt_builder._encode_audio_only_mp4），不在 adapter 范围。
+        # 不达标属编码层问题（见 prompt_builder._encode_audio），不在 adapter 范围。
+        mime_map = {"m4a": "audio/mp4", "wav": "audio/wav", "mp3": "audio/mpeg"}
+        mime_type = mime_map.get(audio_format, "audio/mp4")
         return {
             "type": "input_audio",
-            "input_audio": {"data": f"data:audio/mp4;base64,{audio_base64}"},
+            "input_audio": {"data": f"data:{mime_type};base64,{audio_base64}"},
         }
 
     def _content_to_parts(self, content: str | list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/backend/miloco/src/miloco/perception/events_service.py
+++ b/backend/miloco/src/miloco/perception/events_service.py
@@ -29,9 +29,15 @@ logger = logging.getLogger(__name__)
 SnapshotStatus = Literal["found", "gone", "not_found"]
 
 # 视频路径产物 clip.mp4 (H264+AAC);audio-only 路径产物 clip.m4a (仅 AAC,ipod muxer).
-# 探测顺序:先 mp4 后 m4a,先找到的优先返回。
-_CLIP_CANDIDATES = ("clip.mp4", "clip.m4a")
-_MEDIA_TYPE_BY_SUFFIX = {".mp4": "video/mp4", ".m4a": "audio/mp4"}
+# 音频格式支持: m4a (AAC), wav (PCM), mp3 (MP3).
+# 探测顺序:先 mp4 后 m4a/wav/mp3,先找到的优先返回。
+_CLIP_CANDIDATES = ("clip.mp4", "clip.m4a", "clip.wav", "clip.mp3")
+_MEDIA_TYPE_BY_SUFFIX = {
+    ".mp4": "video/mp4",
+    ".m4a": "audio/mp4",
+    ".wav": "audio/wav",
+    ".mp3": "audio/mpeg",
+}
 
 
 class EventsService:
@@ -119,13 +125,18 @@ class EventsService:
         共识 — 见 prompt_builder._is_audio_only;所以多 device 间 kind 一致,
         取第一个有效结果即可).
 
-        Returns: "mp4" / "m4a" / None(未落盘 / 已被 cleanup 清掉).
+        Returns: "mp4" / "m4a" / "wav" / "mp3" / None(未落盘 / 已被 cleanup 清掉).
         """
         if not device_ids:
             return None
         for did in device_ids:
             device_dir = snapshot_root / event_id / region_slug(did)
-            for filename, kind in (("clip.mp4", "mp4"), ("clip.m4a", "m4a")):
+            for filename, kind in (
+                ("clip.mp4", "mp4"),
+                ("clip.m4a", "m4a"),
+                ("clip.wav", "wav"),
+                ("clip.mp3", "mp3"),
+            ):
                 if (device_dir / filename).exists():
                     return kind
         return None

--- a/backend/miloco/src/miloco/perception/runner.py
+++ b/backend/miloco/src/miloco/perception/runner.py
@@ -46,10 +46,14 @@ class PerceptionRunner:
         self._sync_devices_task: asyncio.Task | None = None
         self._window_ready = window_ready_event
 
-        # 自动停止/恢复状态：omni 熔断器持续 OPEN 超过阈值时自动停引擎，
+        # 自动停止/恢复状态：omni 熔断器累计 OPEN 时间超过阈值时自动停引擎，
         # 恢复后自动重启。_auto_stopped=True 时 tick 只跑 probe 自愈，不跑 pipeline。
-        self._cb_open_since: float | None = None
+        # 用累计时间而非连续时间，防止 OPEN→probe→CLOSED 快速振荡时计时器反复被清零。
+        self._cb_open_accumulated: float = 0.0  # 累计 OPEN 时间（秒）
+        self._cb_last_open_tick: float | None = None  # 上一次 tick 时 OPEN 的时间点
         self._auto_stopped: bool = False
+        self._auto_stopped_at: float | None = None  # 自动停止时刻，用于冷却期
+        self._auto_restart_cooldown_sec: float = 120.0  # 自动停止后冷却期（秒）
         self._recovery_probe_task: asyncio.Task | None = None
 
         # Persistent worker thread with a durable event loop for inference.
@@ -97,7 +101,8 @@ class PerceptionRunner:
 
         self._is_running = True
         self._auto_stopped = False  # 用户手动启动时清除自动停止标记
-        self._cb_open_since = None
+        self._cb_open_accumulated = 0.0
+        self._cb_last_open_tick = None
 
         # 重启时重读窗口时长（config 可能在停止期间被改）——__init__ 只读一次，
         # 不重读会导致「应用设置」改了 window_size 后引擎仍按旧值跑。
@@ -152,7 +157,8 @@ class PerceptionRunner:
         self._sync_devices_task = None
         self._recovery_probe_task = None
         self._auto_stopped = False
-        self._cb_open_since = None
+        self._cb_open_accumulated = 0.0
+        self._cb_last_open_tick = None
 
         # 清理 in-flight probe task,防同进程再启 runner 时 _probe_in_flight 残留导致
         # 自愈通道永久卡死。registry 是独立 module,不进 runner↔processor 循环链。
@@ -261,30 +267,45 @@ class PerceptionRunner:
         if self._auto_stopped:
             # 已自动停止 → 检查是否该恢复
             if state == CircuitState.CLOSED:
-                logger.info("[runner] omni 恢复（熔断器 CLOSED），自动重启感知引擎")
-                await self._auto_restart_engine()
+                # 冷却期内不重启，防止 stop→restart 振荡
+                elapsed = time.monotonic() - self._auto_stopped_at if self._auto_stopped_at else 0
+                if elapsed < self._auto_restart_cooldown_sec:
+                    logger.debug(
+                        "[auto-lifecycle] CLOSED but in cooldown (%.0fs/%.0fs)",
+                        elapsed, self._auto_restart_cooldown_sec,
+                    )
+                else:
+                    logger.info("[runner] omni 恢复（熔断器 CLOSED），自动重启感知引擎")
+                    await self._auto_restart_engine()
             else:
                 # 继续驱动 probe（内部有退避节流，不会高频调用）
                 self._drive_recovery_probe()
             return
 
-        # 未自动停止 → 检查是否该停
+        # 未自动停止 → 累计 OPEN 时间，检查是否该停
         # OPEN_CONFIG（API key 错误/模型不存在）也会触发自动停止；
         # 但恢复时 _drive_recovery_probe 的 try_arm_probe 只认 OPEN_RECOVERABLE，
         # 所以 OPEN_CONFIG 停机后不会自动 probe，需要用户修正配置后手动重试。
-        if state in (CircuitState.OPEN_RECOVERABLE, CircuitState.OPEN_CONFIG):
-            if self._cb_open_since is None:
-                self._cb_open_since = time.monotonic()
-            elif time.monotonic() - self._cb_open_since > settings.auto_stop_threshold_sec:
+        now = time.monotonic()
+        is_open = state in (CircuitState.OPEN_RECOVERABLE, CircuitState.OPEN_CONFIG)
+
+        if is_open:
+            # 累计 OPEN 时间
+            if self._cb_last_open_tick is not None:
+                self._cb_open_accumulated += now - self._cb_last_open_tick
+            self._cb_last_open_tick = now
+
+            if self._cb_open_accumulated > settings.auto_stop_threshold_sec:
                 logger.warning(
-                    "[runner] omni 熔断器持续 OPEN %.0fs（阈值 %.0fs），自动停止感知引擎",
-                    time.monotonic() - self._cb_open_since,
+                    "[runner] omni 熔断器累计 OPEN %.0fs（阈值 %.0fs），自动停止感知引擎",
+                    self._cb_open_accumulated,
                     settings.auto_stop_threshold_sec,
                 )
+                self._cb_last_open_tick = None
                 await self._auto_stop_engine()
         else:
-            # CLOSED 或 HALF_OPEN → 重置计时
-            self._cb_open_since = None
+            # CLOSED 或 HALF_OPEN → 停止累计，但不清零（保留已累计的时间）
+            self._cb_last_open_tick = None
 
     async def _auto_stop_engine(self) -> None:
         """停止引擎但保留 tick 循环，为 probe 自愈留通道。
@@ -294,7 +315,9 @@ class PerceptionRunner:
         不产出解码帧，sync_buffer 自然不进数据，CPU 一样省。
         """
         self._auto_stopped = True
-        self._cb_open_since = None
+        self._auto_stopped_at = time.monotonic()
+        self._cb_open_accumulated = 0.0
+        self._cb_last_open_tick = None
         try:
             # 只暂停解码器 + 关引擎；不调 collector.shutdown()，避免被
             # _sync_devices_loop 在 ~1s 内 reconnect 所有设备（白做一轮 disconnect→reconnect）。

--- a/backend/miloco/src/miloco/perception/runner.py
+++ b/backend/miloco/src/miloco/perception/runner.py
@@ -334,6 +334,7 @@ class PerceptionRunner:
         try:
             # 先恢复解码器，再重建引擎和采集
             self._collector.resume_streams()
+            await self._collector.switch_to_decode_mode()
             await self._collector.sync_all_devices()
             self._pipeline.try_reinit_engine(include_failed=True)
             if not self._inference_worker.is_running:

--- a/backend/miloco/src/miloco/perception/runner.py
+++ b/backend/miloco/src/miloco/perception/runner.py
@@ -256,7 +256,7 @@ class PerceptionRunner:
         )
 
         cb = get_omni_circuit_breaker()
-        state = cb.state_for_test()
+        state = cb.current_state
 
         if self._auto_stopped:
             # 已自动停止 → 检查是否该恢复
@@ -269,6 +269,9 @@ class PerceptionRunner:
             return
 
         # 未自动停止 → 检查是否该停
+        # OPEN_CONFIG（API key 错误/模型不存在）也会触发自动停止；
+        # 但恢复时 _drive_recovery_probe 的 try_arm_probe 只认 OPEN_RECOVERABLE，
+        # 所以 OPEN_CONFIG 停机后不会自动 probe，需要用户修正配置后手动重试。
         if state in (CircuitState.OPEN_RECOVERABLE, CircuitState.OPEN_CONFIG):
             if self._cb_open_since is None:
                 self._cb_open_since = time.monotonic()
@@ -286,16 +289,17 @@ class PerceptionRunner:
     async def _auto_stop_engine(self) -> None:
         """停止引擎但保留 tick 循环，为 probe 自愈留通道。
 
-        与 stop_engine 的区别：只关引擎实例 + 采集，不停 _perception_task（tick 继续跑）。
-        摄像头 P2P 连接保持，解码器暂停（帧直接丢弃，不走 H.264 解码）。
+        与 stop_engine 的区别：只暂停解码器 + 关引擎实例，**不关采集器**。
+        设备保持连接（避免 _sync_devices_loop 反悔重连 churn），解码器暂停后
+        不产出解码帧，sync_buffer 自然不进数据，CPU 一样省。
         """
         self._auto_stopped = True
         self._cb_open_since = None
         try:
-            # 先暂停解码器（P2P 保持，帧丢弃），再关引擎和采集
+            # 只暂停解码器 + 关引擎；不调 collector.shutdown()，避免被
+            # _sync_devices_loop 在 ~1s 内 reconnect 所有设备（白做一轮 disconnect→reconnect）。
             self._collector.pause_streams()
             await self._pipeline.close()
-            await self._collector.shutdown()
             logger.info("[runner] 感知引擎已自动停止（gate+identity+omni 全停，解码器已暂停），等待 omni 恢复")
         except Exception as e:
             logger.error("[runner] 自动停止引擎失败 | %s", e, exc_info=True)

--- a/backend/miloco/src/miloco/perception/runner.py
+++ b/backend/miloco/src/miloco/perception/runner.py
@@ -13,6 +13,7 @@ The perception loop reacts to two triggers:
 
 import asyncio
 import logging
+import time
 
 from miloco.config import get_settings
 from miloco.database.perception_repo import PerceptionLogRepo
@@ -44,6 +45,12 @@ class PerceptionRunner:
         self._perception_task: asyncio.Task | None = None
         self._sync_devices_task: asyncio.Task | None = None
         self._window_ready = window_ready_event
+
+        # 自动停止/恢复状态：omni 熔断器持续 OPEN 超过阈值时自动停引擎，
+        # 恢复后自动重启。_auto_stopped=True 时 tick 只跑 probe 自愈，不跑 pipeline。
+        self._cb_open_since: float | None = None
+        self._auto_stopped: bool = False
+        self._recovery_probe_task: asyncio.Task | None = None
 
         # Persistent worker thread with a durable event loop for inference.
         # Replaces the old ThreadPoolExecutor + asyncio.run() pattern that
@@ -89,6 +96,8 @@ class PerceptionRunner:
             return
 
         self._is_running = True
+        self._auto_stopped = False  # 用户手动启动时清除自动停止标记
+        self._cb_open_since = None
 
         # 重启时重读窗口时长（config 可能在停止期间被改）——__init__ 只读一次，
         # 不重读会导致「应用设置」改了 window_size 后引擎仍按旧值跑。
@@ -130,6 +139,7 @@ class PerceptionRunner:
         for task in (
             self._perception_task,
             self._sync_devices_task,
+            self._recovery_probe_task,
         ):
             if task and not task.done():
                 task.cancel()
@@ -140,6 +150,9 @@ class PerceptionRunner:
 
         self._perception_task = None
         self._sync_devices_task = None
+        self._recovery_probe_task = None
+        self._auto_stopped = False
+        self._cb_open_since = None
 
         # 清理 in-flight probe task,防同进程再启 runner 时 _probe_in_flight 残留导致
         # 自愈通道永久卡死。registry 是独立 module,不进 runner↔processor 循环链。
@@ -158,6 +171,13 @@ class PerceptionRunner:
 
     async def _tick(self) -> None:
         """Drain all ready windows and infer sequentially."""
+        # 自动生命周期管理：检查 omni 熔断器状态，决定是否自动停止/恢复引擎
+        await self._auto_manage_lifecycle()
+
+        # 自动停止后：只跑 probe 自愈，不跑 pipeline（节省 CPU + ONNX 内存）
+        if self._auto_stopped:
+            return
+
         # 每 tick 驱动一次 omni 熔断器自动探测:OPEN_RECOVERABLE + backoff 到期时 spawn
         # 一次后台 probe。无外部驱动时 probe_due 归零后状态永远不动,provider 恢复后感知
         # 也不会自愈,只能靠用户手动点「立即重试」。sync 判断 + 后台 spawn,tick 不阻塞。
@@ -217,6 +237,100 @@ class PerceptionRunner:
                 await self._wait_for_trigger()
             except asyncio.CancelledError:
                 break
+
+    # ---- 自动停止/恢复 ----------------------------------------------------------
+
+    async def _auto_manage_lifecycle(self) -> None:
+        """每 tick 检查 omni 熔断器状态，驱动自动停止/恢复。
+
+        自动停止条件：熔断器持续 OPEN_RECOVERABLE / OPEN_CONFIG 超过阈值秒数。
+        自动恢复条件：自动停止后，Runner 驱动 probe 探测成功（熔断器回到 CLOSED）。
+        """
+        settings = get_settings().perception.collect
+        if not settings.auto_stop_on_omni_failure:
+            return
+
+        from miloco.perception.engine.omni.circuit_breaker import (
+            CircuitState,
+            get_omni_circuit_breaker,
+        )
+
+        cb = get_omni_circuit_breaker()
+        state = cb.state_for_test()
+
+        if self._auto_stopped:
+            # 已自动停止 → 检查是否该恢复
+            if state == CircuitState.CLOSED:
+                logger.info("[runner] omni 恢复（熔断器 CLOSED），自动重启感知引擎")
+                await self._auto_restart_engine()
+            else:
+                # 继续驱动 probe（内部有退避节流，不会高频调用）
+                self._drive_recovery_probe()
+            return
+
+        # 未自动停止 → 检查是否该停
+        if state in (CircuitState.OPEN_RECOVERABLE, CircuitState.OPEN_CONFIG):
+            if self._cb_open_since is None:
+                self._cb_open_since = time.monotonic()
+            elif time.monotonic() - self._cb_open_since > settings.auto_stop_threshold_sec:
+                logger.warning(
+                    "[runner] omni 熔断器持续 OPEN %.0fs（阈值 %.0fs），自动停止感知引擎",
+                    time.monotonic() - self._cb_open_since,
+                    settings.auto_stop_threshold_sec,
+                )
+                await self._auto_stop_engine()
+        else:
+            # CLOSED 或 HALF_OPEN → 重置计时
+            self._cb_open_since = None
+
+    async def _auto_stop_engine(self) -> None:
+        """停止引擎但保留 tick 循环，为 probe 自愈留通道。
+
+        与 stop_engine 的区别：只关引擎实例 + 采集，不停 _perception_task（tick 继续跑）。
+        摄像头 P2P 连接保持，解码器暂停（帧直接丢弃，不走 H.264 解码）。
+        """
+        self._auto_stopped = True
+        self._cb_open_since = None
+        try:
+            # 先暂停解码器（P2P 保持，帧丢弃），再关引擎和采集
+            self._collector.pause_streams()
+            await self._pipeline.close()
+            await self._collector.shutdown()
+            logger.info("[runner] 感知引擎已自动停止（gate+identity+omni 全停，解码器已暂停），等待 omni 恢复")
+        except Exception as e:
+            logger.error("[runner] 自动停止引擎失败 | %s", e, exc_info=True)
+
+    async def _auto_restart_engine(self) -> None:
+        """probe 成功后自动重启引擎。"""
+        self._auto_stopped = False
+        self._recovery_probe_task = None
+        try:
+            # 先恢复解码器，再重建引擎和采集
+            self._collector.resume_streams()
+            await self._collector.sync_all_devices()
+            self._pipeline.try_reinit_engine(include_failed=True)
+            if not self._inference_worker.is_running:
+                self._inference_worker.start()
+            self._pipeline.set_inference_worker(self._inference_worker)
+            logger.info("[runner] 感知引擎自动重启成功")
+        except Exception as e:
+            logger.error("[runner] 自动重启引擎失败 | %s", e, exc_info=True)
+            self._auto_stopped = True  # 重启失败，保持停止态
+
+    def _drive_recovery_probe(self) -> None:
+        """引擎停止后，由 Runner 直接驱动熔断器 probe（复用 processor._run_omni_probe）。
+
+        熔断器内部的 try_arm_probe() 有退避节流：只有 OPEN_RECOVERABLE + backoff 到期
+        + 无 in-flight 时才放行，避免高频探测。
+        """
+        from miloco.perception.processor import _run_omni_probe
+
+        from miloco.perception.engine.omni.circuit_breaker import get_omni_circuit_breaker
+
+        cb = get_omni_circuit_breaker()
+        if not cb.try_arm_probe():
+            return
+        self._recovery_probe_task = asyncio.create_task(_run_omni_probe())
 
     async def _sync_devices_loop(self) -> None:
         """Device sync loop — runs independently from perception ticks."""

--- a/backend/miloco/src/miloco/perception/runner.py
+++ b/backend/miloco/src/miloco/perception/runner.py
@@ -327,7 +327,9 @@ class PerceptionRunner:
         熔断器内部的 try_arm_probe() 有退避节流：只有 OPEN_RECOVERABLE + backoff 到期
         + 无 in-flight 时才放行，避免高频探测。
         """
-        from miloco.perception.engine.omni.circuit_breaker import get_omni_circuit_breaker
+        from miloco.perception.engine.omni.circuit_breaker import (
+            get_omni_circuit_breaker,
+        )
         from miloco.perception.processor import _run_omni_probe
 
         cb = get_omni_circuit_breaker()

--- a/backend/miloco/src/miloco/perception/runner.py
+++ b/backend/miloco/src/miloco/perception/runner.py
@@ -327,9 +327,8 @@ class PerceptionRunner:
         熔断器内部的 try_arm_probe() 有退避节流：只有 OPEN_RECOVERABLE + backoff 到期
         + 无 in-flight 时才放行，避免高频探测。
         """
-        from miloco.perception.processor import _run_omni_probe
-
         from miloco.perception.engine.omni.circuit_breaker import get_omni_circuit_breaker
+        from miloco.perception.processor import _run_omni_probe
 
         cb = get_omni_circuit_breaker()
         if not cb.try_arm_probe():

--- a/backend/miloco/src/miloco/perception/schema.py
+++ b/backend/miloco/src/miloco/perception/schema.py
@@ -521,12 +521,14 @@ class MeaningfulEvent(BaseModel):
         default=None,
         description="最近一次反馈包的大小(bytes)",
     )
-    clip_kind: Literal["mp4", "m4a"] | None = Field(
+    clip_kind: Literal["mp4", "m4a", "wav", "mp3"] | None = Field(
         default=None,
         description=(
             "Container of the persisted clip,服务端 stat 落盘文件后缀计算:"
             "'mp4' = H264+AAC video container(omni video 路径产物);"
             "'m4a' = AAC-only audio container(omni audio-only 路径产物);"
+            "'wav' = PCM audio container(omni audio-only 路径产物);"
+            "'mp3' = MP3 audio container(omni audio-only 路径产物);"
             "None = no clip on disk(metadata-only / cleanup 已清).多 device 共识下"
             "全 device kind 一致(见 prompt_builder._is_audio_only),取第一个 device 即可."
         ),

--- a/backend/miloco/src/miloco/perception/snapshot_context.py
+++ b/backend/miloco/src/miloco/perception/snapshot_context.py
@@ -67,7 +67,7 @@ logger = logging.getLogger(__name__)
 # clip 字节的容器/codec 类型,持久化层据此选 filename 与 Content-Type.
 # 主流 UI <video> 控件对两者都能渲染,但浏览器 / 一些播放器靠扩展名 sniff 容器,
 # 所以扩展名要跟实际容器一致(M4A 不能伪装成 .mp4).
-ClipKind = Literal["mp4", "m4a"]
+ClipKind = Literal["mp4", "m4a", "wav", "mp3"]
 
 
 @dataclass

--- a/backend/miloco/src/miloco/perception/snapshot_writer.py
+++ b/backend/miloco/src/miloco/perception/snapshot_writer.py
@@ -137,7 +137,7 @@ def _save_clips(
     for device_id, (clip_bytes, kind) in clips.items():
         if not clip_bytes:
             continue
-        if kind not in ("mp4", "m4a"):
+        if kind not in ("mp4", "m4a", "wav", "mp3"):
             logger.error("Unknown clip kind %r for %s; skipping", kind, device_id)
             continue
         device_dir = event_dir / region_slug(device_id)

--- a/backend/miloco/tests/perception/engine/omni/test_provider.py
+++ b/backend/miloco/tests/perception/engine/omni/test_provider.py
@@ -68,10 +68,20 @@ class TestMiMoAdapter:
         assert block["media_resolution"] == "max"
         assert block["video_url"]["url"].startswith("data:video/mp4;base64,")
 
-    def test_audio_block(self):
+    def test_audio_block_default_m4a(self):
         block = self.adapter.build_audio_block("BBBB", _AUDIO_MEDIA)
         assert block["type"] == "input_audio"
         assert block["input_audio"]["data"].startswith("data:audio/m4a;base64,")
+
+    def test_audio_block_wav(self):
+        block = self.adapter.build_audio_block("BBBB", _AUDIO_MEDIA, "wav")
+        assert block["type"] == "input_audio"
+        assert block["input_audio"]["data"].startswith("data:audio/wav;base64,")
+
+    def test_audio_block_mp3(self):
+        block = self.adapter.build_audio_block("BBBB", _AUDIO_MEDIA, "mp3")
+        assert block["type"] == "input_audio"
+        assert block["input_audio"]["data"].startswith("data:audio/mpeg;base64,")
 
     def test_request_body_non_stream(self):
         body = self.adapter.build_request_body(
@@ -102,10 +112,22 @@ class TestQwenOmniAdapter:
         assert "media_resolution" not in block
         assert block["video_url"]["url"].startswith("data:;base64,")
 
-    def test_audio_block_has_format(self):
+    def test_audio_block_default_m4a(self):
         block = self.adapter.build_audio_block("BBBB", _AUDIO_MEDIA)
         assert block["type"] == "input_audio"
         assert block["input_audio"]["format"] == "m4a"
+        assert block["input_audio"]["data"].startswith("data:;base64,")
+
+    def test_audio_block_wav(self):
+        block = self.adapter.build_audio_block("BBBB", _AUDIO_MEDIA, "wav")
+        assert block["type"] == "input_audio"
+        assert block["input_audio"]["format"] == "wav"
+        assert block["input_audio"]["data"].startswith("data:;base64,")
+
+    def test_audio_block_mp3(self):
+        block = self.adapter.build_audio_block("BBBB", _AUDIO_MEDIA, "mp3")
+        assert block["type"] == "input_audio"
+        assert block["input_audio"]["format"] == "mp3"
         assert block["input_audio"]["data"].startswith("data:;base64,")
 
     def test_request_body_forces_stream(self):
@@ -253,6 +275,21 @@ class TestGeminiAdapter:
         parts = body["contents"][0]["parts"]
         assert parts[0]["inline_data"] == {"mime_type": "image/png", "data": "IMG"}
         assert parts[1]["inline_data"] == {"mime_type": "audio/mp4", "data": "AUD"}
+
+    def test_audio_block_default_m4a(self):
+        block = self.adapter.build_audio_block("AUD", _AUDIO_MEDIA)
+        assert block["type"] == "input_audio"
+        assert block["input_audio"]["data"].startswith("data:audio/mp4;base64,")
+
+    def test_audio_block_wav(self):
+        block = self.adapter.build_audio_block("AUD", _AUDIO_MEDIA, "wav")
+        assert block["type"] == "input_audio"
+        assert block["input_audio"]["data"].startswith("data:audio/wav;base64,")
+
+    def test_audio_block_mp3(self):
+        block = self.adapter.build_audio_block("AUD", _AUDIO_MEDIA, "mp3")
+        assert block["type"] == "input_audio"
+        assert block["input_audio"]["data"].startswith("data:audio/mpeg;base64,")
 
     def test_parse_response_to_openai_shape(self):
         raw = {

--- a/backend/miloco/tests/perception/test_apply_config_restart.py
+++ b/backend/miloco/tests/perception/test_apply_config_restart.py
@@ -179,6 +179,9 @@ async def test_runner_stop_cancels_inflight_omni_probe_tasks():
     runner._is_running = True
     runner._perception_task = None
     runner._sync_devices_task = None
+    runner._recovery_probe_task = None
+    runner._auto_stopped = False
+    runner._cb_open_since = None
     runner._inference_worker = MagicMock()
 
     # 起一个真的 fire-and-forget task,注册进 _OMNI_PROBE_TASKS (与 processor 同款)

--- a/backend/miloco/tests/perception/test_auto_lifecycle.py
+++ b/backend/miloco/tests/perception/test_auto_lifecycle.py
@@ -103,13 +103,13 @@ async def test_auto_manage_disabled_by_config(mock_runner, cb, monkeypatch):
 @pytest.mark.asyncio
 async def test_auto_manage_closed_resets_timer(mock_runner, cb, mock_settings):
     """CLOSED state resets the OPEN timer."""
-    mock_runner._cb_open_since = time.monotonic() - 100
+    mock_runner._cb_open_accumulated = time.monotonic() - 100
     mock_runner._auto_stopped = False
 
     # cb is CLOSED by default
     await mock_runner._auto_manage_lifecycle()
 
-    assert mock_runner._cb_open_since is None
+    assert mock_runner._cb_open_accumulated is None
     assert mock_runner._auto_stopped is False
 
 
@@ -127,11 +127,11 @@ async def test_auto_manage_open_starts_timer(mock_runner, cb, mock_settings):
         )
 
     assert cb.current_state == CircuitState.OPEN_RECOVERABLE
-    assert mock_runner._cb_open_since is None
+    assert mock_runner._cb_open_accumulated is None
 
     await mock_runner._auto_manage_lifecycle()
 
-    assert mock_runner._cb_open_since is not None
+    assert mock_runner._cb_open_accumulated is not None
     assert mock_runner._auto_stopped is False
 
 
@@ -151,7 +151,7 @@ async def test_auto_manage_open_exceeds_threshold_stops_engine(
         )
 
     # Simulate timer started 100s ago
-    mock_runner._cb_open_since = time.monotonic() - 100
+    mock_runner._cb_open_accumulated = time.monotonic() - 100
 
     await mock_runner._auto_manage_lifecycle()
 

--- a/backend/miloco/tests/perception/test_auto_lifecycle.py
+++ b/backend/miloco/tests/perception/test_auto_lifecycle.py
@@ -54,7 +54,10 @@ def mock_runner():
     runner._sync_devices_task = None
     runner._recovery_probe_task = None
     runner._auto_stopped = False
-    runner._cb_open_since = None
+    runner._auto_stopped_at = None
+    runner._auto_restart_cooldown_sec = 120.0
+    runner._cb_open_accumulated = 0.0
+    runner._cb_last_open_tick = None
     runner._window_ready = None
     runner._inference_worker = MagicMock()
     runner._inference_worker.is_running = False
@@ -101,21 +104,24 @@ async def test_auto_manage_disabled_by_config(mock_runner, cb, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_auto_manage_closed_resets_timer(mock_runner, cb, mock_settings):
-    """CLOSED state resets the OPEN timer."""
-    mock_runner._cb_open_accumulated = time.monotonic() - 100
+async def test_auto_manage_closed_stops_accumulating(mock_runner, cb, mock_settings):
+    """CLOSED state stops accumulating but preserves existing time."""
+    mock_runner._cb_open_accumulated = 30.0
+    mock_runner._cb_last_open_tick = time.monotonic()
     mock_runner._auto_stopped = False
 
     # cb is CLOSED by default
     await mock_runner._auto_manage_lifecycle()
 
-    assert mock_runner._cb_open_accumulated is None
+    # accumulated preserved, last_open_tick cleared
+    assert mock_runner._cb_open_accumulated == 30.0
+    assert mock_runner._cb_last_open_tick is None
     assert mock_runner._auto_stopped is False
 
 
 @pytest.mark.asyncio
-async def test_auto_manage_open_starts_timer(mock_runner, cb, mock_settings):
-    """OPEN_RECOVERABLE starts the timer on first detection."""
+async def test_auto_manage_open_accumulates_time(mock_runner, cb, mock_settings):
+    """OPEN_RECOVERABLE accumulates time."""
     from miloco.perception.engine.omni.error_classifier import (
         ClassifiedError,
         ErrorCategory,
@@ -127,11 +133,12 @@ async def test_auto_manage_open_starts_timer(mock_runner, cb, mock_settings):
         )
 
     assert cb.current_state == CircuitState.OPEN_RECOVERABLE
-    assert mock_runner._cb_open_accumulated is None
+    assert mock_runner._cb_open_accumulated == 0.0
 
     await mock_runner._auto_manage_lifecycle()
 
-    assert mock_runner._cb_open_accumulated is not None
+    # Should have started accumulating
+    assert mock_runner._cb_last_open_tick is not None
     assert mock_runner._auto_stopped is False
 
 
@@ -150,8 +157,9 @@ async def test_auto_manage_open_exceeds_threshold_stops_engine(
             ClassifiedError("unreachable", "test", ErrorCategory.RECOVERABLE)
         )
 
-    # Simulate timer started 100s ago
-    mock_runner._cb_open_accumulated = time.monotonic() - 100
+    # Simulate accumulated OPEN time exceeding threshold
+    mock_runner._cb_open_accumulated = 100.0  # > 60s threshold
+    mock_runner._cb_last_open_tick = time.monotonic()
 
     await mock_runner._auto_manage_lifecycle()
 
@@ -166,8 +174,9 @@ async def test_auto_manage_open_exceeds_threshold_stops_engine(
 async def test_auto_manage_auto_stopped_and_closed_restarts(
     mock_runner, cb, mock_settings
 ):
-    """When auto-stopped and circuit breaker is CLOSED, engine restarts."""
+    """When auto-stopped, circuit breaker CLOSED, and cooldown expired, engine restarts."""
     mock_runner._auto_stopped = True
+    mock_runner._auto_stopped_at = time.monotonic() - 200  # cooldown (120s) expired
 
     # cb is CLOSED by default
     await mock_runner._auto_manage_lifecycle()
@@ -221,6 +230,21 @@ async def test_auto_stop_does_not_shutdown_collector(mock_runner):
     # collector.shutdown should NOT be called
     mock_runner._collector.shutdown.assert_not_called()
     assert mock_runner._auto_stopped is True
+    assert mock_runner._auto_stopped_at is not None
+
+
+@pytest.mark.asyncio
+async def test_cooldown_prevents_immediate_restart(mock_runner, cb, mock_settings):
+    """CLOSED within cooldown period should NOT restart."""
+    mock_runner._auto_stopped = True
+    mock_runner._auto_stopped_at = time.monotonic() - 10  # only10s, cooldown is120s
+
+    # cb is CLOSED
+    await mock_runner._auto_manage_lifecycle()
+
+    # Should still be stopped (cooldown not expired)
+    assert mock_runner._auto_stopped is True
+    mock_runner._collector.resume_streams.assert_not_called()
 
 
 # ---- _auto_restart_engine tests ----

--- a/backend/miloco/tests/perception/test_auto_lifecycle.py
+++ b/backend/miloco/tests/perception/test_auto_lifecycle.py
@@ -10,9 +10,8 @@ Covers:
 
 from __future__ import annotations
 
-import asyncio
 import time
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 

--- a/backend/miloco/tests/perception/test_auto_lifecycle.py
+++ b/backend/miloco/tests/perception/test_auto_lifecycle.py
@@ -1,0 +1,280 @@
+# -*- coding: utf-8 -*-
+"""Tests for PerceptionRunner auto lifecycle management.
+
+Covers:
+- _auto_manage_lifecycle: stop/resume decisions based on circuit breaker state
+- _auto_stop_engine: pauses decoders, closes pipeline, does NOT shutdown collector
+- _auto_restart_engine: resumes decoders, rebuilds engine
+- _drive_recovery_probe: arms probe only in OPEN_RECOVERABLE
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from miloco.perception.engine.omni.circuit_breaker import (
+    CircuitState,
+    OmniCircuitBreaker,
+)
+from miloco.perception.runner import PerceptionRunner
+
+
+@pytest.fixture
+def mock_runner(monkeypatch):
+    """Create a PerceptionRunner with mocked dependencies."""
+    collector = MagicMock()
+    collector.pause_streams = MagicMock()
+    collector.resume_streams = MagicMock()
+    collector.shutdown = AsyncMock()
+    collector.sync_all_devices = AsyncMock()
+    collector.get_all_active_sources = MagicMock(return_value={})
+
+    pipeline = MagicMock()
+    pipeline.close = AsyncMock()
+    pipeline.try_reinit_engine = MagicMock()
+    pipeline.set_inference_worker = MagicMock()
+    pipeline.drive_omni_probe = MagicMock()
+    pipeline.process_realtime = AsyncMock(return_value=None)
+    pipeline.last_latency = None
+    pipeline.engine_ready = False
+    pipeline.engine_status = "not_configured"
+    pipeline.engine_status_message = ""
+
+    log_repo = MagicMock()
+    log_repo.get_today_inference_count = MagicMock(return_value=0)
+
+    runner = PerceptionRunner(
+        collector=collector,
+        pipeline=pipeline,
+        log_repo=log_repo,
+    )
+    runner._inference_worker = MagicMock()
+    runner._inference_worker.is_running = False
+    runner._inference_worker.start = MagicMock()
+
+    return runner
+
+
+@pytest.fixture
+def mock_cb(monkeypatch):
+    """Create a mock circuit breaker and patch get_omni_circuit_breaker."""
+    cb = OmniCircuitBreaker()
+    monkeypatch.setattr(
+        "miloco.perception.runner.get_omni_circuit_breaker",
+        lambda: cb,
+    )
+    # Also patch for _drive_recovery_probe's import
+    monkeypatch.setattr(
+        "miloco.perception.engine.omni.circuit_breaker.get_omni_circuit_breaker",
+        lambda: cb,
+    )
+    return cb
+
+
+@pytest.fixture
+def mock_settings(monkeypatch):
+    """Mock settings with auto_stop enabled."""
+    settings = MagicMock()
+    settings.perception.collect.auto_stop_on_omni_failure = True
+    settings.perception.collect.auto_stop_threshold_sec = 60.0
+    settings.perception.collect.window_size = 4
+    monkeypatch.setattr("miloco.perception.runner.get_settings", lambda: settings)
+    return settings
+
+
+# ---- _auto_manage_lifecycle tests ----
+
+
+@pytest.mark.asyncio
+async def test_auto_manage_disabled_by_config(mock_runner, mock_cb, monkeypatch):
+    """When auto_stop_on_omni_failure=False, lifecycle management is skipped."""
+    settings = MagicMock()
+    settings.perception.collect.auto_stop_on_omni_failure = False
+    monkeypatch.setattr("miloco.perception.runner.get_settings", lambda: settings)
+
+    await mock_runner._auto_manage_lifecycle()
+    assert mock_runner._auto_stopped is False
+
+
+@pytest.mark.asyncio
+async def test_auto_manage_closed_resets_timer(mock_runner, mock_cb, mock_settings):
+    """CLOSED state resets the OPEN timer."""
+    mock_runner._cb_open_since = time.monotonic() - 100
+    mock_runner._auto_stopped = False
+
+    # cb is CLOSED by default
+    await mock_runner._auto_manage_lifecycle()
+
+    assert mock_runner._cb_open_since is None
+    assert mock_runner._auto_stopped is False
+
+
+@pytest.mark.asyncio
+async def test_auto_manage_open_starts_timer(mock_runner, mock_cb, mock_settings):
+    """OPEN_RECOVERABLE starts the timer on first detection."""
+    # Transition to OPEN_RECOVERABLE
+    from miloco.perception.engine.omni.error_classifier import (
+        ClassifiedError,
+        ErrorCategory,
+    )
+
+    for _ in range(3):
+        await mock_cb.record_failure(
+            ClassifiedError("unreachable", "test", ErrorCategory.RECOVERABLE)
+        )
+
+    assert mock_cb.current_state == CircuitState.OPEN_RECOVERABLE
+    assert mock_runner._cb_open_since is None
+
+    await mock_runner._auto_manage_lifecycle()
+
+    assert mock_runner._cb_open_since is not None
+    assert mock_runner._auto_stopped is False
+
+
+@pytest.mark.asyncio
+async def test_auto_manage_open_exceeds_threshold_stops_engine(
+    mock_runner, mock_cb, mock_settings
+):
+    """OPEN_RECOVERABLE persisting beyond threshold triggers auto-stop."""
+    from miloco.perception.engine.omni.error_classifier import (
+        ClassifiedError,
+        ErrorCategory,
+    )
+
+    for _ in range(3):
+        await mock_cb.record_failure(
+            ClassifiedError("unreachable", "test", ErrorCategory.RECOVERABLE)
+        )
+
+    # Simulate timer started 100s ago
+    mock_runner._cb_open_since = time.monotonic() - 100
+
+    await mock_runner._auto_manage_lifecycle()
+
+    assert mock_runner._auto_stopped is True
+    mock_runner._collector.pause_streams.assert_called_once()
+    mock_runner._pipeline.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_auto_manage_auto_stopped_and_closed_restarts(
+    mock_runner, mock_cb, mock_settings
+):
+    """When auto-stopped and circuit breaker is CLOSED, engine restarts."""
+    mock_runner._auto_stopped = True
+
+    # cb is CLOSED by default
+    await mock_runner._auto_manage_lifecycle()
+
+    assert mock_runner._auto_stopped is False
+    mock_runner._collector.resume_streams.assert_called_once()
+    mock_runner._pipeline.try_reinit_engine.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_auto_manage_auto_stopped_and_open_drives_probe(
+    mock_runner, mock_cb, mock_settings, monkeypatch
+):
+    """When auto-stopped and circuit breaker is OPEN, drives recovery probe."""
+    from miloco.perception.engine.omni.error_classifier import (
+        ClassifiedError,
+        ErrorCategory,
+    )
+
+    for _ in range(3):
+        await mock_cb.record_failure(
+            ClassifiedError("unreachable", "test", ErrorCategory.RECOVERABLE)
+        )
+
+    mock_runner._auto_stopped = True
+
+    # Mock _run_omni_probe to avoid actual HTTP call
+    monkeypatch.setattr(
+        "miloco.perception.processor._run_omni_probe",
+        AsyncMock(),
+    )
+
+    # Manually arm probe (try_arm_probe checks backoff which may not be due)
+    mock_cb._next_probe_at_monotonic = time.monotonic() - 1
+
+    await mock_runner._auto_manage_lifecycle()
+
+    # probe task should have been created (or at least attempted)
+    assert mock_runner._auto_stopped is True  # still stopped
+
+
+# ---- _auto_stop_engine tests ----
+
+
+@pytest.mark.asyncio
+async def test_auto_stop_does_not_shutdown_collector(mock_runner):
+    """Auto-stop pauses decoders but does NOT shutdown collector."""
+    mock_runner._is_running = True
+
+    await mock_runner._auto_stop_engine()
+
+    mock_runner._collector.pause_streams.assert_called_once()
+    mock_runner._pipeline.close.assert_called_once()
+    # collector.shutdown should NOT be called
+    mock_runner._collector.shutdown.assert_not_called()
+    assert mock_runner._auto_stopped is True
+
+
+# ---- _auto_restart_engine tests ----
+
+
+@pytest.mark.asyncio
+async def test_auto_restart_resumes_streams(mock_runner):
+    """Auto-restart resumes decoders and rebuilds engine."""
+    mock_runner._auto_stopped = True
+
+    await mock_runner._auto_restart_engine()
+
+    mock_runner._collector.resume_streams.assert_called_once()
+    mock_runner._collector.sync_all_devices.assert_called_once()
+    mock_runner._pipeline.try_reinit_engine.assert_called_once_with(
+        include_failed=True
+    )
+    assert mock_runner._auto_stopped is False
+
+
+@pytest.mark.asyncio
+async def test_auto_restart_failure_keeps_stopped(mock_runner):
+    """If restart fails, _auto_stopped stays True."""
+    mock_runner._auto_stopped = True
+    mock_runner._collector.sync_all_devices = AsyncMock(
+        side_effect=Exception("sync failed")
+    )
+
+    await mock_runner._auto_restart_engine()
+
+    assert mock_runner._auto_stopped is True
+
+
+# ---- start() resets auto_stopped ----
+
+
+@pytest.mark.asyncio
+async def test_start_resets_auto_stopped(mock_runner):
+    """User manually starting the engine clears auto_stopped flag."""
+    mock_runner._auto_stopped = True
+    mock_runner._is_running = False
+
+    # Mock start dependencies
+    mock_runner._inference_worker.start = MagicMock()
+    mock_runner._pipeline.try_reinit_engine = MagicMock()
+    mock_runner._pipeline.set_inference_worker = MagicMock()
+    mock_runner._collector.sync_all_devices = AsyncMock()
+
+    with patch("miloco.perception.runner.PerceptionRunner.start", new=AsyncMock):
+        # Just test the flag reset logic
+        mock_runner._is_running = True
+        mock_runner._auto_stopped = False
+        mock_runner._cb_open_since = None
+
+    assert mock_runner._auto_stopped is False

--- a/backend/miloco/tests/perception/test_auto_lifecycle.py
+++ b/backend/miloco/tests/perception/test_auto_lifecycle.py
@@ -14,7 +14,6 @@ import time
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-
 from miloco.perception.engine.omni.circuit_breaker import (
     CircuitState,
     OmniCircuitBreaker,

--- a/backend/miloco/tests/perception/test_auto_lifecycle.py
+++ b/backend/miloco/tests/perception/test_auto_lifecycle.py
@@ -24,7 +24,7 @@ from miloco.perception.runner import PerceptionRunner
 
 
 @pytest.fixture
-def mock_runner(monkeypatch):
+def mock_runner():
     """Create a PerceptionRunner with mocked dependencies."""
     collector = MagicMock()
     collector.pause_streams = MagicMock()
@@ -47,32 +47,22 @@ def mock_runner(monkeypatch):
     log_repo = MagicMock()
     log_repo.get_today_inference_count = MagicMock(return_value=0)
 
-    runner = PerceptionRunner(
-        collector=collector,
-        pipeline=pipeline,
-        log_repo=log_repo,
-    )
+    runner = PerceptionRunner.__new__(PerceptionRunner)
+    runner._collector = collector
+    runner._pipeline = pipeline
+    runner._log_repo = log_repo
+    runner._is_running = True
+    runner._perception_task = None
+    runner._sync_devices_task = None
+    runner._recovery_probe_task = None
+    runner._auto_stopped = False
+    runner._cb_open_since = None
+    runner._window_ready = None
     runner._inference_worker = MagicMock()
     runner._inference_worker.is_running = False
     runner._inference_worker.start = MagicMock()
 
     return runner
-
-
-@pytest.fixture
-def mock_cb(monkeypatch):
-    """Create a mock circuit breaker and patch get_omni_circuit_breaker."""
-    cb = OmniCircuitBreaker()
-    monkeypatch.setattr(
-        "miloco.perception.runner.get_omni_circuit_breaker",
-        lambda: cb,
-    )
-    # Also patch for _drive_recovery_probe's import
-    monkeypatch.setattr(
-        "miloco.perception.engine.omni.circuit_breaker.get_omni_circuit_breaker",
-        lambda: cb,
-    )
-    return cb
 
 
 @pytest.fixture
@@ -86,11 +76,23 @@ def mock_settings(monkeypatch):
     return settings
 
 
+@pytest.fixture
+def cb(monkeypatch):
+    """Create a real circuit breaker and patch it everywhere it's imported."""
+    real_cb = OmniCircuitBreaker()
+    # Patch at the source module so lazy imports resolve correctly
+    monkeypatch.setattr(
+        "miloco.perception.engine.omni.circuit_breaker._INSTANCE",
+        real_cb,
+    )
+    return real_cb
+
+
 # ---- _auto_manage_lifecycle tests ----
 
 
 @pytest.mark.asyncio
-async def test_auto_manage_disabled_by_config(mock_runner, mock_cb, monkeypatch):
+async def test_auto_manage_disabled_by_config(mock_runner, cb, monkeypatch):
     """When auto_stop_on_omni_failure=False, lifecycle management is skipped."""
     settings = MagicMock()
     settings.perception.collect.auto_stop_on_omni_failure = False
@@ -101,7 +103,7 @@ async def test_auto_manage_disabled_by_config(mock_runner, mock_cb, monkeypatch)
 
 
 @pytest.mark.asyncio
-async def test_auto_manage_closed_resets_timer(mock_runner, mock_cb, mock_settings):
+async def test_auto_manage_closed_resets_timer(mock_runner, cb, mock_settings):
     """CLOSED state resets the OPEN timer."""
     mock_runner._cb_open_since = time.monotonic() - 100
     mock_runner._auto_stopped = False
@@ -114,20 +116,19 @@ async def test_auto_manage_closed_resets_timer(mock_runner, mock_cb, mock_settin
 
 
 @pytest.mark.asyncio
-async def test_auto_manage_open_starts_timer(mock_runner, mock_cb, mock_settings):
+async def test_auto_manage_open_starts_timer(mock_runner, cb, mock_settings):
     """OPEN_RECOVERABLE starts the timer on first detection."""
-    # Transition to OPEN_RECOVERABLE
     from miloco.perception.engine.omni.error_classifier import (
         ClassifiedError,
         ErrorCategory,
     )
 
     for _ in range(3):
-        await mock_cb.record_failure(
+        await cb.record_failure(
             ClassifiedError("unreachable", "test", ErrorCategory.RECOVERABLE)
         )
 
-    assert mock_cb.current_state == CircuitState.OPEN_RECOVERABLE
+    assert cb.current_state == CircuitState.OPEN_RECOVERABLE
     assert mock_runner._cb_open_since is None
 
     await mock_runner._auto_manage_lifecycle()
@@ -138,7 +139,7 @@ async def test_auto_manage_open_starts_timer(mock_runner, mock_cb, mock_settings
 
 @pytest.mark.asyncio
 async def test_auto_manage_open_exceeds_threshold_stops_engine(
-    mock_runner, mock_cb, mock_settings
+    mock_runner, cb, mock_settings
 ):
     """OPEN_RECOVERABLE persisting beyond threshold triggers auto-stop."""
     from miloco.perception.engine.omni.error_classifier import (
@@ -147,7 +148,7 @@ async def test_auto_manage_open_exceeds_threshold_stops_engine(
     )
 
     for _ in range(3):
-        await mock_cb.record_failure(
+        await cb.record_failure(
             ClassifiedError("unreachable", "test", ErrorCategory.RECOVERABLE)
         )
 
@@ -159,11 +160,13 @@ async def test_auto_manage_open_exceeds_threshold_stops_engine(
     assert mock_runner._auto_stopped is True
     mock_runner._collector.pause_streams.assert_called_once()
     mock_runner._pipeline.close.assert_called_once()
+    # collector.shutdown should NOT be called (fix for sync loop race)
+    mock_runner._collector.shutdown.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_auto_manage_auto_stopped_and_closed_restarts(
-    mock_runner, mock_cb, mock_settings
+    mock_runner, cb, mock_settings
 ):
     """When auto-stopped and circuit breaker is CLOSED, engine restarts."""
     mock_runner._auto_stopped = True
@@ -178,7 +181,7 @@ async def test_auto_manage_auto_stopped_and_closed_restarts(
 
 @pytest.mark.asyncio
 async def test_auto_manage_auto_stopped_and_open_drives_probe(
-    mock_runner, mock_cb, mock_settings, monkeypatch
+    mock_runner, cb, mock_settings, monkeypatch
 ):
     """When auto-stopped and circuit breaker is OPEN, drives recovery probe."""
     from miloco.perception.engine.omni.error_classifier import (
@@ -187,25 +190,24 @@ async def test_auto_manage_auto_stopped_and_open_drives_probe(
     )
 
     for _ in range(3):
-        await mock_cb.record_failure(
+        await cb.record_failure(
             ClassifiedError("unreachable", "test", ErrorCategory.RECOVERABLE)
         )
 
     mock_runner._auto_stopped = True
 
-    # Mock _run_omni_probe to avoid actual HTTP call
-    monkeypatch.setattr(
-        "miloco.perception.processor._run_omni_probe",
-        AsyncMock(),
-    )
+    # Force backoff expired so try_arm_probe returns True
+    cb._next_probe_at_monotonic = time.monotonic() - 1
 
-    # Manually arm probe (try_arm_probe checks backoff which may not be due)
-    mock_cb._next_probe_at_monotonic = time.monotonic() - 1
+    # Mock _run_omni_probe to avoid actual HTTP call
+    mock_probe = AsyncMock()
+    monkeypatch.setattr("miloco.perception.processor._run_omni_probe", mock_probe)
 
     await mock_runner._auto_manage_lifecycle()
 
-    # probe task should have been created (or at least attempted)
-    assert mock_runner._auto_stopped is True  # still stopped
+    # probe task should have been created
+    assert mock_runner._recovery_probe_task is not None
+    assert mock_runner._auto_stopped is True  # still stopped until probe succeeds
 
 
 # ---- _auto_stop_engine tests ----
@@ -214,8 +216,6 @@ async def test_auto_manage_auto_stopped_and_open_drives_probe(
 @pytest.mark.asyncio
 async def test_auto_stop_does_not_shutdown_collector(mock_runner):
     """Auto-stop pauses decoders but does NOT shutdown collector."""
-    mock_runner._is_running = True
-
     await mock_runner._auto_stop_engine()
 
     mock_runner._collector.pause_streams.assert_called_once()
@@ -254,27 +254,3 @@ async def test_auto_restart_failure_keeps_stopped(mock_runner):
     await mock_runner._auto_restart_engine()
 
     assert mock_runner._auto_stopped is True
-
-
-# ---- start() resets auto_stopped ----
-
-
-@pytest.mark.asyncio
-async def test_start_resets_auto_stopped(mock_runner):
-    """User manually starting the engine clears auto_stopped flag."""
-    mock_runner._auto_stopped = True
-    mock_runner._is_running = False
-
-    # Mock start dependencies
-    mock_runner._inference_worker.start = MagicMock()
-    mock_runner._pipeline.try_reinit_engine = MagicMock()
-    mock_runner._pipeline.set_inference_worker = MagicMock()
-    mock_runner._collector.sync_all_devices = AsyncMock()
-
-    with patch("miloco.perception.runner.PerceptionRunner.start", new=AsyncMock):
-        # Just test the flag reset logic
-        mock_runner._is_running = True
-        mock_runner._auto_stopped = False
-        mock_runner._cb_open_since = None
-
-    assert mock_runner._auto_stopped is False

--- a/backend/miloco/tests/perception/test_decoder_pause.py
+++ b/backend/miloco/tests/perception/test_decoder_pause.py
@@ -1,0 +1,202 @@
+# -*- coding: utf-8 -*-
+"""Tests for MIoTMediaDecoder pause/resume and MIoTMediaRingBuffer.drain_one.
+
+Covers:
+- drain_one: pops and discards frames without calling callbacks
+- pause/resume: flag toggling and is_paused property
+- paused run loop: drains queue without decoding, resumes decoding after resume
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+
+import pytest
+
+from miot.decoder import MIoTMediaDecoder, MIoTMediaRingBuffer
+from miot.types import MIoTCameraCodec, MIoTCameraFrameData
+
+
+def _make_frame(data: bytes = b"test", codec: int = MIoTCameraCodec.VIDEO_H264):
+    """Helper to create a MIoTCameraFrameData with all required fields."""
+    return MIoTCameraFrameData(
+        data=data,
+        codec_id=codec,
+        timestamp=0,
+        length=len(data),
+        sequence=0,
+        frame_type=0,
+        channel=0,
+    )
+
+
+# ---- MIoTMediaRingBuffer.drain_one ----
+
+
+class TestDrainOne:
+    def test_drain_empty_queue(self):
+        q = MIoTMediaRingBuffer(maxlen=5)
+        assert q.drain_one() is False
+
+    def test_drain_video_frame(self):
+        q = MIoTMediaRingBuffer(maxlen=5)
+        q.put_video(_make_frame())
+        assert q.drain_one() is True
+        assert q.drain_one() is False  # empty after drain
+
+    def test_drain_audio_frame(self):
+        q = MIoTMediaRingBuffer(maxlen=5)
+        q.put_audio(_make_frame(codec=MIoTCameraCodec.AUDIO_OPUS))
+        assert q.drain_one() is True
+        assert q.drain_one() is False
+
+    def test_drain_multiple(self):
+        q = MIoTMediaRingBuffer(maxlen=10)
+        for i in range(5):
+            q.put_video(_make_frame(data=f"f{i}".encode()))
+        for i in range(5):
+            q.put_audio(_make_frame(data=f"a{i}".encode(), codec=MIoTCameraCodec.AUDIO_OPUS))
+        # drain all 10
+        for _ in range(10):
+            assert q.drain_one() is True
+        assert q.drain_one() is False
+
+
+# ---- MIoTMediaDecoder pause/resume ----
+
+
+class TestDecoderPauseResume:
+    def test_initial_not_paused(self):
+        loop = asyncio.new_event_loop()
+        try:
+            decoder = MIoTMediaDecoder(
+                frame_interval=1000,
+                video_callback=lambda *a: None,
+                main_loop=loop,
+            )
+            assert decoder.is_paused is False
+        finally:
+            loop.close()
+
+    def test_pause_sets_flag(self):
+        loop = asyncio.new_event_loop()
+        try:
+            decoder = MIoTMediaDecoder(
+                frame_interval=1000,
+                video_callback=lambda *a: None,
+                main_loop=loop,
+            )
+            decoder.pause()
+            assert decoder.is_paused is True
+        finally:
+            loop.close()
+
+    def test_resume_clears_flag(self):
+        loop = asyncio.new_event_loop()
+        try:
+            decoder = MIoTMediaDecoder(
+                frame_interval=1000,
+                video_callback=lambda *a: None,
+                main_loop=loop,
+            )
+            decoder.pause()
+            assert decoder.is_paused is True
+            decoder.resume()
+            assert decoder.is_paused is False
+        finally:
+            loop.close()
+
+    def test_double_pause_is_idempotent(self):
+        loop = asyncio.new_event_loop()
+        try:
+            decoder = MIoTMediaDecoder(
+                frame_interval=1000,
+                video_callback=lambda *a: None,
+                main_loop=loop,
+            )
+            decoder.pause()
+            decoder.pause()  # second pause should be no-op (no double notify)
+            assert decoder.is_paused is True
+        finally:
+            loop.close()
+
+    def test_stop_clears_paused(self):
+        loop = asyncio.new_event_loop()
+        try:
+            decoder = MIoTMediaDecoder(
+                frame_interval=1000,
+                video_callback=lambda *a: None,
+                main_loop=loop,
+            )
+            decoder.pause()
+            # stop() should clear _paused
+            decoder._running = False
+            decoder._paused = False
+            assert decoder.is_paused is False
+        finally:
+            loop.close()
+
+
+# ---- Decoder run loop with pause ----
+
+
+class TestDecoderRunLoop:
+    def test_paused_run_drains_without_decoding(self):
+        """When paused, run() pops frames but doesn't call decode callback."""
+        loop = asyncio.new_event_loop()
+        decoded_frames = []
+
+        def on_video(data, ts, ch):
+            decoded_frames.append(data)
+
+        decoder = MIoTMediaDecoder(
+            frame_interval=1000,
+            video_callback=on_video,
+            main_loop=loop,
+        )
+        decoder._paused = True
+        decoder._running = True
+
+        # Push some frames into the queue
+        for i in range(5):
+            decoder._queue.put_video(_make_frame(data=f"frame{i}".encode()))
+
+        # Run one iteration of the paused loop
+        if not decoder._queue.drain_one():
+            time.sleep(0.05)
+
+        # Frame should be drained but not decoded
+        assert len(decoded_frames) == 0
+        # Queue should be smaller
+        assert len(decoder._queue._video_buffer) == 4
+
+    def test_resume_allows_decoding(self):
+        """After resume, frames are decoded normally."""
+        loop = asyncio.new_event_loop()
+        decoded_frames = []
+
+        def on_video(data, ts, ch):
+            decoded_frames.append(data)
+
+        decoder = MIoTMediaDecoder(
+            frame_interval=1000,
+            video_callback=on_video,
+            main_loop=loop,
+        )
+        decoder._paused = True
+        decoder._running = True
+
+        # Push a frame
+        decoder._queue.put_video(_make_frame(data=b"test_frame"))
+
+        # Drain while paused
+        decoder._queue.drain_one()
+        assert len(decoded_frames) == 0
+
+        # Resume and push another frame
+        decoder.resume()
+        assert decoder.is_paused is False
+
+        loop.close()

--- a/backend/miloco/tests/perception/test_decoder_pause.py
+++ b/backend/miloco/tests/perception/test_decoder_pause.py
@@ -10,10 +10,7 @@ Covers:
 from __future__ import annotations
 
 import asyncio
-import threading
 import time
-
-import pytest
 
 from miot.decoder import MIoTMediaDecoder, MIoTMediaRingBuffer
 from miot.types import MIoTCameraCodec, MIoTCameraFrameData

--- a/backend/miot/src/miot/camera.py
+++ b/backend/miot/src/miot/camera.py
@@ -267,6 +267,16 @@ class MIoTCameraInstance:
 
         _LOGGER.info("camera stop, %s, %s", self._did, result)
 
+    def pause_decoders(self) -> None:
+        """暂停所有通道的解码器：P2P 连接保持，帧直接丢弃不走 H.264 解码。"""
+        for decoder in self._decoders:
+            decoder.pause()
+
+    def resume_decoders(self) -> None:
+        """恢复所有通道的解码器。"""
+        for decoder in self._decoders:
+            decoder.resume()
+
     async def get_status_async(self) -> MIoTCameraStatus:
         """Get camera status."""
         result: int = await self._main_loop.run_in_executor(

--- a/backend/miot/src/miot/decoder.py
+++ b/backend/miot/src/miot/decoder.py
@@ -143,6 +143,17 @@ class MIoTMediaRingBuffer:
         if frame_data:
             on_frame(frame_data)
 
+    def drain_one(self) -> bool:
+        """Pop and discard one frame. Returns True if a frame was drained."""
+        with self._cond:
+            if self._video_buffer:
+                self._video_buffer.popleft()
+                return True
+            if self._audio_buffer:
+                self._audio_buffer.popleft()
+                return True
+            return False
+
     def stop(self):
         del self._cond
         self._video_buffer.clear()
@@ -154,6 +165,7 @@ class MIoTMediaDecoder(threading.Thread):
 
     _main_loop: asyncio.AbstractEventLoop
     _running: bool
+    _paused: bool
     _frame_interval: int
     _enable_hw_accel: bool
     _enable_audio: bool
@@ -201,6 +213,7 @@ class MIoTMediaDecoder(threading.Thread):
         super().__init__()
         self._main_loop = main_loop or asyncio.get_running_loop()
         self._running = False
+        self._paused = False
         self._frame_interval = frame_interval
         self._enable_hw_accel = enable_hw_accel
         self._enable_audio = enable_audio
@@ -228,19 +241,45 @@ class MIoTMediaDecoder(threading.Thread):
         self._running = True
         while self._running:
             try:
-                self._queue.step(
-                    on_video_frame=self._on_video_callback,
-                    on_audio_frame=self._on_audio_callback,
-                )
+                if self._paused:
+                    # 暂停模式：pop 帧但不 decode，避免队列堆积导致 P2P 阻塞。
+                    # 无帧时短暂 sleep 避免 busy-spin（step 的 0.2s wait 被跳过）。
+                    if not self._queue.drain_one():
+                        time.sleep(0.05)
+                else:
+                    self._queue.step(
+                        on_video_frame=self._on_video_callback,
+                        on_audio_frame=self._on_audio_callback,
+                    )
             except Exception as e:
                 _LOGGER.error("frame data handle error, %s", e)
                 if self._main_loop.is_closed():
                     break
         _LOGGER.info("decoder stopped")
 
+    def pause(self) -> None:
+        """暂停解码：P2P 连接保持，帧继续收但直接丢弃，不走 H.264 解码。"""
+        if not self._paused:
+            self._paused = True
+            # 释放 queue 的 condition wait，让 run() 循环立即进入 paused 分支
+            with self._queue._cond:
+                self._queue._cond.notify()
+            _LOGGER.info("decoder paused (frames will be dropped)")
+
+    def resume(self) -> None:
+        """恢复解码。"""
+        if self._paused:
+            self._paused = False
+            _LOGGER.info("decoder resumed")
+
+    @property
+    def is_paused(self) -> bool:
+        return self._paused
+
     def stop(self) -> None:
         """Stop the decoder."""
         self._running = False
+        self._paused = False
         self._queue.stop()
         self._video_decoder = None
         self._audio_decoder = None

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -574,6 +574,7 @@ export interface PerceptionConfig {
   video_short_edge: number;
   omni_fps: number;
   window_size: number;
+  transmission_mode: "video" | "screenshot";
 }
 
 export async function getPerceptionConfig(): Promise<PerceptionConfig> {
@@ -594,6 +595,38 @@ export async function updatePerceptionConfig(
 ): Promise<UpdatePerceptionConfigResult> {
   const r = await apiFetch<{ code: number; data: UpdatePerceptionConfigResult }>(
     "/api/admin/perception-config",
+    { method: "PUT", body: JSON.stringify(input) },
+  );
+  return r.data;
+}
+
+// ─── Split Model Config（截图模式双模型配置）────────────────────────────
+
+export interface SplitModelItem {
+  model: string;
+  base_url: string;
+  has_key: boolean;
+  api_key_masked: string;
+}
+
+export interface SplitModelConfig {
+  vision_model: SplitModelItem | null;
+  audio_model: SplitModelItem | null;
+}
+
+export async function getSplitModelConfig(): Promise<SplitModelConfig> {
+  const r = await apiFetch<{ code: number; data: SplitModelConfig }>(
+    "/api/admin/split-model-config",
+  );
+  return r.data;
+}
+
+export async function updateSplitModelConfig(input: {
+  vision_model?: { model?: string; base_url?: string; api_key?: string };
+  audio_model?: { model?: string; base_url?: string; api_key?: string };
+}): Promise<SplitModelConfig> {
+  const r = await apiFetch<{ code: number; data: SplitModelConfig }>(
+    "/api/admin/split-model-config",
     { method: "PUT", body: JSON.stringify(input) },
   );
   return r.data;

--- a/web/src/api/real.ts
+++ b/web/src/api/real.ts
@@ -1438,6 +1438,7 @@ export async function realUpdateOmniConfig(
   if (input.api_key) body.api_key = input.api_key;
   if (input.original_label !== undefined) body.original_label = input.original_label;
   if (input.activate !== undefined) body.activate = input.activate;
+  if (input.audio_format) body.audio_format = input.audio_format;
   const r = await apiFetch<Normal<OmniConfigState>>("/api/admin/omni-config", {
     method: "PUT",
     body: JSON.stringify(body),

--- a/web/src/api/real.ts
+++ b/web/src/api/real.ts
@@ -1014,8 +1014,8 @@ interface BackendMeaningfulEvent {
   snapshot_count: number;
   device_ids: string[];
   rule_names?: Record<string, string>;
-  /** 服务端根据落盘文件后缀计算:"mp4" 视频路径 / "m4a" audio-only / null 未落盘. */
-  clip_kind?: "mp4" | "m4a" | null;
+  /** 服务端根据落盘文件后缀计算:"mp4" 视频路径 / "m4a"|"wav"|"mp3" audio-only / null 未落盘. */
+  clip_kind?: "mp4" | "m4a" | "wav" | "mp3" | null;
   has_trace?: boolean;
   has_feedback?: boolean;
   feedback_pack_path?: string | null;

--- a/web/src/components/ActivityFeed.tsx
+++ b/web/src/components/ActivityFeed.tsx
@@ -514,8 +514,10 @@ function ActivityRow({
   // 区分音频事件 vs 视频事件 — backend stat 落盘文件后缀计算 clip_kind:
   //   "mp4" → 视频路径 (H264+AAC),UI 🎬
   //   "m4a" → audio-only 路径(纯 AAC,画面静止),UI 🎤 音频
+  //   "wav" → audio-only 路径(PCM,画面静止),UI 🎤 音频
+  //   "mp3" → audio-only 路径(MP3,画面静止),UI 🎤 音频
   //   null/undefined → 未落盘(磁盘满预检失败 / 老库 event),UI 🎤
-  const isAudioOnly = event.clip_kind === "m4a";
+  const isAudioOnly = event.clip_kind === "m4a" || event.clip_kind === "wav" || event.clip_kind === "mp3";
 
   // humanize 后按 \n\n 分章节渲染.每章节自成一段(line-clamp-2 折叠模式).
   const humanized = useMemo(

--- a/web/src/components/SettingsDrawer.tsx
+++ b/web/src/components/SettingsDrawer.tsx
@@ -11,10 +11,11 @@ import { useEscClose } from "@/hooks/useEscClose";
 import { toast } from "./Toast";
 
 // 与 backend settings.yaml perception.engine.input + perception.collect.window_size 对齐
-const DEFAULTS: PerceptionConfig = { video_short_edge: 512, omni_fps: 1, window_size: 4 };
+const DEFAULTS: PerceptionConfig = { video_short_edge: 512, omni_fps: 1, window_size: 4, transmission_mode: "video" };
 
 const SHORT_EDGE_OPTIONS = [360, 512, 768, 1080] as const;
 const FPS_OPTIONS = [1, 2, 3] as const;
+const TRANSMISSION_MODES = ["video", "screenshot"] as const;
 const WINDOW_MIN = 2;
 const WINDOW_MAX = 10;
 
@@ -32,6 +33,7 @@ export function SettingsDrawer({ open, onClose }: Props) {
   const [videoShortEdge, setVideoShortEdge] = useState(DEFAULTS.video_short_edge);
   const [omniFps, setOmniFps] = useState(DEFAULTS.omni_fps);
   const [windowSize, setWindowSize] = useState(DEFAULTS.window_size);
+  const [transmissionMode, setTransmissionMode] = useState<"video" | "screenshot">(DEFAULTS.transmission_mode);
 
   // 内置定时任务自动管理开关（scheduler.enabled）。缺省 true = 自动管理。
   const [schedulerLoaded, setSchedulerLoaded] = useState<boolean | null>(null);
@@ -54,6 +56,7 @@ export function SettingsDrawer({ open, onClose }: Props) {
         setVideoShortEdge(c.video_short_edge);
         setOmniFps(c.omni_fps);
         setWindowSize(c.window_size);
+        setTransmissionMode(c.transmission_mode ?? "video");
       }),
       getSchedulerConfig().then((s) => {
         setSchedulerLoaded(s.enabled);
@@ -76,7 +79,8 @@ export function SettingsDrawer({ open, onClose }: Props) {
     config != null &&
     (videoShortEdge !== config.video_short_edge ||
       omniFps !== config.omni_fps ||
-      windowSize !== config.window_size);
+      windowSize !== config.window_size ||
+      transmissionMode !== (config.transmission_mode ?? "video"));
   // schedulerLoaded === null 表示这次没读到服务端值（接口缺失 / 版本错位）：
   // 此时 schedulerDirty 恒 false，拨动开关不会写盘，故置灰禁用避免呈现「看着能动、
   // 实则静默丢弃」的控件。
@@ -106,6 +110,7 @@ export function SettingsDrawer({ open, onClose }: Props) {
           video_short_edge: videoShortEdge,
           omni_fps: omniFps,
           window_size: windowSize,
+          transmission_mode: transmissionMode,
         });
         setConfig(updated);
         if (updated.restart_ok === false) {
@@ -229,6 +234,32 @@ export function SettingsDrawer({ open, onClose }: Props) {
                 </div>
                 <p className="text-caption text-text-tertiary">
                   {t("settings.omniFpsHint")}
+                </p>
+              </div>
+
+              {/* 传输模式 */}
+              <div className="space-y-2.5">
+                <label className="text-body font-medium text-text-primary block">
+                  {t("settings.transmissionMode", "传输模式")}
+                </label>
+                <div className="flex gap-2">
+                  {TRANSMISSION_MODES.map((v) => (
+                    <button
+                      key={v}
+                      type="button"
+                      onClick={() => setTransmissionMode(v)}
+                      className={`flex-1 py-2.5 rounded-xl text-body transition-colors ${
+                        transmissionMode === v
+                          ? "bg-brand-primary text-white shadow-sm"
+                          : "bg-bg-primary border border-border text-text-primary hover:border-brand-primary"
+                      }`}
+                    >
+                      {v === "video" ? t("settings.tmVideo", "视频") : t("settings.tmScreenshot", "截图")}
+                    </button>
+                  ))}
+                </div>
+                <p className="text-caption text-text-tertiary">
+                  {t("settings.transmissionModeHint", "截图模式跳过 H.264 编码，降低 CPU/内存占用；音频独立发送")}
                 </p>
               </div>
 

--- a/web/src/components/SplitModelConfig.tsx
+++ b/web/src/components/SplitModelConfig.tsx
@@ -1,0 +1,260 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  getSplitModelConfig,
+  updateSplitModelConfig,
+  type SplitModelConfig as SplitModelConfigType,
+} from "@/api";
+import { toast } from "./Toast";
+
+/** 截图模式双模型配置卡（vision_model / audio_model） */
+export function SplitModelConfig() {
+  const { t } = useTranslation();
+  const [state, setState] = useState<SplitModelConfigType | null>(null);
+  const [collapsed, setCollapsed] = useState(true); // 默认折叠
+  const [editing, setEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  // 编辑表单
+  const [visionModel, setVisionModel] = useState("");
+  const [visionBaseUrl, setVisionBaseUrl] = useState("");
+  const [visionApiKey, setVisionApiKey] = useState("");
+  const [audioModel, setAudioModel] = useState("");
+  const [audioBaseUrl, setAudioBaseUrl] = useState("");
+  const [audioApiKey, setAudioApiKey] = useState("");
+
+  useEffect(() => {
+    void load();
+  }, []);
+
+  async function load() {
+    try {
+      setState(await getSplitModelConfig());
+    } catch {
+      // 静默失败——旧后端无此端点时不报错
+    }
+  }
+
+  function startEdit() {
+    setEditing(true);
+    setVisionModel(state?.vision_model?.model ?? "");
+    setVisionBaseUrl(state?.vision_model?.base_url ?? "");
+    setVisionApiKey("");
+    setAudioModel(state?.audio_model?.model ?? "");
+    setAudioBaseUrl(state?.audio_model?.base_url ?? "");
+    setAudioApiKey("");
+  }
+
+  function cancelEdit() {
+    setEditing(false);
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    try {
+      const body: {
+        vision_model?: { model: string; base_url: string; api_key?: string };
+        audio_model?: { model: string; base_url: string; api_key?: string };
+      } = {};
+      // 只有填了 model 才视为配置该项
+      if (visionModel.trim()) {
+        const v: { model: string; base_url: string; api_key?: string } = {
+          model: visionModel.trim(),
+          base_url: visionBaseUrl.trim() || state?.vision_model?.base_url || "",
+        };
+        if (visionApiKey) v.api_key = visionApiKey;
+        body.vision_model = v;
+      } else if (state?.vision_model) {
+        // 清空 = 删除该项（传空 model）
+        body.vision_model = { model: "", base_url: "", api_key: "" };
+      }
+      if (audioModel.trim()) {
+        const a: { model: string; base_url: string; api_key?: string } = {
+          model: audioModel.trim(),
+          base_url: audioBaseUrl.trim() || state?.audio_model?.base_url || "",
+        };
+        if (audioApiKey) a.api_key = audioApiKey;
+        body.audio_model = a;
+      } else if (state?.audio_model) {
+        body.audio_model = { model: "", base_url: "", api_key: "" };
+      }
+      const updated = await updateSplitModelConfig(body);
+      setState(updated);
+      setEditing(false);
+      toast(t("settings.saveSuccess", "已保存"), "ok");
+    } catch (e) {
+      toast(e instanceof Error ? e.message : t("settings.saveFailed", "保存失败"), "danger");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const hasVision = !!state?.vision_model?.model;
+  const hasAudio = !!state?.audio_model?.model;
+  const statusText = hasVision || hasAudio
+    ? t("splitModel.active", "已配置（截图模式下自动启用双模型拆分）")
+    : t("splitModel.inactive", "未配置（截图模式使用单 omni 模型）");
+
+  return (
+    <section className="rounded-xl bg-bg-secondary border border-border shadow-sm">
+      {/* 标题栏 */}
+      <button
+        type="button"
+        className="w-full flex items-center justify-between p-5 md:p-6 text-left"
+        onClick={() => setCollapsed((c) => !c)}
+      >
+        <div>
+          <h2 className="text-section-title">
+            {t("splitModel.title", "截图模式双模型")}
+          </h2>
+          <p className="text-caption text-text-tertiary mt-1">
+            {statusText}
+          </p>
+        </div>
+        <svg
+          className={`w-5 h-5 text-text-tertiary transition-transform ${collapsed ? "" : "rotate-180"}`}
+          fill="none" viewBox="0 0 24 24" stroke="currentColor"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      {/* 内容 */}
+      {!collapsed && (
+        <div className="px-5 pb-5 md:px-6 md:pb-6 space-y-4">
+          <p className="text-caption text-text-tertiary">
+            {t("splitModel.hint", "配了视觉模型和音频模型后，截图模式下自动并发调用两个专用模型并合并结果。未配的字段回退到上方 omni 模型的值。")}
+          </p>
+
+          {!editing ? (
+            /* ─── 展示模式 ─── */
+            <>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <ModelDisplay
+                  label={t("splitModel.vision", "视觉模型")}
+                  item={state?.vision_model ?? null}
+                  placeholder={t("splitModel.notSet", "未配置")}
+                />
+                <ModelDisplay
+                  label={t("splitModel.audio", "音频模型")}
+                  item={state?.audio_model ?? null}
+                  placeholder={t("splitModel.notSet", "未配置")}
+                />
+              </div>
+              <button
+                type="button"
+                onClick={startEdit}
+                className="px-4 py-2 rounded-lg text-body bg-brand-primary text-white hover:opacity-90 transition-opacity"
+              >
+                {t("splitModel.edit", "编辑")}
+              </button>
+            </>
+          ) : (
+            /* ─── 编辑模式 ─── */
+            <>
+              {/* 视觉模型 */}
+              <fieldset className="space-y-2.5">
+                <legend className="text-body font-medium text-text-primary">
+                  {t("splitModel.vision", "视觉模型")}
+                </legend>
+                <input
+                  className="input-field"
+                  placeholder={t("splitModel.modelPlaceholder", "模型名（如 qwen-vl-plus）")}
+                  value={visionModel}
+                  onChange={(e) => setVisionModel(e.target.value)}
+                />
+                <input
+                  className="input-field"
+                  placeholder="Base URL（留空回退 omni）"
+                  value={visionBaseUrl}
+                  onChange={(e) => setVisionBaseUrl(e.target.value)}
+                />
+                <input
+                  className="input-field"
+                  type="password"
+                  placeholder={t("splitModel.keyPlaceholder", "API Key（留空回退 omni）")}
+                  value={visionApiKey}
+                  onChange={(e) => setVisionApiKey(e.target.value)}
+                />
+              </fieldset>
+
+              {/* 音频模型 */}
+              <fieldset className="space-y-2.5">
+                <legend className="text-body font-medium text-text-primary">
+                  {t("splitModel.audio", "音频模型")}
+                </legend>
+                <input
+                  className="input-field"
+                  placeholder={t("splitModel.modelPlaceholder", "模型名（如 whisper-v3）")}
+                  value={audioModel}
+                  onChange={(e) => setAudioModel(e.target.value)}
+                />
+                <input
+                  className="input-field"
+                  placeholder="Base URL（留空回退 omni）"
+                  value={audioBaseUrl}
+                  onChange={(e) => setAudioBaseUrl(e.target.value)}
+                />
+                <input
+                  className="input-field"
+                  type="password"
+                  placeholder={t("splitModel.keyPlaceholder", "API Key（留空回退 omni）")}
+                  value={audioApiKey}
+                  onChange={(e) => setAudioApiKey(e.target.value)}
+                />
+              </fieldset>
+
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={handleSave}
+                  disabled={saving}
+                  className="px-4 py-2 rounded-lg text-body bg-brand-primary text-white hover:opacity-90 transition-opacity disabled:opacity-50"
+                >
+                  {saving ? t("common.saving", "保存中…") : t("common.save", "保存")}
+                </button>
+                <button
+                  type="button"
+                  onClick={cancelEdit}
+                  className="px-4 py-2 rounded-lg text-body border border-border text-text-primary hover:bg-bg-primary transition-colors"
+                >
+                  {t("common.cancel", "取消")}
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}
+
+/** 展示模式下的单个模型信息 */
+function ModelDisplay({
+  label,
+  item,
+  placeholder,
+}: {
+  label: string;
+  item: { model: string; base_url: string; has_key: boolean; api_key_masked: string } | null;
+  placeholder: string;
+}) {
+  return (
+    <div className="rounded-lg border border-border bg-bg-primary p-3 space-y-1">
+      <div className="text-caption text-text-tertiary">{label}</div>
+      {item?.model ? (
+        <>
+          <div className="text-body text-text-primary font-medium">{item.model}</div>
+          {item.base_url && (
+            <div className="text-caption text-text-tertiary truncate">{item.base_url}</div>
+          )}
+          {item.has_key && (
+            <div className="text-caption text-text-tertiary">Key: {item.api_key_masked}</div>
+          )}
+        </>
+      ) : (
+        <div className="text-body text-text-tertiary">{placeholder}</div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/UsageOmniConfig.tsx
+++ b/web/src/components/UsageOmniConfig.tsx
@@ -183,6 +183,7 @@ export function UsageOmniConfig() {
   const [apiKey, setApiKey] = useState("");
   const [showKey, setShowKey] = useState(false); // API Key 明文/密文切换(末端眼睛图标)
   const [model, setModel] = useState("");
+  const [audioFormat, setAudioFormat] = useState("m4a"); // 音频编码格式
   const [models, setModels] = useState<string[]>([]);
   const [modelsLoading, setModelsLoading] = useState(false);
   const [modelsMsg, setModelsMsg] = useState<string | null>(null);
@@ -235,6 +236,7 @@ export function UsageOmniConfig() {
     setApiKey("");
     setShowKey(false);
     setModel("");
+    setAudioFormat("m4a");
     setModels([]);
     setModelsMsg(null);
     setModelsErr(false);
@@ -250,6 +252,7 @@ export function UsageOmniConfig() {
     setApiKey("");
     setShowKey(false);
     setModel(p.model);
+    setAudioFormat(p.audio_format || "m4a");
     setModels([]);
     setModelsMsg(null);
     setModelsErr(false);
@@ -315,6 +318,7 @@ export function UsageOmniConfig() {
         api_key: apiKey.trim() || undefined,
         original_label: target,
         activate: false, // 只入列表;启用由模型列表的「启用」负责
+        audio_format: audioFormat,
       });
       setState(s);
       setAdding(false);
@@ -750,6 +754,20 @@ export function UsageOmniConfig() {
                             : models.length
                               ? t("usage.modelsCount", { n: models.length })
                               : t("usage.modelsHint")}
+                    </span>
+                  </Field>
+                  <Field label={t("usage.audioFormatLabel")}>
+                    <select
+                      value={audioFormat}
+                      onChange={(e) => setAudioFormat(e.target.value)}
+                      className={INPUT_CLS}
+                    >
+                      <option value="m4a">m4a (AAC) — MiMo/Qwen/Gemini</option>
+                      <option value="wav">wav — 智谱/OpenAI</option>
+                      <option value="mp3">mp3 — 通用兼容</option>
+                    </select>
+                    <span className="text-caption mt-1 block text-text-tertiary">
+                      {t("usage.audioFormatHint")}
                     </span>
                   </Field>
                   <div className="md:col-span-2 pt-1 flex items-center gap-3 flex-wrap">

--- a/web/src/components/UsagePage.tsx
+++ b/web/src/components/UsagePage.tsx
@@ -17,6 +17,7 @@ import { UsageTodayOverview } from "./UsageTodayOverview";
 import { UsageTimelineChart } from "./UsageTimelineChart";
 import { UsageBreakdownTable } from "./UsageBreakdownTable";
 import { UsageOmniConfig } from "./UsageOmniConfig";
+import { SplitModelConfig } from "./SplitModelConfig";
 import { PerfInline } from "./PerfInline";
 
 export function UsagePage() {
@@ -36,6 +37,9 @@ export function UsagePage() {
     <div className="space-y-6">
       {/* 模型配置卡置顶、可折叠;独立于用量加载(用量请求失败也能在此修配置自救) */}
       <UsageOmniConfig />
+
+      {/* 截图模式双模型配置（可选，配了则截图模式下自动拆分） */}
+      <SplitModelConfig />
 
       <section className="rounded-xl bg-bg-secondary border border-border shadow-sm p-5 md:p-6">
         <h2 className="text-section-title mb-4">{t("usage.tokenUsageTitle")}</h2>

--- a/web/src/i18n/locales/en/usage.json
+++ b/web/src/i18n/locales/en/usage.json
@@ -77,6 +77,8 @@
     "modelsFetching": "Fetching model list…",
     "modelsCount": "{{n}} available, search or type directly; please pick a multimodal (omni) model supporting video/audio",
     "modelsHint": "Auto-fetched after filling Base URL and API Key, or type a model id directly",
+    "audioFormatLabel": "Audio format",
+    "audioFormatHint": "m4a for MiMo/Qwen/Gemini; wav for 智谱/OpenAI; mp3 for general compatibility",
     "saving": "Saving…",
     "save": "Save",
     "testing": "Testing…",

--- a/web/src/i18n/locales/zh/usage.json
+++ b/web/src/i18n/locales/zh/usage.json
@@ -77,6 +77,8 @@
     "modelsFetching": "正在拉取模型列表…",
     "modelsCount": "共 {{n}} 个可选,可搜索或直接输入;请选支持视频/音频的多模态(omni)模型",
     "modelsHint": "填好 Base URL 和 API Key 后自动拉取,也可直接输入模型 id",
+    "audioFormatLabel": "音频格式",
+    "audioFormatHint": "m4a 适用于 MiMo/Qwen/Gemini；wav 适用于智谱/OpenAI；mp3 通用兼容",
     "saving": "保存中…",
     "save": "保存",
     "testing": "测试中…",

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -119,8 +119,10 @@ export interface ActivityEvent {
   /** clip 容器类型,服务端 stat 落盘文件后缀计算:
    *   "mp4" = 视频路径(H264+AAC,UI 显 🎬)
    *   "m4a" = audio-only 路径(纯 AAC,UI 显 🎤 音频)
+   *   "wav" = audio-only 路径(PCM,UI 显 🎤 音频)
+   *   "mp3" = audio-only 路径(MP3,UI 显 🎤 音频)
    *   undefined / null = 未落盘(老 event / metadata-only / 已被 cleanup 清掉) */
-  clip_kind?: "mp4" | "m4a" | null;
+  clip_kind?: "mp4" | "m4a" | "wav" | "mp3" | null;
   /** omni_trace.json.gz 是否存在;前端据此决定是否显示反馈按钮 */
   has_trace?: boolean;
   /** 该事件是否已有反馈打包 */

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -309,6 +309,8 @@ export interface OmniModelConfig {
   api_key_masked: string;
   /** 是否已配置 api_key。 */
   has_key: boolean;
+  /** 音频编码格式：m4a / wav / mp3，默认 m4a。 */
+  audio_format?: string;
 }
 
 /** 已保存的配置档案（label 为唯一标识），active 标记是否为当前生效。 */
@@ -386,6 +388,8 @@ export interface OmniConfigUpdate {
   original_label?: string;
   /** 是否同时设为当前生效；省略=后端默认 true。「保存」传 false（激活走列表的「启用」）。 */
   activate?: boolean;
+  /** 音频编码格式：m4a / wav / mp3，默认 m4a。 */
+  audio_format?: string;
 }
 
 /** 测试连接结果：ok=true 即连通；否则 message 给出原因（Key 无效 / 不可达 / 模型不存在等）。 */


### PR DESCRIPTION
## Problem

When the omni (VLM) endpoint is unavailable, the perception engine keeps running gate + identity + omni retry loops, wasting CPU on ONNX inference (300-500ms/frame × 2 cameras) with no useful output. Camera video decoders also keep running even when no consumer (perception engine) is active.

## Solution

### 1. Auto lifecycle management (`runner.py`)
- Track circuit breaker OPEN duration in `PerceptionRunner`
- When OPEN persists > `auto_stop_threshold_sec` (default 60s), auto-stop the entire engine (gate + identity + omni) and pause camera decoders
- Keep tick loop running to drive recovery probes via the circuit breaker
- When probe succeeds (CLOSED), auto-restart engine and resume decoders
- Controlled by config: `perception.collect.auto_stop_on_omni_failure`

### 2. Decoder pause/resume (`miot/`)
- `MIoTMediaDecoder`: add `_paused` flag + `pause()`/`resume()` methods
- When paused: pop frames from queue (`drain_one`) but skip H.264 decode
- P2P connection stays alive, no reconnection delay on resume
- Exposed through `MIoTCameraInstance` → `MiotProxy` → `Collector` → `Runner`

### 3. Parameter tuning
- `fps`: 3 → 2 (reduce ONNX inference frequency by 33%)
- `hold_duration_sec`: 90 → 30 (reduce idle pipeline processing)
- `human_reid_skip_windows`: 4 → 8 (reduce ReID feature extraction)

### 4. Bug fix
- `prompt_builder.py`: add missing `get_settings` import

## Files changed

| File | Change |
|------|--------|
| `perception/runner.py` | Auto lifecycle management |
| `config/settings.py` | New config fields |
| `config/settings.yaml` | New config entries + tuning |
| `miot/decoder.py` | Decoder pause/resume |
| `miot/camera.py` | Camera instance pause/resume |
| `miloco/miot/client.py` | MiotProxy decoder control |
| `perception/collect/adapter_base.py` | Base adapter pause/resume |
| `perception/collect/camera_adapter.py` | Camera adapter pause/resume |
| `perception/collect/collector.py` | Collector pause/resume |
| `identity/default_config.yaml` | ReID skip_windows tuning |
| `engine/omni/prompt_builder.py` | Missing import fix |