### PR TITLE
fix(perception): share tracking ONNX sessions across cameras

### DIFF
--- a/backend/miloco/src/miloco/perception/engine/api.py
+++ b/backend/miloco/src/miloco/perception/engine/api.py
@@ -155,6 +155,7 @@ class PerceptionEngine(BasePerceptionEngine):
 
         # ============ tracking_service 构造参数缓存（懒加载 factory 复用）============
         self._tracking_mode = self._config.identity.tracking_service_mode
+        self._tracking_model_resources = None
         # 把 IdentityEngineConfig.sort 转成 sort.py 的 SortConfig（duck typing：字段同名）
         # 让 SortTracker 拿到 yaml 里的 max_age_sec / n_init / 等用户层配置
         from miloco.perception.engine.identity.sort import (
@@ -179,12 +180,20 @@ class PerceptionEngine(BasePerceptionEngine):
         if self._tracking_mode == "mock":
             self._tracking_service_kwargs = {}
         else:
+            from miloco.perception.engine.identity.model_resources import (
+                TrackingModelResources,
+            )
+
+            self._tracking_model_resources = TrackingModelResources(
+                use_gpu=self._config.identity.perception_use_gpu,
+            )
             common_kwargs = {
                 "model_dir": self._config.identity.perception_model_dir or None,
                 "use_gpu": self._config.identity.perception_use_gpu,
                 "input_width": self._config.identity.perception_input_width,
                 "input_height": self._config.identity.perception_input_height,
                 "fps": self._config.input.fps,   # SortTracker 用 fps 算 max_age_sec → 帧数
+                "model_resources": self._tracking_model_resources,
             }
             if self._tracking_mode == "deep_sort":
                 self._tracking_service_kwargs = {
@@ -396,7 +405,17 @@ class PerceptionEngine(BasePerceptionEngine):
                     self._config.identity.perception_model_dir or None,
                     "human_body_reid_v2.onnx",
                 )
-                inst = HumanReID(model_path=reid_path, use_gpu=False)
+                model_resources = getattr(self, "_tracking_model_resources", None)
+                reid_session = (
+                    model_resources.get_session(reid_path)
+                    if model_resources is not None
+                    else None
+                )
+                inst = HumanReID(
+                    model_path=reid_path,
+                    use_gpu=self._config.identity.perception_use_gpu,
+                    session=reid_session,
+                )
                 if inst.session is None:
                     # init() 内部已 catch+log 具体异常; 这里不缓存坏实例, 直接返 None
                     logger.warning(
@@ -699,6 +718,17 @@ class PerceptionEngine(BasePerceptionEngine):
                 await eng.close()
             except Exception as e:  # noqa: BLE001
                 logger.error("IdentityEngine.close for device=%s 失败：%s", did, e)
+        for svc in self._tracking_services.values():
+            svc.release()
+        self._tracking_services.clear()
+        self._deep_sort_trackers.clear()
+        fallback = self._fallback_human_reid
+        release_fallback = getattr(fallback, "release", None)
+        if callable(release_fallback):
+            release_fallback()
+        self._fallback_human_reid = None
+        if self._tracking_model_resources is not None:
+            self._tracking_model_resources.release()
 
     # ------------------------------------------------------------------
     # Suggestion 事件链表 / cooldown 管理

--- a/backend/miloco/src/miloco/perception/engine/identity/deep_sort.py
+++ b/backend/miloco/src/miloco/perception/engine/identity/deep_sort.py
@@ -55,6 +55,7 @@ class DeepSortTracker:
                    max_age_sec 是墙钟秒,各 fps 下一致生效(不再有 fps<=1 的特殊覆盖)。
         reid_model_path: ReID ONNX 路径;默认走 ``HumanReID`` 类内默认 path。
         use_gpu:   ReID 推理是否走 GPU(部署侧)。
+        reid_session: 可选的共享 ReID ONNX InferenceSession。
 
     track_human_only:由 update() 后置剔除,pet 类目标不进 tracks,只保留 HUMAN class。
     """
@@ -66,6 +67,7 @@ class DeepSortTracker:
         fps: int = 1,
         reid_model_path: str | None = None,
         use_gpu: bool = False,
+        reid_session=None,
     ) -> None:
         from miloco.perception.engine.config import DeepSortConfigDC
         from miloco.perception.engine.identity.tracker.config import TrackerConfig
@@ -80,9 +82,16 @@ class DeepSortTracker:
 
         # ReID(默认 v2 模型路径在 HumanReID 类内)
         if reid_model_path:
-            self._human_reid = HumanReID(model_path=reid_model_path, use_gpu=use_gpu)
+            self._human_reid = HumanReID(
+                model_path=reid_model_path,
+                use_gpu=use_gpu,
+                session=reid_session,
+            )
         else:
-            self._human_reid = HumanReID(use_gpu=use_gpu)
+            self._human_reid = HumanReID(
+                use_gpu=use_gpu,
+                session=reid_session,
+            )
 
         # 把 DeepSortConfigDC 业务字段映射到 TrackerConfig;其它字段
         # (max_cosine_distance / max_iou_distance / static_displacement_ratio /
@@ -114,6 +123,10 @@ class DeepSortTracker:
 
     def reset(self) -> None:
         self._mot.reset()
+
+    def release(self) -> None:
+        """Drop this camera wrapper's reference to the shared ReID session."""
+        self._human_reid.release()
 
     def set_fps(self, fps: int) -> None:
         """运行时更新 fps：重算 max_age 帧数并写穿到内部 MultiObjectTracker.config。

--- a/backend/miloco/src/miloco/perception/engine/identity/model_resources.py
+++ b/backend/miloco/src/miloco/perception/engine/identity/model_resources.py
@@ -1,0 +1,72 @@
+"""Engine-scoped shared ONNX sessions for camera tracking.
+
+Trackers contain mutable, camera-local state and must never be shared. The
+underlying detector and ReID ONNX sessions are immutable inference resources,
+however, and ONNX Runtime supports concurrent ``InferenceSession.run`` calls.
+Keeping them here lets every camera owned by one ``PerceptionEngine`` reuse the
+same native model weights and thread pools.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from pathlib import Path
+from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class TrackingModelResources:
+    """Lazily create and retain ONNX sessions for one perception engine."""
+
+    def __init__(
+        self,
+        *,
+        use_gpu: bool = False,
+        num_threads: int | None = None,
+    ) -> None:
+        self._use_gpu = use_gpu
+        self._num_threads = num_threads
+        self._sessions: dict[tuple[str, bool, int | None], Any] = {}
+        self._lock = threading.Lock()
+
+    def get_session(self, model_path: str):
+        """Return the shared session for ``model_path``, creating it once."""
+        resolved_path = str(Path(model_path).expanduser().resolve())
+        key = (resolved_path, self._use_gpu, self._num_threads)
+
+        # Camera pipelines can start concurrently. Cache access and the rare
+        # first load are serialized; inference itself remains fully concurrent.
+        # Keeping every cache access under the lock also makes release safe.
+        with self._lock:
+            session = self._sessions.get(key)
+            if session is None:
+                from miloco.perception.inference.ort_utils import make_session
+
+                session = make_session(
+                    resolved_path,
+                    use_gpu=self._use_gpu,
+                    num_threads=self._num_threads,
+                )
+                self._sessions[key] = session
+                _LOGGER.info(
+                    "created shared tracking ORT session #%d for %s",
+                    len(self._sessions),
+                    resolved_path,
+                )
+        return session
+
+    def release(self) -> None:
+        """Drop all engine-owned session references."""
+        with self._lock:
+            count = len(self._sessions)
+            self._sessions.clear()
+        if count:
+            _LOGGER.info("released %d shared tracking ORT session(s)", count)
+
+    @property
+    def session_count(self) -> int:
+        """Number of sessions retained (primarily for diagnostics)."""
+        with self._lock:
+            return len(self._sessions)

--- a/backend/miloco/src/miloco/perception/engine/identity/tracker/detector.py
+++ b/backend/miloco/src/miloco/perception/engine/identity/tracker/detector.py
@@ -6,7 +6,7 @@
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 import cv2
 import numpy as np
@@ -71,6 +71,7 @@ class Detector:
         conf_threshold: float = 0.5,
         iou_threshold: float = 0.7,
         use_gpu: bool = False,
+        session: Any | None = None,
     ):
         """
         初始化检测器
@@ -80,15 +81,18 @@ class Detector:
             conf_threshold: 置信度阈值
             iou_threshold: NMS的IoU阈值
             use_gpu: 是否使用GPU推理
+            session: 可选的共享 ONNX InferenceSession
         """
         self.model_path = model_path
         self.conf_threshold = conf_threshold
         self.iou_threshold = iou_threshold
 
         # 加载ONNX模型
-        from miloco.perception.inference.ort_utils import make_session
+        if session is None:
+            from miloco.perception.inference.ort_utils import make_session
 
-        self.session = make_session(self.model_path, use_gpu=use_gpu)
+            session = make_session(self.model_path, use_gpu=use_gpu)
+        self.session = session
 
         # 获取输入输出信息
         self.input_name = self.session.get_inputs()[0].name

--- a/backend/miloco/src/miloco/perception/engine/identity/tracker/human_reid.py
+++ b/backend/miloco/src/miloco/perception/engine/identity/tracker/human_reid.py
@@ -5,7 +5,7 @@
 """
 
 import logging
-from typing import List, Tuple
+from typing import Any, List, Tuple
 
 import cv2
 import numpy as np
@@ -31,6 +31,7 @@ class HumanReID:
         self,
         model_path: str = "models/human_body_reid_v2.onnx",
         use_gpu: bool = False,
+        session: Any | None = None,
     ):
         # v2 模型(10 MB)综合性能均优于旧版,且 input [1,3,192,96] BGR + output
         # head/out_emb:0 [1,1,1,128] + L2-norm 后处理与旧版完全一致,本类的
@@ -41,6 +42,7 @@ class HumanReID:
         Args:
             model_path: ONNX模型路径
             use_gpu: 是否使用GPU推理
+            session: 可选的共享 ONNX InferenceSession
         """
         self.net_h = 192
         self.net_w = 96
@@ -52,7 +54,12 @@ class HumanReID:
         self.output_name = None
         self.model_path = model_path
 
-        self.init(model_path, use_gpu)
+        if session is None:
+            self.init(model_path, use_gpu)
+        else:
+            self.session = session
+            self.input_name = session.get_inputs()[0].name
+            self.output_name = self.output_node
 
     def init(self, model_path: str, use_gpu: bool = False) -> bool:
         """

--- a/backend/miloco/src/miloco/perception/engine/identity/tracking_service.py
+++ b/backend/miloco/src/miloco/perception/engine/identity/tracking_service.py
@@ -80,6 +80,15 @@ class TrackingService(ABC):
     def reset_session(self) -> None:
         """重置跟踪会话状态，子类可按需实现。"""
 
+    def release(self) -> None:
+        """Release camera-local wrappers around shared model resources."""
+        tracker = getattr(self, "_tracker", None)
+        if tracker is not None and hasattr(tracker, "release"):
+            tracker.release()
+        detector = getattr(self, "_detector", None)
+        if detector is not None and hasattr(detector, "release"):
+            detector.release()
+
     def set_fps(self, fps: int) -> None:
         """运行时更新采样 fps：同步 ``_fps`` 并转调底层 tracker 的 set_fps。
 
@@ -125,6 +134,7 @@ class RealTrackingService(TrackingService):
         input_height: int = 720,
         sort_config=None,
         fps: int = 1,
+        model_resources=None,
     ):
         from miloco.perception.engine.identity.sort import SortConfig, SortTracker
         from miloco.perception.engine.identity.tracker.detector import Detector
