### PR TITLE
feat(miot+perception): device property-change history — push subscription (topic fix) + spec-aware throttling

### DIFF
--- a/backend/miloco/src/miloco/config/settings.py
+++ b/backend/miloco/src/miloco/config/settings.py
@@ -239,6 +239,24 @@ class MiotSettings(BaseModel):
     cloud_server: str = Field(
         default="cn", description="MIoT 云区域（cn/de/i2/ru/sg/us）"
     )
+    prop_history_enabled: bool = Field(
+        default=True,
+        description="订阅全部设备的 mips 属性推送并落库(device_prop_history),"
+        "供「某设备几点开的」类历史查询。",
+    )
+    prop_history_retention_days: int = Field(
+        default=30, description="属性历史保留天数;写路径顺带清理过期行。"
+    )
+    prop_history_poll_interval_sec: int = Field(
+        default=60,
+        description="属性历史轮询周期(秒)。mips 推送被 broker ACL 拒绝时的兜底"
+        "采样源,一周期一次批量 prop/get。",
+    )
+    prop_history_poll_extra: list[str] = Field(
+        default_factory=list,
+        description="默认 watchlist(全设备 prop.2.1)之外要轮询的属性,"
+        "形如 'did:prop.4.1'。",
+    )
 
 
 class NotifySettings(BaseModel):

--- a/backend/miloco/src/miloco/config/settings.py
+++ b/backend/miloco/src/miloco/config/settings.py
@@ -247,6 +247,11 @@ class MiotSettings(BaseModel):
     prop_history_retention_days: int = Field(
         default=30, description="属性历史保留天数;写路径顺带清理过期行。"
     )
+    prop_history_poll_enabled: bool = Field(
+        default=True,
+        description="是否启用属性历史的轮询兜底通道。推送是主链路,本开关只管"
+        "兜底采样;关掉后仅保留推送(设备不上报的属性将不再有历史)。",
+    )
     prop_history_poll_interval_sec: int = Field(
         default=300,
         description="属性历史轮询周期(秒)。推送为主链路,轮询只做兜底采样:"
@@ -274,8 +279,9 @@ class MiotSettings(BaseModel):
     )
     prop_history_throttle_rel_delta: float = Field(
         default=0.3,
-        description="高频遥测属性的相对幅度阈值:相对上次**落库值**变化达到该"
-        "比例即落库(不等最小间隔)。0.2 = 20%。",
+        description="高频遥测属性的幅度阈值。spec 有 value-range 时按**满量程**"
+        "比例判定(0–100 的湿度设 0.3 = 变化 30 个百分点才落库);无量程时退化为"
+        "相对上次落库值的比例。0.3 = 30%。",
     )
     prop_history_poll_extra: list[str] = Field(
         default_factory=list,

--- a/backend/miloco/src/miloco/config/settings.py
+++ b/backend/miloco/src/miloco/config/settings.py
@@ -248,9 +248,34 @@ class MiotSettings(BaseModel):
         default=30, description="属性历史保留天数;写路径顺带清理过期行。"
     )
     prop_history_poll_interval_sec: int = Field(
-        default=60,
-        description="属性历史轮询周期(秒)。mips 推送被 broker ACL 拒绝时的兜底"
-        "采样源,一周期一次批量 prop/get。",
+        default=300,
+        description="属性历史轮询周期(秒)。推送为主链路,轮询只做兜底采样:"
+        "覆盖订阅被拒的设备、mips 断连窗口,以及设备根本不推送的属性。"
+        "一周期一次批量 prop/get。",
+    )
+    prop_history_throttle_enabled: bool = Field(
+        default=True,
+        description="属性推送落库前做节流。关闭后遥测类属性(功率/电压等秒级"
+        "推送)会全量落库,库体积增长极快,仅排障时临时关闭。",
+    )
+    prop_history_throttle_window_sec: int = Field(
+        default=600,
+        description="节流的频率判定窗口(秒):窗口内变化次数达到 burst 才按"
+        "高频遥测去抖,低频数值变化(设定温度/档位)不受影响。",
+    )
+    prop_history_throttle_burst: int = Field(
+        default=5,
+        description="判定为高频遥测的窗口内变化次数阈值。",
+    )
+    prop_history_throttle_min_interval_sec: int = Field(
+        default=900,
+        description="高频遥测属性的最小落库间隔(秒);距上次落库超过该间隔的"
+        "变化无条件落库,保证长期趋势不丢。",
+    )
+    prop_history_throttle_rel_delta: float = Field(
+        default=0.3,
+        description="高频遥测属性的相对幅度阈值:相对上次**落库值**变化达到该"
+        "比例即落库(不等最小间隔)。0.2 = 20%。",
     )
     prop_history_poll_extra: list[str] = Field(
         default_factory=list,

--- a/backend/miloco/src/miloco/database/connector.py
+++ b/backend/miloco/src/miloco/database/connector.py
@@ -178,6 +178,10 @@ class SQLiteConnector:
                             create_fn(conn)
                             tables_created.append(tbl)
 
+                    # 建表分支只在缺表时跑,已有该表的库拿不到后补的索引。索引
+                    # 全是 IF NOT EXISTS,这里无条件补一次,让老库也能受益。
+                    self._ensure_prop_history_indices(conn)
+
                     # If new tables were created, commit transaction
                     if tables_created:
                         conn.commit()
@@ -567,6 +571,17 @@ class SQLiteConnector:
                 ts_ms INTEGER NOT NULL
             )
         """)
+        self._ensure_prop_history_indices(conn)
+        logger.info("device_prop_history table created successfully")
+
+    @staticmethod
+    def _ensure_prop_history_indices(conn: sqlite3.Connection) -> None:
+        """Create device_prop_history indices (idempotent).
+
+        建表分支只在缺表时执行,所以索引单独抽出来、在 init 里无条件跑一次,
+        已存在该表的库才能拿到后补的索引。
+        """
+        cursor = conn.cursor()
         # 查询形态只有两种:整设备时间线 / 单属性时间线,都带时间范围倒序。
         cursor.execute(
             "CREATE INDEX IF NOT EXISTS idx_prop_history_did_ts "
@@ -576,7 +591,12 @@ class SQLiteConnector:
             "CREATE INDEX IF NOT EXISTS idx_prop_history_prop_ts "
             "ON device_prop_history(did, siid, piid, ts_ms DESC)"
         )
-        logger.info("device_prop_history table created successfully")
+        # 上面两条都以 did 打头,保留期清理的 `WHERE ts_ms < ?` 用不上,会退化成
+        # 全表扫——而它跑在写路径(即事件循环)上。补一条纯时间索引。
+        cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_prop_history_ts "
+            "ON device_prop_history(ts_ms)"
+        )
 
     def _create_token_usage_table(self, conn: sqlite3.Connection) -> None:
         """Create token_usage table for per-API-call token usage events (last 3 days).

--- a/backend/miloco/src/miloco/database/connector.py
+++ b/backend/miloco/src/miloco/database/connector.py
@@ -168,6 +168,10 @@ class SQLiteConnector:
                             "task_terminate_log",
                             self._create_task_terminate_log_table,
                         ),
+                        (
+                            "device_prop_history",
+                            self._create_device_prop_history_table,
+                        ),
                     ):
                         if tbl not in existing_tables:
                             logger.info("%s table not found, creating...", tbl)
@@ -255,6 +259,7 @@ class SQLiteConnector:
         self._create_task_record_event_table(conn)
         self._create_task_record_event_entry_table(conn)
         self._create_task_terminate_log_table(conn)
+        self._create_device_prop_history_table(conn)
         conn.execute(f"PRAGMA user_version = {_DB_SCHEMA_VERSION}")
         conn.commit()
         logger.info("Database table structure created successfully")
@@ -542,6 +547,36 @@ class SQLiteConnector:
             "ON device_lru(did, touched_at DESC)"
         )
         logger.info("device_lru table created successfully")
+
+    def _create_device_prop_history_table(self, conn: sqlite3.Connection) -> None:
+        """Create device_prop_history table — mips property-push time series.
+
+        One row per property entry of a `properties_changed` push (a push
+        carrying N entries → N rows sharing ts_ms). value stored as JSON so
+        bool/number/string/null all round-trip. Retention is enforced by the
+        DAO (config `miot.prop_history_retention_days`), not by the schema.
+        """
+        cursor = conn.cursor()
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS device_prop_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                did TEXT NOT NULL,
+                siid INTEGER NOT NULL,
+                piid INTEGER NOT NULL,
+                value_json TEXT NOT NULL,
+                ts_ms INTEGER NOT NULL
+            )
+        """)
+        # 查询形态只有两种:整设备时间线 / 单属性时间线,都带时间范围倒序。
+        cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_prop_history_did_ts "
+            "ON device_prop_history(did, ts_ms DESC)"
+        )
+        cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_prop_history_prop_ts "
+            "ON device_prop_history(did, siid, piid, ts_ms DESC)"
+        )
+        logger.info("device_prop_history table created successfully")
 
     def _create_token_usage_table(self, conn: sqlite3.Connection) -> None:
         """Create token_usage table for per-API-call token usage events (last 3 days).

--- a/backend/miloco/src/miloco/database/prop_history_dao.py
+++ b/backend/miloco/src/miloco/database/prop_history_dao.py
@@ -1,0 +1,135 @@
+# Copyright (C) 2025 Xiaomi Corporation
+# This software may be used and distributed according to the terms of the Xiaomi Miloco License Agreement.
+
+"""
+Device property history DAO — SQLite persistence for mips property pushes.
+
+一次 `properties_changed` 推送 = N 行(每个属性条目一行,共享 ts_ms)。value 序列化为
+JSON 存 value_json,bool/数值/字符串/null 都能无损回读。保留期由 DAO 在写路径顺带
+清理(见 `_maybe_prune`),不依赖外部定时任务。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from miloco.database.connector import get_db_connector
+
+logger = logging.getLogger(__name__)
+
+# 每写入这么多行触发一次过期清理。写路径顺带清理避免独立定时器;推送频率低
+# (整屋每分钟几十条),间隔内的过期行只是多占几 KB,无正确性影响。
+_PRUNE_EVERY_N_INSERTS = 500
+
+
+class DevicePropHistoryDao:
+    """Data access object for the device_prop_history table.
+
+    通过 manager 单例持有(`mgr.device_prop_history_dao`),禁止在调用点直接构造。
+    """
+
+    def __init__(self, retention_days: int = 30):
+        self.db_connector = get_db_connector()
+        self._retention_days = max(1, retention_days)
+        self._inserts_since_prune = _PRUNE_EVERY_N_INSERTS  # 首写即触发一次清理
+
+    def insert_changes(
+        self, did: str, changes: list[tuple[int, int, Any]], ts_ms: int
+    ) -> bool:
+        """Insert one push's property entries (each = (siid, piid, value)).
+
+        Returns True on success; False 只记 log 不抛——丢一条历史行不值得让
+        推送回调链路冒泡异常。
+        """
+        if not changes:
+            return True
+        try:
+            rows = [
+                (did, siid, piid, json.dumps(value, ensure_ascii=False), ts_ms)
+                for siid, piid, value in changes
+            ]
+            with self.db_connector.get_connection() as conn:
+                conn.executemany(
+                    "INSERT INTO device_prop_history "
+                    "(did, siid, piid, value_json, ts_ms) VALUES (?, ?, ?, ?, ?)",
+                    rows,
+                )
+                conn.commit()
+            self._inserts_since_prune += len(rows)
+            self._maybe_prune()
+            return True
+        except Exception as e:
+            logger.error("insert device_prop_history failed did=%s: %s", did, e)
+            return False
+
+    def query(
+        self,
+        did: str,
+        *,
+        siid: int | None = None,
+        piid: int | None = None,
+        since_ms: int | None = None,
+        until_ms: int | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """Query history rows, newest first.
+
+        siid/piid 要么都传(单属性时间线)要么都不传(整设备时间线);只传一个按
+        整设备处理(piid 单独无意义)。value_json 解析失败的行原样返回字符串。
+        """
+        clauses = ["did = ?"]
+        params: list[Any] = [did]
+        if siid is not None and piid is not None:
+            clauses.append("siid = ? AND piid = ?")
+            params.extend([siid, piid])
+        if since_ms is not None:
+            clauses.append("ts_ms >= ?")
+            params.append(since_ms)
+        if until_ms is not None:
+            clauses.append("ts_ms <= ?")
+            params.append(until_ms)
+        params.append(max(1, min(limit, 1000)))
+        sql = (
+            "SELECT did, siid, piid, value_json, ts_ms FROM device_prop_history "
+            f"WHERE {' AND '.join(clauses)} ORDER BY ts_ms DESC LIMIT ?"
+        )
+        rows = self.db_connector.execute_query(sql, tuple(params))
+        out: list[dict[str, Any]] = []
+        for r in rows:
+            try:
+                value = json.loads(r["value_json"])
+            except (TypeError, ValueError):
+                value = r["value_json"]
+            out.append(
+                {
+                    "did": r["did"],
+                    "siid": r["siid"],
+                    "piid": r["piid"],
+                    "iid": f"prop.{r['siid']}.{r['piid']}",
+                    "value": value,
+                    "ts": r["ts_ms"],
+                }
+            )
+        return out
+
+    def _maybe_prune(self) -> None:
+        if self._inserts_since_prune < _PRUNE_EVERY_N_INSERTS:
+            return
+        self._inserts_since_prune = 0
+        try:
+            from miloco.utils.time_utils import now_ms
+
+            cutoff = now_ms() - self._retention_days * 86400_000
+            deleted = self.db_connector.execute_update(
+                "DELETE FROM device_prop_history WHERE ts_ms < ?", (cutoff,)
+            )
+            if deleted:
+                logger.info(
+                    "device_prop_history pruned %d rows older than %dd",
+                    deleted,
+                    self._retention_days,
+                )
+        except Exception as e:
+            logger.warning("device_prop_history prune failed: %s", e)

--- a/backend/miloco/src/miloco/manager.py
+++ b/backend/miloco/src/miloco/manager.py
@@ -161,6 +161,24 @@ class Manager:
         return dao
 
     @property
+    def device_prop_history_dao(self):
+        """device_prop_history DAO 懒加载单例(mips 属性推送时间序列).
+
+        写方是 MiotProxy 的属性推送回调,读方是 miot router 的查询端点,
+        共用同一实例以共享 prune 计数.
+        """
+        dao = getattr(self, "_device_prop_history_dao", None)
+        if dao is None:
+            from miloco.config.settings import get_settings
+            from miloco.database.prop_history_dao import DevicePropHistoryDao
+
+            dao = DevicePropHistoryDao(
+                retention_days=get_settings().miot.prop_history_retention_days
+            )
+            self._device_prop_history_dao = dao
+        return dao
+
+    @property
     def events_service(self):
         """events_service 懒加载单例;复用 self.meaningful_events_dao."""
         svc = getattr(self, "_events_service", None)

--- a/backend/miloco/src/miloco/miot/client.py
+++ b/backend/miloco/src/miloco/miot/client.py
@@ -49,10 +49,21 @@ from miloco.miot.mips_listeners import (
     DeviceMetaEventListener,
     SceneEventListener,
 )
+from miloco.miot.prop_throttle import DISCRETE, TELEMETRY, PropChangeThrottle
 from miloco.miot.schema import CameraImgSeq, normalize_sub_devices
 from miloco.miot.welcome_service import DeviceWelcomeService
 
 logger = logging.getLogger(__name__)
+
+# Consecutive properties_changed SUBACK rejections before a did stops being
+# retried on every refresh_devices. The broker normally grants the subtree, so
+# a rejection means transient ACL flap (reconnect window) — worth retrying a
+# few times, not worth replaying ERROR forever.
+_PROP_SUB_MAX_REJECTS = 3
+
+# 每处理这么多次属性推送打一条节流统计。可观测性用:落库/丢弃比例失衡
+# (例如全被丢)一眼可见,而不必开 DEBUG。
+_PROP_THROTTLE_LOG_EVERY = 500
 
 
 def _resolve_camera_switch_iids(spec: dict) -> list[tuple[int, int]]:
@@ -191,16 +202,20 @@ class MiotProxy:
         # _sync_camera_state_subscriptions.
         self._subscribed_state_dids: set[str] = set()
 
-        # Dids whose device/{did}/up/properties_changed topics this proxy
+        # Dids whose device/{did}/up/properties_changed/# topics this proxy
         # intends to subscribe. Mirrors _subscribed_meta_dids; drives the diff
         # in _sync_prop_subscriptions. Empty set when prop history is disabled.
         self._subscribed_prop_dids: set[str] = set()
-        # Dids whose properties_changed SUBACK came back 0x87 Not authorized —
-        # the broker ACL for this app_id does not open the up/ topics (实测
-        # 2026-07-29 全量被拒)。Permanently excluded from retry, so每次
-        # refresh_devices 不会重放 70+ 条 ERROR;property history 由
-        # DevicePropPoller 轮询兜底。ACL 将来放开时重启后自动恢复推送路径。
-        self._prop_sub_rejected: set[str] = set()
+        # Consecutive SUBACK rejections per did. The broker DOES grant the
+        # properties_changed subtree for this app_id (实测 2026-07-29:72/72
+        # 台全部 0x00),所以 0x87 现在是异常而非常态——多为重连期 ACL 抖动,
+        # 重试即恢复。因此不做永久排除:连续被拒 _PROP_SUB_MAX_REJECTS 次后
+        # 才停止重试(避免每次 refresh_devices 重放 ERROR),一次成功即清零。
+        self._prop_sub_rejects: dict[str, int] = {}
+        # 属性推送落库前的节流器(见 prop_throttle)。init() 里按当前配置重建,
+        # 配置关闭时为 None(全量落库)。
+        self._prop_throttle: PropChangeThrottle | None = None
+        self._prop_throttle_log_countdown = _PROP_THROTTLE_LOG_EVERY
 
     def _build_bind_listener(self) -> BindEventListener:
         """Build a fresh BindEventListener.
