### PR TITLE
fix(omni): OPEN_CONFIG black hole — 422 misclassification could halt perception forever

### DIFF
--- a/backend/miloco/src/miloco/perception/engine/omni/circuit_breaker.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/circuit_breaker.py
@@ -71,7 +71,8 @@ class HealthSnapshot:
     next_probe_at_ms: int | None
     # 到下次 tick 探测的剩余秒数(monotonic 差算,不依赖两端时钟一致)。前端直接倒计时
     # 该值,避免 next_probe_at_ms(服务端 unix ms)与客户端 Date.now() 时钟偏差导致
-    # 倒计时不准(家用 NAS/容器场景常见)。CLOSED / OPEN_CONFIG / HALF_OPEN 时为 None。
+    # 倒计时不准(家用 NAS/容器场景常见)。CLOSED / HALF_OPEN 时为 None;
+    # OPEN_CONFIG 也有值(慢速自动探测周期,见 config_probe_interval_sec)。
     next_probe_in_seconds: float | None
     last_probe_at_ms: int | None
     last_probe_result: str | None  # "ok" | "fail" | None
@@ -102,6 +103,7 @@ class OmniCircuitBreaker:
         backoff_multiplier: float = 2.0,
         backoff_caps: dict[str, float] | None = None,
         jitter_ratio: float = 0.2,
+        config_probe_interval_sec: float = 300.0,
     ):
         self._consecutive_threshold = consecutive_threshold
         self._window_seconds = window_seconds
@@ -111,6 +113,12 @@ class OmniCircuitBreaker:
         self._backoff_multiplier = backoff_multiplier
         self._backoff_caps = backoff_caps or {"rate_limited": 60.0, "_default": 600.0}
         self._jitter_ratio = jitter_ratio
+        # OPEN_CONFIG 的慢速自动探测周期。原设计 OPEN_CONFIG 只等「配置变更 / 手动
+        # retry」,但分类误判(如 422 payload 错被当成 config 错)会把感知打进永不
+        # 自愈的黑洞(2026-07-29 实锅:12:14→14:45 全部 short-circuit,零重试)。
+        # 慢周期自动探测兜住误判,同时保持"不拿注定失败的 key 反复打 provider"的
+        # 初衷——5min 一次极简 ping 的代价可忽略。
+        self._config_probe_interval_sec = config_probe_interval_sec
 
         # RLock:允许 try_arm_probe 持锁调 probe_due (probe_due 单独调用时也持锁,
         # 嵌套 acquire 靠 RLock 兼容)。跨 loop / 跨线程访问全部通过它序列化,配合
@@ -228,9 +236,16 @@ class OmniCircuitBreaker:
         self._emit()
 
     def probe_due(self) -> bool:
-        """外部 tick 查询:是否到 HALF_OPEN 时刻(不改状态)。"""
+        """外部 tick 查询:是否到 HALF_OPEN 时刻(不改状态)。
+
+        OPEN_RECOVERABLE 走指数 backoff 周期;OPEN_CONFIG 也参与——走固定慢周期
+        (config_probe_interval_sec),防误判分类造成的永久黑洞。
+        """
         with self._lock:
-            if self._state != CircuitState.OPEN_RECOVERABLE:
+            if self._state not in (
+                CircuitState.OPEN_RECOVERABLE,
+                CircuitState.OPEN_CONFIG,
+            ):
                 return False
             return (
                 self._next_probe_at_monotonic is not None
@@ -238,7 +253,7 @@ class OmniCircuitBreaker:
             )
 
     def try_arm_probe(self) -> bool:
-        """tick 驱动占位:三条件齐(OPEN_RECOVERABLE + probe_due + 未 in-flight)时置
+        """tick 驱动占位:三条件齐(OPEN_* + probe_due + 未 in-flight)时置
         in-flight 位并返回 True。调用方拿到 True 后 spawn probe task,task 里必须走
         mark_half_open → probe_omni → record_probe_result(record_probe_result 会清位)。
 
