### PR TITLE
ci: PR AI 审查 job timeout 30 → 60 分钟

### DIFF
--- a/.github/workflows/pr-review-command.yml
+++ b/.github/workflows/pr-review-command.yml
@@ -72,7 +72,7 @@ jobs:
     needs: authorize
     if: needs.authorize.outputs.matched == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     container:
       image: ghcr.io/xiaomi/xiaomi-miloco/pr-review:trixie
       credentials:

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -23,7 +23,7 @@ jobs:
     # 审所有非草稿 PR（pull_request_target 下 fork 也可用 secrets）
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     container:
       image: ghcr.io/xiaomi/xiaomi-miloco/pr-review:trixie
       credentials:


### PR DESCRIPTION
## 问题

PR AI 审查（`pr-review.yml` 的「AI 审查并按严重度门禁」步骤）读整个 PR diff 评审，时长随 diff 增大。较大的 PR 一轮审查会超过 job 的 `timeout-minutes: 30`，被 GitHub 强制 cancel → 检查 fail（是**超时**、非发现问题），拿不到审查结论。`/review` 命令走的 `pr-review-command.yml` 同样 30 分钟、同一审查脚本，一样会超时。

## 改动

两个 review workflow 的 AI 审查 job `timeout-minutes: 30 → 60`：
- `.github/workflows/pr-review.yml`（pull_request_target 自动触发）
- `.github/workflows/pr-review-command.yml`（`/review` 命令触发）

## 说明

- 止血为主：给足余量让大 PR 的审查能跑完；审查时长仍随 diff 增长，治本是控制单 PR 体量。
- 只改 timeout，不动审查逻辑 / 门禁口径。

### 为什么 60 而不是 90

`.ci/pr-review-gate.sh` 主模型失败时会换备用模型从头再审一轮、两轮共用同一 job 时钟，故有「60 折半 = 30 仍不够」的顾虑。实测不成立：同一个 PR（#460，61 文件 / +6.8k 行）本轮审查 **8m54s** 跑完，此前撞 30 分钟是 AI 负载波动的特例，60 对单轮是 2 倍余量。

「两轮都跑满」只在「主模型故障 + 超大 PR」同时发生时出现，属罕见叠加、代价也只是重跑一次，不值得为此把上限翻倍。更精确的单轮预算（给每轮套 `timeout`）需同时按 exit code 124/137 拆分门禁描述，超出本 PR scope，留后续。