@@ -134,7 +144,16 @@ class RealTrackingService(TrackingService):
         self._fps = fps
 
         det_path = self._resolve_model_path(model_dir, "det_4C.onnx")
-        self._detector = Detector(model_path=det_path, use_gpu=use_gpu)
+        det_session = (
+            model_resources.get_session(det_path)
+            if model_resources is not None
+            else None
+        )
+        self._detector = Detector(
+            model_path=det_path,
+            use_gpu=use_gpu,
+            session=det_session,
+        )
         # SortTracker 需要 fps 来把 SortConfig.max_age_sec 换算成 max_age_frames
         self._tracker = SortTracker(
             config=sort_config or SortConfig(),
@@ -198,6 +217,7 @@ class DeepSortTrackingService(TrackingService):
         input_height: int = 720,
         deep_sort_config=None,
         fps: int = 1,
+        model_resources=None,
     ):
         from miloco.perception.engine.config import DeepSortConfigDC
         from miloco.perception.engine.identity.deep_sort import DeepSortTracker
@@ -208,12 +228,30 @@ class DeepSortTrackingService(TrackingService):
         self._fps = fps
 
         det_path = RealTrackingService._resolve_model_path(model_dir, "det_4C.onnx")
-        self._detector = Detector(model_path=det_path, use_gpu=use_gpu)
+        det_session = (
+            model_resources.get_session(det_path)
+            if model_resources is not None
+            else None
+        )
+        self._detector = Detector(
+            model_path=det_path,
+            use_gpu=use_gpu,
+            session=det_session,
+        )
 
         cfg = deep_sort_config or DeepSortConfigDC()
         reid_path = (
             RealTrackingService._resolve_model_path(model_dir, "human_body_reid_v2.onnx")
             if model_dir else None
+        )
+        shared_reid_path = reid_path or RealTrackingService._resolve_model_path(
+            None,
+            "human_body_reid_v2.onnx",
+        )
+        reid_session = (
+            model_resources.get_session(shared_reid_path)
+            if model_resources is not None
+            else None
         )
         self._tracker = DeepSortTracker(
             detector=self._detector,
@@ -221,6 +259,7 @@ class DeepSortTrackingService(TrackingService):
             fps=fps,
             reid_model_path=reid_path,
             use_gpu=use_gpu,
+            reid_session=reid_session,
         )
 
     def analyze(self, frames: list[NDArray[np.uint8]], fps: int = 2) -> TrackingResponse:

