### PR TITLE
fix: merge loopback/private ranges into NO_PROXY — system proxy must not hijack local calls

### DIFF
--- a/backend/miloco/src/miloco/main.py
+++ b/backend/miloco/src/miloco/main.py
@@ -19,6 +19,34 @@ from urllib.parse import parse_qsl, urlencode
 
 import uvicorn
 from dotenv import load_dotenv
+
+
+def _ensure_no_proxy_for_local() -> None:
+    """把回环 + 私网段并入 NO_PROXY,防系统代理劫持本地/局域网调用。
+
+    macOS 上 urllib.getproxies() 会读**系统级代理设置**(不只环境变量),Clash
+    Verge 等开启系统代理后,httpx(trust_env 默认 True)会把打 localhost:8080
+    (本地推理)、192.168.x(手机节点)的请求也送进代理,代理回连失败返 502 →
+    感知全灭(2026-07-29 实锅:15:07 起 local-gemma/local-qwen 全部 502)。
+    httpx 的 NO_PROXY 支持 hostname / IP / CIDR;云端(openrouter 等)不在列表,
+    照常走代理——在墙内访问云 API 恰恰需要它。setdefault 语义:尊重用户已设
+    条目,只追加缺失项。必须在任何 httpx client 创建前执行(import 早期)。
+    """
+    local_entries = [
+        "localhost",
+        "127.0.0.1",
+        "::1",
+        "10.0.0.0/8",
+        "172.16.0.0/12",
+        "192.168.0.0/16",
+    ]
+    for var in ("NO_PROXY", "no_proxy"):
+        existing = [e.strip() for e in os.environ.get(var, "").split(",") if e.strip()]
+        merged = existing + [e for e in local_entries if e not in existing]
+        os.environ[var] = ",".join(merged)
+
+
+_ensure_no_proxy_for_local()
 from fastapi import FastAPI, Request, Response
 from fastapi.responses import (
     FileResponse,

--- a/cli/src/miloco_cli/client.py
+++ b/cli/src/miloco_cli/client.py
@@ -6,12 +6,21 @@
 """
 
 import json
+import os
 import sys
 from typing import NoReturn
 
 import httpx
 
 from miloco_cli.config import load_config
+
+# 后端在 127.0.0.1:1810——macOS 上 httpx 会读**系统级代理设置**(urllib.getproxies),
+# Clash 等开系统代理后 CLI 打本机后端也被送进代理返 502。回环/私网并入 NO_PROXY
+# (httpx 支持 CIDR),与 backend main._ensure_no_proxy_for_local 同口径。
+for _var in ("NO_PROXY", "no_proxy"):
+    _existing = [e.strip() for e in os.environ.get(_var, "").split(",") if e.strip()]
+    _local = ["localhost", "127.0.0.1", "::1", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
+    os.environ[_var] = ",".join(_existing + [e for e in _local if e not in _existing])
 
 
 def _get_client(cfg: dict) -> httpx.Client:


### PR DESCRIPTION
## 问题 / Problem

macOS 上 `urllib.getproxies()` 会读取**系统级代理设置**(不仅是环境变量)。用户开启 Clash/Surge 等系统代理后,httpx(`trust_env` 默认 True)把 miloco 的本地调用也送进代理:

- backend → `localhost:8080/8081`(本地推理服务)→ 代理回连失败 → 502 → **感知全灭**;
- backend → `192.168.x`(手机/局域网算力节点)→ 同样被劫持;
- CLI → `127.0.0.1:1810`(后端 API)→ 502,所有命令不可用。

实锅(2026-07-29):用户开启系统代理后感知静默停摆近 1 小时,日志只有 502,shell 里 curl 一切正常(curl 不读系统代理),排查极具迷惑性。国内用户"本地跑 miloco + 代理访问云端 API"是常见组合,踩坑面广。

## 修复 / Fix

backend main 与 CLI client 的**进程启动早期**(任何 httpx client 创建之前)把回环 + RFC1918 私网段并入 `NO_PROXY`/`no_proxy`:

```
localhost, 127.0.0.1, ::1, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
```

- httpx 的 NO_PROXY 支持 hostname / IP / **CIDR**,私网段一并覆盖手机等局域网算力节点;
- 云端 API(openrouter 等)不在列表,照常走代理——墙内访问云端恰恰依赖它,不能一刀切 `trust_env=False`;
- 尊重用户已设条目,只追加缺失项(setdefault 语义)。

## 验证 / Verification

开启系统代理复现 502 后应用本修复:backend 对本地推理服务的调用恢复 200,感知恢复;CLI 全部命令恢复;云端档案(openrouter)照常经代理可达。

🤖 Generated with [Claude Code](https://claude.com/claude-code)