@@ -316,8 +331,24 @@ class MiotProxy:
 
         self._token_refresh_task = asyncio.create_task(self._start_token_refresh_task())
 
-        # Property-history poller — the polling fallback while the broker ACL
-        # rejects properties_changed pushes (see _sync_prop_subscriptions).
+        # Property-history throttle — rebuilt per init so a config change takes
+        # effect on rebind without a restart (state is a pure in-memory cache).
+        _mio = get_settings().miot
+        self._prop_throttle = (
+            PropChangeThrottle(
+                window_sec=_mio.prop_history_throttle_window_sec,
+                burst=_mio.prop_history_throttle_burst,
+                min_interval_sec=_mio.prop_history_throttle_min_interval_sec,
+                rel_delta=_mio.prop_history_throttle_rel_delta,
+                classify=self._classify_prop,
+            )
+            if _mio.prop_history_throttle_enabled
+            else None
+        )
+
+        # Property-history poller — safety net beneath the push path: covers
+        # dids whose subscribe was rejected, gaps while mips is disconnected,
+        # and properties the device never pushes (see _sync_prop_subscriptions).
         if self._prop_poller_task:
             self._prop_poller_task.cancel()
             self._prop_poller_task = None
@@ -377,6 +408,10 @@ class MiotProxy:
         self._subscribed_state_dids = set()
         self._subscribed_scene_home_ids = set()
         self._subscribed_prop_dids = set()
+        self._prop_sub_rejects = {}
+        # 节流器状态是纯内存基线,换账号后必须丢弃:否则新账号首条推送会拿
+        # 旧账号的 last_value 做 diff。init() 会按当时的配置重建。
+        self._prop_throttle = None
         # Welcome service survives deinit (rebuilt only in __init__), but its
         # dedup window state must reset alongside the other in-memory caches —
         # otherwise a re-bind of the same did within WELCOME_DEDUP_SEC after an
@@ -1020,13 +1055,16 @@ class MiotProxy:
         are torn down (target = empty set) so a config flip fully converges
         without a restart. Dids containing '/' (Huami/Zepp-bridged
         sub-devices) are skipped — same topic/ACL rationale as
-        _sync_meta_subscriptions.
+        _sync_meta_subscriptions. Dids that hit _PROP_SUB_MAX_REJECTS
+        consecutive rejections drop out until the next successful subscribe
+        resets their counter (see _prop_sub_rejects).
         """
         if get_settings().miot.prop_history_enabled:
             target = {
                 did
                 for did in self._device_info_dict
-                if "/" not in did and did not in self._prop_sub_rejected
+                if "/" not in did
+                and self._prop_sub_rejects.get(did, 0) < _PROP_SUB_MAX_REJECTS
             }
         else:
             target = set()
@@ -1038,12 +1076,29 @@ class MiotProxy:
         async def _sub(did: str) -> str | None:
             try:
                 await self._miot_client.sub_device_prop_async(did)
+                self._prop_sub_rejects.pop(did, None)
                 return did
             except MipsSubscribeRejectedError as e:
-                # ACL 永久拒绝(0x87 等):不再重试,避免每次设备刷新重放全量
-                # ERROR。轮询兜底仍在,DEBUG 留痕即可。
-                self._prop_sub_rejected.add(did)
-                logger.debug("device-prop subscribe rejected did=%s: %s", did, e)
+                # 0x87 现在属异常(ACL 正常放行整棵 properties_changed 子树),
+                # 多为重连期抖动。计数重试,连续 _PROP_SUB_MAX_REJECTS 次后
+                # 才放弃该 did,期间轮询兜底仍覆盖。
+                n = self._prop_sub_rejects.get(did, 0) + 1
+                self._prop_sub_rejects[did] = n
+                if n >= _PROP_SUB_MAX_REJECTS:
+                    logger.warning(
+                        "device-prop subscribe rejected %d×, giving up did=%s: %s",
+                        n,
+                        did,
+                        e,
+                    )
+                else:
+                    logger.debug(
+                        "device-prop subscribe rejected (%d/%d) did=%s: %s",
+                        n,
+                        _PROP_SUB_MAX_REJECTS,
+                        did,
+                        e,
+                    )
                 return None
             except Exception as e:
                 logger.error("subscribe device-prop failed did=%s: %s", did, e)
@@ -1060,7 +1115,7 @@ class MiotProxy:
         removed = await asyncio.gather(*(_unsub(d) for d in to_remove))
         self._subscribed_prop_dids |= {d for d in added if d}
         self._subscribed_prop_dids -= {d for d in removed if d}
-        rejected = len([d for d in to_add if d in self._prop_sub_rejected])
+        rejected = len([d for d in to_add if d in self._prop_sub_rejects])
         logger.info(
             "device-prop subscriptions synced: +%d -%d rejected=%d (total=%d)",
             len([d for d in added if d]),
@@ -1070,9 +1125,10 @@ class MiotProxy:
         )
         if rejected and not self._subscribed_prop_dids:
             logger.warning(
-                "device-prop push fully rejected by broker ACL (%d dids); "
-                "property history relies on the poller fallback",
-                len(self._prop_sub_rejected),
+                "device-prop push rejected for all %d did(s) — expected 0x00 "
+                "for the properties_changed subtree, check broker ACL / topic "
+                "filter; property history falls back to the poller",
+                rejected,
             )
 
     async def _sync_camera_state_subscriptions(self) -> None:
@@ -1138,8 +1194,61 @@ class MiotProxy:
         """
         await self._scene_listener.on_event(msg)
 
+    def _classify_prop(
+        self, did: str, siid: int, piid: int
+    ) -> tuple[str, float | None] | None:
+        """Classify a property as discrete / telemetry from its miot-spec entry.
+
+        返回 ``(kind, span)``;span 是 value-range 的量程跨度(max-min),供节流器
+        按满量程比例判定幅度,未知给 None。判不出返回 None。
+
+        推送回调是同步的,所以只读**已缓存**的 spec(_spec_cache,按 urn 缓存,
+        由 catalog / home-info 构建时填充);缓存未命中返回 None,节流器退回频率
+        启发式,spec 后续补上后下一条推送即用上正确分类——不在热路径触发解析。
+
+        判据(miot-spec 语义,与厂商无关),按优先级:
+
+        1. ``value-list`` / ``format=bool`` → 枚举或开关 = 离散;
+        2. ``writeable`` → 用户可设的目标值(设定温度/亮度/目标湿度)= 离散。
+           **这条必须排在 unit 之前**:空调设定温度带 ``unit=celsius``,只看
+           单位会被误判成遥测,而它恰恰是「几点把温度调到 26 度」要的信号;
+        3. ``value-range`` 或带物理单位,且只读 → 传感器读数 = 遥测。
+        """
+        dev = self._device_info_dict.get(did)
+        if dev is None or not dev.urn:
+            return None
+        spec = self._spec_cache.get(dev.urn)
+        if not spec:
+            return None
+        entry = spec.get(f"prop.{siid}.{piid}")
+        if not entry:
+            # spec 已加载但没有这条属性:厂商私有槽位(实测空调把功率/电压/电流
+            # 挂在 spec 之外的 prop.12.*,推送里占比最高)。**不能直接丢**——个别
+            # 设备把温湿度放在非标 piid 上(见 _build_home_info 的注释),但也不该
+            # 按「低频用户操作」放行,故按最严格的遥测档处理:只有跨过最小间隔或
+            # 大幅跳变才落库。
+            return (TELEMETRY, None)
+        if entry.get("value_list") or entry.get("format") == "bool":
+            return (DISCRETE, None)
+        if entry.get("writeable"):
+            return (DISCRETE, None)
+        if entry.get("value_range") or entry.get("unit"):
+            vr = entry.get("value_range")
+            span: float | None = None
+            if isinstance(vr, (list, tuple)) and len(vr) >= 2:
+                try:
+                    span = abs(float(vr[1]) - float(vr[0])) or None
+                except (TypeError, ValueError):
+                    span = None
+            return (TELEMETRY, span)
+        return None
+
     def _on_device_prop_changed_event(self, msg: MIoTDevicePropChangedEvent) -> None:
         """Persist one property push batch to device_prop_history.
+
+        推送是逐属性、秒级的,遥测类属性会刷屏(实测一台空调的功率属性 1–2s
+        一条),所以先过 PropChangeThrottle:同值重发丢弃、离散属性无条件保留、
+        高频数值按最小间隔+相对幅度去抖。整批被滤空时不落库。
 
         同步回调:单条 executemany 写 WAL 库微秒级,不值得 to_thread。DAO 内部
         吞异常(丢一行历史不冒泡),这里只兜 manager 未就绪的启动窗口。
@@ -1147,10 +1256,22 @@ class MiotProxy:
         try:
             from miloco.manager import get_manager
 
+            changes = [(c.siid, c.piid, c.value) for c in msg.changes]
+            throttle = self._prop_throttle
+            if throttle is not None:
+                changes = [
+                    c
+                    for c in changes
+                    if throttle.allow(msg.did, c[0], c[1], c[2], msg.timestamp_ms)
+                ]
+                self._prop_throttle_log_countdown -= 1
+                if self._prop_throttle_log_countdown <= 0:
+                    self._prop_throttle_log_countdown = _PROP_THROTTLE_LOG_EVERY
+                    logger.info("device-prop throttle stats: %s", throttle.stats())
+            if not changes:
+                return
             get_manager().device_prop_history_dao.insert_changes(
-                msg.did,
-                [(c.siid, c.piid, c.value) for c in msg.changes],
-                msg.timestamp_ms,
+                msg.did, changes, msg.timestamp_ms
             )
         except Exception as e:
             logger.warning("persist device prop push failed did=%s: %s", msg.did, e)

--- a/backend/miloco/src/miloco/miot/client.py
+++ b/backend/miloco/src/miloco/miot/client.py
@@ -322,7 +322,7 @@ class MiotProxy:
         # disconnect window may have caused us to miss events. Registered AFTER
         # init_async on purpose: the first connect during setup should not
         # pre-empt the initial full refresh done by refresh_miot_info below.
-        self._miot_client.register_mips_connect_callback(self.refresh_devices)
+        self._miot_client.register_mips_connect_callback(self._on_mips_reconnect)
         await self.refresh_miot_info()
 
         if self._token_refresh_task:
@@ -349,13 +349,14 @@ class MiotProxy:
         # Property-history poller — safety net beneath the push path: covers
         # dids whose subscribe was rejected, gaps while mips is disconnected,
         # and properties the device never pushes (see _sync_prop_subscriptions).
+        # 任务无条件常驻:开关与周期由 poller 每轮重读,配置改了下一轮生效,
+        # 不必重启后端(与订阅 sync 的收敛方式一致)。关闭时循环体直接返回。
         if self._prop_poller_task:
             self._prop_poller_task.cancel()
             self._prop_poller_task = None
-        if get_settings().miot.prop_history_enabled:
-            from miloco.miot.prop_poller import DevicePropPoller
+        from miloco.miot.prop_poller import DevicePropPoller
 
-            self._prop_poller_task = asyncio.create_task(DevicePropPoller(self).run())
+        self._prop_poller_task = asyncio.create_task(DevicePropPoller(self).run())
 
     async def deinit(self):
         """Deinit MIoT proxy: cancel tasks, destroy cameras, close client, clear all state."""
@@ -1193,6 +1194,22 @@ class MiotProxy:
         thin shim, mirroring ``_on_user_bind_event``.
         """
         await self._scene_listener.on_event(msg)
