### PR TITLE
perf(backend): 缓解 glibc arena 碎片导致的 RSS 长跑增长

### DIFF
--- a/backend/miloco/src/miloco/config/settings.py
+++ b/backend/miloco/src/miloco/config/settings.py
@@ -310,7 +310,7 @@ class PerceptionSettings(BaseModel):
     event_ttl_days: int = Field(
         default=7,
         description=(
-            "meaningful_events 表保留天数;_log_cleanup_loop 24h 周期按 created_at 删旧行."
+            "meaningful_events 表保留天数;_daily_maintenance_loop 24h 周期按 created_at 删旧行."
             "产品决策:近 7 天数据足够回看,不保留更长元数据."
             "LRU 触发(磁盘满 5GB)时 clip 可能先于 row 被清,API 返 410,前端"
             "ClipPlayer/AudioClipPlayer onError 触发降级占位('🎬 已过期'/'🎤 音频已过期')."

--- a/backend/miloco/src/miloco/main.py
+++ b/backend/miloco/src/miloco/main.py
@@ -7,6 +7,7 @@ Provides FastAPI application setup, middleware configuration, and server startup
 """
 
 import asyncio
+import ctypes
 import functools
 import logging
 import os
@@ -77,9 +78,30 @@ logger = logging.getLogger(__name__)
 # add_done_callback 自清,确定性比"靠 generator frame 保活"强。
 _BG_TASKS: set[asyncio.Task[object]] = set()
 
+# glibc 独有的 malloc_trim:把各 arena 里 freed-but-not-returned 的内存还给 OS。
+# musl / macOS 的 libc 无此符号,探测失败置 None → _trim_malloc_arenas 变 no-op。
+# 用符号探测而非判发行版:platform.libc_ver() 在 musl 上不可靠。
+try:
+    _malloc_trim = ctypes.CDLL("libc.so.6", use_errno=True).malloc_trim
+    _malloc_trim.argtypes = [ctypes.c_size_t]
+    _malloc_trim.restype = ctypes.c_int
+except (OSError, AttributeError):
+    _malloc_trim = None
 
-async def _log_cleanup_loop() -> None:
-    """Background task: clean up perception/rule logs + observability tables/files."""
+
+def _trim_malloc_arenas() -> None:
+    """把 glibc arena 里 freed-but-not-returned 的内存还给 OS;非 glibc 时 no-op。
+
+    decoder 每帧产 MB 级 BGR buffer,高频大块 malloc/free 在 glibc per-thread arena
+    里碎片化、freed 块留在 free-list 不还 OS,长跑 RSS 只涨不落(真机实测单次可吐
+    ~880MB)。supervisord 的 MALLOC_* 环境变量负责预防,这里周期回收残余。
+    """
+    if _malloc_trim is not None:
+        _malloc_trim(0)
+
+
+async def _daily_maintenance_loop() -> None:
+    """每日进程维护:日志/DB/快照清理 + glibc arena 内存回收。"""
     settings = get_settings()
     mgr = get_manager()
     obs_db_path = settings.directories.workspace_dir / "observability.db"
@@ -170,6 +192,13 @@ async def _log_cleanup_loop() -> None:
                 conn.execute("PRAGMA incremental_vacuum(10000)")
         except Exception as e:
             logger.error("Miloco DB incremental_vacuum failed: %s", e)
+        # glibc arena 内存回收:与上面 incremental_vacuum 同理,把 freed 内存还 OS。
+        # to_thread:trim ~GB arena 可能耗时百 ms 级,别阻塞 event loop。
+        try:
+            await asyncio.to_thread(_trim_malloc_arenas)
+            logger.info("malloc_trim done")
+        except Exception as e:
+            logger.error("malloc_trim failed: %s", e)
         await asyncio.sleep(86400)
 
 
@@ -397,7 +426,7 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     _BG_TASKS.add(_onboarding_task)
     _onboarding_task.add_done_callback(_BG_TASKS.discard)
 
-    cleanup_task = asyncio.create_task(_log_cleanup_loop())
+    maintenance_task = asyncio.create_task(_daily_maintenance_loop())
 
     rollover_task = asyncio.create_task(_rollover_daily_loop())
     _BG_TASKS.add(rollover_task)
@@ -412,9 +441,9 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
 
     watchdog.enter_shutdown()
 
-    cleanup_task.cancel()
+    maintenance_task.cancel()
     try:
-        await cleanup_task
+        await maintenance_task
     except asyncio.CancelledError:
         pass
 

--- a/backend/miloco/src/miloco/main.py
+++ b/backend/miloco/src/miloco/main.py
@@ -89,15 +89,18 @@ except (OSError, AttributeError):
     _malloc_trim = None
 
 
-def _trim_malloc_arenas() -> None:
+def _trim_malloc_arenas() -> int | None:
     """把 glibc arena 里 freed-but-not-returned 的内存还给 OS;非 glibc 时 no-op。
 
     decoder 每帧产 MB 级 BGR buffer,高频大块 malloc/free 在 glibc per-thread arena
     里碎片化、freed 块留在 free-list 不还 OS,长跑 RSS 只涨不落(真机实测单次可吐
     ~880MB)。supervisord 的 MALLOC_* 环境变量负责预防,这里周期回收残余。
+
+    返回 malloc_trim 结果(1=有内存被释放,0=无);非 glibc(无此符号)返回 None。
     """
-    if _malloc_trim is not None:
-        _malloc_trim(0)
+    if _malloc_trim is None:
+        return None
+    return _malloc_trim(0)
 
 
 async def _daily_maintenance_loop() -> None:
@@ -195,8 +198,9 @@ async def _daily_maintenance_loop() -> None:
         # glibc arena 内存回收:与上面 incremental_vacuum 同理,把 freed 内存还 OS。
         # to_thread:trim ~GB arena 可能耗时百 ms 级,别阻塞 event loop。
         try:
-            await asyncio.to_thread(_trim_malloc_arenas)
-            logger.info("malloc_trim done")
+            released = await asyncio.to_thread(_trim_malloc_arenas)
+            if released is not None:  # None = 非 glibc no-op,不打误导日志
+                logger.info("malloc_trim done (released=%s)", released)
         except Exception as e:
             logger.error("malloc_trim failed: %s", e)
         await asyncio.sleep(86400)

--- a/backend/miloco/src/miloco/main.py
+++ b/backend/miloco/src/miloco/main.py
@@ -433,6 +433,8 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     _onboarding_task.add_done_callback(_BG_TASKS.discard)
 
     maintenance_task = asyncio.create_task(_daily_maintenance_loop())
+    _BG_TASKS.add(maintenance_task)
+    maintenance_task.add_done_callback(_BG_TASKS.discard)
 
     rollover_task = asyncio.create_task(_rollover_daily_loop())
     _BG_TASKS.add(rollover_task)

--- a/backend/miloco/src/miloco/main.py
+++ b/backend/miloco/src/miloco/main.py
@@ -104,7 +104,7 @@ def _trim_malloc_arenas() -> int | None:
 
 
 async def _daily_maintenance_loop() -> None:
-    """每日进程维护:日志/DB/快照清理 + glibc arena 内存回收。"""
+    """每日进程维护:日志/DB/快照清理。"""
     settings = get_settings()
     mgr = get_manager()
     obs_db_path = settings.directories.workspace_dir / "observability.db"
@@ -195,15 +195,27 @@ async def _daily_maintenance_loop() -> None:
                 conn.execute("PRAGMA incremental_vacuum(10000)")
         except Exception as e:
             logger.error("Miloco DB incremental_vacuum failed: %s", e)
-        # glibc arena 内存回收:与上面 incremental_vacuum 同理,把 freed 内存还 OS。
-        # to_thread:trim ~GB arena 可能耗时百 ms 级,别阻塞 event loop。
+        await asyncio.sleep(86400)
+
+
+async def _malloc_trim_loop() -> None:
+    """周期性 malloc_trim 回收 glibc arena 碎片,避免长跑 RSS 只涨不落。
+
+    decoder 每帧产 MB 级 buffer,高频大块 malloc/free 在 arena 里碎片化、freed 块
+    留 free-list 不还 OS。周期 malloc_trim(0) 主动把这些空闲页 madvise 还 OS。
+    实测:有碎片时单次 ~25ms 可吐数百 MB,稳态无可收时 ~0.1ms 空转,故无条件周期
+    执行即可,无需 RSS 水位判断。非 glibc(_malloc_trim 为 None)时直接退出。
+    to_thread:trim 可能耗时几十 ms,别阻塞 event loop。
+    """
+    if _malloc_trim is None:
+        return
+    while True:
+        await asyncio.sleep(21600)  # 6h
         try:
             released = await asyncio.to_thread(_trim_malloc_arenas)
-            if released is not None:  # None = 非 glibc no-op,不打误导日志
-                logger.info("malloc_trim done (released=%s)", released)
+            logger.info("malloc_trim done (released=%s)", released)
         except Exception as e:
             logger.error("malloc_trim failed: %s", e)
-        await asyncio.sleep(86400)
 
 
 async def _rollover_daily_loop() -> None:
@@ -432,6 +444,8 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
 
     maintenance_task = asyncio.create_task(_daily_maintenance_loop())
 
+    trim_task = asyncio.create_task(_malloc_trim_loop())
+
     rollover_task = asyncio.create_task(_rollover_daily_loop())
     _BG_TASKS.add(rollover_task)
     rollover_task.add_done_callback(_BG_TASKS.discard)
@@ -448,6 +462,12 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     maintenance_task.cancel()
     try:
         await maintenance_task
+    except asyncio.CancelledError:
+        pass
+
+    trim_task.cancel()
+    try:
+        await trim_task
     except asyncio.CancelledError:
         pass
 

--- a/backend/miloco/src/miloco/main.py
+++ b/backend/miloco/src/miloco/main.py
@@ -94,8 +94,9 @@ def _trim_malloc_arenas() -> int | None:
 
     decoder 每帧产 MB 级 BGR buffer,高频大块 malloc/free 在 glibc per-thread arena
     里碎片化、freed 块留在 free-list 不还 OS,长跑 RSS 只涨不落(真机实测单次可吐
-    ~880MB)。supervisord 的 MALLOC_ARENA_MAX 只封顶 arena 数(限制碎片乘数),碎片
-    回收靠这里的周期 malloc_trim——是主力,不是兜底。
+    ~880MB)。压 RSS 的主力是 supervisord 注入的 MMAP_THRESHOLD_ 钉死(大帧永远走
+    mmap、free 即还 OS)+ ARENA_MAX 封顶 arena 数;这里的周期 malloc_trim 是兜底,收
+    回主 arena 里非帧的小块慢变量碎片(钉死管不到的部分)。
 
     返回 malloc_trim 结果(1=有内存被释放,0=无);非 glibc(无此符号)返回 None。
     """
@@ -105,7 +106,7 @@ def _trim_malloc_arenas() -> int | None:
 
 
 async def _daily_maintenance_loop() -> None:
-    """每日进程维护:日志/DB/快照清理。"""
+    """每日进程维护:日志/DB/快照清理 + glibc arena 内存回收。"""
     settings = get_settings()
     mgr = get_manager()
     obs_db_path = settings.directories.workspace_dir / "observability.db"
@@ -196,27 +197,15 @@ async def _daily_maintenance_loop() -> None:
                 conn.execute("PRAGMA incremental_vacuum(10000)")
         except Exception as e:
             logger.error("Miloco DB incremental_vacuum failed: %s", e)
-        await asyncio.sleep(86400)
-
-
-async def _malloc_trim_loop() -> None:
-    """周期性 malloc_trim 回收 glibc arena 碎片,避免长跑 RSS 只涨不落。
-
-    decoder 每帧产 MB 级 buffer,高频大块 malloc/free 在 arena 里碎片化、freed 块
-    留 free-list 不还 OS。周期 malloc_trim(0) 主动把这些空闲页 madvise 还 OS。
-    实测:有碎片时单次 ~25ms 可吐数百 MB,稳态无可收时 ~0.1ms 空转,故无条件周期
-    执行即可,无需 RSS 水位判断。非 glibc(_malloc_trim 为 None)时直接退出。
-    to_thread:trim 可能耗时几十 ms,别阻塞 event loop。
-    """
-    if _malloc_trim is None:
-        return
-    while True:
-        await asyncio.sleep(21600)  # 6h
+        # glibc arena 内存回收:与上面 incremental_vacuum 同理,把 freed 内存还 OS。
+        # to_thread:trim ~GB arena 可能耗时百 ms 级,别阻塞 event loop。
         try:
             released = await asyncio.to_thread(_trim_malloc_arenas)
-            logger.info("malloc_trim done (released=%s)", released)
+            if released is not None:  # None = 非 glibc no-op,不打误导日志
+                logger.info("malloc_trim done (released=%s)", released)
         except Exception as e:
             logger.error("malloc_trim failed: %s", e)
+        await asyncio.sleep(86400)
 
 
 async def _rollover_daily_loop() -> None:
@@ -445,8 +434,6 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
 
     maintenance_task = asyncio.create_task(_daily_maintenance_loop())
 
-    trim_task = asyncio.create_task(_malloc_trim_loop())
-
     rollover_task = asyncio.create_task(_rollover_daily_loop())
     _BG_TASKS.add(rollover_task)
     rollover_task.add_done_callback(_BG_TASKS.discard)
@@ -463,13 +450,6 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     maintenance_task.cancel()
     try:
         await maintenance_task
-    except asyncio.CancelledError:
-        # cancel() 后 await 抛 CancelledError 是预期的正常退出信号,吞掉即可
-        pass
-
-    trim_task.cancel()
-    try:
-        await trim_task
     except asyncio.CancelledError:
         # cancel() 后 await 抛 CancelledError 是预期的正常退出信号,吞掉即可
         pass

--- a/backend/miloco/src/miloco/main.py
+++ b/backend/miloco/src/miloco/main.py
@@ -94,7 +94,8 @@ def _trim_malloc_arenas() -> int | None:
 
     decoder 每帧产 MB 级 BGR buffer,高频大块 malloc/free 在 glibc per-thread arena
     里碎片化、freed 块留在 free-list 不还 OS,长跑 RSS 只涨不落(真机实测单次可吐
-    ~880MB)。supervisord 的 MALLOC_* 环境变量负责预防,这里周期回收残余。
+    ~880MB)。supervisord 的 MALLOC_ARENA_MAX 只封顶 arena 数(限制碎片乘数),碎片
+    回收靠这里的周期 malloc_trim——是主力,不是兜底。
 
     返回 malloc_trim 结果(1=有内存被释放,0=无);非 glibc(无此符号)返回 None。
     """

--- a/backend/miloco/src/miloco/main.py
+++ b/backend/miloco/src/miloco/main.py
@@ -463,18 +463,21 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     try:
         await maintenance_task
     except asyncio.CancelledError:
+        # cancel() 后 await 抛 CancelledError 是预期的正常退出信号,吞掉即可
         pass
 
     trim_task.cancel()
     try:
         await trim_task
     except asyncio.CancelledError:
+        # cancel() 后 await 抛 CancelledError 是预期的正常退出信号,吞掉即可
         pass
 
     rollover_task.cancel()
     try:
         await rollover_task
     except asyncio.CancelledError:
+        # cancel() 后 await 抛 CancelledError 是预期的正常退出信号,吞掉即可
         pass
 
     # 关闭顺序遵循"生产者先于消费者":

--- a/backend/miloco/src/miloco/task_record/rollover.py
+++ b/backend/miloco/src/miloco/task_record/rollover.py
@@ -8,7 +8,7 @@ recurring + 活跃行，按 ``window`` 边界（day/week/month）判断今天是
 到点则调 ``TaskRecordService.rollover_one`` 完成 archive + insert new。
 
 设计选择（偏离 plan §P3，原因记在 commit message）：
-- 不引入 ``apscheduler``——沿用 ``_log_cleanup_loop`` 的 ``asyncio.sleep`` 模式，
+- 不引入 ``apscheduler``——沿用 ``_daily_maintenance_loop`` 的 ``asyncio.sleep`` 模式，
   在 ``main.py`` lifespan 中 ``create_task`` 一个 daemon coroutine。
 - ``recurring_pattern`` 不做 cron-like 解析（plugin 端无此 parser，spec 也未
   约束格式）——只识别 ``{window: "day|week|month|longterm"}`` 这一种结构。

--- a/backend/miloco/tests/test_cleanup_loop_integration.py
+++ b/backend/miloco/tests/test_cleanup_loop_integration.py
@@ -13,7 +13,7 @@ import asyncio
 import time
 import uuid
 from datetime import datetime, timedelta
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -154,3 +154,21 @@ class TestCleanupLoop:
         ):
             # 不应抛 OSError
             await _run_one_cycle()
+
+    def test_trim_malloc_arenas_noop_when_symbol_unavailable(self):
+        """非 glibc(符号缺失):_trim_malloc_arenas 返回 None、不抛."""
+        from miloco import main as main_module
+
+        with patch.object(main_module, "_malloc_trim", None):
+            assert main_module._trim_malloc_arenas() is None
+
+    @pytest.mark.asyncio
+    async def test_malloc_trim_failure_does_not_block_loop(self, isolated_env):
+        """B9:malloc_trim 抛异常 → 维护循环不崩(异常被吞、不冒泡)."""
+        from miloco import main as main_module
+
+        boom = MagicMock(side_effect=RuntimeError("trim boom"))
+        with patch.object(main_module, "_malloc_trim", boom):
+            # 不应抛 RuntimeError
+            await _run_one_cycle()
+            assert boom.called

--- a/backend/miloco/tests/test_cleanup_loop_integration.py
+++ b/backend/miloco/tests/test_cleanup_loop_integration.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2025 Xiaomi Corporation
 # This software may be used and distributed according to the terms of the Xiaomi Miloco License Agreement.
 
-"""集成测试:_log_cleanup_loop 追加的两块清理(D3-T11).
+"""集成测试:_daily_maintenance_loop 追加的两块清理(D3-T11).
 
 直接跑一轮 cleanup 逻辑(不走 24h sleep),验证:
 - meaningful_events.delete_before_days 被调用
@@ -44,8 +44,8 @@ def isolated_env(tmp_path, monkeypatch):
 
 
 async def _run_one_cycle():
-    """运行 _log_cleanup_loop 的一轮 body(跳过初始 60s 与末尾 86400s 等待)."""
-    # 直接调 main.py 的 _log_cleanup_loop,但 patch 掉两个 sleep
+    """运行 _daily_maintenance_loop 的一轮 body(跳过初始 60s 与末尾 86400s 等待)."""
+    # 直接调 main.py 的 _daily_maintenance_loop,但 patch 掉两个 sleep
     from miloco import main as main_module
 
     real_sleep = asyncio.sleep
@@ -61,7 +61,7 @@ async def _run_one_cycle():
 
     with patch.object(asyncio, "sleep", side_effect=_short_sleep):
         try:
-            await main_module._log_cleanup_loop()
+            await main_module._daily_maintenance_loop()
         except asyncio.CancelledError:
             pass
 

--- a/backend/miloco/tests/test_cleanup_loop_integration.py
+++ b/backend/miloco/tests/test_cleanup_loop_integration.py
@@ -1,12 +1,13 @@
 # Copyright (C) 2025 Xiaomi Corporation
 # This software may be used and distributed according to the terms of the Xiaomi Miloco License Agreement.
 
-"""集成测试:_daily_maintenance_loop 追加的两块清理(D3-T11).
+"""集成测试:_daily_maintenance_loop 清理逻辑 + _malloc_trim_loop 内存回收.
 
-直接跑一轮 cleanup 逻辑(不走 24h sleep),验证:
+直接跑一轮 loop body(不走真实 sleep),验证:
 - meaningful_events.delete_before_days 被调用
 - cleanup_snapshots 被调用
 - 任一块失败不阻塞其它块(B9 强约束)
+- _malloc_trim_loop:非 glibc 直接退出、正常调 trim、trim 失败不崩
 """
 
 import asyncio
@@ -62,6 +63,26 @@ async def _run_one_cycle():
     with patch.object(asyncio, "sleep", side_effect=_short_sleep):
         try:
             await main_module._daily_maintenance_loop()
+        except asyncio.CancelledError:
+            pass
+
+
+async def _run_trim_once():
+    """运行 _malloc_trim_loop 的一轮 body(第一次 sleep 放行,第二次抛 Cancel 退出)."""
+    from miloco import main as main_module
+
+    real_sleep = asyncio.sleep
+    call_count = [0]
+
+    async def _short_sleep(secs):
+        call_count[0] += 1
+        if call_count[0] >= 2:
+            raise asyncio.CancelledError()
+        await real_sleep(0)
+
+    with patch.object(asyncio, "sleep", side_effect=_short_sleep):
+        try:
+            await main_module._malloc_trim_loop()
         except asyncio.CancelledError:
             pass
 
@@ -163,12 +184,37 @@ class TestCleanupLoop:
             assert main_module._trim_malloc_arenas() is None
 
     @pytest.mark.asyncio
-    async def test_malloc_trim_failure_does_not_block_loop(self, isolated_env):
-        """B9:malloc_trim 抛异常 → 维护循环不崩(异常被吞、不冒泡)."""
+    async def test_malloc_trim_loop_exits_when_non_glibc(self):
+        """非 glibc(_malloc_trim 为 None):_malloc_trim_loop 立即返回,不进循环."""
+        from miloco import main as main_module
+
+        with patch.object(main_module, "_malloc_trim", None):
+            # 未进 while 应瞬时返回;若进了循环会卡在真实 sleep,超时即回归
+            await asyncio.wait_for(main_module._malloc_trim_loop(), timeout=1)
+
+    @pytest.mark.asyncio
+    async def test_malloc_trim_loop_invokes_trim(self):
+        """正常路径:_malloc_trim_loop 一轮里调用 _trim_malloc_arenas."""
+        from miloco import main as main_module
+
+        trim = MagicMock(return_value=1)
+        with (
+            patch.object(main_module, "_trim_malloc_arenas", trim),
+            patch.object(main_module, "_malloc_trim", MagicMock()),
+        ):
+            await _run_trim_once()
+            assert trim.called
+
+    @pytest.mark.asyncio
+    async def test_malloc_trim_loop_failure_does_not_block(self):
+        """B9:malloc_trim 抛异常 → trim 循环不崩(异常被吞、不冒泡)."""
         from miloco import main as main_module
 
         boom = MagicMock(side_effect=RuntimeError("trim boom"))
-        with patch.object(main_module, "_malloc_trim", boom):
+        with (
+            patch.object(main_module, "_trim_malloc_arenas", boom),
+            patch.object(main_module, "_malloc_trim", MagicMock()),
+        ):
             # 不应抛 RuntimeError
-            await _run_one_cycle()
+            await _run_trim_once()
             assert boom.called

--- a/backend/miloco/tests/test_cleanup_loop_integration.py
+++ b/backend/miloco/tests/test_cleanup_loop_integration.py
@@ -43,11 +43,14 @@ def isolated_env(tmp_path, monkeypatch):
     reset_settings()
 
 
-async def _run_loop_until_second_sleep(loop_coro_factory):
-    """跑一轮 loop body:第一次 sleep 立即放行,第二次抛 Cancel 顶出 while True。
+async def _run_one_cycle():
+    """跑一轮 _daily_maintenance_loop body(跳过开头 60s 与末尾 86400s 等待)。
 
-    首个 sleep 是启动延迟、之后 sleep 是周期等待,用此驱动跳过两段等待只跑一轮 body。
+    patch 掉 asyncio.sleep:第一次(开头 60s)立即放行,第二次(末尾 86400s)抛
+    CancelledError 顶出 while True,body 恰好执行一轮。
     """
+    from miloco import main as main_module
+
     real_sleep = asyncio.sleep
     call_count = [0]
 
@@ -59,17 +62,9 @@ async def _run_loop_until_second_sleep(loop_coro_factory):
 
     with patch.object(asyncio, "sleep", side_effect=_short_sleep):
         try:
-            await loop_coro_factory()
+            await main_module._daily_maintenance_loop()
         except asyncio.CancelledError:
             pass
-
-
-async def _run_one_cycle():
-    """运行 _daily_maintenance_loop 的一轮 body(跳过初始 60s 与末尾 86400s 等待)."""
-    from miloco import main as main_module
-
-    await _run_loop_until_second_sleep(main_module._daily_maintenance_loop)
-
 
 
 class TestCleanupLoop:

--- a/backend/miloco/tests/test_cleanup_loop_integration.py
+++ b/backend/miloco/tests/test_cleanup_loop_integration.py
@@ -1,13 +1,12 @@
 # Copyright (C) 2025 Xiaomi Corporation
 # This software may be used and distributed according to the terms of the Xiaomi Miloco License Agreement.
 
-"""集成测试:_daily_maintenance_loop 清理逻辑 + _malloc_trim_loop 内存回收.
+"""集成测试:_daily_maintenance_loop 追加的两块清理(D3-T11).
 
-直接跑一轮 loop body(不走真实 sleep),验证:
+直接跑一轮 cleanup 逻辑(不走 24h sleep),验证:
 - meaningful_events.delete_before_days 被调用
 - cleanup_snapshots 被调用
 - 任一块失败不阻塞其它块(B9 强约束)
-- _malloc_trim_loop:非 glibc 直接退出、正常调 trim、trim 失败不崩
 """
 
 import asyncio
@@ -47,8 +46,7 @@ def isolated_env(tmp_path, monkeypatch):
 async def _run_loop_until_second_sleep(loop_coro_factory):
     """跑一轮 loop body:第一次 sleep 立即放行,第二次抛 Cancel 顶出 while True。
 
-    维护/trim 两条循环结构相同(首个 sleep 是启动延迟、之后 sleep 是周期等待),
-    共用此驱动,避免两份 patch 逻辑各自漂移。
+    首个 sleep 是启动延迟、之后 sleep 是周期等待,用此驱动跳过两段等待只跑一轮 body。
     """
     real_sleep = asyncio.sleep
     call_count = [0]
@@ -72,12 +70,6 @@ async def _run_one_cycle():
 
     await _run_loop_until_second_sleep(main_module._daily_maintenance_loop)
 
-
-async def _run_trim_once():
-    """运行 _malloc_trim_loop 的一轮 body(跳过 6h 等待)."""
-    from miloco import main as main_module
-
-    await _run_loop_until_second_sleep(main_module._malloc_trim_loop)
 
 
 class TestCleanupLoop:
@@ -177,37 +169,12 @@ class TestCleanupLoop:
             assert main_module._trim_malloc_arenas() is None
 
     @pytest.mark.asyncio
-    async def test_malloc_trim_loop_exits_when_non_glibc(self):
-        """非 glibc(_malloc_trim 为 None):_malloc_trim_loop 立即返回,不进循环."""
-        from miloco import main as main_module
-
-        with patch.object(main_module, "_malloc_trim", None):
-            # 未进 while 应瞬时返回;若进了循环会卡在真实 sleep,超时即回归
-            await asyncio.wait_for(main_module._malloc_trim_loop(), timeout=1)
-
-    @pytest.mark.asyncio
-    async def test_malloc_trim_loop_invokes_trim(self):
-        """正常路径:_malloc_trim_loop 一轮里调用 _trim_malloc_arenas."""
-        from miloco import main as main_module
-
-        trim = MagicMock(return_value=1)
-        with (
-            patch.object(main_module, "_trim_malloc_arenas", trim),
-            patch.object(main_module, "_malloc_trim", MagicMock()),
-        ):
-            await _run_trim_once()
-            assert trim.called
-
-    @pytest.mark.asyncio
-    async def test_malloc_trim_loop_failure_does_not_block(self):
-        """B9:malloc_trim 抛异常 → trim 循环不崩(异常被吞、不冒泡)."""
+    async def test_malloc_trim_failure_does_not_block_loop(self, isolated_env):
+        """B9:malloc_trim 抛异常 → 维护循环不崩(异常被吞、不冒泡)."""
         from miloco import main as main_module
 
         boom = MagicMock(side_effect=RuntimeError("trim boom"))
-        with (
-            patch.object(main_module, "_trim_malloc_arenas", boom),
-            patch.object(main_module, "_malloc_trim", MagicMock()),
-        ):
+        with patch.object(main_module, "_malloc_trim", boom):
             # 不应抛 RuntimeError
-            await _run_trim_once()
+            await _run_one_cycle()
             assert boom.called

--- a/backend/miloco/tests/test_cleanup_loop_integration.py
+++ b/backend/miloco/tests/test_cleanup_loop_integration.py
@@ -44,47 +44,40 @@ def isolated_env(tmp_path, monkeypatch):
     reset_settings()
 
 
-async def _run_one_cycle():
-    """运行 _daily_maintenance_loop 的一轮 body(跳过初始 60s 与末尾 86400s 等待)."""
-    # 直接调 main.py 的 _daily_maintenance_loop,但 patch 掉两个 sleep
-    from miloco import main as main_module
+async def _run_loop_until_second_sleep(loop_coro_factory):
+    """跑一轮 loop body:第一次 sleep 立即放行,第二次抛 Cancel 顶出 while True。
 
+    维护/trim 两条循环结构相同(首个 sleep 是启动延迟、之后 sleep 是周期等待),
+    共用此驱动,避免两份 patch 逻辑各自漂移。
+    """
     real_sleep = asyncio.sleep
     call_count = [0]
 
     async def _short_sleep(secs):
         call_count[0] += 1
         if call_count[0] >= 2:
-            # 第二次 sleep(末尾 86400)→ 抛 CancelledError 退出 while True
             raise asyncio.CancelledError()
-        # 第一次 sleep(开头 60)→ 立即返回
         await real_sleep(0)
 
     with patch.object(asyncio, "sleep", side_effect=_short_sleep):
         try:
-            await main_module._daily_maintenance_loop()
+            await loop_coro_factory()
         except asyncio.CancelledError:
             pass
+
+
+async def _run_one_cycle():
+    """运行 _daily_maintenance_loop 的一轮 body(跳过初始 60s 与末尾 86400s 等待)."""
+    from miloco import main as main_module
+
+    await _run_loop_until_second_sleep(main_module._daily_maintenance_loop)
 
 
 async def _run_trim_once():
-    """运行 _malloc_trim_loop 的一轮 body(第一次 sleep 放行,第二次抛 Cancel 退出)."""
+    """运行 _malloc_trim_loop 的一轮 body(跳过 6h 等待)."""
     from miloco import main as main_module
 
-    real_sleep = asyncio.sleep
-    call_count = [0]
-
-    async def _short_sleep(secs):
-        call_count[0] += 1
-        if call_count[0] >= 2:
-            raise asyncio.CancelledError()
-        await real_sleep(0)
-
-    with patch.object(asyncio, "sleep", side_effect=_short_sleep):
-        try:
-            await main_module._malloc_trim_loop()
-        except asyncio.CancelledError:
-            pass
+    await _run_loop_until_second_sleep(main_module._malloc_trim_loop)
 
 
 class TestCleanupLoop:

--- a/cli/src/miloco_cli/commands/service.py
+++ b/cli/src/miloco_cli/commands/service.py
@@ -262,6 +262,16 @@ def _generate_supervisor_conf(server_cmd: str) -> None:
     tz = _resolve_timezone()
     # 解析到时区才追加 TZ + MILOCO_TIMEZONE；否则不塞,交给子进程继承宿主 + backend 兜底。
     tz_env = f',TZ="{tz}",MILOCO_TIMEZONE="{tz}"' if tz else ""
+    # glibc(ptmalloc2)长跑内存调优:decoder 每帧 MB 级 buffer 高频 malloc/free,在
+    # per-thread arena 里碎片化、freed 不还 OS,RSS 只涨不落(真机实测 malloc_trim 可
+    # 吐 ~880MB)。MMAP_THRESHOLD_ 钉死 128KB 并关掉动态自增→大块永远 mmap、free 即
+    # 还 OS(主力);ARENA_MAX=6 封顶 arena 数(2~32 核通用,是上限非目标);
+    # TRIM_THRESHOLD_ 钉死→主 arena 堆顶更勤还 OS。musl/macOS 无视这些变量,注入无害。
+    malloc_env = (
+        ',MALLOC_ARENA_MAX="6"'
+        ',MALLOC_MMAP_THRESHOLD_="131072"'
+        ',MALLOC_TRIM_THRESHOLD_="131072"'
+    )
     conf = f"""\
 [supervisord]
 logfile={_supervisor_log()}
@@ -290,7 +300,7 @@ redirect_stderr=true
 stdout_logfile={log_dir}/miloco-backend.log
 stdout_logfile_maxbytes=10MB
 stdout_logfile_backups=20
-environment=MILOCO_SUPERVISED="1",MILOCO_HOME="{miloco_home()}"{tz_env}
+environment=MILOCO_SUPERVISED="1",MILOCO_HOME="{miloco_home()}"{tz_env}{malloc_env}
 """
     if sup_conf_path.exists() and sup_conf_path.read_text() == conf:
         return

--- a/cli/src/miloco_cli/commands/service.py
+++ b/cli/src/miloco_cli/commands/service.py
@@ -269,10 +269,13 @@ def _generate_supervisor_conf(server_cmd: str) -> None:
     # 是上限非目标);TRIM_THRESHOLD_ 钉死→主 arena 堆顶更勤还 OS。musl/macOS 无视这些
     # 变量,注入无害。
     #
-    # 曾担心"每帧大块走 mmap 付 sys 税"而一度去掉钉死,后实测证伪:那个 sys 税只在
-    # 单块 malloc/free 紧循环里成立(默认态白捡 arena 复用→钉死打掉它才暴涨)。真实解码
-    # 路径每帧产两块 6.2MB buffer(to_ndarray + astype),默认态本就复用不上、已在缺页,
-    # 钉死增量仅 +0.1~0.2ms/帧,单摄像头 15fps 平摊 ~0.2% 单核,可忽略。故保留钉死。
+    # MMAP 钉死的 CPU 代价:曾担心"每帧大块走 mmap 付 sys 税"而一度去掉,后实测证伪——
+    # 那个 sys 税只在单块 malloc/free 紧循环里成立(默认态白捡 arena 复用→钉死打掉它才
+    # 暴涨)。真实解码路径每帧产两块 6.2MB buffer(to_ndarray + astype),默认态本就复用不
+    # 上、已在缺页,钉死增量仅 +0.1~0.2ms/帧(x86+RK3588 实测,后者需 numpy>=2.2),单摄
+    # 像头 15fps 平摊 ~0.2% 单核,可忽略。
+    # ARENA_MAX=6 的代价另算:arena 变少理论上增多线程(多摄像头 = 多解码线程)malloc 锁
+    # 争用,本场景线程数下预期可忽略但未单独实测;若解码线程数上去,关注帧延迟 p99。
     malloc_env = (
         ',MALLOC_ARENA_MAX="6"'
         ',MALLOC_MMAP_THRESHOLD_="131072"'

--- a/cli/src/miloco_cli/commands/service.py
+++ b/cli/src/miloco_cli/commands/service.py
@@ -264,7 +264,9 @@ def _generate_supervisor_conf(server_cmd: str) -> None:
     tz_env = f',TZ="{tz}",MILOCO_TIMEZONE="{tz}"' if tz else ""
     # glibc(ptmalloc2)长跑内存调优:decoder 每帧 MB 级 buffer 高频 malloc/free,在
     # per-thread arena 里碎片化、freed 不还 OS,RSS 只涨不落。ARENA_MAX=6 封顶 arena
-    # 数(2~32 核通用,限制碎片乘数,无 CPU 成本)。不钉 MMAP_THRESHOLD_:钉死会让每帧
+    # 数(2~32 核通用,限制碎片乘数;不同于 MMAP 每帧 sys 税,它不在分配热路径加每帧开
+    # 销,唯一理论代价是 arena 变少致多线程 malloc 锁争用略增、本场景线程数下可忽略、未
+    # 单独实测)。不钉 MMAP_THRESHOLD_:钉死会让每帧
     # 大块走 mmap、free 即还,虽稳住 RSS 但每帧付 mmap+缺页的 sys CPU 税;放开后帧走
     # arena 复用免此税,碎片改由 backend 的 _malloc_trim_loop 周期 malloc_trim 回收。
     # musl/macOS 无视此变量,注入无害。

--- a/cli/src/miloco_cli/commands/service.py
+++ b/cli/src/miloco_cli/commands/service.py
@@ -263,15 +263,12 @@ def _generate_supervisor_conf(server_cmd: str) -> None:
     # 解析到时区才追加 TZ + MILOCO_TIMEZONE；否则不塞,交给子进程继承宿主 + backend 兜底。
     tz_env = f',TZ="{tz}",MILOCO_TIMEZONE="{tz}"' if tz else ""
     # glibc(ptmalloc2)长跑内存调优:decoder 每帧 MB 级 buffer 高频 malloc/free,在
-    # per-thread arena 里碎片化、freed 不还 OS,RSS 只涨不落(真机实测 malloc_trim 可
-    # 吐 ~880MB)。MMAP_THRESHOLD_ 钉死 128KB 并关掉动态自增→大块永远 mmap、free 即
-    # 还 OS(主力);ARENA_MAX=6 封顶 arena 数(2~32 核通用,是上限非目标);
-    # TRIM_THRESHOLD_ 钉死→主 arena 堆顶更勤还 OS。musl/macOS 无视这些变量,注入无害。
-    malloc_env = (
-        ',MALLOC_ARENA_MAX="6"'
-        ',MALLOC_MMAP_THRESHOLD_="131072"'
-        ',MALLOC_TRIM_THRESHOLD_="131072"'
-    )
+    # per-thread arena 里碎片化、freed 不还 OS,RSS 只涨不落。ARENA_MAX=6 封顶 arena
+    # 数(2~32 核通用,限制碎片乘数,无 CPU 成本)。不钉 MMAP_THRESHOLD_:钉死会让每帧
+    # 大块走 mmap、free 即还,虽稳住 RSS 但每帧付 mmap+缺页的 sys CPU 税;放开后帧走
+    # arena 复用免此税,碎片改由 backend 的 _malloc_trim_loop 周期 malloc_trim 回收。
+    # musl/macOS 无视此变量,注入无害。
+    malloc_env = ',MALLOC_ARENA_MAX="6"'
     conf = f"""\
 [supervisord]
 logfile={_supervisor_log()}

--- a/cli/src/miloco_cli/commands/service.py
+++ b/cli/src/miloco_cli/commands/service.py
@@ -263,14 +263,21 @@ def _generate_supervisor_conf(server_cmd: str) -> None:
     # 解析到时区才追加 TZ + MILOCO_TIMEZONE；否则不塞,交给子进程继承宿主 + backend 兜底。
     tz_env = f',TZ="{tz}",MILOCO_TIMEZONE="{tz}"' if tz else ""
     # glibc(ptmalloc2)长跑内存调优:decoder 每帧 MB 级 buffer 高频 malloc/free,在
-    # per-thread arena 里碎片化、freed 不还 OS,RSS 只涨不落。ARENA_MAX=6 封顶 arena
-    # 数(2~32 核通用,限制碎片乘数;不同于 MMAP 每帧 sys 税,它不在分配热路径加每帧开
-    # 销,唯一理论代价是 arena 变少致多线程 malloc 锁争用略增、本场景线程数下可忽略、未
-    # 单独实测)。不钉 MMAP_THRESHOLD_:钉死会让每帧
-    # 大块走 mmap、free 即还,虽稳住 RSS 但每帧付 mmap+缺页的 sys CPU 税;放开后帧走
-    # arena 复用免此税,碎片改由 backend 的 _malloc_trim_loop 周期 malloc_trim 回收。
-    # musl/macOS 无视此变量,注入无害。
-    malloc_env = ',MALLOC_ARENA_MAX="6"'
+    # per-thread arena 里碎片化、freed 不还 OS,RSS 只涨不落(真机实测 malloc_trim 可
+    # 吐 ~880MB)。MMAP_THRESHOLD_ 钉死 128KB 并关掉动态自增→大块永远 mmap、free 即
+    # 还 OS(主力,真机实测显著压低 RSS 水平值);ARENA_MAX=6 封顶 arena 数(2~32 核通用,
+    # 是上限非目标);TRIM_THRESHOLD_ 钉死→主 arena 堆顶更勤还 OS。musl/macOS 无视这些
+    # 变量,注入无害。
+    #
+    # 曾担心"每帧大块走 mmap 付 sys 税"而一度去掉钉死,后实测证伪:那个 sys 税只在
+    # 单块 malloc/free 紧循环里成立(默认态白捡 arena 复用→钉死打掉它才暴涨)。真实解码
+    # 路径每帧产两块 6.2MB buffer(to_ndarray + astype),默认态本就复用不上、已在缺页,
+    # 钉死增量仅 +0.1~0.2ms/帧,单摄像头 15fps 平摊 ~0.2% 单核,可忽略。故保留钉死。
+    malloc_env = (
+        ',MALLOC_ARENA_MAX="6"'
+        ',MALLOC_MMAP_THRESHOLD_="131072"'
+        ',MALLOC_TRIM_THRESHOLD_="131072"'
+    )
     conf = f"""\
 [supervisord]
 logfile={_supervisor_log()}

--- a/cli/tests/test_commands.py
+++ b/cli/tests/test_commands.py
@@ -1955,6 +1955,17 @@ def test_generate_supervisor_conf_omits_timezone_when_unset(runner, tmp_path, mo
     assert 'MILOCO_SUPERVISED="1"' in conf
 
 
+def test_generate_supervisor_conf_always_injects_malloc_tunables(runner, tmp_path, monkeypatch):
+    """三个 MALLOC_* 无条件注入(glibc arena 碎片调优),与 TZ 是否解析到无关。"""
+    import miloco_cli.commands.service as svc_mod
+
+    svc_mod._generate_supervisor_conf("/x/python -m miloco")
+    conf = svc_mod._supervisor_conf().read_text()
+    assert 'MALLOC_ARENA_MAX="6"' in conf
+    assert 'MALLOC_MMAP_THRESHOLD_="131072"' in conf
+    assert 'MALLOC_TRIM_THRESHOLD_="131072"' in conf
+
+
 def test_service_logs_dir_not_found(runner, tmp_path, monkeypatch):
     """日志目录不存在时，logs 以非零退出。"""
     # 切换 MILOCO_HOME 到一个不存在 log/ 子目录的临时目录


### PR DESCRIPTION
## 问题

`miloco.main` 进程长跑 RSS 单调涨到 2GB+。真机排查结论：**glibc arena 碎片，非逻辑泄漏**。

## 根因（实证）

- 现象矛盾：RSS 2185MB，但进程内 py_heap 只报 35.8MB（`sys.getsizeof(ndarray)` 只算对象壳、不含 buffer，帧内存对它不可见）。
- memray `-leaks`：97-98% 保留内存来自 `decoder.py` 每帧 `to_ndarray(bgr24)` 的 MB 级 BGR buffer（1080p ≈ 6.2MB/帧，per-camera 高频）。
- smaps：RSS **100% 在 glibc 分配器**手里（多个 64MB arena 段 + 主堆），.so/代码段仅 ~108MB。
- **决定性实证**：`gdb call malloc_trim(0)` 使 RSS 稳态从 1337MB 降到 860MB，一次收回 **477MB（35.7%）**。坐实是 arena 扣住的 freed-but-not-returned 碎片。

机制：glibc（ptmalloc2）把 free 的大块留在 arena 复用、不主动还 OS，碎片让堆顶收不回；高频大块帧分配把 arena 撑到峰值工作集高度。

## 方案

**预防（压 RSS 主力）** — `supervisord.conf` 生成器注入 glibc tunable：
- `MALLOC_MMAP_THRESHOLD_=131072` 钉死 128KB 并关掉动态自增 → MB 级大帧永远走 mmap、free 即 munmap 还 OS。真机实测**显著压低 RSS 水平值**。
- `MALLOC_TRIM_THRESHOLD_=131072` 钉死 → 主 arena 堆顶更勤还 OS。
- `MALLOC_ARENA_MAX=6` 封顶 arena 数（碎片乘数上限，2~32 核通用）。

**兜底** — `_daily_maintenance_loop` 末尾每日 `malloc_trim(0)`，收回主 arena 里**非帧的小块慢变量碎片**（钉死管不到的部分）。glibc-only 符号探测，`_trim_malloc_arenas` 单一职责，非 glibc 自动 no-op。

## 为何保留 MMAP 钉死（撤回一次错误迭代）

初版（本 PR）就用 MMAP 钉死。中途曾担心"每帧大块走 mmap 有 sys CPU 税"（本地微基准 20000 帧 sys 0.03s→27s）而一度去掉钉死、改走 arena 复用 + 独立 6h trim。**后经 x86 + ARM 实测证伪该顾虑，完整回滚**。

那个吓人的 27s 是**单 buffer 紧循环的假象**：单块 malloc/free 时默认态白捡 glibc 动态阈值的 arena 复用（sys≈0），钉死把复用打掉才暴涨。真实解码路径每帧产**两块** 6.2MB buffer（`to_ndarray` + `astype`），是另一种分配模式。

### CPU 实测（20000/2000 帧，6.2MB/帧，per-frame sys）

| 平台 · numpy | 默认 sys/帧 | 钉死 sys/帧 | 钉死增量 | 平摊 @15fps |
|---|---|---|---|---|
| x86 · numpy 2.4（生产版本区间） | 2.55ms | 2.75ms | +0.2ms | ~0.2% 单核/摄像头 |
| **ARM RK3588 · numpy 2.2（生产版本）** | 4.42ms | 4.44ms | **~0（噪声级）** | **~0.15% 单核/摄像头** |
| ARM RK3588 · numpy 1.21（系统旧版，仅对照） | 2.14ms | 4.44ms | +2.3ms | ~3.3% 单核/摄像头 |

ARM 侧方法：Orange Pi 5 / RK3588 / glibc 2.35，`taskset` 钉 A76 大核、default/pinned 交替 4 轮、35-37°C 无降频。

**规律**：钉死值（~4.4ms/帧 ARM）两 numpy 版本几乎相同——钉死后两块 buffer 都强制走 mmap+缺页+清零，成本由内核清零主导、与 numpy 版本无关，是个天花板。变的是**默认态离天花板多远**：numpy 1.21 默认复用掉约 1 块（离天花板远，钉死增量大），**numpy 2.2 默认就不复用、已贴天花板**（钉死没东西可打掉，增量≈0）。

**结论**：生产 pin 的是 `numpy>=2.2`，该版本默认态本就把每帧 ~4.4ms sys（ARM）付掉了，**开 MMAP 钉死 CPU 一分不多花、白拿 RSS 收益**。x86 与 ARM 生产版本一致，钉死 CPU 代价 ~0.15-0.2% 单核/摄像头，可忽略。此前担心的"弱 CPU 上钉死代价放大"被证伪——钉死代价由 **numpy 版本**（是否复用）决定，不是 CPU 强弱。

> **口径边界**：以上只针对 `MMAP_THRESHOLD_/TRIM_THRESHOLD_` 钉死这笔代价。`ARENA_MAX=6` 减少 arena 数、理论上会增多线程（多摄像头 = 多解码线程）并发 malloc 的锁争用，**这笔未单独实测**——上述 microbench 是单线程的。当前解码线程数下预期可忽略；若摄像头/解码线程数上去，用帧延迟 p99（`decoded_unix_ms - recv_unix_ms`）作为观察指标。

## 真机验证（单路摄像头）

- 部署后 RSS 从"单调涨向 2GB"变为 **946~1330MB band 内稳定震荡、无单调爬升**。
- band 震荡由活跃帧瞬时驻留起伏主导；MMAP 钉死让帧 free 即还 OS 是压 RSS 主力，每日 trim 收慢变量碎片。
- floor ≈ 860MB 是真实工作集（trim 治不了），如需再降只能靠 pipeline 限流 / 降分辨率，属另一议题。

## 跨平台

- `MALLOC_MMAP_THRESHOLD_` / `TRIM_THRESHOLD_` / `ARENA_MAX` 在 musl/macOS 上被无视（无害，那两平台本无此病）。
- `malloc_trim` 是 glibc 独有符号；符号探测缺失时 `_trim_malloc_arenas` 自动 no-op，不 crash。

## 生效

- 代码改动重启即生效。
- env 需重新生成 supervisord.conf（CLI 下次重启服务时自动重写，或手动补参数后重启）。

## 测试

`test_cleanup_loop_integration.py` 覆盖 `_daily_maintenance_loop` 清理 + trim（6 项全过，ruff 通过）：
- 旧 meaningful_events 删除 / cleanup_snapshots 调用
- B9：任一清理块失败不阻塞其它块、不冒泡崩循环
- `_trim_malloc_arenas` 非 glibc 符号缺失降级 no-op、不抛
- B9：malloc_trim 抛异常时维护循环不崩