--- a/backend/miloco/tests/perception/engine/identity/test_model_resources.py
+++ b/backend/miloco/tests/perception/engine/identity/test_model_resources.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from miloco.perception.engine.api import PerceptionEngine
+from miloco.perception.engine.identity.model_resources import TrackingModelResources
+from miloco.perception.engine.identity.tracking_service import (
+    DeepSortTrackingService,
+)
+
+
+def _session_for(model_path: str):
+    session = MagicMock(name=model_path)
+    if model_path.endswith("det_4C.onnx"):
+        session.get_inputs.return_value = [
+            SimpleNamespace(name="images", shape=[1, 3, 640, 640])
+        ]
+        session.get_outputs.return_value = [SimpleNamespace(name="output0")]
+    else:
+        session.get_inputs.return_value = [
+            SimpleNamespace(name="input", shape=[1, 3, 192, 96])
+        ]
+        session.get_outputs.return_value = [
+            SimpleNamespace(name="head/out_emb:0")
+        ]
+    return session
+
+
+def test_session_created_once_under_concurrent_first_access(monkeypatch, tmp_path):
+    created = []
+
+    def fake_make_session(model_path, **kwargs):
+        created.append((model_path, kwargs))
+        return _session_for(model_path)
+
+    monkeypatch.setattr(
+        "miloco.perception.inference.ort_utils.make_session",
+        fake_make_session,
+    )
+    resources = TrackingModelResources(use_gpu=True, num_threads=2)
+    model_path = str(tmp_path / "det_4C.onnx")
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        sessions = list(executor.map(resources.get_session, [model_path] * 32))
+
+    assert all(session is sessions[0] for session in sessions)
+    assert len(created) == 1
+    assert created[0][1] == {"use_gpu": True, "num_threads": 2}
+    assert resources.session_count == 1
+
+    resources.release()
+    assert resources.session_count == 0
+
+
+def test_two_cameras_share_sessions_but_not_trackers(monkeypatch, tmp_path):
+    created = []
+
+    def fake_make_session(model_path, **kwargs):
+        created.append(model_path)
+        return _session_for(model_path)
+
+    monkeypatch.setattr(
+        "miloco.perception.inference.ort_utils.make_session",
+        fake_make_session,
+    )
+    resources = TrackingModelResources()
+
+    first = DeepSortTrackingService(
+        model_dir=str(tmp_path),
+        model_resources=resources,
+    )
+    second = DeepSortTrackingService(
+        model_dir=str(tmp_path),
+        model_resources=resources,
+    )
+
+    assert first._detector.session is second._detector.session
+    assert first.tracker.human_reid.session is second.tracker.human_reid.session
+    assert first.tracker is not second.tracker
+    assert first.tracker._mot is not second.tracker._mot
+    assert len(created) == 2
+    assert resources.session_count == 2
+
+    first.release()
+    assert resources.session_count == 2
+    second.release()
+    resources.release()
+
+
+async def test_engine_close_releases_wrappers_before_shared_sessions():
+    events = []
+
+    class _IdentityEngine:
+        async def close(self):
+            events.append("identity")
+
+    class _TrackingService:
+        def release(self):
+            events.append("tracking")
+
+    class _Fallback:
+        def release(self):
+            events.append("fallback")
+
+    class _Resources:
+        def release(self):
+            events.append("resources")
+
+    engine = SimpleNamespace(
+        _tierc_clear_task=None,
+        _identity_engines={"cam": _IdentityEngine()},
+        _tracking_services={"cam": _TrackingService()},
+        _deep_sort_trackers={"cam": object()},
+        _fallback_human_reid=_Fallback(),
+        _tracking_model_resources=_Resources(),
+    )
+
+    await PerceptionEngine.close(engine)
+
+    assert events == ["identity", "tracking", "fallback", "resources"]
+    assert engine._tracking_services == {}
+    assert engine._deep_sort_trackers == {}
+    assert engine._fallback_human_reid is None

