### PR TITLE
feat(perception): 规则提醒日志展示「任务 + 规则」

### DIFF
--- a/backend/miloco/src/miloco/database/task_repo.py
+++ b/backend/miloco/src/miloco/database/task_repo.py
@@ -61,6 +61,15 @@ class TaskRepo:
             ).fetchone()
             return row is not None
 
+    def get_description(self, task_id: str) -> str | None:
+        """按 task_id 取任务描述（住户日志「所属任务」用）；无此行返回 None。
+        轻量单列查询，不联 cron/rule（与 get_full_view 区分）。"""
+        with self.db.get_connection() as conn:
+            row = conn.execute(
+                "SELECT description FROM task WHERE task_id = ?", (task_id,)
+            ).fetchone()
+            return row["description"] if row else None
+
     def get_full_view(self, task_id: str) -> dict[str, Any] | None:
         """单 task 视图: task 元信息 + cron_refs (rule_briefs 由 service 层拼装)."""
         with self.db.get_connection() as conn:

--- a/backend/miloco/src/miloco/perception/client.py
+++ b/backend/miloco/src/miloco/perception/client.py
@@ -945,6 +945,8 @@ async def _persist_meaningful_event(
         # (没找到 rule_name 时 fallback 用 rule_id).
         rule_names: dict[str, str] = {}
         rule_queries: dict[str, str] = {}
+        task_descs: dict[str, str] = {}  # rule_id → 所属任务 task.description
+        _desc_cache: dict[str, str | None] = {}  # task_id → description（同任务去重查询）
         if result.matched_rules:
             for mr in result.matched_rules:
                 try:
@@ -953,10 +955,21 @@ async def _persist_meaningful_event(
                         if rule.name:
                             rule_names[mr.rule_id] = rule.name
                         rule_queries[mr.rule_id] = rule.condition.query
+                        tid = rule.task_id
+                        if tid:
+                            if tid not in _desc_cache:
+                                _desc_cache[tid] = mgr.task_service.get_description(tid)
+                            if _desc_cache[tid]:
+                                task_descs[mr.rule_id] = _desc_cache[tid]
                 except Exception:  # noqa: BLE001
                     pass
 
-        text = build_agent_text(result, rule_names=rule_names, rule_queries=rule_queries)
+        text = build_agent_text(
+            result,
+            rule_names=rule_names,
+            rule_queries=rule_queries,
+            task_descs=task_descs,
+        )
 
         # relevant 为空(如老测试数据未标 source_device_ids)时保持原有全量列表不收窄;
         # 否则 device_ids 和 artifacts.clips 必须同步收窄——两者分别驱动"日志展示哪些

--- a/backend/miloco/src/miloco/perception/event_text_builder.py
+++ b/backend/miloco/src/miloco/perception/event_text_builder.py
@@ -17,6 +17,8 @@
 
 from __future__ import annotations
 
+import re
+
 from miloco.perception.types import (
     CaptionEntry,
     MatchedRule,
@@ -90,13 +92,27 @@ def _fmt_speech(s: Speech) -> str:
     )
 
 
-def _fmt_matched_rule(r: MatchedRule, name: str, query: str = "") -> str:
+def _strip_task_prefix(name: str) -> str:
+    """去掉 rule.name 的工程指针前缀 `[task_id] `，只留住户可读的规则短名。
+    住户日志不展示 task_id；无前缀时原样返回。"""
+    return re.sub(r"^\[[^\]]+\]\s*", "", name)
+
+
+def _fmt_matched_rule(
+    r: MatchedRule, task_desc: str, rule_label: str, query: str = ""
+) -> str:
+    # 「对应规则」= [规则短名] + 触发条件 query 合并成一行；query 空则只留短名。
+    # 规则短名退化为空（name 仅有 [task_id] 前缀）时不渲染空方括号，用 query 兜底。
+    if rule_label:
+        rule_line = f"[{rule_label}] {query}" if query else f"[{rule_label}]"
+    else:
+        rule_line = query or rule_label
     return _build_lines(
-        ("任务名称", name),
+        ("所属任务", task_desc),
+        ("对应规则", rule_line),
         ("时间", _fmt_time_field(r.time_window)),
         ("来源", _fmt_source_field(r.room_name, r.device_name, r.source_device_ids or None)),
         ("画面描述", r.caption.rstrip("。.") if r.caption else ""),
-        ("触发条件", query),
         ("触发原因", r.reason.rstrip("。.")),
     )
 
@@ -134,9 +150,14 @@ def build_matched_rules_text(
     matched_rules: list[MatchedRule],
     rule_names: dict[str, str] | None = None,
     rule_queries: dict[str, str] | None = None,
+    task_descs: dict[str, str] | None = None,
 ) -> str | None:
     """拼接规则命中文本（仅入表用；client.py 的 matched_rules 推送走 rule_service.update_state，
     不经过本函数）。
+
+    住户日志形态（后端即构造成住户可读形态，前端不再 strip）：
+    - 「所属任务」= ``task_descs[rule_id]``（rule.task_id → task.description；缺省则省略该行）
+    - 「对应规则」= ``[规则短名] query``（规则短名 = rule.name 去 [task_id] 前缀）
 
     Returns None 表示无 rule 命中。
     """
@@ -145,8 +166,10 @@ def build_matched_rules_text(
     blocks: list[str] = []
     for r in matched_rules:
         name = (rule_names or {}).get(r.rule_id) or r.rule_name or r.rule_id
+        rule_label = _strip_task_prefix(name)
         query = (rule_queries or {}).get(r.rule_id, "")
-        blocks.append(_fmt_matched_rule(r, name, query))
+        task_desc = (task_descs or {}).get(r.rule_id, "")
+        blocks.append(_fmt_matched_rule(r, task_desc, rule_label, query))
     return build_text(HEADER_MATCHED_RULE, blocks)
 
 
@@ -165,6 +188,7 @@ def build_agent_text(
     result: RealtimePerceptionResult,
     rule_names: dict[str, str] | None = None,
     rule_queries: dict[str, str] | None = None,
+    task_descs: dict[str, str] | None = None,
 ) -> str:
     """拼接 meaningful_events.text 字段（聚合三类信息，顺序固定：指令 → 提醒 → 规则）。"""
     parts: list[str] = []
@@ -172,6 +196,9 @@ def build_agent_text(
         parts.append(sp)
     if sg := build_suggestions_text(_with_caption(result.suggestions, result.caption)):
         parts.append(sg)
-    if mr := build_matched_rules_text(_with_caption(result.matched_rules, result.caption), rule_names, rule_queries):
+    if mr := build_matched_rules_text(
+        _with_caption(result.matched_rules, result.caption),
+        rule_names, rule_queries, task_descs,
+    ):
         parts.append(mr)
     return "\n\n".join(parts) if parts else ""

--- a/backend/miloco/src/miloco/perception/event_text_builder.py
+++ b/backend/miloco/src/miloco/perception/event_text_builder.py
@@ -101,15 +101,15 @@ def _strip_task_prefix(name: str) -> str:
 def _fmt_matched_rule(
     r: MatchedRule, task_desc: str, rule_label: str, query: str = ""
 ) -> str:
-    # 「对应规则」= [规则短名] + 触发条件 query 合并成一行；query 空则只留短名。
+    # 「规则」= [规则短名] + 触发条件 query 合并成一行；query 空则只留短名。
     # 规则短名退化为空（name 仅有 [task_id] 前缀）时不渲染空方括号，用 query 兜底。
     if rule_label:
         rule_line = f"[{rule_label}] {query}" if query else f"[{rule_label}]"
     else:
         rule_line = query or rule_label
     return _build_lines(
-        ("所属任务", task_desc),
-        ("对应规则", rule_line),
+        ("任务", task_desc),
+        ("规则", rule_line),
         ("时间", _fmt_time_field(r.time_window)),
         ("来源", _fmt_source_field(r.room_name, r.device_name, r.source_device_ids or None)),
         ("画面描述", r.caption.rstrip("。.") if r.caption else ""),
@@ -156,8 +156,8 @@ def build_matched_rules_text(
     不经过本函数）。
 
     住户日志形态（后端即构造成住户可读形态，前端不再 strip）：
-    - 「所属任务」= ``task_descs[rule_id]``（rule.task_id → task.description；缺省则省略该行）
-    - 「对应规则」= ``[规则短名] query``（规则短名 = rule.name 去 [task_id] 前缀）
+    - 「任务」= ``task_descs[rule_id]``（rule.task_id → task.description；缺省则省略该行）
+    - 「规则」= ``[规则短名] query``（规则短名 = rule.name 去 [task_id] 前缀）
 
     Returns None 表示无 rule 命中。
     """

--- a/backend/miloco/src/miloco/perception/event_text_builder.py
+++ b/backend/miloco/src/miloco/perception/event_text_builder.py
@@ -92,10 +92,11 @@ def _fmt_speech(s: Speech) -> str:
 
 def _fmt_matched_rule(r: MatchedRule, name: str, query: str = "") -> str:
     return _build_lines(
+        ("任务名称", name),
         ("时间", _fmt_time_field(r.time_window)),
         ("来源", _fmt_source_field(r.room_name, r.device_name, r.source_device_ids or None)),
         ("画面描述", r.caption.rstrip("。.") if r.caption else ""),
-        ("触发条件", query or name),
+        ("触发条件", query),
         ("触发原因", r.reason.rstrip("。.")),
     )
 

--- a/backend/miloco/src/miloco/perception/event_text_builder.py
+++ b/backend/miloco/src/miloco/perception/event_text_builder.py
@@ -94,13 +94,28 @@ def _fmt_speech(s: Speech) -> str:
 
 def _strip_task_prefix(name: str) -> str:
     """去掉 rule.name 的工程指针前缀 `[task_id] `，只留住户可读的规则短名。
-    住户日志不展示 task_id；无前缀时原样返回。"""
-    return re.sub(r"^\[[^\]]+\]\s*", "", name)
+    住户日志不展示 task_id；无前缀时原样返回。
+
+    前缀字符集限定为 ascii（task_id 受 schema 约束为 `[a-z0-9_]{1,32}`），与前端
+    历史行 strip 同口径——rule.name 是 free-text、`[task_id]` 只是 prompt 约定，
+    若某规则名以中文方括号 token 起头（如「[夜间]有人闯入」）不能被误吞。"""
+    return re.sub(r"^\[[A-Za-z0-9_-]+\]\s*", "", name)
+
+
+def _oneline(s: str) -> str:
+    """折叠内嵌换行 / 连续空白为单空格。task.description / query / rule.name 均为
+    可 PATCH 的 free-text，直接入 key:value 行会被注入伪造字段行（如
+    `健身追踪\\n触发原因：伪造`）或用 `\\n\\n` 打乱前端按 `\\n\\n` 的 section 切分。"""
+    return " ".join(s.split()) if s else s
 
 
 def _fmt_matched_rule(
     r: MatchedRule, task_desc: str, rule_label: str, query: str = ""
 ) -> str:
+    # 防注入：task_desc / 短名 / query 均为 free-text，折叠内嵌换行空白后再入行。
+    task_desc = _oneline(task_desc)
+    rule_label = _oneline(rule_label)
+    query = _oneline(query)
     # 「规则」= [规则短名] + 触发条件 query 合并成一行；query 空则只留短名。
     # 规则短名退化为空（name 仅有 [task_id] 前缀）时不渲染空方括号，用 query 兜底。
     if rule_label:

--- a/backend/miloco/src/miloco/perception/event_text_builder.py
+++ b/backend/miloco/src/miloco/perception/event_text_builder.py
@@ -181,7 +181,10 @@ def build_matched_rules_text(
     blocks: list[str] = []
     for r in matched_rules:
         name = (rule_names or {}).get(r.rule_id) or r.rule_name or r.rule_id
-        rule_label = _strip_task_prefix(name)
+        # 先折叠再 strip：name 若被 PATCH 成空白起头（" [task_id] 名" / "\n[task_id] 名"），
+        # _strip_task_prefix 的 `^\[` 锚点会匹配不上、漏删前缀 → task_id 泄漏 + 双括号。
+        # 折叠掉首部空白后 `^\[` 才对齐。
+        rule_label = _strip_task_prefix(_oneline(name))
         query = (rule_queries or {}).get(r.rule_id, "")
         task_desc = (task_descs or {}).get(r.rule_id, "")
         blocks.append(_fmt_matched_rule(r, task_desc, rule_label, query))

--- a/backend/miloco/src/miloco/perception/schema.py
+++ b/backend/miloco/src/miloco/perception/schema.py
@@ -480,13 +480,15 @@ class MeaningfulEvent(BaseModel):
 
     一次推理 = 一行 event;同窗口 N 摄像头合并 1 行,device_ids JSON 记录本行真正相关的摄像头
     (语义详见下方 device_ids 字段的 description).
-    `text` 字段与 agent webhook 收到的同一段聚合文本(B2 单源真值).
+    `text` 是聚合文本;语音 / 事件提醒段与 agent webhook 同源(B2 单源真值),但**规则段
+    另分叉**——住户日志走 build_matched_rules_text(任务 / 规则 / 触发原因),agent 实时回调
+    走 build_rule_callbacks_text(触发条件 + 意图段),两者不再逐字相同.
     响应不含 payload_json / schema_version / created_at(后端复盘用,API 不返).
     """
 
     event_id: str = Field(..., description="UUID,DB 主键")
     timestamp: int = Field(..., description="Millisecond Unix timestamp,感知窗口 start_ms")
-    text: str = Field(..., description="聚合 agent 视图文本(与 agent webhook 一字不差)")
+    text: str = Field(..., description="聚合住户日志文本(语音/事件段同 webhook;规则段分叉)")
     has_rule_hit: bool = Field(default=False, description="是否含规则命中")
     has_suggestion: bool = Field(default=False, description="是否含主动建议")
     has_asr: bool = Field(default=False, description="是否含 needs_response ASR")

--- a/backend/miloco/src/miloco/task/service.py
+++ b/backend/miloco/src/miloco/task/service.py
@@ -57,6 +57,10 @@ class TaskService:
     def update_description(self, task_id: str, req: TaskUpdateRequest) -> bool:
         return self.repo.update_description(task_id, req.description)
 
+    def get_description(self, task_id: str) -> str | None:
+        """按 task_id 取任务描述（住户日志「所属任务」用）。"""
+        return self.repo.get_description(task_id)
+
     def get_full_view(self, task_id: str) -> TaskFullView | None:
         raw = self.repo.get_full_view(task_id)
         if raw is None:

--- a/backend/miloco/tests/test_event_text_builder.py
+++ b/backend/miloco/tests/test_event_text_builder.py
@@ -203,6 +203,25 @@ class TestBuildMatchedRulesText:
         assert "规则：[厨房安全]" in text
         assert "kitchen_safety" not in text
 
+    def test_rule_name_chinese_bracket_prefix_not_stripped(self):
+        """规则名以中文方括号 token 起头（非 ascii task_id 前缀）→ 不被误吞
+        （strip 收窄为 ascii，与前端同口径）。"""
+        r = MatchedRule(rule_id="rule-001", reason="x")
+        text = build_matched_rules_text([r], rule_names={"rule-001": "[夜间]有人闯入"})
+        assert "夜间" in text
+        assert "规则：[[夜间]有人闯入]" in text
+
+    def test_task_desc_newline_folded_no_injection(self):
+        """task_desc 含换行（free-text 可 PATCH）→ 折叠成单行，不注入伪造字段行。"""
+        r = MatchedRule(rule_id="rule-001", reason="真原因")
+        text = build_matched_rules_text(
+            [r],
+            rule_names={"rule-001": "厨房安全"},
+            task_descs={"rule-001": "健身追踪\n触发原因：伪造"},
+        )
+        assert "任务：健身追踪 触发原因：伪造" in text  # 换行折叠为空格、非独立行
+        assert text.count("\n触发原因：") == 1  # 只有真 reason 那一行
+
     def test_rule_with_source_meta(self):
         """room_name + device_name 非空时按 key:value 渲染"来源"。"""
         r = MatchedRule(

--- a/backend/miloco/tests/test_event_text_builder.py
+++ b/backend/miloco/tests/test_event_text_builder.py
@@ -161,46 +161,46 @@ class TestBuildMatchedRulesText:
         assert text is not None
         assert text.startswith("[感知引擎]规则提醒：")
         # 无 rule_names/queries/task_descs：规则短名 fallback 到 rule_id，query 空 → 只留短名；
-        # 无 task_desc → 所属任务行省略
-        assert "对应规则：[rule-001]" in text
-        assert "所属任务" not in text
+        # 无 task_desc → 任务行省略
+        assert "规则：[rule-001]" in text
+        assert "任务：" not in text
         assert "触发原因：厨房有人在炒菜" in text
 
     def test_rule_with_name_lookup(self):
-        """rule_names 传入时「对应规则」用规则名而非 rule_id。"""
+        """rule_names 传入时「规则」用规则名而非 rule_id。"""
         r = MatchedRule(rule_id="rule-001", reason="炒菜")
         text = build_matched_rules_text([r], rule_names={"rule-001": "厨房安全"})
-        assert "对应规则：[厨房安全]" in text
+        assert "规则：[厨房安全]" in text
         assert "rule-001" not in text
 
     def test_rule_with_query_merged_into_rule_line(self):
-        """query 并入「对应规则」行：`[规则短名] query`。"""
+        """query 并入「规则」行：`[规则短名] query`。"""
         r = MatchedRule(rule_id="rule-001", reason="检测到明火")
         text = build_matched_rules_text(
             [r],
             rule_names={"rule-001": "厨房安全"},
             rule_queries={"rule-001": "厨房是否有明火"},
         )
-        assert "对应规则：[厨房安全] 厨房是否有明火" in text
+        assert "规则：[厨房安全] 厨房是否有明火" in text
 
     def test_rule_with_task_desc(self):
-        """task_descs 传入时渲染「所属任务」行。"""
+        """task_descs 传入时渲染「任务」行。"""
         r = MatchedRule(rule_id="rule-001", reason="炒菜")
         text = build_matched_rules_text(
             [r],
             rule_names={"rule-001": "厨房安全"},
             task_descs={"rule-001": "厨房安防"},
         )
-        assert "所属任务：厨房安防" in text
-        assert "对应规则：[厨房安全]" in text
+        assert "任务：厨房安防" in text
+        assert "规则：[厨房安全]" in text
 
     def test_rule_name_strips_task_prefix(self):
-        """rule.name 带 [task_id] 前缀时，「对应规则」短名去前缀。"""
+        """rule.name 带 [task_id] 前缀时，「规则」短名去前缀。"""
         r = MatchedRule(rule_id="rule-001", reason="炒菜")
         text = build_matched_rules_text(
             [r], rule_names={"rule-001": "[kitchen_safety] 厨房安全"}
         )
-        assert "对应规则：[厨房安全]" in text
+        assert "规则：[厨房安全]" in text
         assert "kitchen_safety" not in text
 
     def test_rule_with_source_meta(self):

--- a/backend/miloco/tests/test_event_text_builder.py
+++ b/backend/miloco/tests/test_event_text_builder.py
@@ -160,26 +160,30 @@ class TestBuildMatchedRulesText:
         text = build_matched_rules_text([r])
         assert text is not None
         assert text.startswith("[感知引擎]规则提醒：")
-        assert "触发条件：rule-001" in text
+        # 无 rule_names / rule_queries 时任务名称 fallback 到 rule_id，触发条件行省略
+        assert "任务名称：rule-001" in text
+        assert "触发条件" not in text
         assert "触发原因：厨房有人在炒菜" in text
 
     def test_rule_with_name_lookup(self):
-        """rule_names dict 传入时用名称替代 rule_id(query 空则 fallback 到 name)."""
+        """rule_names dict 传入时任务名称用名称替代 rule_id."""
         r = MatchedRule(rule_id="rule-001", reason="炒菜")
         text = build_matched_rules_text([r], rule_names={"rule-001": "厨房安全"})
-        assert "触发条件：厨房安全" in text
+        assert "任务名称：厨房安全" in text
         assert "rule-001" not in text
+        # 有 name 无 query：触发条件行整条省略
+        assert "触发条件" not in text
 
     def test_rule_with_query(self):
-        """rule_queries dict 传入时 '触发条件' 渲染 query 而非 name."""
+        """query 与 name 分别渲染到 '触发条件' / '任务名称' 两行。"""
         r = MatchedRule(rule_id="rule-001", reason="检测到明火")
         text = build_matched_rules_text(
             [r],
             rule_names={"rule-001": "厨房安全"},
             rule_queries={"rule-001": "厨房是否有明火"},
         )
+        assert "任务名称：厨房安全" in text
         assert "触发条件：厨房是否有明火" in text
-        assert "厨房安全" not in text
 
     def test_rule_with_source_meta(self):
         """room_name + device_name 非空时按 key:value 渲染"来源"。"""

--- a/backend/miloco/tests/test_event_text_builder.py
+++ b/backend/miloco/tests/test_event_text_builder.py
@@ -160,30 +160,48 @@ class TestBuildMatchedRulesText:
         text = build_matched_rules_text([r])
         assert text is not None
         assert text.startswith("[感知引擎]规则提醒：")
-        # 无 rule_names / rule_queries 时任务名称 fallback 到 rule_id，触发条件行省略
-        assert "任务名称：rule-001" in text
-        assert "触发条件" not in text
+        # 无 rule_names/queries/task_descs：规则短名 fallback 到 rule_id，query 空 → 只留短名；
+        # 无 task_desc → 所属任务行省略
+        assert "对应规则：[rule-001]" in text
+        assert "所属任务" not in text
         assert "触发原因：厨房有人在炒菜" in text
 
     def test_rule_with_name_lookup(self):
-        """rule_names dict 传入时任务名称用名称替代 rule_id."""
+        """rule_names 传入时「对应规则」用规则名而非 rule_id。"""
         r = MatchedRule(rule_id="rule-001", reason="炒菜")
         text = build_matched_rules_text([r], rule_names={"rule-001": "厨房安全"})
-        assert "任务名称：厨房安全" in text
+        assert "对应规则：[厨房安全]" in text
         assert "rule-001" not in text
-        # 有 name 无 query：触发条件行整条省略
-        assert "触发条件" not in text
 
-    def test_rule_with_query(self):
-        """query 与 name 分别渲染到 '触发条件' / '任务名称' 两行。"""
+    def test_rule_with_query_merged_into_rule_line(self):
+        """query 并入「对应规则」行：`[规则短名] query`。"""
         r = MatchedRule(rule_id="rule-001", reason="检测到明火")
         text = build_matched_rules_text(
             [r],
             rule_names={"rule-001": "厨房安全"},
             rule_queries={"rule-001": "厨房是否有明火"},
         )
-        assert "任务名称：厨房安全" in text
-        assert "触发条件：厨房是否有明火" in text
+        assert "对应规则：[厨房安全] 厨房是否有明火" in text
+
+    def test_rule_with_task_desc(self):
+        """task_descs 传入时渲染「所属任务」行。"""
+        r = MatchedRule(rule_id="rule-001", reason="炒菜")
+        text = build_matched_rules_text(
+            [r],
+            rule_names={"rule-001": "厨房安全"},
+            task_descs={"rule-001": "厨房安防"},
+        )
+        assert "所属任务：厨房安防" in text
+        assert "对应规则：[厨房安全]" in text
+
+    def test_rule_name_strips_task_prefix(self):
+        """rule.name 带 [task_id] 前缀时，「对应规则」短名去前缀。"""
+        r = MatchedRule(rule_id="rule-001", reason="炒菜")
+        text = build_matched_rules_text(
+            [r], rule_names={"rule-001": "[kitchen_safety] 厨房安全"}
+        )
+        assert "对应规则：[厨房安全]" in text
+        assert "kitchen_safety" not in text
 
     def test_rule_with_source_meta(self):
         """room_name + device_name 非空时按 key:value 渲染"来源"。"""

--- a/backend/miloco/tests/test_event_text_builder.py
+++ b/backend/miloco/tests/test_event_text_builder.py
@@ -203,6 +203,14 @@ class TestBuildMatchedRulesText:
         assert "规则：[厨房安全]" in text
         assert "kitchen_safety" not in text
 
+    def test_rule_name_leading_whitespace_prefix_still_stripped(self):
+        """rule.name 被 PATCH 成空白起头 → 先折叠再 strip，[task_id] 不泄漏、无双括号。"""
+        for name in ("  [kitchen] 明火", "\n[kitchen] 明火", "\t[kitchen] 明火"):
+            r = MatchedRule(rule_id="rule-001", reason="x")
+            text = build_matched_rules_text([r], rule_names={"rule-001": name})
+            assert "规则：[明火]" in text, name
+            assert "kitchen" not in text, name
+
     def test_rule_name_chinese_bracket_prefix_not_stripped(self):
         """规则名以中文方括号 token 起头（非 ascii task_id 前缀）→ 不被误吞
         （strip 收窄为 ascii，与前端同口径）。"""

--- a/backend/miloco/tests/test_persist_meaningful_event.py
+++ b/backend/miloco/tests/test_persist_meaningful_event.py
@@ -372,6 +372,60 @@ class TestPersistMeaningfulEvent:
         assert rows[0]["has_rule_hit"] is True
         assert "rule 已被删" in rows[0]["text"]
 
+    async def test_task_desc_wired_into_text(self, isolated_db, dao):
+        """client.py 接线：反查 rule → 按 rule.task_id 取 task.description → 以 rule_id 回填 →
+        落库 text 含「所属任务」+「对应规则」；同 task 多规则 get_description 只调一次（去重缓存）。"""
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock, MagicMock
+
+        from miloco.manager import get_manager
+
+        result = RealtimePerceptionResult(
+            matched_rules=[
+                MatchedRule(rule_id="r1", reason="炒菜", source_device_ids=["cam_k"]),
+                MatchedRule(rule_id="r2", reason="看火", source_device_ids=["cam_k"]),
+            ]
+        )
+        rules = {
+            "r1": SimpleNamespace(
+                name="[kitchen] 灶台有人", task_id="kitchen",
+                condition=SimpleNamespace(query="灶台前有人"),
+            ),
+            "r2": SimpleNamespace(
+                name="[kitchen] 明火", task_id="kitchen",
+                condition=SimpleNamespace(query="是否有明火"),
+            ),
+        }
+        get_desc = MagicMock(return_value="厨房安防")
+
+        mgr = get_manager()
+
+        class _FakeRuleService:
+            get_rule = AsyncMock(side_effect=lambda rid: rules.get(rid))
+
+        class _FakeTaskService:
+            get_description = get_desc
+
+        mgr._rule_service = _FakeRuleService()
+        mgr._task_service = _FakeTaskService()
+        try:
+            await _persist_meaningful_event(
+                result=result, device_ids=["cam_k"], artifacts=_artifacts({}),
+            )
+        finally:
+            for attr in ("_rule_service", "_task_service"):
+                if hasattr(mgr, attr):
+                    delattr(mgr, attr)
+
+        rows = dao.query()
+        assert len(rows) == 1
+        text = rows[0]["text"]
+        assert "所属任务：厨房安防" in text
+        assert "对应规则：[灶台有人] 灶台前有人" in text
+        assert "对应规则：[明火] 是否有明火" in text
+        # 同 task 两条规则 → description 只查一次（去重缓存生效）
+        assert get_desc.call_count == 1
+
     async def test_asr_from_mic_off_cam_stripped_not_persisted(self, isolated_db, dao):
         """默认关(opt-in):相机不在拾音白名单 → speech 在 _persist 内被
         _filter_voice_enabled 剥掉,speech-only 结果不入表。

--- a/backend/miloco/tests/test_persist_meaningful_event.py
+++ b/backend/miloco/tests/test_persist_meaningful_event.py
@@ -374,7 +374,7 @@ class TestPersistMeaningfulEvent:
 
     async def test_task_desc_wired_into_text(self, isolated_db, dao):
         """client.py 接线：反查 rule → 按 rule.task_id 取 task.description → 以 rule_id 回填 →
-        落库 text 含「所属任务」+「对应规则」；同 task 多规则 get_description 只调一次（去重缓存）。"""
+        落库 text 含「任务」+「规则」；同 task 多规则 get_description 只调一次（去重缓存）。"""
         from types import SimpleNamespace
         from unittest.mock import AsyncMock, MagicMock
 
@@ -420,9 +420,9 @@ class TestPersistMeaningfulEvent:
         rows = dao.query()
         assert len(rows) == 1
         text = rows[0]["text"]
-        assert "所属任务：厨房安防" in text
-        assert "对应规则：[灶台有人] 灶台前有人" in text
-        assert "对应规则：[明火] 是否有明火" in text
+        assert "任务：厨房安防" in text
+        assert "规则：[灶台有人] 灶台前有人" in text
+        assert "规则：[明火] 是否有明火" in text
         # 同 task 两条规则 → description 只查一次（去重缓存生效）
         assert get_desc.call_count == 1
 

--- a/backend/miloco/tests/test_persist_meaningful_event.py
+++ b/backend/miloco/tests/test_persist_meaningful_event.py
@@ -426,6 +426,61 @@ class TestPersistMeaningfulEvent:
         # 同 task 两条规则 → description 只查一次（去重缓存生效）
         assert get_desc.call_count == 1
 
+    async def test_task_desc_cross_task_attribution(self, isolated_db, dao):
+        """不同 task 的规则 → 各自 description 正确归属（不串行）；每个 task 各查一次。"""
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock, MagicMock
+
+        from miloco.manager import get_manager
+
+        result = RealtimePerceptionResult(
+            matched_rules=[
+                MatchedRule(rule_id="r1", reason="炒菜", source_device_ids=["cam_k"]),
+                MatchedRule(rule_id="r2", reason="躺床", source_device_ids=["cam_b"]),
+            ]
+        )
+        rules = {
+            "r1": SimpleNamespace(
+                name="[kitchen] 灶台有人", task_id="kitchen",
+                condition=SimpleNamespace(query=""),
+            ),
+            "r2": SimpleNamespace(
+                name="[bedroom] 有人躺床", task_id="bedroom",
+                condition=SimpleNamespace(query=""),
+            ),
+        }
+        descs = {"kitchen": "厨房安防", "bedroom": "卧室监控"}
+        get_desc = MagicMock(side_effect=lambda tid: descs.get(tid))
+
+        mgr = get_manager()
+
+        class _FakeRuleService:
+            get_rule = AsyncMock(side_effect=lambda rid: rules.get(rid))
+
+        class _FakeTaskService:
+            get_description = get_desc
+
+        mgr._rule_service = _FakeRuleService()
+        mgr._task_service = _FakeTaskService()
+        try:
+            await _persist_meaningful_event(
+                result=result, device_ids=["cam_k", "cam_b"], artifacts=_artifacts({}),
+            )
+        finally:
+            for attr in ("_rule_service", "_task_service"):
+                if hasattr(mgr, attr):
+                    delattr(mgr, attr)
+
+        text = dao.query()[0]["text"]
+        blocks = text.split("═══")
+        kb = next(b for b in blocks if "灶台有人" in b)
+        bb = next(b for b in blocks if "有人躺床" in b)
+        # 各自块内归属正确、不串行
+        assert "任务：厨房安防" in kb and "卧室监控" not in kb
+        assert "任务：卧室监控" in bb and "厨房安防" not in bb
+        # 两个不同 task → 各查一次
+        assert get_desc.call_count == 2
+
     async def test_asr_from_mic_off_cam_stripped_not_persisted(self, isolated_db, dao):
         """默认关(opt-in):相机不在拾音白名单 → speech 在 _persist 内被
         _filter_voice_enabled 剥掉,speech-only 结果不入表。

--- a/backend/miloco/tests/test_task_repo_sqlite.py
+++ b/backend/miloco/tests/test_task_repo_sqlite.py
@@ -160,3 +160,10 @@ def test_list_all_returns_all_tasks_with_cron_refs(repo):
     assert by_id["t2"]["cron_refs"] == [
         {"ref": "c2", "dispatch_owner": "internal"}
     ]
+
+
+def test_get_description(repo):
+    """get_description 轻量取 task.description（住户日志「所属任务」用）。"""
+    repo.create_task(task_id="t_desc", description="健身追踪")
+    assert repo.get_description("t_desc") == "健身追踪"
+    assert repo.get_description("nonexistent") is None

--- a/web/src/lib/eventText.ts
+++ b/web/src/lib/eventText.ts
@@ -36,7 +36,11 @@ export function humanizeRulesInText(
         // 行内空白用 [^\S\n]* 而非 \s*：显示名退化成「仅前缀」时不吞掉换行、粘连下一行
         return section
           .replace(/任务名称：\[[^\]]+\][^\S\n]*/g, "任务名称：")
-          .replace(/触发规则：\[[^\]]+\][^\S\n]*/g, "触发规则：");
+          .replace(/触发规则：\[[^\]]+\][^\S\n]*/g, "触发规则：")
+          // 兼容旧数据：本 PR 前 query 空时「触发条件」会兜底成 [task_id] 规则名，一并 strip。
+          // 前缀限定 task_id 形态（ascii snake/kebab）——「触发条件」当前格式放的是自然语言
+          // query，若某条 query 以中文方括号 token 开头（如「[夜间]是否有人闯入」）不能被误 strip。
+          .replace(/触发条件：\[[A-Za-z0-9_-]+\][^\S\n]*/g, "触发条件：");
       }
 
       // --- 旧格式 v2：统一 `[感知引擎] 提醒:` 前缀 ---

--- a/web/src/lib/eventText.ts
+++ b/web/src/lib/eventText.ts
@@ -1,14 +1,16 @@
 /**
- * 把事件 text 里规则相关内容的 `[task_id] 规则名` 前缀 strip 为纯中文名。
+ * 清理事件 text 里规则相关内容残留的 `[task_id]` 工程指针前缀。
  *
- * miloco 强制 rule.name 带工程指针 `[task_id]`,task_id 是 Agent 任务模型的
- * 稳定 invariant,跟前端 UI 正交。展示给住户时统一去掉,只留中文。
- * spec B2 (DB.text == webhook) 仍守:DB 里依旧带前缀,这里只在 UI 渲染层 strip。
+ * 当前格式（所属任务 / 对应规则）后端已构造成住户可读形态、DB 里就不带 `[task_id]`，
+ * 前端原样渲染、无需处理。本函数只清理**同 header 的历史旧行**（触发规则 / 触发条件）
+ * 以及旧 v1/v2 格式里残留的 `[task_id]` 前缀——那些旧数据 DB 里仍带前缀。
  *
- * 兼容四种格式:
- * - 当前格式(分类 header): `[感知引擎]规则提醒：` 规则行含 `任务名称：[task_id] 规则名` +
- *   `触发条件：query` + `触发原因：reason` → strip 任务名称行的 [task_id] 前缀
+ * 兼容格式:
+ * - 当前格式(分类 header): `[感知引擎]规则提醒：` 块含 `所属任务：<任务描述>` +
+ *   `对应规则：[规则短名] query` —— 后端已构造成住户可读形态（无 [task_id]），无需 strip。
+ *   下面几条 strip 只清理**同 header 的旧行**里残留的 [task_id] 前缀（历史数据兼容）。
  * - 旧格式 v3(分类 header): 规则行含 `触发规则：[task_id] 规则名。` → strip [task_id]
+ * - 旧数据(query 空时): `触发条件：[task_id] 规则名` → strip [task_id]（ascii 前缀，放过中文方括号 query）
  * - 旧格式 v2(统一 header): `[感知引擎] 提醒:` + `检测到：[task_id] 规则名。`
  * - 旧格式 v1(JSON 行): `1. {"rule_id":"...","reason":"..."}` → 反查 rule_names
  */
@@ -33,13 +35,12 @@ export function humanizeRulesInText(
     .map((section) => {
       // --- 当前格式：分类 header ---
       if (PERCEPTION_HEADERS.some((h) => section.startsWith(h))) {
-        // 行内空白用 [^\S\n]* 而非 \s*：显示名退化成「仅前缀」时不吞掉换行、粘连下一行
+        // 新格式（所属任务 / 对应规则）后端已 strip、无需处理；下面只清历史旧行的
+        // [task_id] 前缀。行内空白用 [^\S\n]* 而非 \s*：短名退化成「仅前缀」时不吞换行。
         return section
-          .replace(/任务名称：\[[^\]]+\][^\S\n]*/g, "任务名称：")
           .replace(/触发规则：\[[^\]]+\][^\S\n]*/g, "触发规则：")
-          // 兼容旧数据：本 PR 前 query 空时「触发条件」会兜底成 [task_id] 规则名，一并 strip。
-          // 前缀限定 task_id 形态（ascii snake/kebab）——「触发条件」当前格式放的是自然语言
-          // query，若某条 query 以中文方括号 token 开头（如「[夜间]是否有人闯入」）不能被误 strip。
+          // 旧数据：query 空时「触发条件」兜底成 [task_id] 规则名。前缀限定 task_id 形态
+          // （ascii snake/kebab），放过以中文方括号 token 开头的合法 query（如「[夜间]…」）。
           .replace(/触发条件：\[[A-Za-z0-9_-]+\][^\S\n]*/g, "触发条件：");
       }
 

--- a/web/src/lib/eventText.ts
+++ b/web/src/lib/eventText.ts
@@ -15,7 +15,9 @@
  * - 旧格式 v1(JSON 行): `1. {"rule_id":"...","reason":"..."}` → 反查 rule_names
  */
 function stripTaskPrefix(name: string): string {
-  return name.replace(/^\[[^\]]+\]\s*/, "");
+  // 前缀限定 ascii（task_id 受后端 schema 约束为 [a-z0-9_]），与 Python
+  // _strip_task_prefix 同口径——不误吞以中文方括号 token 起头的规则名。
+  return name.replace(/^\[[A-Za-z0-9_-]+\]\s*/, "");
 }
 
 const PERCEPTION_HEADERS = [
@@ -38,7 +40,7 @@ export function humanizeRulesInText(
         // 新格式（任务 / 规则）后端已 strip、无需处理；下面只清历史旧行的
         // [task_id] 前缀。行内空白用 [^\S\n]* 而非 \s*：短名退化成「仅前缀」时不吞换行。
         return section
-          .replace(/触发规则：\[[^\]]+\][^\S\n]*/g, "触发规则：")
+          .replace(/触发规则：\[[A-Za-z0-9_-]+\][^\S\n]*/g, "触发规则：")
           // 旧数据：query 空时「触发条件」兜底成 [task_id] 规则名。前缀限定 task_id 形态
           // （ascii snake/kebab），放过以中文方括号 token 开头的合法 query（如「[夜间]…」）。
           .replace(/触发条件：\[[A-Za-z0-9_-]+\][^\S\n]*/g, "触发条件：");

--- a/web/src/lib/eventText.ts
+++ b/web/src/lib/eventText.ts
@@ -6,7 +6,8 @@
  * spec B2 (DB.text == webhook) 仍守:DB 里依旧带前缀,这里只在 UI 渲染层 strip。
  *
  * 兼容四种格式:
- * - 当前格式(分类 header): `[感知引擎]规则提醒：` 规则行含 `触发条件：query。触发原因：reason。`（无需 strip）
+ * - 当前格式(分类 header): `[感知引擎]规则提醒：` 规则行含 `任务名称：[task_id] 规则名` +
+ *   `触发条件：query` + `触发原因：reason` → strip 任务名称行的 [task_id] 前缀
  * - 旧格式 v3(分类 header): 规则行含 `触发规则：[task_id] 规则名。` → strip [task_id]
  * - 旧格式 v2(统一 header): `[感知引擎] 提醒:` + `检测到：[task_id] 规则名。`
  * - 旧格式 v1(JSON 行): `1. {"rule_id":"...","reason":"..."}` → 反查 rule_names
@@ -32,10 +33,10 @@ export function humanizeRulesInText(
     .map((section) => {
       // --- 当前格式：分类 header ---
       if (PERCEPTION_HEADERS.some((h) => section.startsWith(h))) {
-        return section.replace(
-          /触发规则：\[[^\]]+\]\s*/g,
-          "触发规则：",
-        );
+        // 行内空白用 [^\S\n]* 而非 \s*：显示名退化成「仅前缀」时不吞掉换行、粘连下一行
+        return section
+          .replace(/任务名称：\[[^\]]+\][^\S\n]*/g, "任务名称：")
+          .replace(/触发规则：\[[^\]]+\][^\S\n]*/g, "触发规则：");
       }
 
       // --- 旧格式 v2：统一 `[感知引擎] 提醒:` 前缀 ---

--- a/web/src/lib/eventText.ts
+++ b/web/src/lib/eventText.ts
@@ -1,13 +1,13 @@
 /**
  * 清理事件 text 里规则相关内容残留的 `[task_id]` 工程指针前缀。
  *
- * 当前格式（所属任务 / 对应规则）后端已构造成住户可读形态、DB 里就不带 `[task_id]`，
+ * 当前格式（任务 / 规则）后端已构造成住户可读形态、DB 里就不带 `[task_id]`，
  * 前端原样渲染、无需处理。本函数只清理**同 header 的历史旧行**（触发规则 / 触发条件）
  * 以及旧 v1/v2 格式里残留的 `[task_id]` 前缀——那些旧数据 DB 里仍带前缀。
  *
  * 兼容格式:
- * - 当前格式(分类 header): `[感知引擎]规则提醒：` 块含 `所属任务：<任务描述>` +
- *   `对应规则：[规则短名] query` —— 后端已构造成住户可读形态（无 [task_id]），无需 strip。
+ * - 当前格式(分类 header): `[感知引擎]规则提醒：` 块含 `任务：<任务描述>` +
+ *   `规则：[规则短名] query` —— 后端已构造成住户可读形态（无 [task_id]），无需 strip。
  *   下面几条 strip 只清理**同 header 的旧行**里残留的 [task_id] 前缀（历史数据兼容）。
  * - 旧格式 v3(分类 header): 规则行含 `触发规则：[task_id] 规则名。` → strip [task_id]
  * - 旧数据(query 空时): `触发条件：[task_id] 规则名` → strip [task_id]（ascii 前缀，放过中文方括号 query）
@@ -35,7 +35,7 @@ export function humanizeRulesInText(
     .map((section) => {
       // --- 当前格式：分类 header ---
       if (PERCEPTION_HEADERS.some((h) => section.startsWith(h))) {
-        // 新格式（所属任务 / 对应规则）后端已 strip、无需处理；下面只清历史旧行的
+        // 新格式（任务 / 规则）后端已 strip、无需处理；下面只清历史旧行的
         // [task_id] 前缀。行内空白用 [^\S\n]* 而非 \s*：短名退化成「仅前缀」时不吞换行。
         return section
           .replace(/触发规则：\[[^\]]+\][^\S\n]*/g, "触发规则：")

--- a/web/src/lib/eventText.ts
+++ b/web/src/lib/eventText.ts
@@ -48,8 +48,9 @@ export function humanizeRulesInText(
 
       // --- 旧格式 v2：统一 `[感知引擎] 提醒:` 前缀 ---
       if (section.startsWith("[感知引擎] 提醒:")) {
+        // 前缀限定 ascii，与其余三处 strip 同口径（不误吞中文方括号规则名）
         return section.replace(
-          /检测到：\[[^\]]+\]\s*/g,
+          /检测到：\[[A-Za-z0-9_-]+\]\s*/g,
           "检测到：",
         );
       }

--- a/web/tests/eventText.test.ts
+++ b/web/tests/eventText.test.ts
@@ -9,15 +9,15 @@ import { describe, it, expect } from "vitest";
 import { humanizeRulesInText } from "@/lib/eventText";
 
 describe("humanizeRulesInText", () => {
-  it("新格式：所属任务 + 对应规则[短名] 原样保留（方括号短名不被误 strip）", () => {
+  it("新格式：任务 + 规则[短名] 原样保留（方括号短名不被误 strip）", () => {
     const text =
       "[感知引擎]规则提醒：\n" +
-      "所属任务：书房安防\n" +
-      "对应规则：[书桌前有人] 有人坐在书桌前面向屏幕\n" +
+      "任务：书房安防\n" +
+      "规则：[书桌前有人] 有人坐在书桌前面向屏幕\n" +
       "触发原因：画面中有人";
     const out = humanizeRulesInText(text);
-    expect(out).toContain("所属任务：书房安防");
-    expect(out).toContain("对应规则：[书桌前有人] 有人坐在书桌前面向屏幕");
+    expect(out).toContain("任务：书房安防");
+    expect(out).toContain("规则：[书桌前有人] 有人坐在书桌前面向屏幕");
   });
 
   it("旧数据 v3：触发规则行 strip [task_id] 前缀", () => {

--- a/web/tests/eventText.test.ts
+++ b/web/tests/eventText.test.ts
@@ -47,6 +47,13 @@ describe("humanizeRulesInText", () => {
     expect(humanizeRulesInText(text)).toContain("触发规则：[夜间]有人闯入");
   });
 
+  it("旧格式 v2：检测到 ascii [task_id] 前缀被 strip、中文方括号保留", () => {
+    const ascii = "[感知引擎] 提醒:\n检测到：[kitchen] 厨房安全";
+    expect(humanizeRulesInText(ascii)).toContain("检测到：厨房安全");
+    const cn = "[感知引擎] 提醒:\n检测到：[夜间]有人闯入";
+    expect(humanizeRulesInText(cn)).toContain("检测到：[夜间]有人闯入");
+  });
+
   it("旧格式 v1：rule_name ascii [task_id] 前缀被 strip、中文方括号保留", () => {
     const asciiPrefix =
       '[感知引擎] 命中以下规则:\n1. {"rule_id":"r1","rule_name":"[kitchen] 厨房安全","reason":"x"}';

--- a/web/tests/eventText.test.ts
+++ b/web/tests/eventText.test.ts
@@ -27,4 +27,15 @@ describe("humanizeRulesInText 任务名称前缀 strip", () => {
     const text = "[感知引擎]规则提醒：\n任务名称：厨房安全\n触发原因：x";
     expect(humanizeRulesInText(text)).toContain("任务名称：厨房安全");
   });
+
+  it("显示名退化成仅前缀时，不吞换行、不粘连下一行", () => {
+    // [^\S\n]* 而非 \s*：前缀后无中文名时不能把换行一起吃掉
+    const text =
+      "[感知引擎]规则提醒：\n" +
+      "任务名称：[kitchen_safety]\n" +
+      "触发原因：检测到明火";
+    const out = humanizeRulesInText(text);
+    expect(out).toContain("任务名称：\n触发原因：检测到明火");
+    expect(out).not.toContain("任务名称：触发原因"); // 不粘连
+  });
 });

--- a/web/tests/eventText.test.ts
+++ b/web/tests/eventText.test.ts
@@ -41,4 +41,21 @@ describe("humanizeRulesInText", () => {
       "[感知引擎]规则提醒：\n触发条件：[夜间]是否有人闯入\n触发原因：x";
     expect(humanizeRulesInText(text)).toContain("触发条件：[夜间]是否有人闯入");
   });
+
+  it("旧数据 v3：触发规则中文方括号 token 不被误 strip（ascii 口径）", () => {
+    const text = "[感知引擎]规则提醒：\n触发规则：[夜间]有人闯入\n触发原因：x";
+    expect(humanizeRulesInText(text)).toContain("触发规则：[夜间]有人闯入");
+  });
+
+  it("旧格式 v1：rule_name ascii [task_id] 前缀被 strip、中文方括号保留", () => {
+    const asciiPrefix =
+      '[感知引擎] 命中以下规则:\n1. {"rule_id":"r1","rule_name":"[kitchen] 厨房安全","reason":"x"}';
+    const outAscii = humanizeRulesInText(asciiPrefix);
+    expect(outAscii).toContain("厨房安全");
+    expect(outAscii).not.toContain("kitchen");
+
+    const cnBracket =
+      '[感知引擎] 命中以下规则:\n1. {"rule_id":"r1","rule_name":"[夜间]有人闯入","reason":"x"}';
+    expect(humanizeRulesInText(cnBracket)).toContain("夜间");
+  });
 });

--- a/web/tests/eventText.test.ts
+++ b/web/tests/eventText.test.ts
@@ -1,0 +1,30 @@
+/**
+ * humanizeRulesInText 渲染层单测。
+ *
+ * 后端 meaningful_events.text 里规则提醒块新增「任务名称：[task_id] 规则名」行，
+ * DB 存带前缀全名（spec B2: DB==webhook），UI 渲染时 strip 掉 [task_id] 前缀。
+ */
+
+import { describe, it, expect } from "vitest";
+import { humanizeRulesInText } from "@/lib/eventText";
+
+describe("humanizeRulesInText 任务名称前缀 strip", () => {
+  it("strip 任务名称行的 [task_id] 前缀，只留中文名", () => {
+    const text =
+      "[感知引擎]规则提醒：\n" +
+      "任务名称：[kitchen_safety] 厨房安全\n" +
+      "触发条件：厨房是否有明火\n" +
+      "触发原因：检测到明火";
+    const out = humanizeRulesInText(text);
+    expect(out).toContain("任务名称：厨房安全");
+    expect(out).not.toContain("[kitchen_safety]");
+    // 其它行保持不变
+    expect(out).toContain("触发条件：厨房是否有明火");
+    expect(out).toContain("触发原因：检测到明火");
+  });
+
+  it("任务名称不带前缀时原样保留", () => {
+    const text = "[感知引擎]规则提醒：\n任务名称：厨房安全\n触发原因：x";
+    expect(humanizeRulesInText(text)).toContain("任务名称：厨房安全");
+  });
+});

--- a/web/tests/eventText.test.ts
+++ b/web/tests/eventText.test.ts
@@ -1,39 +1,36 @@
 /**
  * humanizeRulesInText 渲染层单测。
  *
- * 后端 meaningful_events.text 里规则提醒块新增「任务名称：[task_id] 规则名」行，
- * DB 存带前缀全名（spec B2: DB==webhook），UI 渲染时 strip 掉 [task_id] 前缀。
+ * 当前格式的「所属任务 / 对应规则」由后端构造成住户可读形态（无 [task_id]），
+ * 前端原样保留、不 strip；只清理同 header 旧行残留的 [task_id] 前缀（触发规则 / 触发条件）。
  */
 
 import { describe, it, expect } from "vitest";
 import { humanizeRulesInText } from "@/lib/eventText";
 
-describe("humanizeRulesInText 任务名称前缀 strip", () => {
-  it("strip 任务名称行的 [task_id] 前缀，只留中文名", () => {
+describe("humanizeRulesInText", () => {
+  it("新格式：所属任务 + 对应规则[短名] 原样保留（方括号短名不被误 strip）", () => {
     const text =
       "[感知引擎]规则提醒：\n" +
-      "任务名称：[kitchen_safety] 厨房安全\n" +
-      "触发条件：厨房是否有明火\n" +
-      "触发原因：检测到明火";
+      "所属任务：书房安防\n" +
+      "对应规则：[书桌前有人] 有人坐在书桌前面向屏幕\n" +
+      "触发原因：画面中有人";
     const out = humanizeRulesInText(text);
-    expect(out).toContain("任务名称：厨房安全");
-    expect(out).not.toContain("[kitchen_safety]");
-    // 其它行保持不变
-    expect(out).toContain("触发条件：厨房是否有明火");
-    expect(out).toContain("触发原因：检测到明火");
+    expect(out).toContain("所属任务：书房安防");
+    expect(out).toContain("对应规则：[书桌前有人] 有人坐在书桌前面向屏幕");
   });
 
-  it("任务名称不带前缀时原样保留", () => {
-    const text = "[感知引擎]规则提醒：\n任务名称：厨房安全\n触发原因：x";
-    expect(humanizeRulesInText(text)).toContain("任务名称：厨房安全");
-  });
-
-  it("旧数据：触发条件行兜底成 [task_id] 名时也 strip 前缀", () => {
-    // 本 PR 前 query 空时后端会写 触发条件：[task_id] 规则名，历史行需一并清洗
+  it("旧数据 v3：触发规则行 strip [task_id] 前缀", () => {
     const text =
-      "[感知引擎]规则提醒：\n" +
-      "触发条件：[kitchen_safety] 厨房安全\n" +
-      "触发原因：检测到明火";
+      "[感知引擎]规则提醒：\n触发规则：[kitchen_safety] 厨房安全\n触发原因：x";
+    const out = humanizeRulesInText(text);
+    expect(out).toContain("触发规则：厨房安全");
+    expect(out).not.toContain("[kitchen_safety]");
+  });
+
+  it("旧数据：触发条件兜底成 [task_id] 名时 strip 前缀", () => {
+    const text =
+      "[感知引擎]规则提醒：\n触发条件：[kitchen_safety] 厨房安全\n触发原因：x";
     const out = humanizeRulesInText(text);
     expect(out).toContain("触发条件：厨房安全");
     expect(out).not.toContain("[kitchen_safety]");
@@ -43,16 +40,5 @@ describe("humanizeRulesInText 任务名称前缀 strip", () => {
     const text =
       "[感知引擎]规则提醒：\n触发条件：[夜间]是否有人闯入\n触发原因：x";
     expect(humanizeRulesInText(text)).toContain("触发条件：[夜间]是否有人闯入");
-  });
-
-  it("显示名退化成仅前缀时，不吞换行、不粘连下一行", () => {
-    // [^\S\n]* 而非 \s*：前缀后无中文名时不能把换行一起吃掉
-    const text =
-      "[感知引擎]规则提醒：\n" +
-      "任务名称：[kitchen_safety]\n" +
-      "触发原因：检测到明火";
-    const out = humanizeRulesInText(text);
-    expect(out).toContain("任务名称：\n触发原因：检测到明火");
-    expect(out).not.toContain("任务名称：触发原因"); // 不粘连
   });
 });

--- a/web/tests/eventText.test.ts
+++ b/web/tests/eventText.test.ts
@@ -28,6 +28,23 @@ describe("humanizeRulesInText 任务名称前缀 strip", () => {
     expect(humanizeRulesInText(text)).toContain("任务名称：厨房安全");
   });
 
+  it("旧数据：触发条件行兜底成 [task_id] 名时也 strip 前缀", () => {
+    // 本 PR 前 query 空时后端会写 触发条件：[task_id] 规则名，历史行需一并清洗
+    const text =
+      "[感知引擎]规则提醒：\n" +
+      "触发条件：[kitchen_safety] 厨房安全\n" +
+      "触发原因：检测到明火";
+    const out = humanizeRulesInText(text);
+    expect(out).toContain("触发条件：厨房安全");
+    expect(out).not.toContain("[kitchen_safety]");
+  });
+
+  it("触发条件里以中文方括号 token 开头的合法 query 不被误 strip", () => {
+    const text =
+      "[感知引擎]规则提醒：\n触发条件：[夜间]是否有人闯入\n触发原因：x";
+    expect(humanizeRulesInText(text)).toContain("触发条件：[夜间]是否有人闯入");
+  });
+
   it("显示名退化成仅前缀时，不吞换行、不粘连下一行", () => {
     // [^\S\n]* 而非 \s*：前缀后无中文名时不能把换行一起吃掉
     const text =


### PR DESCRIPTION
## 背景
住户活动日志的「[感知引擎]规则提醒」看不出是哪个任务触发的。最初只加了一行「任务名称」，
但它取的是 rule.name（规则级），而 task:rule 是 1:N——标签叫「任务名称」名不副实。

## 改动（后端 + 前端；agent 回调不受影响）
规则块改为两行分清层级：
- 任务：`<task.description>`——按 rule.task_id 查 task 表拿真正的任务描述。
- 规则：`[<规则短名>] <query>`——规则短名 = rule.name 去 [task_id] 前缀，
  原「触发条件」query 并入同一行；query 空则只留短名。

后端直接构造住户可读形态（不带 [task_id]），前端 eventText.ts 不再 strip 这两行，
仅保留对历史旧行的 [task_id] 兼容清洗。给 agent 的回调 build_rule_callbacks_text 不动。

- task_repo/task_service 加轻量 get_description(task_id)。
- client._persist_meaningful_event 反查 rule 时顺带取任务描述（同 task 去重缓存）透传 builder。

## 效果示例
```
任务：书房安防
规则：[书桌前有人] 有人坐在书桌前的椅子上面向电脑屏幕
时间：16:50:08
来源：书房的小米智能摄像机C500双摄版(did=…)
画面描述：…
触发原因：…
```
<img width="1872" height="452" alt="20260724-175336" src="https://github.com/user-attachments/assets/b8e71748-ddc7-4b3d-b7cd-d396ae68dc7d" />


## 测试
- test_event_text_builder：任务/规则渲染、[task_id] strip、query 合并、空短名兜底。
- test_persist_meaningful_event：task_descs 接线端到端 + 同 task 去重缓存。
- test_task_repo_sqlite：get_description。
- web/tests/eventText.test.ts：新格式原样保留 + 旧行兼容 strip。