@@ -246,7 +261,10 @@ class OmniCircuitBreaker:
         原子;并发调用只有一个能拿到 True。
         """
         with self._lock:
-            if self._state != CircuitState.OPEN_RECOVERABLE:
+            if self._state not in (
+                CircuitState.OPEN_RECOVERABLE,
+                CircuitState.OPEN_CONFIG,
+            ):
                 return False
             if self._probe_in_flight:
                 return False
@@ -276,7 +294,10 @@ class OmniCircuitBreaker:
     async def mark_half_open(self) -> None:
         """外部驱动:进入 HALF_OPEN(发起 probe 前调)。"""
         with self._lock:
-            if self._state == CircuitState.OPEN_RECOVERABLE:
+            if self._state in (
+                CircuitState.OPEN_RECOVERABLE,
+                CircuitState.OPEN_CONFIG,
+            ):
                 self._state = CircuitState.HALF_OPEN
         self._emit()
 
@@ -299,9 +320,9 @@ class OmniCircuitBreaker:
             mono_now = time.monotonic()
             next_ms: int | None = None
             next_in_s: float | None = None
-            if (
-                self._next_probe_at_monotonic is not None
-                and self._state == CircuitState.OPEN_RECOVERABLE
+            if self._next_probe_at_monotonic is not None and self._state in (
+                CircuitState.OPEN_RECOVERABLE,
+                CircuitState.OPEN_CONFIG,
             ):
                 delta_s = max(0.0, self._next_probe_at_monotonic - mono_now)
                 next_ms = now_ms + int(delta_s * 1000)
@@ -380,7 +401,12 @@ class OmniCircuitBreaker:
         self._state = CircuitState.OPEN_CONFIG
         self._state_since = time.monotonic()
         self._current_code, self._current_message = err.code, err.message
-        self._next_probe_at_monotonic = None
+        # 慢速自动探测逃生通道:固定周期(不指数增长——config 错不会因等得久而好转,
+        # 周期本身已经够长)。record_probe_result 失败仍是 CONFIG 时会重入本函数,
+        # 自动排下一次。
+        self._next_probe_at_monotonic = (
+            time.monotonic() + self._config_probe_interval_sec
+        )
         self._current_backoff = 0.0
 
     def _transition_to_closed_locked(self) -> None:

--- a/backend/miloco/src/miloco/perception/engine/omni/error_classifier.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/error_classifier.py
@@ -51,7 +51,7 @@ _MESSAGES: dict[str, str] = {
     "bad_key": "API Key 无效或无权限",
     "no_key": "未配置 API Key",
     "not_found": "模型或地址不存在",
-    "rejected_authed": "已连接，但请求被拒绝（模型名或 API Key 可能有误）",
+    "rejected_authed": "已连接，但请求被拒绝（请求体/媒体数据、模型名或 API Key 可能有误）",
     "bad_response": "omni 响应格式异常",
     "cancelled": "重试被中断",
 }
@@ -88,8 +88,13 @@ def classify_response(resp: httpx.Response) -> ClassifiedError | None:
             "not_found", _MESSAGES["not_found"], ErrorCategory.CONFIG
         )
     if s in (400, 422):
+        # 运行时语境的 400/422 绝大多数是**单次请求体问题**(坏帧、媒体编码、缺字段
+        # ——2026-07-29 实锅:audio 路由 input_audio 缺 format 字段打本地 mlx server
+        # 422×3 → OPEN_CONFIG 黑洞,感知停摆 2.5h)。归 RECOVERABLE 让熔断走
+        # backoff+自动探测(probe 是极简文本 ping,配置真有问题探测自己会失败);
+        # 真·key/模型名错误主要走 401/403/404 分支,不依赖这里。
         return ClassifiedError(
-            "rejected_authed", _MESSAGES["rejected_authed"], ErrorCategory.CONFIG
+            "rejected_authed", _MESSAGES["rejected_authed"], ErrorCategory.RECOVERABLE
         )
     if s == 429:
         retry_after = _parse_retry_after(resp.headers.get("Retry-After"))

--- a/backend/miloco/src/miloco/perception/engine/omni/provider.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/provider.py
@@ -132,9 +132,15 @@ class MiMoAdapter(OpenAICompatAdapter):
         }
 
     def build_audio_block(self, audio_base64: str, media: LocalMediaInfo) -> dict[str, Any]:
+        # OpenAI 规范 input_audio 的 data+format 均必填——本地 mlx-vlm server 严格
+        # 校验,缺 format 直接 422(2026-07-29 感知停摆根因);宽松 provider 忽略
+        # 多余字段无副作用。载荷是 audio-only mp4(AAC),format 报容器名。
         return {
             "type": "input_audio",
-            "input_audio": {"data": f"data:audio/m4a;base64,{audio_base64}"},
+            "input_audio": {
+                "data": f"data:audio/m4a;base64,{audio_base64}",
+                "format": "mp4",
+            },
         }
 
     def build_request_body(

--- a/backend/miloco/src/miloco/perception/runner.py
+++ b/backend/miloco/src/miloco/perception/runner.py
@@ -158,12 +158,13 @@ class PerceptionRunner:
 
     async def _tick(self) -> None:
         """Drain all ready windows and infer sequentially."""
-        # 每 tick 驱动一次 omni 熔断器自动探测:OPEN_RECOVERABLE + backoff 到期时 spawn
-        # 一次后台 probe。无外部驱动时 probe_due 归零后状态永远不动,provider 恢复后感知
-        # 也不会自愈,只能靠用户手动点「立即重试」。sync 判断 + 后台 spawn,tick 不阻塞。
+        # 每 tick 驱动一次 omni 熔断器自动探测:OPEN_RECOVERABLE(backoff 到期)或
+        # OPEN_CONFIG(慢周期到期,防分类误判黑洞)时 spawn 一次后台 probe。无外部驱动时
+        # probe_due 归零后状态永远不动,provider 恢复后感知也不会自愈,只能靠用户手动点
+        # 「立即重试」。sync 判断 + 后台 spawn,tick 不阻塞。
         # 前置到 active_sources 判断之前:无摄像头联调 / 摄像头全部掉线场景下也要能自愈,
         # 否则 backoff 到期后 next_probe_at_monotonic 卡在过去、SSE 快照持续显示"0 秒后下次探测"。
-        # 非 OPEN_RECOVERABLE 时 try_arm_probe 零开销直接返 False,前置安全。
+        # CLOSED / HALF_OPEN 时 try_arm_probe 零开销直接返 False,前置安全。
         self._pipeline.drive_omni_probe()
 
         if not self._collector.get_all_active_sources():


### PR DESCRIPTION
## 问题 / Problem

真实事故(2026-07-29,本地推理环境):audio 路由的 `input_audio` 块缺 OpenAI 规范必填的 `format` 字段 → 严格校验的 OpenAI 兼容 server 连续返回 422 → 分类器把 422 判为 CONFIG 错("模型名或 API Key 可能有误")→ 熔断进入 **OPEN_CONFIG**——该状态短路一切且**永不自动探测**,只等配置变更或手动重试 → 感知静默停摆 2.5 小时,全程零重试。

A single malformed request class (422) tripped the breaker into OPEN_CONFIG, which never auto-probes — perception silently halted for 2.5h with zero retries. Any deployment hitting a strict OpenAI-compatible server (local mlx/vLLM etc.) can reproduce this.

## 三层修复 / Three-layer fix

1. **根因 / Root cause** — `build_audio_block` 补上 OpenAI 规范必填的 `format` 字段(宽松 provider 忽略多余字段,无副作用)。
2. **分类 / Classification** — 400/422 从 CONFIG 改判 RECOVERABLE:运行时语境下绝大多数是单次请求体问题(坏帧/媒体编码/缺字段),应走 backoff 自动探测;真·凭证/模型名错误主要由 401/403/404 分支覆盖,不受影响。
3. **逃生通道 / Escape hatch** — OPEN_CONFIG 增加慢速自动探测(`config_probe_interval_sec` 默认 300s,固定周期):保留"不拿注定失败的 key 反复打 provider"的设计初衷,但任何分类误判都不再造成永久黑洞。probe 失败仍为 CONFIG 时自动重排下一次;健康快照对 OPEN_CONFIG 也暴露下次探测倒计时(前端横条可显示)。

## 验证 / Verification

- 行为检查:422→RECOVERABLE;OPEN_CONFIG 有探测排期、到期放行、探通闭合、探败重排(5 项全过)。
- 实机:修复部署后感知即刻恢复,连续推理零 short-circuit;后又经历一次网络层故障(代理劫持),熔断按新逻辑自动恢复,无需人工干预。

🤖 Generated with [Claude Code](https://claude.com/claude-code)