--- a/backend/miloco/tests/perception/engine/test_get_reid_extractor_fallback.py
+++ b/backend/miloco/tests/perception/engine/test_get_reid_extractor_fallback.py
@@ -20,8 +20,12 @@ def _fake_engine(model_dir: str) -> SimpleNamespace:
     return SimpleNamespace(
         _deep_sort_trackers={},
         _fallback_human_reid=None,
+        _tracking_model_resources=None,
         _config=SimpleNamespace(
-            identity=SimpleNamespace(perception_model_dir=model_dir),
+            identity=SimpleNamespace(
+                perception_model_dir=model_dir,
+                perception_use_gpu=False,
+            ),
         ),
     )
 
@@ -30,8 +34,10 @@ def test_fallback_uses_resolved_abs_path_and_caches(monkeypatch):
     captured = {}
 
     class _FakeHumanReID:
-        def __init__(self, model_path, use_gpu=False):
+        def __init__(self, model_path, use_gpu=False, session=None):
             captured["model_path"] = model_path
+            captured["use_gpu"] = use_gpu
+            captured["session"] = session
             self.session = object()  # 模拟加载成功
 
     monkeypatch.setattr(_HUMAN_REID, _FakeHumanReID)
@@ -41,6 +47,8 @@ def test_fallback_uses_resolved_abs_path_and_caches(monkeypatch):
 
     # 解析成 model_dir/文件名 的绝对路径, 不是 HumanReID 默认相对 "models/..."
     assert captured["model_path"] == "/models/human_body_reid_v2.onnx"