+
+    async def _on_mips_reconnect(self) -> dict[str, MIoTDeviceInfo] | None:
+        """MQTT (重)连后的收口:清空属性订阅被拒计数,再全量刷设备。
+
+        `_prop_sub_rejects` 记的是**连续**失败,但只在订阅成功时清零——若某 did
+        永远失败,计数就退化成"累计",一次跨天的偶发抖动攒够 3 次也会让它被永久
+        放弃。重连意味着 broker 换了一份 ACL 快照,此前的失败不再有参考价值,
+        这里清零让每条新连接都是一次干净的重试机会。
+        """
+        if self._prop_sub_rejects:
+            logger.info(
+                "mips reconnected, clearing %d device-prop reject counter(s)",
+                len(self._prop_sub_rejects),
+            )
+            self._prop_sub_rejects.clear()
+        return await self.refresh_devices()
 
     def _classify_prop(
         self, did: str, siid: int, piid: int

--- a/backend/miloco/src/miloco/miot/client.py
+++ b/backend/miloco/src/miloco/miot/client.py
@@ -22,6 +22,7 @@ from miot.types import (
     MIoTCameraInfo,
     MIoTDeviceBindEvent,
     MIoTDeviceInfo,
+    MIoTDevicePropChangedEvent,
     MIoTDeviceStateEvent,
     MIoTGetPropertyParam,
     MIoTLanDeviceInfo,
@@ -30,6 +31,7 @@ from miot.types import (
     MIoTSceneChangedEvent,
     MIoTSetPropertyParam,
     MIoTUserInfo,
+    MipsSubscribeRejectedError,
 )
 from pydantic_core import to_jsonable_python
 
@@ -102,6 +104,7 @@ class MiotProxy:
         self.init_miot_info_dict()
         self._camera_img_managers: dict[str, CameraVisionHandler] = {}
         self._token_refresh_task: asyncio.Task | None = None
+        self._prop_poller_task: asyncio.Task | None = None
         # Serialize refresh_devices: multiple entries (MQTT reconnect,
         # bind-debounce, device refresh, lazy load) can fire concurrently
         # and would otherwise race on _device_info_dict / KV / diff log.
@@ -188,6 +191,17 @@ class MiotProxy:
         # _sync_camera_state_subscriptions.
         self._subscribed_state_dids: set[str] = set()
 
+        # Dids whose device/{did}/up/properties_changed topics this proxy
+        # intends to subscribe. Mirrors _subscribed_meta_dids; drives the diff
+        # in _sync_prop_subscriptions. Empty set when prop history is disabled.
+        self._subscribed_prop_dids: set[str] = set()
+        # Dids whose properties_changed SUBACK came back 0x87 Not authorized —
+        # the broker ACL for this app_id does not open the up/ topics (实测
+        # 2026-07-29 全量被拒)。Permanently excluded from retry, so每次
+        # refresh_devices 不会重放 70+ 条 ERROR;property history 由
+        # DevicePropPoller 轮询兜底。ACL 将来放开时重启后自动恢复推送路径。
+        self._prop_sub_rejected: set[str] = set()
+
     def _build_bind_listener(self) -> BindEventListener:
         """Build a fresh BindEventListener.
 
@@ -266,6 +280,7 @@ class MiotProxy:
             refresh_camera_online_status=self.refresh_camera_online_status
         )
         self._subscribed_state_dids = set()
+        self._subscribed_prop_dids = set()
         self._miot_client.register_user_bind_callback(self._on_user_bind_event)
         # Device meta change (rename/hr_change): refresh the list so the new
         # name/room/home propagates. Kept off the bind welcome path.
@@ -280,6 +295,11 @@ class MiotProxy:
         )
         # Home scene change (rename/delete/edit): refresh the scene list.
         self._miot_client.register_scene_changed_callback(self._on_scene_changed_event)
+        # Device property push (properties_changed): persist to
+        # device_prop_history so "几点开的空调"类历史查询有数据源。
+        self._miot_client.register_device_prop_changed_callback(
+            self._on_device_prop_changed_event
+        )
 
         await self._miot_client.init_async()
 
@@ -296,12 +316,25 @@ class MiotProxy:
 
         self._token_refresh_task = asyncio.create_task(self._start_token_refresh_task())
 
+        # Property-history poller — the polling fallback while the broker ACL
+        # rejects properties_changed pushes (see _sync_prop_subscriptions).
+        if self._prop_poller_task:
+            self._prop_poller_task.cancel()
+            self._prop_poller_task = None
+        if get_settings().miot.prop_history_enabled:
+            from miloco.miot.prop_poller import DevicePropPoller
+
+            self._prop_poller_task = asyncio.create_task(DevicePropPoller(self).run())
+
     async def deinit(self):
         """Deinit MIoT proxy: cancel tasks, destroy cameras, close client, clear all state."""
         # 1. Cancel token refresh background task
         if self._token_refresh_task:
             self._token_refresh_task.cancel()
             self._token_refresh_task = None
+        if self._prop_poller_task:
+            self._prop_poller_task.cancel()
+            self._prop_poller_task = None
 
         # 1b. Cancel any pending bind/rename-event debounce timers — otherwise
         # they might fire during teardown and try to call refresh_devices on a
@@ -343,6 +376,7 @@ class MiotProxy:
         self._subscribed_meta_dids = set()
         self._subscribed_state_dids = set()
         self._subscribed_scene_home_ids = set()
+        self._subscribed_prop_dids = set()
         # Welcome service survives deinit (rebuilt only in __init__), but its
         # dedup window state must reset alongside the other in-memory caches —
         # otherwise a re-bind of the same did within WELCOME_DEDUP_SEC after an
@@ -809,6 +843,7 @@ class MiotProxy:
                 self._device_info_dict = devices
                 await self._sync_meta_subscriptions()
                 await self._sync_scene_subscriptions()
+                await self._sync_prop_subscriptions()
                 return devices
             except Exception as e:
                 logger.error("Failed to refresh devices: %s", e)
@@ -973,6 +1008,73 @@ class MiotProxy:
             len(self._subscribed_meta_dids),
         )
 
+    async def _sync_prop_subscriptions(self) -> None:
+        """Reconcile per-device property push subs to the device list.
+
+        Called at the tail of refresh_devices (under _refresh_devices_lock,
+        same race-free contract as _sync_meta_subscriptions). Account-wide,
+        all devices — a property history is as useful for an out-of-scope
+        device as for a managed one, and per-device volume is trivial.
+
+        Gated by ``miot.prop_history_enabled``; when disabled, existing subs
+        are torn down (target = empty set) so a config flip fully converges
+        without a restart. Dids containing '/' (Huami/Zepp-bridged
+        sub-devices) are skipped — same topic/ACL rationale as
+        _sync_meta_subscriptions.
+        """
+        if get_settings().miot.prop_history_enabled:
+            target = {
+                did
+                for did in self._device_info_dict
+                if "/" not in did and did not in self._prop_sub_rejected
+            }
+        else:
+            target = set()
+        to_add = target - self._subscribed_prop_dids
+        to_remove = self._subscribed_prop_dids - target
+        if not to_add and not to_remove:
+            return
+
+        async def _sub(did: str) -> str | None:
+            try:
+                await self._miot_client.sub_device_prop_async(did)
+                return did
+            except MipsSubscribeRejectedError as e:
+                # ACL 永久拒绝(0x87 等):不再重试,避免每次设备刷新重放全量
+                # ERROR。轮询兜底仍在,DEBUG 留痕即可。
+                self._prop_sub_rejected.add(did)
+                logger.debug("device-prop subscribe rejected did=%s: %s", did, e)
+                return None
+            except Exception as e:
+                logger.error("subscribe device-prop failed did=%s: %s", did, e)
+                return None
+
+        async def _unsub(did: str) -> str | None:
+            try:
+                await self._miot_client.unsub_device_prop_async(did)
+            except Exception as e:
+                logger.error("unsubscribe device-prop failed did=%s: %s", did, e)
+            return did
+
+        added = await asyncio.gather(*(_sub(d) for d in to_add))
+        removed = await asyncio.gather(*(_unsub(d) for d in to_remove))
+        self._subscribed_prop_dids |= {d for d in added if d}
+        self._subscribed_prop_dids -= {d for d in removed if d}
+        rejected = len([d for d in to_add if d in self._prop_sub_rejected])
+        logger.info(
+            "device-prop subscriptions synced: +%d -%d rejected=%d (total=%d)",
+            len([d for d in added if d]),
+            len([d for d in removed if d]),
+            rejected,
+            len(self._subscribed_prop_dids),
+        )
+        if rejected and not self._subscribed_prop_dids:
+            logger.warning(
+                "device-prop push fully rejected by broker ACL (%d dids); "
+                "property history relies on the poller fallback",
+                len(self._prop_sub_rejected),
+            )
+
     async def _sync_camera_state_subscriptions(self) -> None:
         """Reconcile per-device cloud state (online/offline) subs to the
         camera list.
@@ -1035,6 +1137,23 @@ class MiotProxy:
         thin shim, mirroring ``_on_user_bind_event``.
         """
         await self._scene_listener.on_event(msg)
+
+    def _on_device_prop_changed_event(self, msg: MIoTDevicePropChangedEvent) -> None:
+        """Persist one property push batch to device_prop_history.
+
+        同步回调:单条 executemany 写 WAL 库微秒级,不值得 to_thread。DAO 内部
+        吞异常(丢一行历史不冒泡),这里只兜 manager 未就绪的启动窗口。
+        """
+        try:
+            from miloco.manager import get_manager
+
+            get_manager().device_prop_history_dao.insert_changes(
+                msg.did,
+                [(c.siid, c.piid, c.value) for c in msg.changes],
+                msg.timestamp_ms,
+            )
+        except Exception as e:
+            logger.warning("persist device prop push failed did=%s: %s", msg.did, e)
 
     def _collect_home_ids(self) -> set[str]:
         """Union of home_ids across cached devices / cameras / scenes.

--- a/backend/miloco/src/miloco/miot/prop_poller.py
+++ b/backend/miloco/src/miloco/miot/prop_poller.py
@@ -1,0 +1,133 @@
+# Copyright (C) 2025 Xiaomi Corporation
+# This software may be used and distributed according to the terms of the Xiaomi Miloco License Agreement.
+
+"""
+Device property poller — polling fallback for property history.
+
+mips `device/{did}/up/properties_changed` 推送对本 app_id 被 broker ACL 全量拒绝
+(0x87,实测 2026-07-29),属性历史退而求其次用批量轮询:每周期一次
+`/app/v2/miotspec/prop/get`(单请求上限 150 条,整屋 70+ 设备 × 主开关 1 条 =
+1 次 HTTP 调用),diff 内存中的上次值,变化才落 device_prop_history。
+
+Watchlist 免配置自筛选:对全部设备读 ``prop.2.1``(miot-spec 惯例的主开关 /
+occupancy-status 槽位);没有该属性的设备云端返回无 value 条目,当次跳过,零成本。
+额外属性用 ``miot.prop_history_poll_extra``(形如 ``did:prop.S.P``)配置。
+
+轮询语义与推送不同:只能保证「变化被发现的时间 ≤ 实际变化时间 + 周期」,行里
+ts 是发现时刻。周期默认 60s——对「几点开的空调」这类问题分钟级足够。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any
+
+from miot.types import MIoTGetPropertyParam
+
+from miloco.config import get_settings
+
+if TYPE_CHECKING:
+    from miloco.miot.client import MiotProxy
+
+logger = logging.getLogger(__name__)
+
+# 单次 /miotspec/prop/get 的条目上限(云端限制 150,留余量)。
+_BATCH_LIMIT = 140
+
+
+class DevicePropPoller:
+    """Poll a self-selecting prop watchlist and persist value changes."""
+
+    def __init__(self, proxy: "MiotProxy"):
+        self._proxy = proxy
+        # (did, siid, piid) -> last seen value。进程内基线;首见 key 先对 DB
+        # 最新行 diff,避免每次重启都写一遍全量基线行。
+        self._last: dict[tuple[str, int, int], Any] = {}
+
+    async def run(self) -> None:
+        """Poll loop. Cancelled by MiotProxy.deinit()."""
+        interval = max(10, get_settings().miot.prop_history_poll_interval_sec)
+        logger.info("device-prop poller started (interval=%ds)", interval)
+        while True:
+            try:
+                await self._poll_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                # 单周期失败(云端限频/网络抖动)只记 log,下周期自愈。
+                logger.warning("device-prop poll cycle failed: %s", e)
+            await asyncio.sleep(interval)
+
+    def _watch_params(self) -> list[MIoTGetPropertyParam]:
+        params = [
+            MIoTGetPropertyParam(did=did, siid=2, piid=1)
+            for did, dev in self._proxy._device_info_dict.items()
+            if "/" not in did and dev.online
+        ]
+        seen = {(p.did, p.siid, p.piid) for p in params}
+        for entry in get_settings().miot.prop_history_poll_extra:
+            try:
+                did, iid = entry.split(":", 1)
+                s, p = iid.removeprefix("prop.").split(".")
+                key = (did, int(s), int(p))
+            except ValueError:
+                logger.warning("prop_history_poll_extra 条目非法,已跳过: %r", entry)
+                continue
+            if key not in seen:
+                seen.add(key)
+                params.append(
+                    MIoTGetPropertyParam(did=key[0], siid=key[1], piid=key[2])
+                )
+        return params
+
+    async def _poll_once(self) -> None:
+        if not get_settings().miot.prop_history_enabled:
+            return
+        client = self._proxy._miot_client
+        if client is None or not self._proxy.is_authenticated:
+            return
+        params = self._watch_params()
+        if not params:
+            return
+        results: list[dict] = []
+        for i in range(0, len(params), _BATCH_LIMIT):
+            results.extend(
+                await client.http_client.get_props_async(params[i : i + _BATCH_LIMIT])
+            )
+
+        from miloco.manager import get_manager
+        from miloco.utils.time_utils import now_ms
+
+        dao = get_manager().device_prop_history_dao
+        ts = now_ms()
+        changed_by_did: dict[str, list[tuple[int, int, Any]]] = {}
+        for r in results:
+            if not isinstance(r, dict) or "value" not in r:
+                continue  # 设备无此属性 / 离线 / 读失败:自筛选跳过
+            try:
+                key = (str(r["did"]), int(r["siid"]), int(r["piid"]))
+            except (KeyError, TypeError, ValueError):
+                continue
+            value = r["value"]
+            if key in self._last:
+                if self._last[key] != value:
+                    changed_by_did.setdefault(key[0], []).append(
+                        (key[1], key[2], value)
+                    )
+                self._last[key] = value
+                continue
+            # 首见:对 DB 最新行 diff——重启后值未变则不写基线行,
+            # 值变了(停机窗口内发生的变化)补一行,历史时间线保持连续。
+            self._last[key] = value
+            latest = dao.query(key[0], siid=key[1], piid=key[2], limit=1)
+            if not latest or latest[0]["value"] != value:
+                changed_by_did.setdefault(key[0], []).append((key[1], key[2], value))
+        for did, changes in changed_by_did.items():
+            dao.insert_changes(did, changes, ts)
+        if changed_by_did:
+            logger.info(
+                "device-prop poll: %d change(s) across %d device(s) persisted",
+                sum(len(c) for c in changed_by_did.values()),
+                len(changed_by_did),
+            )

--- a/backend/miloco/src/miloco/miot/prop_poller.py
+++ b/backend/miloco/src/miloco/miot/prop_poller.py
@@ -32,6 +32,7 @@ from typing import TYPE_CHECKING, Any
 from miot.types import MIoTGetPropertyParam
 
 from miloco.config import get_settings
+from miloco.miot.prop_throttle import same_value
 
 if TYPE_CHECKING:
     from miloco.miot.client import MiotProxy
@@ -52,9 +53,12 @@ class DevicePropPoller:
         self._last: dict[tuple[str, int, int], Any] = {}
 
     async def run(self) -> None:
-        """Poll loop. Cancelled by MiotProxy.deinit()."""
-        interval = max(10, get_settings().miot.prop_history_poll_interval_sec)
-        logger.info("device-prop poller started (interval=%ds)", interval)
+        """Poll loop. Cancelled by MiotProxy.deinit().
+
+        任务**常驻**(即使启动时开关是关的):周期与开关每轮重读,配置改了
+        下一轮即生效,不必重启后端。_poll_once 在关闭时直接返回。
+        """
+        logger.info("device-prop poller task started")
         while True:
             try:
                 await self._poll_once()
@@ -63,7 +67,9 @@ class DevicePropPoller:
             except Exception as e:
                 # 单周期失败(云端限频/网络抖动)只记 log,下周期自愈。
                 logger.warning("device-prop poll cycle failed: %s", e)
-            await asyncio.sleep(interval)
+            await asyncio.sleep(
+                max(10, get_settings().miot.prop_history_poll_interval_sec)
+            )
 
     def _watch_params(self) -> list[MIoTGetPropertyParam]:
         params = [
@@ -88,7 +94,10 @@ class DevicePropPoller:
         return params
 
     async def _poll_once(self) -> None:
-        if not get_settings().miot.prop_history_enabled:
+        mio = get_settings().miot
+        # 两个开关分开判:prop_history_enabled 管整个能力,poll_enabled 只管
+        # 这条兜底通道——推送已是主链路,用户可以只关轮询而保留推送。
+        if not mio.prop_history_enabled or not mio.prop_history_poll_enabled:
             return
         client = self._proxy._miot_client
         if client is None or not self._proxy.is_authenticated:
@@ -116,18 +125,21 @@ class DevicePropPoller:
             except (KeyError, TypeError, ValueError):
                 continue
             value = r["value"]
-            if key in self._last:
-                if self._last[key] != value:
-                    changed_by_did.setdefault(key[0], []).append(
-                        (key[1], key[2], value)
-                    )
-                self._last[key] = value
-                continue
-            # 首见:对 DB 最新行 diff——重启后值未变则不写基线行,
-            # 值变了(停机窗口内发生的变化)补一行,历史时间线保持连续。
+            if key in self._last and same_value(self._last[key], value):
+                continue  # 同值:零成本跳过,不查库不写库
             self._last[key] = value
+            # 值与进程内基线不同 → **一律再对 DB 最新行确认一次**。
+            #
+            # 这一步是推送与轮询共存的关键:推送落库不会更新轮询的 _last,
+            # 若只信 _last,每次真实变化都会被轮询"再发现一遍"——22:00:00 的
+            # 关机会在库里同时留下 false@22:00:00(推送,事件时刻)和
+            # false@22:04:10(轮询,发现时刻),而 `ORDER BY ts DESC LIMIT 1`
+            # 恰好取到偏晚且不准的那行。以 DB 为两条通道的唯一真相即可消除。
+            #
+            # 同一逻辑天然覆盖「重启后首见」:值没变不写基线行,停机窗口内变了
+            # 补一行,时间线保持连续。
             latest = dao.query(key[0], siid=key[1], piid=key[2], limit=1)
-            if not latest or latest[0]["value"] != value:
+            if not latest or not same_value(latest[0]["value"], value):
                 changed_by_did.setdefault(key[0], []).append((key[1], key[2], value))
         for did, changes in changed_by_did.items():
             dao.insert_changes(did, changes, ts)

--- a/backend/miloco/src/miloco/miot/prop_poller.py
+++ b/backend/miloco/src/miloco/miot/prop_poller.py
@@ -2,19 +2,25 @@
 # This software may be used and distributed according to the terms of the Xiaomi Miloco License Agreement.
 
 """
-Device property poller — polling fallback for property history.
+Device property poller — 属性历史的兜底采样源(**主链路是 mips 推送**)。
 
-mips `device/{did}/up/properties_changed` 推送对本 app_id 被 broker ACL 全量拒绝
-(0x87,实测 2026-07-29),属性历史退而求其次用批量轮询:每周期一次
-`/app/v2/miotspec/prop/get`(单请求上限 150 条,整屋 70+ 设备 × 主开关 1 条 =
-1 次 HTTP 调用),diff 内存中的上次值,变化才落 device_prop_history。
+推送覆盖不到的三种情况由本轮询补上:
+
+1. 订阅被 broker 拒(0x87)的设备——正常情况下不会发生(实测 2026-07-29:72 台
+   设备的 ``properties_changed`` 子树全部 0x00 放行),但重连窗口存在 ACL 抖动;
+2. mips 断连窗口内发生的变化——推送不补发,轮询下一周期能发现;
+3. 设备**根本不推送**的属性——推送是设备侧行为,不是所有属性都上报。
+
+实现:每周期一次 `/app/v2/miotspec/prop/get`(单请求上限 150 条,整屋 70+ 设备 ×
+主开关 1 条 = 1 次 HTTP 调用),diff 内存中的上次值,变化才落 device_prop_history。
 
 Watchlist 免配置自筛选:对全部设备读 ``prop.2.1``(miot-spec 惯例的主开关 /
 occupancy-status 槽位);没有该属性的设备云端返回无 value 条目,当次跳过,零成本。
 额外属性用 ``miot.prop_history_poll_extra``(形如 ``did:prop.S.P``)配置。
 
 轮询语义与推送不同:只能保证「变化被发现的时间 ≤ 实际变化时间 + 周期」,行里
-ts 是发现时刻。周期默认 60s——对「几点开的空调」这类问题分钟级足够。
+ts 是发现时刻。周期默认 300s——推送转正后轮询只是安全网,不必再按秒级采样;
+推送路径本身是**事件时刻**,精度不受这个周期影响。
 """
 
 from __future__ import annotations

--- a/backend/miloco/src/miloco/miot/prop_throttle.py
+++ b/backend/miloco/src/miloco/miot/prop_throttle.py
@@ -1,0 +1,213 @@
+# Copyright (C) 2025 Xiaomi Corporation
+# This software may be used and distributed according to the terms of the Xiaomi Miloco License Agreement.
+
+"""
+Property-change throttle — 决定一条属性变化推送是否值得落进 device_prop_history。
+
+**为什么必须有**：mips 推送是逐属性的，设备的遥测属性会以秒级刷屏。实测
+(2026-07-29，72 台设备)一台空调的功率属性 `12/3` 每 1–2 秒推一次，120 秒内
+522 条推送里它一台占 95 条；全量落库一天几十万行，30 天保留期直接把库撑爆。
+同时设备开关机会**整包重发全部属性**，其中含大量同值条目（实测关→开一次推了
+约 25 条，含重复值）。
+
+**取舍**：属性历史要回答的是「空调几点开的」「传感器什么时候检测到人」这类
+**离散状态**问题，不是能耗曲线。所以：
+
+* 同值重发 → 一律丢弃（整包重发去重，与类型无关）。
+* 非数值属性（bool / str / null）→ 变化即落库，无条件。开关、模式串、占用
+  状态都在这一类，永不因节流丢失。
+* 数值属性 → 分「离散」与「遥测」两类，只对遥测做「最小间隔 + 幅度」双阈值
+  去抖，两者满足其一即落库。分类优先看 miot-spec（`classify` 回调），
+  判据见 `MiotProxy._classify_prop`；spec 未命中（缓存冷、非标属性）时退回
+  **频率启发式**：窗口内变化次数少的当离散，多的当遥测。
+
+两个反直觉但被实测数据逼出来的设计：
+
+1. **「可写」比「有单位」更能说明问题。** 空调设定温度 `prop.2.4` 带
+   `unit=celsius`，看着像遥测，其实是用户意图；而同一台设备上真正刷屏的是只读
+   的环境湿度 `prop.4.9`。所以 writeable 优先于 unit 判定。
+2. **幅度要按满量程算，不能按「相对上次值」。** 摄像头「人数」1→2 是 100% 的
+   相对变化却是噪声，空调功率 1140→1150 只有 0.9% 同样是噪声；换成满量程口径
+   二者都被正确压掉，而开机瞬间 0→1140（满量程 38%）照常落库。
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import deque
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+_Key = tuple[str, int, int]
+
+# classify 回调的返回值。None = 无法判定（spec 缓存冷 / 非标属性），退回启发式。
+DISCRETE = "discrete"
+TELEMETRY = "telemetry"
+
+# classify(did, siid, piid) -> (kind, span) | None
+# span = 该属性 value-range 的量程跨度（max-min），用于幅度判定；未知给 None。
+PropClassifier = Callable[[str, int, int], Optional[tuple[str, Optional[float]]]]
+
+
+def _same_value(a: Any, b: Any) -> bool:
+    """类型敏感的相等判断。
+
+    Python 里 ``True == 1``、``False == 0``，直接用 ``==`` 会把 bool 开关与
+    int 枚举的互变当成同值丢掉。bool 与非 bool 一律视为不同值。
+    """
+    if isinstance(a, bool) != isinstance(b, bool):
+        return False
+    return a == b
+
+
+def _is_numeric(v: Any) -> bool:
+    return isinstance(v, (int, float)) and not isinstance(v, bool)
+
+
+class _KeyState:
+    __slots__ = ("last_value", "last_kept_ms", "seen", "has_value")
+
+    def __init__(self) -> None:
+        self.last_value: Any = None
+        self.has_value: bool = False
+        self.last_kept_ms: int = 0
+        # 近期「观察到变化」的时间戳（含被丢弃的），用于频率判定。
+        self.seen: deque[int] = deque()
+
+
+class PropChangeThrottle:
+    """Decide which property changes are worth persisting.
+
+    线程/协程无关：调用点是单一的 mips 推送回调（同步、在主 loop 上），无需加锁。
+    """
+
+    def __init__(
+        self,
+        *,
+        window_sec: int = 600,
+        burst: int = 5,
+        min_interval_sec: int = 900,
+        rel_delta: float = 0.3,
+        max_keys: int = 20000,
+        classify: PropClassifier | None = None,
+    ) -> None:
+        self._classify = classify
+        self._window_ms = max(1, window_sec) * 1000
+        self._burst = max(2, burst)
+        self._min_interval_ms = max(0, min_interval_sec) * 1000
+        self._rel_delta = max(0.0, rel_delta)
+        self._max_keys = max(1000, max_keys)
+        self._state: dict[_Key, _KeyState] = {}
+        self.kept = 0
+        self.dropped_same_value = 0
+        self.dropped_throttled = 0
+
+    # ------------------------------------------------------------------ api
+
+    def allow(self, did: str, siid: int, piid: int, value: Any, ts_ms: int) -> bool:
+        """True if this change should be persisted."""
+        key = (did, siid, piid)
+        st = self._state.get(key)
+        if st is None:
+            st = self._state[key] = _KeyState()
+            self._evict_if_needed()
+
+        if st.has_value and _same_value(value, st.last_value):
+            # 整包重发 / 设备重复上报：不是一次真实变化。
+            self.dropped_same_value += 1
+            return False
+
+        st.seen.append(ts_ms)
+        cutoff = ts_ms - self._window_ms
+        while st.seen and st.seen[0] < cutoff:
+            st.seen.popleft()
+
+        kind, span = self._kind(key)
+        if self._should_keep(st, value, ts_ms, kind, span):
+            st.last_value = value
+            st.has_value = True
+            st.last_kept_ms = ts_ms
+            self.kept += 1
+            return True
+
+        # 被节流丢弃时**不**更新 last_value：下次比较仍以最后落库的值为基准，
+        # 幅度阈值才是相对「历史上有记录的那个值」而非相对某个从未落库的中间值，
+        # 否则每次 0.9% 的漂移累积起来永远迈不过阈值，长期漂移会被完全吞掉。
+        self.dropped_throttled += 1
+        return False
+
+    def stats(self) -> dict[str, int]:
+        return {
+            "kept": self.kept,
+            "dropped_same_value": self.dropped_same_value,
+            "dropped_throttled": self.dropped_throttled,
+            "keys": len(self._state),
+        }
+
+    # -------------------------------------------------------------- internals
+
+    def _kind(self, key: _Key) -> tuple[str | None, float | None]:
+        """spec 判定的属性种类与量程跨度；无 classify / 判不出时返回 (None, None)。
+
+        classify 由调用方注入（读 miot-spec 缓存），缓存冷时会返回 None，
+        此处不缓存判定结果——spec 后续被填充时下一条推送就能用上正确分类。
+        """
+        if self._classify is None:
+            return (None, None)
+        try:
+            got = self._classify(*key)
+        except Exception:
+            logger.debug("prop classify failed key=%s", key, exc_info=True)
+            return (None, None)
+        return got if got else (None, None)
+
+    def _should_keep(
+        self,
+        st: _KeyState,
+        value: Any,
+        ts_ms: int,
+        kind: str | None,
+        span: float | None,
+    ) -> bool:
+        if not st.has_value:
+            return True  # 首见即基线，必须落库
+        if not _is_numeric(value) or not _is_numeric(st.last_value):
+            # 离散属性（开关 / 模式串 / 占用 / null）：变化即历史，无条件落库。
+            return True
+        if kind == DISCRETE:
+            # spec 说了这是枚举 / 开关 / 用户可写的设定值，哪怕值是数字也一律
+            # 落库——模式 1→2、设定温度 26→27 都是用户可感知的状态变更。
+            return True
+        if kind != TELEMETRY and len(st.seen) < self._burst:
+            # spec 判不出且变化节奏低：按用户操作对待。spec 已明确是遥测时不走
+            # 这条——冷启动的头几条同样不该放行。
+            return True
+        # 遥测：最小间隔与幅度阈值满足其一即落库。
+        if ts_ms - st.last_kept_ms >= self._min_interval_ms:
+            return True
+        delta = abs(value - st.last_value)
+        if span:
+            # 有量程时按**满量程比例**判定。相对上次值的比例对小整数量毫无意义
+            # ——摄像头「人数」1→2 是 100%，功率 1140→1150 只有 0.9%，但前者
+            # 才是噪声。满量程口径下两者都被正确压掉，而 0→1140 这种开机跃变
+            # （满量程的 38%）照样放行。
+            return delta >= self._rel_delta * span
+        base = abs(st.last_value)
+        return delta >= self._rel_delta * base if base else delta > 0
+
+    def _evict_if_needed(self) -> None:
+        """Bound memory: 属性 key 数上限，超了丢最久没动过的那批。
+
+        did × 属性数在真实家庭里是几千量级，正常远达不到上限；这里只防设备
+        频繁增删或异常 did 导致的无界增长。
+        """
+        if len(self._state) <= self._max_keys:
+            return
+        victims = sorted(
+            self._state.items(),
+            key=lambda kv: kv[1].seen[-1] if kv[1].seen else kv[1].last_kept_ms,
+        )[: len(self._state) // 10]
+        for key, _ in victims:
+            self._state.pop(key, None)
+        logger.debug("prop throttle evicted %d cold keys", len(victims))

--- a/backend/miloco/src/miloco/miot/prop_throttle.py
+++ b/backend/miloco/src/miloco/miot/prop_throttle.py
@@ -50,7 +50,7 @@ TELEMETRY = "telemetry"
 PropClassifier = Callable[[str, int, int], Optional[tuple[str, Optional[float]]]]
 
 
-def _same_value(a: Any, b: Any) -> bool:
+def same_value(a: Any, b: Any) -> bool:
     """类型敏感的相等判断。
 
     Python 里 ``True == 1``、``False == 0``，直接用 ``==`` 会把 bool 开关与
@@ -111,14 +111,16 @@ class PropChangeThrottle:
         st = self._state.get(key)
         if st is None:
             st = self._state[key] = _KeyState()
-            self._evict_if_needed()
 
-        if st.has_value and _same_value(value, st.last_value):
+        if st.has_value and same_value(value, st.last_value):
             # 整包重发 / 设备重复上报：不是一次真实变化。
             self.dropped_same_value += 1
             return False
 
         st.seen.append(ts_ms)
+        # 淘汰放在 seen 记录**之后**:排序键取 seen[-1],刚新建的 key 若在记录前
+        # 参与排序会退化到 last_kept_ms=0 而被立刻淘汰——正好淘汰掉最新的那个。
+        self._evict_if_needed()
         cutoff = ts_ms - self._window_ms
         while st.seen and st.seen[0] < cutoff:
             st.seen.popleft()

--- a/backend/miloco/src/miloco/miot/router.py
+++ b/backend/miloco/src/miloco/miot/router.py
@@ -324,9 +324,11 @@ async def get_prop_history(
         try:
             siid, piid = int(parts[0]), int(parts[1])
         except (IndexError, ValueError):
+            # 本仓库的 HTTPException 签名是 (message, status_code)，不是 FastAPI 的
+            # (status_code, detail) —— 写成后者会在这里抛 TypeError 而不是返回 400。
             raise HTTPException(
-                status_code=400, detail=f"iid 格式非法(期望 prop.S.P): {iid!r}"
-            )
+                message=f"iid 格式非法(期望 prop.S.P): {iid!r}", status_code=400
+            ) from None
     rows = manager.device_prop_history_dao.query(
         did, siid=siid, piid=piid, since_ms=since, until_ms=until, limit=limit
     )

--- a/backend/miloco/src/miloco/miot/router.py
+++ b/backend/miloco/src/miloco/miot/router.py
@@ -313,9 +313,20 @@ async def get_prop_history(
 ):
     """按设备(可选按单属性)查询属性变化历史,新→旧排序。
 
-    数据来自 mips `properties_changed` 推送落库(``miot.prop_history_enabled``,
-    默认开)。只包含订阅生效期间设备**主动上报**的变化——backend 停机窗口、
-    不上报的属性、订阅前的历史都不在库里。
+    数据来自两条通道(均受 ``miot.prop_history_enabled`` 管,默认开):
+
+    * **mips `properties_changed` 推送**——主链路,行内 ``ts`` 是事件时刻(秒级);
+    * **批量轮询兜底**(``prop_history_poll_interval_sec``,默认 300s)——覆盖推送
+      够不到的部分:订阅被拒的设备、mips 断连窗口、以及设备根本不上报的属性。
+      轮询补的行 ``ts`` 是**发现时刻**,最多晚于真实变化一个周期。
+
+    两点会影响读数,查询方需知晓:
+
+    * **落库前有节流**(``prop_history_throttle_enabled``,默认开)。开关、模式、
+      占用等离散属性变化即落库、一条不丢;而只读的数值遥测(功率/湿度/PM2.5…)
+      按满量程幅度与最小间隔去抖,时间线上会有最长 ``throttle_min_interval_sec``
+      (默认 900s)的空洞——**这类属性不适合用来还原连续曲线**。
+    * 订阅生效之前的历史不在库里(无回填)。
     """
     siid: int | None = None
     piid: int | None = None

--- a/backend/miloco/src/miloco/miot/router.py
+++ b/backend/miloco/src/miloco/miot/router.py
@@ -296,6 +296,46 @@ async def get_device_history(current_user: str = Depends(verify_token)):
 
 
 @router.get(
+    path="/prop-history",
+    summary="Query mips property-push history (device_prop_history table)",
+    response_model=NormalResponse,
+)
+async def get_prop_history(
+    did: str,
+    iid: str | None = Query(
+        default=None,
+        description="属性 iid,形如 prop.2.1 或 2.1;不传返回整设备时间线",
+    ),
+    since: int | None = Query(default=None, description="起始时间戳(ms,含)"),
+    until: int | None = Query(default=None, description="结束时间戳(ms,含)"),
+    limit: int = Query(default=100, ge=1, le=1000),
+    current_user: str = Depends(verify_token),
+):
+    """按设备(可选按单属性)查询属性变化历史,新→旧排序。
+
+    数据来自 mips `properties_changed` 推送落库(``miot.prop_history_enabled``,
+    默认开)。只包含订阅生效期间设备**主动上报**的变化——backend 停机窗口、
+    不上报的属性、订阅前的历史都不在库里。
+    """
+    siid: int | None = None
+    piid: int | None = None
+    if iid:
+        parts = iid.removeprefix("prop.").split(".")
+        try:
+            siid, piid = int(parts[0]), int(parts[1])
+        except (IndexError, ValueError):
+            raise HTTPException(
+                status_code=400, detail=f"iid 格式非法(期望 prop.S.P): {iid!r}"
+            )
+    rows = manager.device_prop_history_dao.query(
+        did, siid=siid, piid=piid, since_ms=since, until_ms=until, limit=limit
+    )
+    return NormalResponse(
+        code=0, message="ok", data={"did": did, "count": len(rows), "items": rows}
+    )
+
+
+@router.get(
     path="/devices/{did}/status",
     summary="Get device property status",
     response_model=NormalResponse,

--- a/backend/miloco/tests/test_prop_history.py
+++ b/backend/miloco/tests/test_prop_history.py
@@ -1,0 +1,202 @@
+# Copyright (C) 2025 Xiaomi Corporation
+# This software may be used and distributed according to the terms of the Xiaomi Miloco License Agreement.
+
+"""Unit tests for device property history: DevicePropHistoryDao + DevicePropPoller.
+
+Poller 的核心正确性约束:
+* 值变化才落库(同值周期零写入,连日志都不刷);
+* 首见 key 对 DB 最新行 diff——重启后值未变不写重复基线行,停机窗口内变了补一行;
+* watchlist = 在线设备 prop.2.1 + prop_history_poll_extra 配置项(非法条目跳过)。
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+@pytest.fixture
+def real_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "test.db"
+    monkeypatch.setenv("MILOCO_DATABASE__PATH", str(db_file))
+
+    from miloco.config import reset_settings
+
+    reset_settings()
+    import miloco.database.connector as connector_module
+
+    monkeypatch.setattr(connector_module, "db_connector", None)
+    connector_module.init_database()
+    yield db_file
+    reset_settings()
+
+
+@pytest.fixture
+def dao(real_db):
+    from miloco.database.prop_history_dao import DevicePropHistoryDao
+
+    return DevicePropHistoryDao(retention_days=30)
+
+
+# ------------------------------------------------------------------------ DAO
+
+
+def _now() -> int:
+    import time
+
+    return int(time.time() * 1000)
+
+
+def test_dao_insert_and_query_roundtrip(dao):
+    assert dao.insert_changes("d1", [(2, 1, True), (2, 4, 26)], ts_ms := _now())
+    rows = dao.query("d1")
+    assert len(rows) == 2
+    by_iid = {r["iid"]: r for r in rows}
+    # bool / int JSON 往返无损
+    assert by_iid["prop.2.1"]["value"] is True
+    assert by_iid["prop.2.4"]["value"] == 26
+    assert by_iid["prop.2.1"]["ts"] == ts_ms
+
+
+def test_dao_query_single_prop_and_time_range(dao):
+    t1, t2 = _now() - 1000, _now()
+    dao.insert_changes("d1", [(2, 1, False)], t1)
+    dao.insert_changes("d1", [(2, 1, True)], t2)
+    dao.insert_changes("d1", [(3, 1, "x")], t2)
+    dao.insert_changes("d2", [(2, 1, True)], t2)
+
+    rows = dao.query("d1", siid=2, piid=1)
+    assert [(r["ts"], r["value"]) for r in rows] == [(t2, True), (t1, False)]
+
+    rows = dao.query("d1", siid=2, piid=1, since_ms=t1 + 500)
+    assert len(rows) == 1 and rows[0]["ts"] == t2
+
+    rows = dao.query("d1", siid=2, piid=1, until_ms=t1 + 500)
+    assert len(rows) == 1 and rows[0]["ts"] == t1
+
+    assert len(dao.query("d1", limit=2)) == 2  # limit 生效
+
+
+def test_dao_null_and_string_values(dao):
+    dao.insert_changes("d1", [(2, 1, None), (2, 2, "auto")], _now())
+    by_iid = {r["iid"]: r["value"] for r in dao.query("d1")}
+    assert by_iid["prop.2.1"] is None
+    assert by_iid["prop.2.2"] == "auto"
+
+
+def test_dao_empty_changes_noop(dao):
+    assert dao.insert_changes("d1", [], _now())
+    assert dao.query("d1") == []
+
+
+# --------------------------------------------------------------------- poller
+
+
+def _make_poller(monkeypatch, dao, *, devices, results, extra=None):
+    """Build a DevicePropPoller against fakes.
+
+    devices: {did: online}; results: get_props_async 返回值。
+    """
+    from miloco.miot.prop_poller import DevicePropPoller
+
+    settings = SimpleNamespace(
+        miot=SimpleNamespace(
+            prop_history_enabled=True,
+            prop_history_poll_interval_sec=60,
+            prop_history_poll_extra=extra or [],
+            prop_history_retention_days=30,
+        )
+    )
+    import miloco.miot.prop_poller as poller_mod
+
+    monkeypatch.setattr(poller_mod, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        "miloco.manager.get_manager",
+        lambda: SimpleNamespace(device_prop_history_dao=dao),
+    )
+
+    proxy = SimpleNamespace(
+        is_authenticated=True,
+        _device_info_dict={
+            did: SimpleNamespace(online=online) for did, online in devices.items()
+        },
+        _miot_client=SimpleNamespace(
+            http_client=SimpleNamespace(get_props_async=AsyncMock(return_value=results))
+        ),
+    )
+    return DevicePropPoller(proxy), proxy
+
+
+@pytest.mark.asyncio
+async def test_poller_first_sight_writes_baseline_once(monkeypatch, dao):
+    results = [{"did": "d1", "siid": 2, "piid": 1, "value": True}]
+    poller, _ = _make_poller(monkeypatch, dao, devices={"d1": True}, results=results)
+
+    await poller._poll_once()
+    assert len(dao.query("d1")) == 1  # 空库首见 → 基线行
+
+    await poller._poll_once()
+    assert len(dao.query("d1")) == 1  # 同值周期零写入
+
+
+@pytest.mark.asyncio
+async def test_poller_writes_on_change_only(monkeypatch, dao):
+    results = [{"did": "d1", "siid": 2, "piid": 1, "value": True}]
+    poller, proxy = _make_poller(monkeypatch, dao, devices={"d1": True}, results=results)
+    await poller._poll_once()
+
+    proxy._miot_client.http_client.get_props_async.return_value = [
+        {"did": "d1", "siid": 2, "piid": 1, "value": False}
+    ]
+    await poller._poll_once()
+    rows = dao.query("d1", siid=2, piid=1)
+    assert [r["value"] for r in rows] == [False, True]
+
+
+@pytest.mark.asyncio
+async def test_poller_restart_skips_baseline_when_db_matches(monkeypatch, dao):
+    # 模拟重启前库里已有同值最新行
+    dao.insert_changes("d1", [(2, 1, True)], _now() - 60000)
+    results = [{"did": "d1", "siid": 2, "piid": 1, "value": True}]
+    poller, _ = _make_poller(monkeypatch, dao, devices={"d1": True}, results=results)
+    await poller._poll_once()
+    assert len(dao.query("d1")) == 1  # 不产生重复基线行
+
+    # 停机窗口内值变了 → 补一行保持时间线连续
+    dao2_results = [{"did": "d1", "siid": 2, "piid": 1, "value": False}]
+    poller2, _ = _make_poller(monkeypatch, dao, devices={"d1": True}, results=dao2_results)
+    await poller2._poll_once()
+    assert [r["value"] for r in dao.query("d1")] == [False, True]
+
+
+@pytest.mark.asyncio
+async def test_poller_skips_failed_entries_and_offline_devices(monkeypatch, dao):
+    results = [
+        {"did": "d1", "siid": 2, "piid": 1},  # 无 value = 云端读失败/设备无此属性
+        {"did": "d1", "siid": 2, "code": -704},  # 缺 piid
+    ]
+    poller, proxy = _make_poller(
+        monkeypatch, dao, devices={"d1": True, "d-off": False}, results=results
+    )
+    await poller._poll_once()
+    assert dao.query("d1") == []
+    # 离线设备不进 watchlist
+    params = proxy._miot_client.http_client.get_props_async.await_args.args[0]
+    assert all(p.did != "d-off" for p in params)
+
+
+@pytest.mark.asyncio
+async def test_poller_extra_watchlist_and_invalid_entries(monkeypatch, dao):
+    poller, proxy = _make_poller(
+        monkeypatch,
+        dao,
+        devices={"d1": True},
+        results=[],
+        extra=["d1:prop.4.1", "d9:5.2", "garbage", "d1:prop.2.1"],  # 最后一条与默认重复
+    )
+    await poller._poll_once()
+    params = proxy._miot_client.http_client.get_props_async.await_args.args[0]
+    keys = {(p.did, p.siid, p.piid) for p in params}
+    assert keys == {("d1", 2, 1), ("d1", 4, 1), ("d9", 5, 2)}

--- a/backend/miloco/tests/test_prop_history.py
+++ b/backend/miloco/tests/test_prop_history.py
@@ -200,3 +200,109 @@ async def test_poller_extra_watchlist_and_invalid_entries(monkeypatch, dao):
     params = proxy._miot_client.http_client.get_props_async.await_args.args[0]
     keys = {(p.did, p.siid, p.piid) for p in params}
     assert keys == {("d1", 2, 1), ("d1", 4, 1), ("d9", 5, 2)}
+
+
+# ------------------------------------------- push path: spec 分类 + 节流落库
+#
+# 这一段守的是 2026-07-29 实测暴露的两个真实问题:
+# 1. 推送 topic 带 /{siid}/{piid} 两级,订阅与 decoder 都必须覆盖(否则静默丢弃);
+# 2. 遥测属性秒级刷屏(一台空调 30 分钟 858 条),必须在落库前节流。
+
+
+def _proxy_with_spec(spec: dict, *, urn: str = "urn:x:ac"):
+    """Bare MiotProxy carrying just what _classify_prop reads."""
+    from miloco.miot.client import MiotProxy
+
+    proxy = MiotProxy.__new__(MiotProxy)
+    proxy._device_info_dict = {"ac": SimpleNamespace(urn=urn)}
+    proxy._spec_cache = {urn: spec}
+    return proxy
+
+
+def test_classify_prop_reads_spec_semantics():
+    from miloco.miot.prop_throttle import DISCRETE, TELEMETRY
+
+    proxy = _proxy_with_spec(
+        {
+            "prop.2.1": {"format": "bool", "writeable": True},          # 开关
+            "prop.2.2": {"format": "uint8", "value_list": [{"value": 2}]},  # 模式
+            "prop.2.4": {"format": "float", "unit": "celsius",           # 设定温度
+                         "writeable": True, "value_range": [16, 31, 0.5]},
+            "prop.4.9": {"format": "uint8", "unit": "percentage",        # 环境湿度
+                         "writeable": False, "value_range": [0, 100, 1]},
+        }
+    )
+    assert proxy._classify_prop("ac", 2, 1) == (DISCRETE, None)
+    assert proxy._classify_prop("ac", 2, 2) == (DISCRETE, None)
+    # 可写 > 有单位:设定温度是用户意图,不能因 unit=celsius 被当成遥测
+    assert proxy._classify_prop("ac", 2, 4) == (DISCRETE, None)
+    # 只读 + 量程 → 遥测,并带回满量程跨度供幅度判定
+    assert proxy._classify_prop("ac", 4, 9) == (TELEMETRY, 100.0)
+
+
+def test_classify_prop_unknown_device_or_cold_cache():
+    proxy = _proxy_with_spec({"prop.2.1": {"format": "bool"}})
+    assert proxy._classify_prop("missing-did", 2, 1) is None
+    proxy._spec_cache = {}                      # 缓存冷 → 交给频率启发式
+    assert proxy._classify_prop("ac", 2, 1) is None
+
+
+def test_classify_prop_vendor_slot_absent_from_spec():
+    """厂商私有槽位(实测空调 prop.12.*)按最严格遥测处理,而不是放行。"""
+    from miloco.miot.prop_throttle import TELEMETRY
+
+    proxy = _proxy_with_spec({"prop.2.1": {"format": "bool"}})
+    assert proxy._classify_prop("ac", 12, 3) == (TELEMETRY, None)
+
+
+def test_push_handler_throttles_before_persisting(monkeypatch, dao):
+    """整包重发里的同值条目不落库,开关变化必须落库。"""
+    from miloco.miot.client import MiotProxy
+    from miloco.miot.prop_throttle import PropChangeThrottle
+
+    monkeypatch.setattr(
+        "miloco.manager.get_manager",
+        lambda: SimpleNamespace(device_prop_history_dao=dao),
+    )
+    proxy = MiotProxy.__new__(MiotProxy)
+    proxy._prop_throttle = PropChangeThrottle(classify=None)
+    proxy._prop_throttle_log_countdown = 10_000
+
+    def push(changes, ts):
+        proxy._on_device_prop_changed_event(
+            SimpleNamespace(
+                did="ac",
+                timestamp_ms=ts,
+                changes=[SimpleNamespace(siid=s, piid=p, value=v) for s, p, v in changes],
+            )
+        )
+
+    base = _now()
+    push([(2, 1, True)], base)
+    push([(2, 1, True)], base + 1_000)   # 整包重发,同值 → 不落库
+    push([(2, 1, False)], base + 2_000)
+    rows = dao.query("ac", siid=2, piid=1, limit=10)
+    assert [r["value"] for r in rows] == [False, True]
+
+
+def test_push_handler_without_throttle_persists_everything(monkeypatch, dao):
+    """节流关闭时行为不变(排障用的逃生开关)。"""
+    from miloco.miot.client import MiotProxy
+
+    monkeypatch.setattr(
+        "miloco.manager.get_manager",
+        lambda: SimpleNamespace(device_prop_history_dao=dao),
+    )
+    proxy = MiotProxy.__new__(MiotProxy)
+    proxy._prop_throttle = None
+    proxy._prop_throttle_log_countdown = 10_000
+    base = _now()
+    for ts in (base, base + 1_000, base + 2_000):
+        proxy._on_device_prop_changed_event(
+            SimpleNamespace(
+                did="ac",
+                timestamp_ms=ts,
+                changes=[SimpleNamespace(siid=12, piid=3, value=1140)],
+            )
+        )
+    assert len(dao.query("ac", siid=12, piid=3, limit=10)) == 3

--- a/backend/miloco/tests/test_prop_history.py
+++ b/backend/miloco/tests/test_prop_history.py
@@ -104,6 +104,7 @@ def _make_poller(monkeypatch, dao, *, devices, results, extra=None):
     settings = SimpleNamespace(
         miot=SimpleNamespace(
             prop_history_enabled=True,
+            prop_history_poll_enabled=True,
             prop_history_poll_interval_sec=60,
             prop_history_poll_extra=extra or [],
             prop_history_retention_days=30,
@@ -327,3 +328,56 @@ def test_prop_history_endpoint_rejects_malformed_iid():
         asyncio.run(get_prop_history(did="d1", iid="不是iid", current_user="t"))
     assert ei.value.http_status == 400
     assert "prop.S.P" in str(ei.value.message)
+
+
+# --------------------------------------------- 推送与轮询共存：轮询必须让位
+
+
+@pytest.mark.asyncio
+async def test_poller_defers_to_push_persisted_change(monkeypatch, dao):
+    """推送已落库的变化，轮询不得再写一行。
+
+    推送落库不会更新轮询的进程内 `_last`，若轮询只信 `_last`，每次真实变化都会
+    被"再发现一遍"：22:00:00 的关机会同时留下 false@22:00:00（推送，事件时刻）
+    和 false@22:04:10（轮询，发现时刻），而 `ORDER BY ts DESC LIMIT 1` 恰好取到
+    偏晚且不准的那行。以 DB 为两条通道的唯一真相即可消除。
+    """
+    results = [{"did": "d1", "siid": 2, "piid": 1, "value": True}]
+    poller, _ = _make_poller(monkeypatch, dao, devices={"d1": True}, results=results)
+    await poller._poll_once()                       # 建立基线 True
+    assert len(dao.query("d1", siid=2, piid=1, limit=10)) == 1
+
+    # 推送先落库一条 False（事件时刻），轮询的 _last 仍是 True
+    dao.insert_changes("d1", [(2, 1, False)], _now())
+    results[:] = [{"did": "d1", "siid": 2, "piid": 1, "value": False}]
+
+    await poller._poll_once()
+    rows = dao.query("d1", siid=2, piid=1, limit=10)
+    assert [r["value"] for r in rows] == [False, True], "轮询重复写入了推送已记的变化"
+
+
+@pytest.mark.asyncio
+async def test_poller_still_writes_change_push_missed(monkeypatch, dao):
+    """推送漏掉的变化（断连窗口 / 设备不上报）轮询仍要补上。"""
+    results = [{"did": "d1", "siid": 2, "piid": 1, "value": True}]
+    poller, _ = _make_poller(monkeypatch, dao, devices={"d1": True}, results=results)
+    await poller._poll_once()
+
+    results[:] = [{"did": "d1", "siid": 2, "piid": 1, "value": False}]
+    await poller._poll_once()
+    assert [r["value"] for r in dao.query("d1", siid=2, piid=1, limit=10)] == [
+        False,
+        True,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_poller_respects_poll_enabled_switch(monkeypatch, dao):
+    """轮询开关独立于总开关：关掉只停兜底采样，推送不受影响。"""
+    results = [{"did": "d1", "siid": 2, "piid": 1, "value": True}]
+    poller, _ = _make_poller(monkeypatch, dao, devices={"d1": True}, results=results)
+    import miloco.miot.prop_poller as poller_mod
+
+    poller_mod.get_settings().miot.prop_history_poll_enabled = False
+    await poller._poll_once()
+    assert dao.query("d1", siid=2, piid=1, limit=10) == []

--- a/backend/miloco/tests/test_prop_history.py
+++ b/backend/miloco/tests/test_prop_history.py
@@ -306,3 +306,24 @@ def test_push_handler_without_throttle_persists_everything(monkeypatch, dao):
             )
         )
     assert len(dao.query("ac", siid=12, piid=3, limit=10)) == 3
+
+
+# ---------------------------------------------------------------- API 参数校验
+
+
+def test_prop_history_endpoint_rejects_malformed_iid():
+    """非法 iid 必须返回 400，而不是把 TypeError 冒到 500。
+
+    本仓库的 HTTPException 签名是 ``(message, status_code)``，与 FastAPI 的
+    ``(status_code, detail)`` 不同；按后者写会在构造异常时就 TypeError，用户
+    拿到的是 500 而非参数错误。这条守住调用签名。
+    """
+    import asyncio
+
+    from miloco.middleware.exceptions import HTTPException
+    from miloco.miot.router import get_prop_history
+
+    with pytest.raises(HTTPException) as ei:
+        asyncio.run(get_prop_history(did="d1", iid="不是iid", current_user="t"))
+    assert ei.value.http_status == 400
+    assert "prop.S.P" in str(ei.value.message)

--- a/backend/miloco/tests/test_prop_throttle.py
+++ b/backend/miloco/tests/test_prop_throttle.py
@@ -1,0 +1,219 @@
+# Copyright (C) 2025 Xiaomi Corporation
+# This software may be used and distributed according to the terms of the Xiaomi Miloco License Agreement.
+
+"""Tests for PropChangeThrottle — 属性推送落库前的节流。
+
+真实流量特征(实测 2026-07-29,cn-ha.mqtt.io.mi.com,72 台设备):
+
+* 空调功率 `12/3` 每 1–2 秒推一次,120 秒内一台占 95 条推送;
+* 设备关→开会**整包重发**全部属性(~25 条/秒),其中含同值条目;
+* 开关类属性 `2/1` 只在用户操作时推,是历史查询真正要的信号。
+
+节流必须做到:遥测被压掉、开关一条不丢、同值重发去重。
+"""
+
+from __future__ import annotations
+
+from miloco.miot.prop_throttle import DISCRETE, TELEMETRY, PropChangeThrottle
+
+SEC = 1000
+
+
+def _t(**kw) -> PropChangeThrottle:
+    return PropChangeThrottle(**kw)
+
+
+# --------------------------------------------------------------- 同值去重
+
+
+def test_same_value_repost_dropped():
+    """整包重发里的同值条目不是一次变化。"""
+    t = _t()
+    assert t.allow("d", 2, 1, True, 0) is True
+    assert t.allow("d", 2, 1, True, 1 * SEC) is False
+    assert t.allow("d", 2, 1, False, 2 * SEC) is True
+    assert t.stats()["dropped_same_value"] == 1
+
+
+def test_bool_and_int_are_not_the_same_value():
+    """Python 里 True == 1;开关 bool 与枚举 int 的互变不能被当成同值吞掉。"""
+    t = _t()
+    assert t.allow("d", 2, 1, True, 0) is True
+    assert t.allow("d", 2, 1, 1, 1 * SEC) is True
+    assert t.allow("d", 2, 1, False, 2 * SEC) is True
+    assert t.allow("d", 2, 1, 0, 3 * SEC) is True
+
+
+# ------------------------------------------------------- 离散属性无条件落库
+
+
+def test_discrete_switch_never_throttled():
+    """开关狂按也一条不丢——历史查询的核心信号。"""
+    t = _t(burst=2, min_interval_sec=300)
+    for i in range(20):
+        assert t.allow("d", 2, 1, i % 2 == 0, i * SEC) is True
+
+
+def test_string_and_null_values_never_throttled():
+    t = _t(burst=2)
+    for i, v in enumerate(["45-65", "0,0,0,0", None, "45-65", None]):
+        assert t.allow("d", 10, 6, v, i * SEC) is True
+
+
+# ------------------------------------------------------- 高频数值遥测去抖
+
+
+def test_high_frequency_telemetry_is_throttled():
+    """空调功率的真实节奏:1140→1150→1130… 每秒一条,微幅漂移。"""
+    t = _t(window_sec=60, burst=5, min_interval_sec=300, rel_delta=0.2)
+    values = [1140, 1150, 1130, 1170, 1150, 1140, 1150, 1130, 1160, 1150]
+    kept = [t.allow("ac", 12, 3, v, i * SEC) for i, v in enumerate(values)]
+    # burst 前视作低频照常落库,达到 burst 后微幅漂移被压掉。
+    assert kept[0] is True
+    assert sum(kept) < len(values)
+    assert kept[-1] is False
+
+
+def test_low_frequency_numeric_not_throttled():
+    """设定温度 26→27 幅度只有 3.8%,但节奏低,属于用户操作,必须落库。"""
+    t = _t(window_sec=60, burst=5, min_interval_sec=300, rel_delta=0.2)
+    assert t.allow("ac", 2, 4, 26.0, 0) is True
+    assert t.allow("ac", 2, 4, 27.0, 600 * SEC) is True
+    assert t.allow("ac", 2, 4, 26.0, 1200 * SEC) is True
+
+
+def test_large_jump_breaks_through_throttle():
+    """开机瞬间功率 0→1140:幅度远超阈值,不等最小间隔立刻落库。"""
+    t = _t(window_sec=60, burst=3, min_interval_sec=300, rel_delta=0.2)
+    for i, v in enumerate([1140, 1150, 1130, 1145]):
+        t.allow("ac", 12, 3, v, i * SEC)
+    assert t.allow("ac", 12, 3, 0, 5 * SEC) is True
+
+
+def test_min_interval_lets_slow_drift_through():
+    """长期漂移不能被永久吞掉:超过最小间隔无条件落库。"""
+    t = _t(window_sec=60, burst=3, min_interval_sec=300, rel_delta=0.2)
+    for i, v in enumerate([1140, 1150, 1130, 1145, 1150]):
+        t.allow("ac", 12, 3, v, i * SEC)
+    assert t.allow("ac", 12, 3, 1155, 400 * SEC) is True
+
+
+def test_throttled_change_does_not_move_the_baseline():
+    """幅度阈值必须相对**上次落库值**,否则每次微涨都过不了阈值,
+    累积起来的长期漂移会被完全吞掉。"""
+    t = _t(window_sec=600, burst=2, min_interval_sec=10_000, rel_delta=0.2)
+    assert t.allow("ac", 12, 3, 100, 0) is True
+    for i, v in enumerate([104, 108, 112, 116], start=1):
+        assert t.allow("ac", 12, 3, v, i * SEC) is False
+    # 相对基线 100 已涨 20%,应放行;若基线被中间值污染则会误判为仅涨 3.4%
+    assert t.allow("ac", 12, 3, 120, 5 * SEC) is True
+
+
+def test_zero_baseline_keeps_any_change():
+    """基线为 0 时相对幅度无意义,任何非零变化都落库。"""
+    t = _t(window_sec=60, burst=2, min_interval_sec=300, rel_delta=0.2)
+    t.allow("d", 11, 1, 0.0, 0)
+    t.allow("d", 11, 1, 0.0, 1 * SEC)
+    assert t.allow("d", 11, 1, 0.3, 2 * SEC) is True
+
+
+# ------------------------------------------------------------------ 其它
+
+
+def test_keys_are_independent():
+    """一台设备的遥测刷屏不能拖累同设备的开关属性。"""
+    t = _t(window_sec=60, burst=3, min_interval_sec=300, rel_delta=0.5)
+    for i in range(10):
+        t.allow("ac", 12, 3, 1140 + i, i * SEC)
+    assert t.allow("ac", 2, 1, True, 10 * SEC) is True
+    assert t.allow("ac", 2, 1, False, 11 * SEC) is True
+
+
+def test_first_value_is_always_kept():
+    t = _t(burst=1)
+    assert t.allow("d", 9, 5, 318.7, 0) is True
+
+
+def test_eviction_bounds_memory():
+    t = _t(max_keys=1000)
+    for i in range(1200):
+        t.allow(f"d{i}", 2, 1, True, i)
+    assert t.stats()["keys"] <= 1200
+    assert len(t._state) < 1200
+
+
+# ------------------------------------------------------------ spec 分类接入
+
+
+def _classifier(mapping):
+    return lambda did, s, p: mapping.get((did, s, p))
+
+
+def test_spec_discrete_beats_frequency_heuristic():
+    """spec 说是枚举:哪怕以遥测的节奏狂推,也一条不丢(风机档位连打)。"""
+    t = _t(burst=2, classify=_classifier({("d", 3, 2): (DISCRETE, None)}))
+    for i, v in enumerate([1, 2, 3, 1, 2, 3, 1, 2]):
+        assert t.allow("d", 3, 2, v, i * SEC) is True
+
+
+def test_spec_telemetry_throttles_from_the_second_sample():
+    """spec 说是遥测:不给「低频宽限」,冷启动头几条也按遥测处理。
+
+    没有这条,重启后每个遥测属性都会先放行 burst 条噪声。
+    """
+    t = _t(burst=5, min_interval_sec=900, rel_delta=0.3,
+           classify=_classifier({("d", 4, 9): (TELEMETRY, 100.0)}))
+    assert t.allow("d", 4, 9, 68, 0) is True           # 首见基线
+    assert t.allow("d", 4, 9, 69, 1 * SEC) is False    # 满量程 1% → 压掉
+    assert t.allow("d", 4, 9, 67, 2 * SEC) is False
+
+
+def test_full_scale_span_beats_relative_delta_for_small_ints():
+    """摄像头「人数」0..10 量程:1→2 相对变化 100%,满量程只有 10%,是噪声。"""
+    t = _t(burst=2, min_interval_sec=900, rel_delta=0.3,
+           classify=_classifier({("cam", 8, 30): (TELEMETRY, 10.0)}))
+    assert t.allow("cam", 8, 30, 1, 0) is True
+    assert t.allow("cam", 8, 30, 2, 1 * SEC) is False
+    assert t.allow("cam", 8, 30, 1, 2 * SEC) is False
+    # 但真正的大跳变(0→5,满量程 50%)必须放行
+    assert t.allow("cam", 8, 30, 5, 3 * SEC) is True
+
+
+def test_writeable_setpoint_stays_discrete():
+    """空调设定温度带 unit=celsius 却是用户意图,spec 侧判为 discrete;
+    26→27 幅度仅 3.8%,若被当成遥测就会丢掉「几点调到 27 度」。"""
+    t = _t(burst=2, min_interval_sec=900, rel_delta=0.3,
+           classify=_classifier({("ac", 2, 4): (DISCRETE, None)}))
+    for i, v in enumerate([26.0, 27.0, 26.0, 28.0, 26.0]):
+        assert t.allow("ac", 2, 4, v, i * SEC) is True
+
+
+def test_classifier_returning_none_falls_back_to_heuristic():
+    """spec 缓存冷:退回频率启发式,低频照常落库。"""
+    t = _t(burst=5, classify=_classifier({}))
+    assert t.allow("d", 2, 4, 26.0, 0) is True
+    assert t.allow("d", 2, 4, 27.0, 600 * SEC) is True
+
+
+def test_classifier_exception_does_not_break_persistence():
+    """分类器抛异常不能连累落库——历史采集必须比分类更可靠。"""
+
+    def boom(did, s, p):
+        raise RuntimeError("spec cache exploded")
+
+    t = _t(burst=5, classify=boom)
+    assert t.allow("d", 2, 1, True, 0) is True
+    assert t.allow("d", 2, 1, False, SEC) is True
+
+
+def test_stats_accounting():
+    t = _t(window_sec=60, burst=2, min_interval_sec=300, rel_delta=0.5)
+    t.allow("d", 2, 1, True, 0)
+    t.allow("d", 2, 1, True, SEC)          # same value
+    t.allow("ac", 12, 3, 100, 0)
+    t.allow("ac", 12, 3, 101, SEC)
+    t.allow("ac", 12, 3, 102, 2 * SEC)     # throttled
+    s = t.stats()
+    assert s["dropped_same_value"] == 1
+    assert s["dropped_throttled"] >= 1
+    assert s["kept"] >= 2

--- a/backend/miloco/tests/test_prop_throttle.py
+++ b/backend/miloco/tests/test_prop_throttle.py
@@ -217,3 +217,17 @@ def test_stats_accounting():
     assert s["dropped_same_value"] == 1
     assert s["dropped_throttled"] >= 1
     assert s["kept"] >= 2
+
+
+def test_eviction_does_not_drop_the_key_being_recorded():
+    """淘汰不能把刚新建的 key 当成最冷的一个丢掉。
+
+    排序键取 `seen[-1]`；若在 seen 记录**之前**淘汰，新 key 的排序键退化到
+    `last_kept_ms=0`，必然排在最前——每次超限都恰好淘汰掉最新的那个，
+    热 key 反而永远建不起来。
+    """
+    t = _t(max_keys=1000)
+    for i in range(1100):
+        t.allow(f"d{i}", 2, 1, True, i)
+    # 最后写入的 key 必须还在（未被自己的插入触发的淘汰清掉）
+    assert ("d1099", 2, 1) in t._state

--- a/backend/miot/src/miot/client.py
+++ b/backend/miot/src/miot/client.py
@@ -37,6 +37,7 @@ from .types import (
     MIoTCameraStatus,
     MIoTDeviceBindEvent,
     MIoTDeviceInfo,
+    MIoTDevicePropChangedEvent,
     MIoTDeviceStateEvent,
     MIoTHomeInfo,
     MIoTLanDeviceInfo,
@@ -109,6 +110,14 @@ class MIoTClient:
     # (intended to be) subscribed. Same ownership/replay model as
     # _meta_sub_dids.
     _state_sub_dids: set
+    # Device-level property push handler (`properties_changed`). Fires with
+    # the decoded per-device change batch; the consumer persists / reacts.
+    _callback_device_prop_changed: Optional[
+        Callable[[MIoTDevicePropChangedEvent], Any]
+    ]
+    # Dids whose `device/{did}/up/properties_changed` topic is (intended to
+    # be) subscribed. Same ownership/replay model as _meta_sub_dids.
+    _prop_sub_dids: set
     # Home ids whose `home/{home_id}/scene/#` topic is (intended to be)
     # subscribed. Same ownership model as _meta_sub_dids, but per home.
     _scene_sub_home_ids: set
@@ -174,6 +183,8 @@ class MIoTClient:
         self._meta_sub_dids = set()
         self._state_sub_dids = set()
         self._scene_sub_home_ids = set()
+        self._callback_device_prop_changed = None
+        self._prop_sub_dids = set()
         self._callback_scene_changed = None
         self._callback_mips_connect: Optional[Callable[[], Any]] = None
 
@@ -427,9 +438,11 @@ class MIoTClient:
             self._callback_user_bind = None
             self._callback_device_meta_changed = None
             self._callback_device_state_changed = None
+            self._callback_device_prop_changed = None
             self._meta_sub_dids = set()
             self._state_sub_dids = set()
             self._scene_sub_home_ids = set()
+            self._prop_sub_dids = set()
             self._callback_scene_changed = None
             self._callback_mips_connect = None
             self._init_done = False
@@ -928,6 +941,27 @@ class MIoTClient:
                 len(dids),
             )
 
+        # Same replay for per-device property push subs.
+        if self._prop_sub_dids:
+            dids = sorted(self._prop_sub_dids)
+            self._prop_sub_dids = set()
+            ok = 0
+            for did in dids:
+                try:
+                    await self.sub_device_prop_async(did)
+                    ok += 1
+                except Exception as e:
+                    _LOGGER.error(
+                        "mips_cloud re-subscribe device-prop FAILED did=%s: %s",
+                        did,
+                        e,
+                    )
+            _LOGGER.info(
+                "mips_cloud re-subscribed device-prop for %d/%d devices",
+                ok,
+                len(dids),
+            )
+
     def register_user_bind_callback(
         self, callback: Optional[Callable[[MIoTDeviceBindEvent], Any]]
     ) -> None:
@@ -1044,6 +1078,50 @@ class MIoTClient:
         if mips is None:
             return
         await mips.unsub_device_state_async(did)
+
+    def register_device_prop_changed_callback(
+        self, callback: Optional[Callable[[MIoTDevicePropChangedEvent], Any]]
+    ) -> None:
+        """Register the single property-push handler.
+
+        Fires once per `properties_changed` message of every subscribed
+        device, with the decoded change batch. Pass None to clear.
+        """
+        self._callback_device_prop_changed = callback
+
+    def _on_device_prop_msg(self, msg: MIoTDevicePropChangedEvent) -> None:
+        cb = self._callback_device_prop_changed
+        if cb is None:
+            return
+        ret = cb(msg)
+        if asyncio.iscoroutine(ret):
+            asyncio.ensure_future(ret)
+
+    async def sub_device_prop_async(self, did: str) -> None:
+        """Subscribe one device's `device/{did}/up/properties_changed` topic
+        (idempotent).
+
+        Same ownership/replay contract as sub_device_meta_async: failed
+        SUBACK propagates WITHOUT recording the did (so the proxy diff
+        retries it); if mips is not connected yet only the intent is
+        recorded and the actual subscribe happens at the next setup.
+        """
+        if did in self._prop_sub_dids:
+            return
+        mips = self._mips_cloud
+        if mips is None or not mips.is_connected:
+            self._prop_sub_dids.add(did)
+            return
+        await mips.sub_device_prop_async(did, self._on_device_prop_msg)
+        self._prop_sub_dids.add(did)
+
+    async def unsub_device_prop_async(self, did: str) -> None:
+        """Unsubscribe one device's property push topic."""
+        self._prop_sub_dids.discard(did)
+        mips = self._mips_cloud
+        if mips is None:
+            return
+        await mips.unsub_device_prop_async(did)
 
     def register_scene_changed_callback(
         self, callback: Optional[Callable[[MIoTSceneChangedEvent], Any]]

--- a/backend/miot/src/miot/mips_cloud.py
+++ b/backend/miot/src/miot/mips_cloud.py
@@ -47,7 +47,9 @@ from .const import (
 )
 from .types import (
     MIoTDeviceBindEvent,
+    MIoTDevicePropChangedEvent,
     MIoTDeviceStateEvent,
+    MIoTPropChange,
     MIoTSceneChangedEvent,
     MipsConnectionError,
     MipsSubscribeRejectedError,
@@ -109,6 +111,14 @@ _TOPIC_DEVICE_STATE = re.compile(
     r"^device/([^/]+)/state/(" + "|".join(_DEVICE_STATE_OPS) + r")$"
 )
 
+# Device-level property push: `device/{did}/up/properties_changed`.
+# did = group(1). Exact leaf topic (no wildcard), matching the HA
+# `xiaomi_home` MIPS convention. Payload (per that convention):
+# `{"id":..,"method":"properties_changed","params":[{"did":..,"siid":..,
+# "piid":..,"value":..},...]}` — entries missing siid/piid are skipped by the
+# decoder, the raw payload is kept verbatim on the event for forensics.
+_TOPIC_DEVICE_PROP = re.compile(r"^device/([^/]+)/up/properties_changed$")
+
 
 # Handler signatures accepted by sub_*_async methods. They receive a fully
 # decoded message object and may be sync or async — both are dispatched on the
@@ -116,6 +126,9 @@ _TOPIC_DEVICE_STATE = re.compile(
 BindHandler = Callable[[MIoTDeviceBindEvent], Union[None, Awaitable[None]]]
 SceneChangedHandler = Callable[[MIoTSceneChangedEvent], Union[None, Awaitable[None]]]
 DeviceStateHandler = Callable[[MIoTDeviceStateEvent], Union[None, Awaitable[None]]]
+PropChangedHandler = Callable[
+    [MIoTDevicePropChangedEvent], Union[None, Awaitable[None]]
+]
 MipsStateHandler = Callable[[bool], Union[None, Awaitable[None]]]
 # Fired when an unattended subscribe (no awaiter, e.g. the reconnect-time
 # re-issue in _on_connect) fails. Arg tuple = (topic, reason_code,
@@ -501,6 +514,23 @@ class MIoTMipsCloud:
         for op in _DEVICE_STATE_OPS:
             await self._unsubscribe_async(f"device/{did}/state/{op}")
 
+    async def sub_device_prop_async(
+        self, did: str, handler: PropChangedHandler
+    ) -> None:
+        """Subscribe a device's property push topic:
+        `device/{did}/up/properties_changed`.
+
+        Exact leaf topic — same ACL rationale as the other per-device subs.
+        SUBACK rejection raises MipsSubscribeRejectedError.
+        """
+        decoder = self._make_prop_decoder()
+        await self._subscribe_async(
+            f"device/{did}/up/properties_changed", handler, decoder
+        )
+
+    async def unsub_device_prop_async(self, did: str) -> None:
+        await self._unsubscribe_async(f"device/{did}/up/properties_changed")
+
     # ------------------------------------------------------- subscribe core
 
     async def _subscribe_async(
@@ -866,6 +896,64 @@ class MIoTMipsCloud:
                 did=did,
                 event=op,  # type: ignore[arg-type]  # op ∈ {online,offline}
                 raw=raw if isinstance(raw, dict) else {},
+                timestamp_ms=_now_ms(),
+            )
+
+        return decode
+
+    @staticmethod
+    def _make_prop_decoder() -> Callable[
+        [str, bytes], Optional[MIoTDevicePropChangedEvent]
+    ]:
+        # `device/{did}/up/properties_changed`: did comes from the topic. The
+        # payload follows the HA `xiaomi_home` convention — a `params` list of
+        # `{did,siid,piid,value}` dicts — but is not formally documented for
+        # this broker, so decoding is defensive: a bare dict payload with
+        # siid/piid is accepted as a single entry, entries without integer
+        # siid+piid are skipped, and a message that yields zero entries decodes
+        # to None (dropped) with the raw payload logged at DEBUG.
+        def decode(
+            topic: str, payload: bytes
+        ) -> Optional[MIoTDevicePropChangedEvent]:
+            m = _TOPIC_DEVICE_PROP.match(topic)
+            if not m:
+                return None
+            did = m.group(1)
+            raw = _parse_json_payload(payload)
+            if not isinstance(raw, dict):
+                _LOGGER.debug(
+                    "properties_changed non-dict payload dropped: did=%s", did
+                )
+                return None
+            params = raw.get("params")
+            if isinstance(params, dict):
+                params = [params]
+            elif not isinstance(params, list):
+                # Some pushes may put the entry at the top level.
+                params = [raw] if "siid" in raw else []
+            changes: list[MIoTPropChange] = []
+            for entry in params:
+                if not isinstance(entry, dict):
+                    continue
+                try:
+                    siid = int(entry["siid"])
+                    piid = int(entry["piid"])
+                except (KeyError, TypeError, ValueError):
+                    continue
+                changes.append(
+                    MIoTPropChange(siid=siid, piid=piid, value=entry.get("value"))
+                )
+            if not changes:
+                _LOGGER.debug(
+                    "properties_changed with no decodable entries: did=%s raw=%r",
+                    did,
+                    raw,
+                )
+                return None
+            return MIoTDevicePropChangedEvent(
+                did=did,
+                changes=changes,
+                raw=raw,
                 timestamp_ms=_now_ms(),
             )
 

--- a/backend/miot/src/miot/mips_cloud.py
+++ b/backend/miot/src/miot/mips_cloud.py
@@ -111,13 +111,22 @@ _TOPIC_DEVICE_STATE = re.compile(
     r"^device/([^/]+)/state/(" + "|".join(_DEVICE_STATE_OPS) + r")$"
 )
 
-# Device-level property push: `device/{did}/up/properties_changed`.
-# did = group(1). Exact leaf topic (no wildcard), matching the HA
-# `xiaomi_home` MIPS convention. Payload (per that convention):
-# `{"id":..,"method":"properties_changed","params":[{"did":..,"siid":..,
-# "piid":..,"value":..},...]}` — entries missing siid/piid are skipped by the
-# decoder, the raw payload is kept verbatim on the event for forensics.
-_TOPIC_DEVICE_PROP = re.compile(r"^device/([^/]+)/up/properties_changed$")
+# Device-level property push: `device/{did}/up/properties_changed/{siid}/{piid}`.
+# did = group(1); the trailing siid/piid segments are informational (the same
+# ids repeat inside the payload, which is what the decoder reads).
+#
+# The leaf-only filter `device/{did}/up/properties_changed` is NOT usable:
+# it matches no published topic, and the broker ACL rejects it outright with
+# 0x87 Not authorized. The ACL grants the subtree — `properties_changed/#`
+# and `properties_changed/+/+` are accepted, while the broader `up/#` and
+# `device/{did}/#` are rejected (measured against 72 devices, 2026-07-29).
+#
+# Payload is a SINGLE change per message, `params` a bare dict (not the list
+# the HA `xiaomi_home` convention suggests):
+# `{"method":"properties_changed","params":{"did":..,"siid":..,"piid":..,
+# "value":..,"parent":..}}` — the decoder accepts both shapes; entries missing
+# siid/piid are skipped and the raw payload is kept verbatim for forensics.
+_TOPIC_DEVICE_PROP = re.compile(r"^device/([^/]+)/up/properties_changed(?:/.*)?$")
 
 
 # Handler signatures accepted by sub_*_async methods. They receive a fully
@@ -517,19 +526,21 @@ class MIoTMipsCloud:
     async def sub_device_prop_async(
         self, did: str, handler: PropChangedHandler
     ) -> None:
-        """Subscribe a device's property push topic:
-        `device/{did}/up/properties_changed`.
+        """Subscribe a device's property push subtree:
+        `device/{did}/up/properties_changed/#`.
 
-        Exact leaf topic — same ACL rationale as the other per-device subs.
+        Wildcard is REQUIRED, not a convenience: pushes land on
+        `.../properties_changed/{siid}/{piid}`, and the leaf-only filter is
+        rejected by the broker ACL with 0x87 (see _TOPIC_DEVICE_PROP).
         SUBACK rejection raises MipsSubscribeRejectedError.
         """
         decoder = self._make_prop_decoder()
         await self._subscribe_async(
-            f"device/{did}/up/properties_changed", handler, decoder
+            f"device/{did}/up/properties_changed/#", handler, decoder
         )
 
     async def unsub_device_prop_async(self, did: str) -> None:
-        await self._unsubscribe_async(f"device/{did}/up/properties_changed")
+        await self._unsubscribe_async(f"device/{did}/up/properties_changed/#")
 
     # ------------------------------------------------------- subscribe core
 
@@ -905,13 +916,13 @@ class MIoTMipsCloud:
     def _make_prop_decoder() -> Callable[
         [str, bytes], Optional[MIoTDevicePropChangedEvent]
     ]:
-        # `device/{did}/up/properties_changed`: did comes from the topic. The
-        # payload follows the HA `xiaomi_home` convention — a `params` list of
-        # `{did,siid,piid,value}` dicts — but is not formally documented for
-        # this broker, so decoding is defensive: a bare dict payload with
-        # siid/piid is accepted as a single entry, entries without integer
-        # siid+piid are skipped, and a message that yields zero entries decodes
-        # to None (dropped) with the raw payload logged at DEBUG.
+        # `device/{did}/up/properties_changed/{siid}/{piid}`: did comes from
+        # the topic. Observed payloads carry ONE change with `params` as a bare
+        # dict; the HA `xiaomi_home` convention documents a `params` list. The
+        # broker documents neither, so decoding accepts both: a bare dict is
+        # wrapped as a single entry, entries without integer siid+piid are
+        # skipped, and a message that yields zero entries decodes to None
+        # (dropped) with the raw payload logged at DEBUG.
         def decode(
             topic: str, payload: bytes
         ) -> Optional[MIoTDevicePropChangedEvent]:

--- a/backend/miot/src/miot/types.py
+++ b/backend/miot/src/miot/types.py
@@ -429,6 +429,36 @@ class MIoTDeviceStateEvent(BaseModel):
     timestamp_ms: int = Field(default=0)
 
 
+class MIoTPropChange(BaseModel):
+    """One property change entry inside a `properties_changed` push."""
+
+    siid: int = Field(description="Service instance id")
+    piid: int = Field(description="Property instance id")
+    value: Any = Field(default=None, description="New property value")
+
+
+class MIoTDevicePropChangedEvent(BaseModel):
+    """Decoded `device/{did}/up/properties_changed` payload.
+
+    Per-device property push. One MQTT message may carry several property
+    entries (`params` list) — they are kept together in `changes` so the
+    handler can persist them under one timestamp. `did` comes from the topic;
+    the full payload is kept verbatim in `raw` for forensics (broker payload
+    schema follows the HA `xiaomi_home` MIPS convention but is not formally
+    documented for this broker).
+    """
+
+    did: str = Field(description="Device id")
+    changes: List[MIoTPropChange] = Field(
+        default_factory=list, description="Decoded property entries"
+    )
+    raw: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Raw decoded payload (broker schema is undocumented)",
+    )
+    timestamp_ms: int = Field(default=0)
+
+
 class MipsConnectionError(Exception):
     """MIPS cloud client failed to connect."""
 

--- a/backend/miot/tests/test_client_meta_sub.py
+++ b/backend/miot/tests/test_client_meta_sub.py
@@ -47,6 +47,7 @@ def _bare_client(mips: _FakeMips | None) -> MIoTClient:
     client._meta_sub_dids = set()
     client._scene_sub_home_ids = set()
     client._state_sub_dids = set()
+    client._prop_sub_dids = set()
     client._mips_cloud = mips
     client._callback_device_meta_changed = None
     client._callback_scene_changed = None
@@ -170,6 +171,7 @@ class _SetupFakeMips:
         self.sub_device_meta_changed_async = AsyncMock(side_effect=self._meta)
         self.sub_home_scene_changed_async = AsyncMock()
         self.sub_device_state_async = AsyncMock(side_effect=self._state)
+        self.sub_device_prop_async = AsyncMock()
 
     async def _meta(self, did: str, handler) -> None:
         if did in self._fail_meta_dids:
@@ -185,7 +187,7 @@ class _SetupFakeMips:
 
 
 def _setup_client(
-    monkeypatch, fake, *, meta_dids, scene_home_ids, state_dids=()
+    monkeypatch, fake, *, meta_dids, scene_home_ids, state_dids=(), prop_dids=()
 ) -> MIoTClient:
     monkeypatch.setattr(client_mod, "MIoTMipsCloud", lambda **kw: fake)
     client = MIoTClient.__new__(MIoTClient)
@@ -200,9 +202,11 @@ def _setup_client(
     client._meta_sub_dids = set(meta_dids)
     client._scene_sub_home_ids = set(scene_home_ids)
     client._state_sub_dids = set(state_dids)
+    client._prop_sub_dids = set(prop_dids)
     client._callback_device_meta_changed = None
     client._callback_scene_changed = None
     client._callback_device_state_changed = None
+    client._callback_device_prop_changed = None
     return client
 
 
@@ -409,3 +413,29 @@ def test_home_scene_subscribe_results_do_not_touch_user_error():
     client._mips_user_sub_error = "stale user error"
     client._on_mips_subscribe_success("home/h1/scene/edit")
     assert client._mips_user_sub_error == "stale user error"
+
+
+@pytest.mark.asyncio
+async def test_setup_replays_prop_subscriptions(monkeypatch):
+    """属性推送订阅同样要在 re-OAuth / fresh setup 后重放。
+
+    _setup_mips_async 会新建 mips 实例（老实例的 _subs 全丢），已跟踪的
+    did 必须逐个重新订阅——漏了的话该设备的属性历史会静默断流，直到下一次
+    refresh_devices 的 diff 才补上。
+    """
+    fake = _SetupFakeMips()
+    client = _setup_client(
+        monkeypatch,
+        fake,
+        meta_dids=set(),
+        scene_home_ids=set(),
+        prop_dids={"dev-1", "dev-2"},
+    )
+
+    await client._setup_mips_async()
+
+    assert {c.args[0] for c in fake.sub_device_prop_async.await_args_list} == {
+        "dev-1",
+        "dev-2",
+    }
+    assert client._prop_sub_dids == {"dev-1", "dev-2"}

--- a/backend/miot/tests/test_client_prop_sub.py
+++ b/backend/miot/tests/test_client_prop_sub.py
@@ -12,16 +12,17 @@ Tracking follows the same contract as sub_device_meta_async:
 * While mips is disconnected only the intent is recorded (replayed at setup).
 * Already-tracked dids are a no-op (idempotent).
 
-The decoder is defensive: the broker payload schema follows the HA
-`xiaomi_home` convention (`params` list of {did,siid,piid,value}) but is not
-formally documented, so bare-dict payloads are accepted, entries without
-integer siid+piid are skipped, and zero decodable entries → None (dropped).
+The decoder is defensive: real pushes carry ONE change per message with
+`params` as a bare dict, on topic `.../properties_changed/{siid}/{piid}`;
+the HA `xiaomi_home` convention documents a `params` list on the leaf topic.
+Neither is formally specified by the broker, so both shapes are accepted,
+entries without integer siid+piid are skipped, and zero decodable entries →
+None (dropped).
 """
 
 from __future__ import annotations
 
 import json
-
 from unittest.mock import AsyncMock
 
 import pytest
@@ -154,3 +155,73 @@ def test_decoder_drops_garbage_and_empty():
 
 def test_decoder_ignores_other_topics():
     assert _decode("device/d1/state/online", b"{}") is None
+
+
+# ------------------------------------------------- real broker payload shape
+#
+# Captured 2026-07-29 from cn-ha.mqtt.io.mi.com against a live account: the
+# topic carries siid/piid and `params` is a single bare dict, not a list.
+
+
+def test_decoder_real_push_shape():
+    """Topic with /{siid}/{piid} suffix + bare-dict params (production shape)."""
+    payload = json.dumps(
+        {
+            "method": "properties_changed",
+            "params": {
+                "did": "436264078",
+                "siid": 2,
+                "piid": 1,
+                "value": False,
+                "parent": "70009373680",
+            },
+        }
+    ).encode()
+    evt = _decode("device/436264078/up/properties_changed/2/1", payload)
+    assert evt is not None and evt.did == "436264078"
+    assert [(c.siid, c.piid, c.value) for c in evt.changes] == [(2, 1, False)]
+
+
+@pytest.mark.parametrize(
+    "value",
+    [True, False, 26.0, 1140, "0,100,1,1", None],
+)
+def test_decoder_real_push_value_types(value):
+    """Live traffic mixes bool / int / float / str / null values."""
+    payload = json.dumps(
+        {"method": "properties_changed", "params": {"siid": 12, "piid": 3, "value": value}}
+    ).encode()
+    evt = _decode("device/d1/up/properties_changed/12/3", payload)
+    assert evt is not None and evt.changes[0].value == value
+
+
+def test_decoder_accepts_deep_topic_but_not_sibling_subtree():
+    """`properties_changed/#` must decode; `event_occured` must not."""
+    payload = json.dumps({"params": {"siid": 9, "piid": 5, "value": 318.7}}).encode()
+    assert _decode("device/d1/up/properties_changed/9/5", payload) is not None
+    assert _decode("device/d1/up/event_occured/9/8", payload) is None
+
+
+# ----------------------------------------------------------- subscribe topic
+
+
+@pytest.mark.asyncio
+async def test_subscribe_uses_wildcard_subtree_topic():
+    """The leaf-only filter is rejected by the broker ACL with 0x87 and matches
+    no published topic — the subtree wildcard is mandatory (verified against
+    72 devices, 2026-07-29). Guard against a silent regression to the leaf.
+    """
+    from unittest.mock import AsyncMock as _AsyncMock
+
+    mips = MIoTMipsCloud.__new__(MIoTMipsCloud)
+    mips._subscribe_async = _AsyncMock()
+    mips._unsubscribe_async = _AsyncMock()
+    await MIoTMipsCloud.sub_device_prop_async(mips, "did-1", lambda _evt: None)
+    topic = mips._subscribe_async.await_args.args[0]
+    assert topic == "device/did-1/up/properties_changed/#"
+
+    await MIoTMipsCloud.unsub_device_prop_async(mips, "did-1")
+    assert (
+        mips._unsubscribe_async.await_args.args[0]
+        == "device/did-1/up/properties_changed/#"
+    )

--- a/backend/miot/tests/test_client_prop_sub.py
+++ b/backend/miot/tests/test_client_prop_sub.py
@@ -1,0 +1,156 @@
+# Copyright (C) 2025 Xiaomi Corporation
+# This software may be used and distributed according to the terms of the Xiaomi Miloco License Agreement.
+
+"""Tests for device property push: MIoTClient.sub_device_prop_async tracking
+and the mips_cloud `properties_changed` decoder.
+
+Tracking follows the same contract as sub_device_meta_async:
+
+* A successful subscribe (mips connected) records the did.
+* A FAILED subscribe must NOT record it — otherwise the idempotency guard
+  would short-circuit the proxy-level retry in _sync_prop_subscriptions.
+* While mips is disconnected only the intent is recorded (replayed at setup).
+* Already-tracked dids are a no-op (idempotent).
+
+The decoder is defensive: the broker payload schema follows the HA
+`xiaomi_home` convention (`params` list of {did,siid,piid,value}) but is not
+formally documented, so bare-dict payloads are accepted, entries without
+integer siid+piid are skipped, and zero decodable entries → None (dropped).
+"""
+
+from __future__ import annotations
+
+import json
+
+from unittest.mock import AsyncMock
+
+import pytest
+from miot.client import MIoTClient
+from miot.mips_cloud import MIoTMipsCloud
+
+
+class _FakeMips:
+    def __init__(self, *, connected: bool = True, fail: bool = False) -> None:
+        self.is_connected = connected
+        self._fail = fail
+        self.sub_device_prop_async = AsyncMock(side_effect=self._maybe_fail)
+        self.unsub_device_prop_async = AsyncMock()
+
+    async def _maybe_fail(self, *args, **kwargs) -> None:
+        if self._fail:
+            raise RuntimeError("SUBACK rejected")
+
+
+def _bare_client(mips: _FakeMips | None) -> MIoTClient:
+    client = MIoTClient.__new__(MIoTClient)
+    client._prop_sub_dids = set()
+    client._mips_cloud = mips
+    client._callback_device_prop_changed = None
+    return client
+
+
+# ------------------------------------------------------------------- tracking
+
+
+@pytest.mark.asyncio
+async def test_sub_prop_success_records_did():
+    mips = _FakeMips(connected=True)
+    client = _bare_client(mips)
+    await client.sub_device_prop_async("did-1")
+    assert client._prop_sub_dids == {"did-1"}
+    mips.sub_device_prop_async.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_sub_prop_failure_does_not_record_did():
+    mips = _FakeMips(connected=True, fail=True)
+    client = _bare_client(mips)
+    with pytest.raises(RuntimeError):
+        await client.sub_device_prop_async("did-1")
+    assert client._prop_sub_dids == set()
+
+
+@pytest.mark.asyncio
+async def test_sub_prop_disconnected_records_intent_without_broker_call():
+    mips = _FakeMips(connected=False)
+    client = _bare_client(mips)
+    await client.sub_device_prop_async("did-1")
+    assert client._prop_sub_dids == {"did-1"}
+    mips.sub_device_prop_async.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_sub_prop_idempotent():
+    mips = _FakeMips(connected=True)
+    client = _bare_client(mips)
+    await client.sub_device_prop_async("did-1")
+    await client.sub_device_prop_async("did-1")
+    assert mips.sub_device_prop_async.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_unsub_prop_discards_and_forwards():
+    mips = _FakeMips(connected=True)
+    client = _bare_client(mips)
+    await client.sub_device_prop_async("did-1")
+    await client.unsub_device_prop_async("did-1")
+    assert client._prop_sub_dids == set()
+    mips.unsub_device_prop_async.assert_awaited_once()
+
+
+# -------------------------------------------------------------------- decoder
+
+
+def _decode(topic: str, payload: bytes):
+    return MIoTMipsCloud._make_prop_decoder()(topic, payload)
+
+
+def test_decoder_params_list():
+    payload = json.dumps(
+        {
+            "id": 1,
+            "method": "properties_changed",
+            "params": [
+                {"did": "d1", "siid": 2, "piid": 1, "value": True},
+                {"did": "d1", "siid": 2, "piid": 4, "value": 26},
+            ],
+        }
+    ).encode()
+    evt = _decode("device/d1/up/properties_changed", payload)
+    assert evt is not None and evt.did == "d1"
+    assert [(c.siid, c.piid, c.value) for c in evt.changes] == [
+        (2, 1, True),
+        (2, 4, 26),
+    ]
+
+
+def test_decoder_bare_dict_payload():
+    evt = _decode(
+        "device/d1/up/properties_changed",
+        json.dumps({"siid": 3, "piid": 2, "value": "lo"}).encode(),
+    )
+    assert evt is not None
+    assert (evt.changes[0].siid, evt.changes[0].piid) == (3, 2)
+
+
+def test_decoder_skips_entries_without_siid_piid():
+    payload = json.dumps(
+        {"params": [{"nope": 1}, {"did": "d1", "siid": 2, "piid": 1, "value": 0}]}
+    ).encode()
+    evt = _decode("device/d1/up/properties_changed", payload)
+    assert evt is not None and len(evt.changes) == 1
+
+
+def test_decoder_drops_garbage_and_empty():
+    assert _decode("device/d1/up/properties_changed", b"not json") is None
+    assert (
+        _decode(
+            "device/d1/up/properties_changed",
+            json.dumps({"params": [{"nope": 1}]}).encode(),
+        )
+        is None
+    )
+
+
+def test_decoder_ignores_other_topics():
+    assert _decode("device/d1/state/online", b"{}") is None

--- a/cli/src/miloco_cli/commands/device.py
+++ b/cli/src/miloco_cli/commands/device.py
@@ -476,6 +476,58 @@ def device_status(did, iids, pretty):
     print_result(data, pretty)
 
 
+@device_group.command("history")
+@click.argument("did")
+@click.argument("iid", required=False)
+@click.option(
+    "--since",
+    default="24h",
+    help="相对时长,支持 h/m/s/d 单位及组合(1h、30m、7d、2h30m),默认 24h。",
+)
+@click.option("--limit", default=100, type=int, help="最大返回条数(默认 100,上限 1000)。")
+@click.option("--pretty", is_flag=True)
+def device_history(did, iid, since, limit, pretty):
+    """查询设备属性变化历史(mips 推送落库,新→旧)。
+
+    \b
+    IID 可选:形如 prop.2.1(也接受 2.1)或 spec_name(如 on@空调);
+    不传返回整设备的属性时间线。
+      miloco-cli device history 436264078 prop.2.1 --since 2d
+    """
+    import re as _re
+    import time
+
+    from miloco_cli.client import api_get
+
+    m = _re.fullmatch(r"(?:(\d+)d)?(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?", since.strip())
+    if not m or not any(m.groups()):
+        print(json.dumps({"error": f"--since 格式非法: {since!r}"}), file=sys.stderr)
+        sys.exit(1)
+    d, h, mi, s = (int(g or 0) for g in m.groups())
+    since_ms = int(time.time() * 1000) - ((d * 86400 + h * 3600 + mi * 60 + s) * 1000)
+
+    params: dict = {"did": did, "since": since_ms, "limit": limit}
+    if iid:
+        if _re.fullmatch(r"(?:prop\.)?\d+\.\d+", iid):
+            params["iid"] = iid
+        else:
+            # spec_name 形态(on@空调)→ 借 home_info 解析成 prop.S.P
+            from miloco_cli.home_info import (
+                ValidationError,
+                get_home_info,
+                lookup_iid_by_key,
+            )
+
+            try:
+                params["iid"] = lookup_iid_by_key(did, iid, get_home_info())
+            except ValidationError as e:
+                print(json.dumps({"error": str(e)}), file=sys.stderr)
+                sys.exit(1)
+
+    data = api_get("/api/miot/prop-history", params)
+    print_result(data, pretty)
+
+
 # ─── device action ────────────────────────────────────────────────────────────
 
 

--- a/plugins/skills/miloco-devices/SKILL.md
+++ b/plugins/skills/miloco-devices/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: miloco-devices
-description: 查询与控制米家智能家居设备。查询能力包括设备开关状态、运行状态、电量、设定温度、当前温湿度、PM2.5 等环境与设备数据；控制能力包括开关灯、调节空调温度/模式/风速、控制窗帘开合、启动或停止扫地机器人、开关摄像头等设备操作；场景能力包括触发已有米家场景，如回家、离家、睡眠等智能场景；以及刷新设备列表缓存。
+description: 查询与控制米家智能家居设备。查询能力包括设备开关状态、运行状态、电量、设定温度、当前温湿度、PM2.5 等环境与设备数据，以及设备状态的**历史变化时间线**（"空调几点开的""传感器什么时候检测到人""灯今天开过几次"）；控制能力包括开关灯、调节空调温度/模式/风速、控制窗帘开合、启动或停止扫地机器人、开关摄像头等设备操作；场景能力包括触发已有米家场景，如回家、离家、睡眠等智能场景；以及刷新设备列表缓存。
 metadata:
   author: miloco
   version: "1.7"
@@ -20,6 +20,7 @@ metadata:
 | ----------------- | --------------------------------------------------- |
 | **control**       | "打开灯" "空调调到26度" "把窗帘拉上" "扫地"         |
 | **query**         | "灯开着吗" "空调设定的温度" "客厅多少度" "湿度多少" |
+| **history**       | "空调几点开的" "灯什么时候关的" "今天开过几次" "上次有人是啥时候" |
 | **scene_trigger** | "执行回家模式" "触发离家场景"                       |
 | **refresh**       | "刷新设备列表" "更新设备信息" "重新拉一遍"           |
 
@@ -71,7 +72,8 @@ metadata:
 | access | 用途 | 命令 |
 | --------- | ---- | ---- |
 | `w` | 控制属性 | 单属性 `device control <did> <spec_name> <value>`；多属性 `device control <did> --set <spec_name> <v> --set <spec_name> <v>` |
-| `r` | 查询属性 | `device props <did> [spec_name ...]` |
+| `r` | 查询**当前值** | `device props <did> [spec_name ...]` |
+| `r` | 查询**历史变化**(何时变的) | `device history <did> [<iid>] --since 24h` |
 | `x` | 执行动作 | `device action <did> <spec_name> [<值1> <值2>…]`（**只传值，不传参数名**） |
 
 **4.2 参数检查**
@@ -207,6 +209,9 @@ miloco-cli device control 4912 --set brightness 30 --set on true ; miloco-cli de
 | "关客厅灯"（设 on 本身，灯的开关就是 `on`） | `device control 4912 on false` |
 | "空调设定的温度"（查询） | `device props 4962 target-temperature` → 26 |
 | "客厅多少度"（环境数据，同样走 props） | `device props ht01 temperature` → 24.5 |
+| "空调几点开的"（**历史**：问的是"何时变的"，不是当前值） | `device history 4962 on@空调 --since 24h` → `true@08:12` |
+| "今天灯开过几次"（历史，数变化次数） | `device history 4912 on --since 24h` |
+| "上次有人是啥时候"（人在传感器，历史） | `device history 2033601557 --since 24h` |
 | "家里有几盏灯"（集合 → grep 每轮重查） | `device list \| grep -E '灯\|light'` |
 | "扫地机回去充电"（access=x → action 只传值） | `device action 4981 start-charge` |
 


### PR DESCRIPTION
## 摘要 / Summary

为 miloco 增加**设备属性变化历史**能力,回答"空调几点开的""传感器什么时候检测到人"这类家居最自然的问题。当前 miloco 完全没有这个数据源:`main` 上 `properties_changed` 只出现在一行 docstring 里,没有任何订阅链路、没有落库、没有查询接口——想知道设备状态什么时候变的,只能人工查当前值。

Adds **device property-change history** to miloco. `main` has no property-push subscription at all (`properties_changed` appears only in one docstring), so state changes are invisible: you can read a device's current value, never when it changed.

---

## ⚠️ 本次更新推翻了初版的核心归因 / Root-cause correction

初版 PR 描述称"官方 app_id 被 broker ACL 挡在 `properties_changed` 之外(SUBACK 0x87),只能靠轮询兜底",并据此向 MIoT 平台申请开通 ACL。**这个结论是错的,现已撤回该请求。**

2026-07-29 用独立 client_id 对本人 72 台设备做了对照实验(生产 broker `cn-ha.mqtt.io.mi.com`,复用现有 access_token):

| 实验 | topic filter | SUBACK |
|---|---|---|
| A 裸订阅(初版做法) | `device/{did}/up/properties_changed` | **0x87 NotAuthorized** |
| B 先订阅 meta 再订阅 | 同上(精确形态) | **仍然 0x87** |
| C 先订阅 meta 再订阅 | `…/properties_changed/#` | **0x00 成功** |
| D 全新连接、**不做任何 meta 订阅** | `…/properties_changed/#` | **0x00 成功** |
| E 剩余 63 台批量订阅 | `…/properties_changed/#` | **63/63 全成功** |

**真正的原因是 topic 层级写少了一级。** 真实推送带 siid/piid 两级:

```
topic:   device/436264078/up/properties_changed/2/1
payload: {"method":"properties_changed","params":{"did":"436264078","siid":2,"piid":1,
          "value":false,"parent":"70009373680"}}
```

ACL 授权的是 `properties_changed/` 这棵**子树**,而 `properties_changed`(无后缀)既匹配不到任何已发布 topic、也不在白名单里,故被拒。topic 形态矩阵进一步印证边界:

- ✅ `properties_changed/#` ／ `properties_changed/+/+` ／ `properties_changed/2/1`
- ✅ `event_occured/#`(事件推送同样可用)
- ❌ `device/{did}/up/#` ／ `device/{did}/#`(ACL 精确到子树,不给更上层)

顺带更正一处对 #361 的旁证解读:该 PR 把 0x87 归因为"米家云端要求先建 meta 订阅才授权属性订阅",并实现了 meta 先行 + 5s 重试。实验 B 做了 meta 仍被拒、实验 D 不做 meta 却成功,说明 meta 订阅与属性 ACL 无关——两者当时应是被一起改动而产生了误判。**这不影响 #361 的功能正确性**(它用的就是通配 topic),只是归因需要修正。

30 分钟连续监听共收到 **1044 条真实推送**,全程无掉线;手动关→开空调被完整捕获(`2/1` false→true,秒级到达)。

---

## 一、推送主链路 / Push path

- miot lib: `sub_device_prop_async` 订阅 `device/{did}/up/properties_changed/#` + decoder。decoder 正则同步放宽到 `(?:/.*)?$`——**这一处不改的话,即使订阅成功,每条推送也会因 topic 不匹配被静默丢弃**。
- payload 解析兼容两种形态:实测的单条 `params` 裸 dict,与 HA `xiaomi_home` 约定的 `params` 列表;缺 siid/piid 的条目跳过,零可解条目的消息丢弃并 DEBUG 留痕。
- 断线重放、deinit 清理与既有 meta/state 订阅同契约。SUBACK 被拒不再永久拉黑:0x87 现在属异常(重连期 ACL 抖动),连续 3 次才放弃该 did,一次成功即清零。

## 二、落库前节流 / Throttling(本次新增,非可选)

推送是逐属性、秒级的。实测 30 分钟 1039 条属性推送里,**一台空调的功率属性 `12/3` 独占 95 条**(每 1–2 秒一条);设备关→开还会**整包重发全部属性**(一秒内约 25 条,含大量同值条目)。全量落库约 5 万行/天、150 万行/30 天(≈220MB),且绝大多数是能耗遥测噪声——这是本能力落地的真实阻碍,故新增 `prop_throttle.py`:

1. **同值重发** → 一律丢弃(整包重发去重)。
2. **非数值属性**(bool/str/null)→ 变化即落库,无条件。开关、模式、占用状态永不因节流丢失。
3. **数值属性** → 按 miot-spec 语义分流,仅对遥测做「最小间隔 + 幅度」双阈值去抖,满足其一即落库;spec 未命中时退回频率启发式。

两个反直觉但被数据逼出来的判据:

- **`writeable` 比 `unit` 更能区分语义。** 空调设定温度 `prop.2.4` 带 `unit=celsius`,看着像遥测,实为用户意图;同台设备上真正刷屏的是**只读**的环境湿度 `prop.4.9`。故 writeable 优先于 unit 判定,"几点把温度调到 26 度"不会被误杀。
- **幅度要按满量程算,不能按"相对上次值"。** 摄像头「人数」1→2 是 100% 的相对变化却是噪声;空调功率 1140→1150 只有 0.9% 同样是噪声。换成满量程口径二者都被正确压掉,而开机瞬间 0→1140W(满量程 38%)照常落库。
- spec 里查不到的厂商私有槽位(实测空调把功率/电压/电流挂在 spec 之外的 `prop.12.*`)按最严格的遥测档处理,而不是直接丢——个别设备会把温湿度放在非标 piid 上。

用上述 1039 条真实推送回放的效果:

| | 落库 | 外推 | 30 天 |
|---|---|---|---|
| 不节流 | 1039 (100%) | ~50k 行/天 | 1.5M 行 ≈ 220MB |
| 仅频率启发式 | 253 (24.4%) | 12k 行/天 | 360k 行 ≈ 54MB |
| **spec 分类 + 满量程幅度** | **118 (11.4%)** | **5.6k 行/天** | **168k 行 ≈ 25MB** |

压缩约 9 倍,同时空调开关的 3 次变化一条不丢。`prop_history_throttle_enabled=false` 可整体关闭(排障用逃生开关),各阈值均可配。

## 三、轮询安全网 / Polling safety net

`DevicePropPoller` 保留但**降级为兜底**,周期 60s → 300s。推送覆盖不到的三种情况由它补上:订阅被拒的设备、mips 断连窗口内的变化、以及**设备根本不推送**的属性(推送是设备侧行为,并非所有属性都上报)。一周期一次批量 `/app/v2/miotspec/prop/get`(≤150 条/请求,整屋一次 HTTP 调用),watchlist 零配置自筛选(全部在线设备的 `prop.2.1`),`miot.prop_history_poll_extra` 可扩展任意属性。变化才落库,重启后首见 key 与 DB 最新行 diff,不产生重复基线行。

## 四、存储与查询 / Storage & query

- 新表 `device_prop_history`(缺表兜底建,与既有 schema 演进模式一致),默认保留 30 天,写路径顺带清理,无独立定时任务。
- `GET /api/miot/prop-history?did&iid&since&until&limit`
- CLI: `miloco-cli device history <did> [iid] --since 2d`(iid 支持 `prop.S.P` 与 spec_name 两种形态)

## 语义与取舍 / Semantics & trade-offs

- 推送路径的 `ts` 是**事件时刻**(秒级);轮询补上的行 `ts` 是**发现时刻**(±一个周期),字段描述与文档均已注明。
- `prop_history_enabled` 默认 **true**(能力开箱即用,云端压力极小);若维护者倾向 opt-in 请直说,一行改动。

## 测试 / Tests

- `backend/miot`: 19 条(订阅跟踪契约、decoder 各形态与坏输入、**真实 topic 形态与 payload**、bool/int/float/str/null 各值类型、`event_occured` 不误吃、以及一条防回归断言——订阅 topic 必须是通配子树)。
- `backend/miloco`: 34 条(节流 20 + 历史 14),含 spec 分类矩阵、满量程幅度、离散属性零丢失、分类器抛异常不连累落库、推送落库链路端到端。
- 顺带修复一处**初版引入的既有回归**:`_setup_mips_async` 会重放属性订阅,但 `test_client_meta_sub.py` 的 bare client 未建 `_prop_sub_dids`,导致该文件 4 条用例 AttributeError;已补齐并新增一条属性订阅重放断言(与 state 对称)。
- 真实环境已连续运行验证:72 设备家庭,72/72 订阅成功,30 分钟 1044 条推送,人工开关空调被完整记录。

## 与 #361 的关系 / Relation to #361

#361(米家事件触发感知)与本 PR 改动**同一套底层管道**(`backend/miot` 的 `client.py` / `mips_cloud.py` / `types.py`),两者都需要属性推送订阅,合并时会有冲突。二者目的正交——#361 用属性变化**当场触发摄像头感知**,本 PR 把变化**落库供回查**——底层订阅完全可以共用。维护者若倾向先合其一,我可以配合把本 PR rebase 到其上,只保留历史落库部分。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
