### PR TITLE
chore: 根 .gitignore 忽略非 pnpm 锁文件

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,23 @@ node_modules
 .pnp
 .pnp.js
 
+# 非 pnpm 的锁文件：web/ 与 plugins/openclaw/ 两个 JS 项目都用 pnpm，pnpm-lock.yaml
+# 才是唯一锁文件。这类文件在本地是**预期产物**——没装 pnpm 时安装器会走 npm 回退
+# (plugins/hermes/install-hermes.sh 里 pnpm 优先、npm 兜底)——但不该进仓：同一目录下两份
+# 互相独立的依赖锁，会让本地 npm ci 与 CI 的 pnpm install --frozen-lockfile 解析出不同的
+# 传递依赖版本，出「我这儿是好的」类问题时极难定位；顺带也让走 npm 回退的贡献者不再因为
+# 它被 dependency-guard 拦下而困惑(package-lock.json 本就在那份 LOCKFILES 里)。
+# 放根目录而非各子项目：单点声明、不留「两份规则要同步」的隐性 invariant；根目录本身
+# 不是 npm 项目，无误伤。
+# 注：只有 package-lock.json 有实际出现记录；其余名字本仓库从未出现、也无对应工具链，
+# 一并列入只是零成本的宽度。bun 两个名字都写：bun.lock(1.2+ 文本格式，当前默认)与
+# bun.lockb(旧二进制)。
+package-lock.json
+npm-shrinkwrap.json
+yarn.lock
+bun.lock
+bun.lockb
+
 # Local env files
 .env
 .env.local


### PR DESCRIPTION
## 背景

`web/` 与 `plugins/openclaw/` 两个 JS 项目都用 pnpm（各有 `pnpm-lock.yaml`，CI 与 `scripts/build.sh` 都跑 `pnpm install --frozen-lockfile`）。

但仓库**自带一条设计好的 npm 回退路径**：用户没装 pnpm 时，安装器会在 `web/` 里跑 `npm install`（`plugins/hermes/install-hermes.sh:644-649`，pnpm 优先、npm 兜底）。所以 `web/package-lock.json` **不是误用产物，而是这条受支持路径的正常输出**——本地工作树里那个 110KB 的它（7 月 22 日，未跟踪、未被忽略，`git check-ignore` 确认畅通）大概就是这么来的。历史上 `web_ui/package-lock.json` 也真进过仓一次。

## 要解决什么

一句话：**这类锁文件在本地是预期的，但不该进仓**。两个具体后果：

1. **两份互相独立的依赖锁**：同一目录下 `pnpm-lock.yaml` 与 `package-lock.json` 并存，本地 `npm ci` 与 CI 的 `pnpm install --frozen-lockfile` 会解析出不同的传递依赖版本。表现是「我这儿是好的」，排查成本高，而 diff 上看只是多了个看起来无害的 lockfile。
2. **给走 npm 回退路径的贡献者省一次困惑**：`package-lock.json` 已在 `.ci/dependency-guard.mjs` 的 `LOCKFILES` 里，所以他 `git add -A` 后会撞上 CI 的依赖准入拦截、需要维护者评论 `/allow-dependencies-change` 放行——而他并没有真的想改依赖。让它压根不进索引，这次拦截就不会发生。

## 改动

只改根 `.gitignore`（+17 行，含说明注释）：

```gitignore
package-lock.json
npm-shrinkwrap.json
yarn.lock
bun.lock
bun.lockb
```

两个说明：

- **放根目录，不放各子项目**：两个 pnpm 项目在包管理器上同构，一处声明即同时覆盖两边（也覆盖将来新增的 JS 子项目），不留「两份规则要同步」的隐性约束。根目录本身不是 npm 项目（无 `package.json`），不会误伤合法的根级 lockfile。
- **只有 `package-lock.json` 有实际证据**（上面两处来源）。`npm-shrinkwrap.json` / `yarn.lock` / `bun.lock*` 在本仓库历史上**从未出现过**、也没有对应工具链——一并列入只是零成本的宽度（`.gitignore` 没有策略后果），并非针对已观察到的问题。若 reviewer 认为该收窄到单个名字，删掉其余四行即可。

**刻意没做**：不动 `.ci/dependency-guard.mjs` 的 `LOCKFILES`。给它补上 yarn/bun/shrinkwrap 属于**改 CI 准入策略**（将来谁真要加个 `yarn.lock` 就得维护者签字），而这几个名字在本仓库无任何出现记录——这种策略决定该由维护者单独拍，不该由一个清理游离文件的 chore PR 顺手带。

## 验证

`git check-ignore -v` 逐个核对 **3 个位置 × 5 个名字 = 15 种组合**，全部命中：

| 位置 | package-lock.json | npm-shrinkwrap.json | yarn.lock | bun.lock | bun.lockb |
|---|---|---|---|---|---|
| `web/` | ✅ | ✅ | ✅ | ✅ | ✅ |
| `plugins/openclaw/` | ✅ | ✅ | ✅ | ✅ | ✅ |
| 仓库根 | ✅ | ✅ | ✅ | ✅ | ✅ |

- 无误伤：`web/pnpm-lock.yaml`、`plugins/openclaw/pnpm-lock.yaml` 与仓库里的 `uv.lock` **均未被忽略、仍被 git 跟踪**
- 那个游离的 `web/package-lock.json` 已在本地删除；它从未入库，故不在本 PR diff 里
- 无代码改动，不影响构建与 CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