+    assert captured["use_gpu"] is False
+    assert captured["session"] is None
     # 成功实例被返回并缓存
     assert inst is not None
     assert eng._fallback_human_reid is inst
@@ -48,7 +56,7 @@ def test_fallback_uses_resolved_abs_path_and_caches(monkeypatch):
 
 def test_fallback_returns_none_and_not_cached_when_load_fails(monkeypatch):
     class _FakeHumanReID:
-        def __init__(self, model_path, use_gpu=False):
+        def __init__(self, model_path, use_gpu=False, session=None):
             self.session = None  # 模拟 make_session 失败被 init() 静默吞
 
     monkeypatch.setattr(_HUMAN_REID, _FakeHumanReID)
@@ -59,3 +67,28 @@ def test_fallback_returns_none_and_not_cached_when_load_fails(monkeypatch):
     # 加载失败 → 返 None、不缓存坏实例
     assert inst is None
     assert eng._fallback_human_reid is None
+
+
+def test_fallback_reuses_engine_session(monkeypatch):
+    shared_session = object()
+    captured = {}
+
+    class _FakeResources:
+        def get_session(self, model_path):
+            captured["resource_path"] = model_path
+            return shared_session
+
+    class _FakeHumanReID:
+        def __init__(self, model_path, use_gpu=False, session=None):
+            captured["session"] = session
+            self.session = session
+
+    monkeypatch.setattr(_HUMAN_REID, _FakeHumanReID)
+    eng = _fake_engine("/models")
+    eng._tracking_model_resources = _FakeResources()
+
+    inst = PerceptionEngine.get_reid_extractor(eng)
+
+    assert inst is not None
+    assert captured["resource_path"] == "/models/human_body_reid_v2.onnx"
+    assert captured["session"] is shared_session


### PR DESCRIPTION
## What changed

- add an engine-scoped `TrackingModelResources` pool that lazily creates one
  detector session and one ReID session
- inject those sessions into each camera's detector/ReID wrapper
- keep every camera's DeepSORT/SORT tracker, Kalman state, track IDs, and
  embedding history independent
- release camera-local wrappers before dropping the shared session references
- reuse the same ReID session for the registration fallback path

## Why

Each camera previously constructed its own detector and ReID
`onnxruntime.InferenceSession`. With multiple camera channels this duplicated
model weights, native thread pools, and allocator workspaces even though the
sessions are safe to use concurrently.

For three active camera channels, this changes the tracking model session count
from six to two without sharing mutable tracking state.

## Impact

In a three-camera deployment, warm RSS decreased from roughly 5.36 GiB to about
3.0 GiB (around 40–45%). CPU inference frequency is unchanged by this PR.

The resource pool is optional at the tracking-service API boundary, so existing
standalone construction and tests keep the previous behavior.

## Validation

- `cd backend && MILOCO_HOME=<isolated-dir> uv run pytest -q`
  - 2798 passed
- targeted model-resource and fallback tests
  - 6 passed
- Ruff on the affected identity modules and tests
- `ty` on the new production resource module

