### PR TITLE
fix(miot): 不再把缓存里的「上次已知值」当成设备的当前值端出去

### DIFF
--- a/backend/miloco/src/miloco/miot/client.py
+++ b/backend/miloco/src/miloco/miot/client.py
@@ -1262,10 +1262,20 @@ class MiotProxy:
             logger.error("Failed to set device properties: %s", e)
             raise
 
-    async def get_device_properties(self, params: list[MIoTGetPropertyParam]) -> list:
-        """Get device properties via MIoT cloud API."""
+    async def get_device_properties(
+        self, params: list[MIoTGetPropertyParam], datasource: int = 1
+    ) -> list:
+        """Get device properties via MIoT cloud API.
+
+        ``datasource=2`` reads through to the device instead of the cloud's cache;
+        see ``MIoTHttpClient.get_props_async`` for the measured trade-off. Callers
+        that use a reading as a *predicate* — "is the light on, so should I act?" —
+        want 2, because a cached reading cannot tell them it is stale.
+        """
         try:
-            return await self.miot_client.http_client.get_props_async(params)
+            return await self.miot_client.http_client.get_props_async(
+                params, datasource=datasource
+            )
         except Exception as e:
             logger.error("Failed to get device properties: %s", e)
             raise

--- a/backend/miloco/src/miloco/miot/service.py
+++ b/backend/miloco/src/miloco/miot/service.py
@@ -1012,12 +1012,40 @@ class MiotService:
                 MIoTGetPropertyParam(did=did, siid=siid, piid=piid)
                 for siid, piid in (_parse_prop_iid(iid) for iid in iids)
             ]
-            results = await self._miot_proxy.get_device_properties(params)
+            # 定点查询读真机,全量冷查询读缓存。
+            #
+            # 分档线复用上面已有的 user_specified,不新发明概念,而它恰好把两侧的需求
+            # 分开了:传了 iid 的调用方是在**拿这个值当判据**(「灯开着吗?那我该不该
+            # 播报」),它需要知道读数是不是活的;不传 iid 的是面板那种全量冷查询,
+            # WebUI 一屏 30+ 台同时打,那边的注释已写明会撞上 MiOT 约 10 QPS 的限频。
+            #
+            # 这条分档线是有事故支撑的:一条「主卧灯还亮着就播报睡眠提醒」的定时任务,
+            # 因为灯离线后缓存永远停在 on=true,在 00:00~02:30 每 30 分钟播报一次。
+            # 它的日志行是 `did: 1112398686, iid: prop.2.1` —— 传了 iid,所以走这一档
+            # 之后判据自然为假,那条任务一个字都不用改。
+            #
+            # 代价实测(真实账号,每台 15 属性中位):在线 167~249ms vs 缓存 61ms;
+            # 离线 67~90ms —— **不慢**,云端凭在线注册表秒拒,不等超时。
+            results = await self._miot_proxy.get_device_properties(
+                params, datasource=2 if user_specified else 1
+            )
             properties = [
                 {
                     "iid": f"prop.{r['siid']}.{r['piid']}",
                     "value": r.get("value"),
                     "code": r.get("code", 0),
+                    # 云端每一行状态属性都自带 updateTime(epoch 秒)——「这个值上次被
+                    # 写入的时刻」。此前这里把它丢掉了,于是一个 182 天前的读数与一个
+                    # 刚读到的读数在响应里完全同形。
+                    #
+                    # 原样透传、不做换算、不做判断:它是云端字段,不是我们的结论。
+                    # 缺失给 None 而不是 0 —— siid=1 那组静态设备信息(厂商/型号/序列号)
+                    # 本来就没有这个字段,给 0 会让调用方算出 56 年的年龄。
+                    #
+                    # **它不是「设备还活着吗」**:实测在线设备的缓存读数也可以很老
+                    # (净饮机 25.1 小时、三开开关 22.3 小时)—— 一个开关属性长期不变
+                    # 本来就正常。所以它只能做 as-of 注解,不能单独当陈旧闸门。
+                    "updated_at": r.get("updateTime"),
                 }
                 for r in results
             ]

--- a/backend/miloco/src/miloco/rule/runner.py
+++ b/backend/miloco/src/miloco/rule/runner.py
@@ -1331,10 +1331,21 @@ class RuleRunner:
         is_prop = action.iid.startswith("prop.")
 
         # Idempotent check: query current state, skip if already at target.
+        #
+        # **必须 datasource=2(读真机),不能读云端缓存。** 这里读到的值直接决定
+        # "要不要下发",而缓存对不可达的设备会返回**最后已知值 + code 0**,没有任何
+        # 标记可以分辨。最坏情况恰是最常见的:断电 → 缓存停在 on → 规则「开灯」
+        # 读到陈旧的 on → 判定"已在目标态" → 跳过。而这个 return 在**所有**
+        # _write_action_ledger 之前 —— 动作永久丢失,台账一行都不写,没有任何痕迹。
+        #
+        # 下面那句 `code == 0` 的判据**不需要改**:ds=2 下不可达设备由云端自己返回
+        # -704042011,条件不成立 → 照常下发 → 写失败正常落台账。单属性、离线秒拒
+        # (实测 +17ms),代价可忽略。
         if action.idempotent and is_prop and action.value is not None:
             try:
                 results = await self._miot_proxy.get_device_properties(
-                    [MIoTGetPropertyParam(did=action.did, siid=siid, piid=p_a_id)]
+                    [MIoTGetPropertyParam(did=action.did, siid=siid, piid=p_a_id)],
+                    datasource=2,
                 )
                 if results and results[0].get("code", -1) == 0:
                     if results[0].get("value") == action.value:

--- a/backend/miloco/tests/test_miot_read_through_batching.py
+++ b/backend/miloco/tests/test_miot_read_through_batching.py
@@ -1,0 +1,153 @@
+# Copyright (C) 2025 Xiaomi Corporation
+# This software may be used and distributed according to the terms of the Xiaomi Miloco License Agreement.
+
+"""``datasource=2`` 的批量悬崖 —— 见 ``miot.cloud.READ_THROUGH_MAX_PROPS_PER_REQ``。
+
+读真机是**全或无**的:一次请求里的属性数超过该设备能在约 4.2 秒内答完的数量,
+整批返回 ``-704220043`` 且不带 ``updateTime``。于是一台健康在线的设备会被整台
+报成"读不到" —— 把一个响亮的假阳性换成了一个安静的**假阴性**,正是这条修复要
+避免的方向。而 ``GET /devices/{did}/status?iid=`` 收逗号分隔的多个 iid,真实家里
+33 台设备中有 11 台可读属性 ≥15 个,一次点名就能踩上去。
+
+用例测的是 ``miot`` 包(``backend/miot``),文件却放在这里:``backend/pyproject.toml``
+的 ``norecursedirs = ["miot", ...]`` 把 ``backend/miot/tests`` 整个排除在收集之外
+(那边是要真账号 OAuth 的联调用例),放过去等于不跑。
+"""
+
+import pytest
+from miot.cloud import READ_THROUGH_MAX_PROPS_PER_REQ, MIoTHttpClient
+from miot.types import MIoTGetPropertyParam
+
+# 超时那批整批返回的码,仓库码表里渲染成「属性值不正确」。
+_CLIFF_CODE = -704220043
+
+
+def _params(n: int) -> list[MIoTGetPropertyParam]:
+    """n 个互不相同的属性,piid 从 1 递增 —— 用来验证顺序。"""
+    return [MIoTGetPropertyParam(did="dev1", siid=2, piid=i + 1) for i in range(n)]
+
+
+def _echo(data: dict, code: int = 0) -> dict:
+    """云端的正常返回形状:逐属性一行,原样回 did/siid/piid。"""
+    return {
+        "result": [
+            {
+                "did": p["did"],
+                "siid": p["siid"],
+                "piid": p["piid"],
+                # value 取 piid,好让"顺序错了"这件事在断言里现形
+                "value": p["piid"],
+                "code": code,
+                **({"updateTime": 1785408130} if code == 0 else {}),
+            }
+            for p in data["params"]
+        ]
+    }
+
+
+def _make_client(responder):
+    """构造一个 HTTP 往返被替换掉的 client;``responder(data) -> res_obj``。
+
+    卡的接缝是 ``__mihome_api_post_async``(一次 HTTP 往返),不是更上层的封装 ——
+    要验的正是"发出去几个请求、每个请求里装了几个属性"。私有方法被 name mangling
+    改了名,所以这里用改名后的属性名遮蔽它。
+    """
+    client = MIoTHttpClient(cloud_server="cn", access_token="token")
+    calls: list[dict] = []
+
+    async def _post(url_path: str, data: dict, **kwargs):
+        calls.append(data)
+        return responder(data)
+
+    setattr(client, "_MIoTHttpClient__mihome_api_post_async", _post)
+    return client, calls
+
+
+@pytest.mark.asyncio
+async def test_read_through_is_split_below_the_cliff():
+    """超过 chunk 的点名查询必须**全部成功返回**,而不是整批栽掉。
+
+    实测悬崖因设备而异(空调 14→15,净化器/洗衣机 16→20),所以分批值取的是
+    最低那条的一半;这里只钉住"确实按 chunk 拆了、每个属性恰好被问一次"。
+    """
+    params = _params(42)
+    client, calls = _make_client(_echo)
+
+    out = await client.get_props_async(params, datasource=2)
+
+    assert [len(c["params"]) for c in calls] == [8, 8, 8, 8, 8, 2]
+    assert all(c["datasource"] == 2 for c in calls), "每一批都得照样是读真机"
+    asked = [(p["siid"], p["piid"]) for c in calls for p in c["params"]]
+    assert asked == [(p.siid, p.piid) for p in params], "每个属性恰好被问一次,不重不漏"
+    assert len(out) == 42
+    assert all(r["code"] == 0 for r in out)
+
+
+@pytest.mark.asyncio
+async def test_batched_results_keep_request_order():
+    """调用方按 iid 对号,分批不能打乱顺序。"""
+    params = _params(20)
+    client, _ = _make_client(_echo)
+
+    out = await client.get_props_async(params, datasource=2)
+
+    assert [(r["siid"], r["piid"]) for r in out] == [(p.siid, p.piid) for p in params]
+    assert [r["value"] for r in out] == list(range(1, 21))
+
+
+@pytest.mark.asyncio
+async def test_one_failed_batch_does_not_take_the_others_down():
+    """中间一批栽了,后面的批照发,而且那批的错误码**原样返回**。
+
+    不吞掉、也不改写:只有云端真的返回过的码才算失败(#394),在本地合成或抹掉
+    都会让调用方失去"这几个属性到底怎么了"的唯一线索。
+    """
+    params = _params(24)
+
+    def responder(data: dict) -> dict:
+        # 第 2 批(piid 9..16)整批超时
+        if data["params"][0]["piid"] == 9:
+            return _echo(data, code=_CLIFF_CODE)
+        return _echo(data)
+
+    client, calls = _make_client(responder)
+    out = await client.get_props_async(params, datasource=2)
+
+    assert len(calls) == 3, "中间那批失败不该让第 3 批发不出去"
+    assert [r["code"] for r in out] == [0] * 8 + [_CLIFF_CODE] * 8 + [0] * 8
+    assert len(out) == 24, "失败的批也要占位返回,不能悄悄少几行"
+    assert all("updateTime" not in r for r in out[8:16]), "超时那批本来就没有 updateTime"
+
+
+@pytest.mark.asyncio
+async def test_cache_reads_are_not_split():
+    """``ds=1`` 读云端缓存,没有这个悬崖(实测 15 个属性 61ms)。
+
+    把它也拆细只会白白把面板那种全量冷查询变慢,还更容易撞上 MiOT 约 10 QPS 的限频。
+    """
+    client, calls = _make_client(_echo)
+
+    await client.get_props_async(_params(150))
+
+    assert len(calls) == 1
+    assert calls[0]["datasource"] == 1
+    assert len(calls[0]["params"]) == 150
+
+
+@pytest.mark.asyncio
+async def test_short_read_through_stays_a_single_request():
+    """不到一批的点名查询不该平白多花一次往返。"""
+    client, calls = _make_client(_echo)
+
+    await client.get_props_async(_params(READ_THROUGH_MAX_PROPS_PER_REQ), datasource=2)
+
+    assert len(calls) == 1
+
+
+def test_chunk_size_stays_below_the_lowest_measured_cliff():
+    """实测最低的一条悬崖在空调上:14 个属性成功,15 个整批返回 -704220043。
+
+    悬崖位置因设备而异,而云端不给上限,所以这个值只能靠实测兜底 —— 谁要往上调,
+    先去重测最慢的那台设备。
+    """
+    assert 1 <= READ_THROUGH_MAX_PROPS_PER_REQ <= 14

--- a/backend/miloco/tests/test_miot_service_lru.py
+++ b/backend/miloco/tests/test_miot_service_lru.py
@@ -138,3 +138,76 @@ async def test_lru_failure_does_not_break_control(tmp_path, monkeypatch):
     req = DeviceControlRequest(type="set_property", iid="prop.2.1", value=True)
     result = await svc.control_device("dev1", req)
     assert "results" in result
+
+
+# ── 陈旧读数 ──────────────────────────────────────────────────────────────
+#
+# 云端对不可达设备返回**最后已知值 + code 0**,响应里没有任何一处承认存疑。
+# 实测真实账号上的读数年龄:离线加湿器 182.4 天、离线驱蚊器 21.1 天,而**在线**的
+# 净饮机也有 25.1 小时 —— 所以「在线/离线」不是正确的判据轴,「多老」才是。
+#
+# 后果是有事故的:一条「主卧灯还亮着就播报睡眠提醒」的定时任务,因为灯离线后缓存
+# 永远停在 on=true,00:00~02:30 每 30 分钟朝卧室音箱播报一次。
+
+
+@pytest.mark.asyncio
+async def test_targeted_query_reads_through_to_the_device(tmp_path):
+    """传了 iid = 调用方在**拿这个值当判据**,必须读真机。
+
+    读缓存的话它拿到的是一个自称成功、实则可能几个月前的值,而响应里没有任何
+    线索能让它分辨。事故那条定时任务的日志行正是 `iid: prop.2.1` —— 走这一档
+    之后,离线设备由云端自己返回 -704042011,判据自然为假。
+    """
+    svc, _ = _make_service(tmp_path)
+    await svc.get_device_status("dev1", ["prop.2.1"])
+    assert svc._miot_proxy.get_device_properties.await_args.kwargs["datasource"] == 2
+
+
+@pytest.mark.asyncio
+async def test_full_cold_query_stays_on_the_cheap_cache(tmp_path):
+    """不传 iid = 面板那种全量冷查询。WebUI 一屏 30+ 台同时打,那边的注释已写明
+    会撞上 MiOT 约 10 QPS 的限频 —— 必须留在便宜的缓存读上。"""
+    svc, _ = _make_service(tmp_path)
+    await svc.get_device_status("dev1", None)
+    assert svc._miot_proxy.get_device_properties.await_args.kwargs["datasource"] == 1
+
+
+@pytest.mark.asyncio
+async def test_update_time_is_passed_through(tmp_path):
+    """云端每一行状态属性都带 updateTime。此前这里把它丢掉了,于是一个 182 天前的
+    读数与一个刚读到的读数在响应里完全同形。"""
+    svc, _ = _make_service(tmp_path)
+    svc._miot_proxy.get_device_properties.return_value = [
+        {"siid": 2, "piid": 1, "value": True, "code": 0, "updateTime": 1769919538}
+    ]
+    out = await svc.get_device_status("dev1", ["prop.2.1"])
+    assert out["properties"][0]["updated_at"] == 1769919538
+
+
+@pytest.mark.asyncio
+async def test_missing_update_time_is_none_not_zero(tmp_path):
+    """siid=1 那组静态设备信息(厂商/型号/序列号)本来就没有这个字段。
+    给 0 会让调用方算出 56 年的年龄,比不给更糟。"""
+    svc, _ = _make_service(tmp_path)
+    svc._miot_proxy.get_device_properties.return_value = [
+        {"siid": 1, "piid": 1, "value": "xiaomi", "code": 0}
+    ]
+    out = await svc.get_device_status("dev1", ["prop.1.1"])
+    assert out["properties"][0]["updated_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_cloud_reported_codes_are_not_rewritten(tmp_path):
+    """**不伪造 code。** 离线设备的返回是混合体:同一次查询里既有缓存命中的
+    `code:0`,也有云端自己报的 `-704042011`(实测电饭煲 15 个属性里 4 个如此)。
+    在后端合成一个码会覆盖掉云端逐属性给出的真实结果,也正撞 #394 的立意
+    (只有云端返回的负码才算失败,本地不许凭空判定)。
+    """
+    svc, _ = _make_service(tmp_path)
+    svc._miot_proxy.get_device_properties.return_value = [
+        {"siid": 2, "piid": 1, "value": 4, "code": 0, "updateTime": 1785408130},
+        {"siid": 2, "piid": 17, "value": None, "code": -704042011},
+    ]
+    props = (await svc.get_device_status("dev1", ["prop.2.1", "prop.2.17"]))["properties"]
+    assert [p["code"] for p in props] == [0, -704042011]
+    assert [p["value"] for p in props] == [4, None]

--- a/backend/miloco/tests/test_rule.py
+++ b/backend/miloco/tests/test_rule.py
@@ -499,6 +499,46 @@ class TestRuleRunnerActionExecution:
         mock_miot_proxy.set_device_properties.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_idempotent_precheck_reads_through_to_the_device(
+        self, runner, mock_miot_proxy
+    ):
+        """幂等预检**不能**读云端缓存。
+
+        缓存对不可达的设备返回「最后已知值 + code 0」,没有任何标记可以分辨。
+        最坏情况恰是最常见的:断电 → 缓存停在 on → 规则「开灯」读到陈旧的 on →
+        判定"已在目标态" → 跳过。而这个 return 在**所有** _write_action_ledger
+        之前 —— 动作永久丢失,台账一行都不写,没有任何痕迹。
+        """
+        mock_miot_proxy.get_device_properties = AsyncMock(
+            return_value=[{"code": 0, "value": True}]
+        )
+        action = _make_action(value=True, idempotent=True)
+        rule = _make_static_rule(rule_id="rule-ds", name="ds", actions=[action])
+        runner.add_rule(rule)
+        await runner.trigger_rule("rule-ds", TRIGGER_CONTEXT)
+        assert mock_miot_proxy.get_device_properties.await_args.kwargs["datasource"] == 2
+
+    @pytest.mark.asyncio
+    async def test_unreachable_device_is_not_mistaken_for_already_at_target(
+        self, runner, mock_miot_proxy
+    ):
+        """设备不可达时**照常下发**,由写路径去失败并落台账。
+
+        这是上一条的另一面:ds=2 下云端自己返回 -704042011,已有的 `code == 0`
+        判据自然不成立。断电的灯不会被当成"已经开着了"而永久跳过。
+        """
+        mock_miot_proxy.get_device_properties = AsyncMock(
+            return_value=[{"code": -704042011, "value": None}]
+        )
+        action = _make_action(value=True, idempotent=True)
+        rule = _make_static_rule(rule_id="rule-off", name="off", actions=[action])
+        runner.add_rule(rule)
+
+        result = await runner.trigger_rule("rule-off", TRIGGER_CONTEXT)
+        assert result.action_results[0].skipped is not True, "不可达 ≠ 已在目标态"
+        mock_miot_proxy.set_device_properties.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_idempotent_executes_when_not_at_target(
         self, runner, mock_miot_proxy
     ):

--- a/backend/miot/src/miot/cloud.py
+++ b/backend/miot/src/miot/cloud.py
@@ -846,11 +846,37 @@ class MIoTHttpClient:
                 _LOGGER.error("unknown sub devices, %s, %s", did, parent_did)
         return results
 
-    async def get_props_async(self, params: List[MIoTGetPropertyParam]) -> List:
-        """Get props."""
+    async def get_props_async(
+        self, params: List[MIoTGetPropertyParam], datasource: int = 1
+    ) -> List:
+        """Get props.
+
+        ``datasource`` selects where the cloud reads from. It used to be hardcoded
+        to 1 with no comment; measured semantics:
+
+        - ``1`` — the cloud's cached copy. Cheap (~61ms regardless of how many
+          properties are asked for) but returns the last known value with
+          ``code: 0`` even when the device is unreachable, with nothing in the
+          response to say so. Observed ages on a real home: 25 hours for an
+          *online* water purifier, 182 days for an offline humidifier.
+        - ``2`` — read through to the device. The cloud answers offline devices
+          itself with ``-704042011`` instead of a stale value, and refreshes
+          ``updateTime`` for online ones.
+
+        Cost, measured on a real account (15 properties per device, median):
+        online 167–249ms vs 61ms for ``ds=1``; offline 67–90ms — *not* slower,
+        because the cloud rejects from its own registry rather than waiting for a
+        timeout. 30 devices concurrently: 290ms at ``ds=2`` vs 356ms at ``ds=1``,
+        no rate limiting hit.
+
+        Default stays 1 so existing callers are unchanged.
+        """
         res_obj = await self.__mihome_api_post_async(
             url_path="/app/v2/miotspec/prop/get",
-            data={"datasource": 1, "params": [param.model_dump() for param in params]},
+            data={
+                "datasource": datasource,
+                "params": [param.model_dump() for param in params],
+            },
         )
         if "result" not in res_obj:
             raise MIoTHttpError("invalid response result")

--- a/backend/miot/src/miot/cloud.py
+++ b/backend/miot/src/miot/cloud.py
@@ -53,6 +53,30 @@ _LOGGER = logging.getLogger(__name__)
 
 TOKEN_EXPIRES_TS_RATIO = 0.7
 
+# ── datasource=2 的批量悬崖 ──────────────────────────────────────────────────
+#
+# ``datasource=2`` 是真正的设备侧读回,服务端有约 **4.2 秒**的截止时间,而且是
+# **全或无**:一次请求里的属性数超过该设备能在时限内答完的数量时,**整批**返回
+# ``-704220043``(码表里渲染成「属性值不正确」)且不带 ``updateTime`` —— 一台
+# 健康在线的设备会被整台报成"读不到"。
+#
+# 悬崖位置**因设备而异**、但对同一台设备是确定性的(重复扫边界结果一致):
+#
+#     空调    14 个 ok(369ms) → 15 个整批 -704220043(4374ms)
+#     净化器  16 个 ok(857ms) → 20 个整批 -704220043(4739ms)
+#     洗衣机  16 个 ok(368ms) → 20 个整批 -704220043(4179ms)
+#
+# 也就是说云端没有一个可以照抄的固定上限,只能取一个低于最慢设备的保守值。
+#
+# 取 8 —— 实测最低的那条悬崖(空调 15)的一半,给设备状态差时留余量。同一台空调
+# 42 个属性:一次问完 4198ms 后整批失败,按 8 分批则全部返回 ``code 0``
+# (实测 1.8~5.2s,视设备当时的响应速度)。分批比不分批**更快** —— 注定要失败的
+# 那次请求会把 4.2 秒的截止时间烧满。
+#
+# ``datasource=1`` 读的是云端缓存,不受此限(实测 15 个属性 61ms),所以**只有
+# 读真机这条路分批**;把批量拆细会白白拖慢面板那种全量冷查询。
+READ_THROUGH_MAX_PROPS_PER_REQ = 8
+
 
 class MIoTOAuth2Client:
     """OAuth2 agent url, default: product env."""
@@ -869,8 +893,33 @@ class MIoTHttpClient:
         timeout. 30 devices concurrently: 290ms at ``ds=2`` vs 356ms at ``ds=1``,
         no rate limiting hit.
 
+        ``ds=2`` is additionally sent in batches of
+        ``READ_THROUGH_MAX_PROPS_PER_REQ`` — see that constant for why. Results
+        are concatenated in request order, so callers can keep matching them up
+        positionally. ``ds=1`` is sent as a single request, unchanged.
+
         Default stays 1 so existing callers are unchanged.
         """
+        if datasource == 1 or len(params) <= READ_THROUGH_MAX_PROPS_PER_REQ:
+            return await self.__get_props_once_async(params, datasource)
+
+        # 顺序发,不并发。并发对同一台设备开 6 路读回既加重设备负担,也更容易撞上
+        # MiOT 约 10 QPS 的限频;而顺序分批本来就比"一次问完然后整批失败"更快。
+        #
+        # **一批失败不牵连其它批**:超时那批由云端自己回 -704220043,它是正常返回、
+        # 不抛异常,原样并进结果里 —— 不吞掉、也不改写(#394:只有云端真的返回过的
+        # 码才算失败)。传输层异常则照常上抛:那意味着"没读到",而这条路的全部意义
+        # 就是不让"没读到"打扮成一个读数;悄悄少几行比整体失败危险得多。
+        results: List = []
+        for i in range(0, len(params), READ_THROUGH_MAX_PROPS_PER_REQ):
+            chunk = params[i : i + READ_THROUGH_MAX_PROPS_PER_REQ]
+            results.extend(await self.__get_props_once_async(chunk, datasource))
+        return results
+
+    async def __get_props_once_async(
+        self, params: List[MIoTGetPropertyParam], datasource: int
+    ) -> List:
+        """One /miotspec/prop/get round trip. No batching, no retry."""
         res_obj = await self.__mihome_api_post_async(
             url_path="/app/v2/miotspec/prop/get",
             data={

--- a/cli/src/miloco_cli/commands/device.py
+++ b/cli/src/miloco_cli/commands/device.py
@@ -2,6 +2,7 @@
 
 import json
 import sys
+import time
 
 import click
 
@@ -469,9 +470,19 @@ def device_status(did, iids, pretty):
                 iid_to_key = _resolve_keys_for_device(spec)
             except Exception:
                 iid_to_key = {}
+            now = int(time.time())
             for p in props:
                 if isinstance(p, dict) and p.get("iid"):
                     p["spec_name"] = iid_to_key.get(p["iid"], p["iid"])
+                    # 后端透传的 updated_at 是 epoch 秒(云端字段)。读它的主要是
+                    # agent,而 agent 读 1769919538 得不出任何结论 —— 换算成"多少秒前"
+                    # 才有用。**保留原字段**,不做破坏性替换。
+                    #
+                    # 缺失时不补:siid=1 那组静态设备信息本来就没有这个字段,
+                    # 补一个 age 会让它看起来像"56 年没更新过"。
+                    ts = p.get("updated_at")
+                    if isinstance(ts, int) and ts > 0:
+                        p["age_s"] = max(0, now - ts)
     _annotate_result_codes(data)
     print_result(data, pretty)
 

--- a/cli/tests/test_commands.py
+++ b/cli/tests/test_commands.py
@@ -2405,3 +2405,44 @@ def test_scope_camera_list_shows_composite_did(runner):
     data = json.loads(result.output)["data"]
     assert [r["did"] for r in data] == ["solo", "dual:ch0", "dual:ch1"]
     assert all("channel" not in r and "channel_count" not in r for r in data)
+
+
+# ── 读数新鲜度 ────────────────────────────────────────────────────────────
+
+
+def test_device_props_reports_reading_age(runner, fake_home_info):
+    """agent 读 epoch 秒得不出任何结论,换算成"多少秒前"才有用。
+
+    这是事故的近因之一:调用方拿到一个自称成功的读数,而响应里没有任何线索
+    告诉它这个值可能是几天前的。
+    """
+    import time as _t
+
+    now = int(_t.time())
+    with patch("miloco_cli.client.api_get") as mock:
+        mock.return_value = {
+            "code": 0,
+            "data": {"properties": [
+                {"iid": "prop.2.1", "value": True, "code": 0, "updated_at": now - 3600},
+            ]},
+        }
+        result = runner.invoke(cli, ["device", "props", "lamp_001"])
+    assert result.exit_code == 0
+    p = json.loads(result.output)["data"]["properties"][0]
+    assert p["updated_at"] == now - 3600, "原字段必须保留,不做破坏性替换"
+    assert 3590 <= p["age_s"] <= 3610
+
+
+def test_device_props_omits_age_without_a_timestamp(runner, fake_home_info):
+    """siid=1 那组静态设备信息(厂商/型号/序列号)本来就没有这个字段。
+    补一个 age 会让它看起来像"56 年没更新过"。"""
+    with patch("miloco_cli.client.api_get") as mock:
+        mock.return_value = {
+            "code": 0,
+            "data": {"properties": [
+                {"iid": "prop.2.1", "value": "xiaomi", "code": 0, "updated_at": None},
+            ]},
+        }
+        result = runner.invoke(cli, ["device", "props", "lamp_001"])
+    assert result.exit_code == 0
+    assert "age_s" not in json.loads(result.output)["data"]["properties"][0]

--- a/plugins/skills/miloco-devices/SKILL.md
+++ b/plugins/skills/miloco-devices/SKILL.md
@@ -176,7 +176,8 @@ miloco-cli device control 4912 --set brightness 30 --set on true ; miloco-cli de
 | ---- | ---- | ---- |
 | 设备不在目录 | `device list \| grep` 拉全量再搜（别省） | （静默） |
 | 设备未找到 | `device refresh` → 重试一次 | "没找到，正在刷新…" |
-| 设备离线 | **照常下命令**，CLI 返回体 `results[]`/`result` 的 `code_msg` 会标"设备离线" | "{设备名}离线了" |
+| 设备离线（**控制**） | **照常下命令**，CLI 返回体 `results[]`/`result` 的 `code_msg` 会标"设备离线" | "{设备名}离线了" |
+| **读到的属性值可能是旧的** | `props` 返回体每条带 `updated_at`（该值上次被写入的时刻）。**要把读数当事实告诉用户、或拿它当判断依据时，先看这个时间**——不能只看"没报错" | "灯的状态还是3天前的，现在读不到" |
 | 设备侧执行失败 | 看返回体 `results[]`/`result` 的 `code_msg` 中文原因（属性不可写 / 属性不存在 / 属性值不正确等）→ 据此回复或改对重发 | "{设备名}该属性不可写" |
 | 参数越界 | CLI 报 `out of range [min,max;step] <unit>` → 按范围改对 | "亮度范围1-100" |
 | 枚举值非法 | CLI 报 `not a valid enum; allowed: …` → 从列出的可选值里挑对的重发 | "风速可选 自动/1-8 档" |
@@ -190,7 +191,8 @@ miloco-cli device control 4912 --set brightness 30 --set on true ; miloco-cli de
 1. **`spec_name` / action `iid` 不硬编码**——以 catalog / `device spec` 为准（`@` 后缀、`play-text` 等因设备而异）。
 2. **安全设备控制必须二次确认**——门锁/摄像头/燃气阀/烟雾报警器（步骤5）。
 3. **控制非 on 属性强制补该设备实际开关 spec_name**（并入同一条 `--set`，可能 `on@空调`，非字面 `on`）——不查不分轮（步骤4）。
-4. **离线设备照常下命令**——由 CLI 兜底。
+4. **离线设备照常下命令**——由 CLI 兜底。**仅限控制路径**：`control` / `action` 发出去、由设备侧回执告诉你成不成。
+5. **读数不等于现状**——`device props` 对不可达的设备可能返回**最后已知值**且 `code: 0`。判据类查询（"灯还开着吗？那我要不要提醒"）必须看 `updated_at`，或先确认设备在线；单看"调用成功"会拿到一个几天前甚至几个月前的值当成现在。
 
 ## 边界
 


### PR DESCRIPTION
Closes #484

## 一句话根因

**每一层存的都是「上次已知值」,端出去时却按「当前值」的形状呈现** —— 于是「没读到设备」和「设备就是这个值」在数据上不可区分。

事故:一条「主卧灯还亮着就播报睡眠提醒」的定时任务,在灯离线后 00:00~02:30 每 30 分钟朝卧室音箱播报一次,把睡着的人吵醒。灯的读数是 `{"value": true, "code": 0}`,响应里没有一处承认存疑。当晚 6/6 条可解析的 agent trajectory 都先看到 `offline`、都复述了 offline,然后照样相信读数 —— 不是没判断,是判断了、判反了。

**读设备状态在语义上是一次请求,不是一次查表**:结果有三态 —— 开、关、读不到。今天的实现把第三态折叠进了前两态。

## 改了什么

**1. `datasource` 从硬编码提成参数**(`backend/miot/src/miot/cloud.py`)。此前 `{"datasource": 1}` 硬编码、无注释。实测:`1` 读云端缓存,对不可达设备返回**最后已知值 + code 0**;`2` 读真机,不可达设备由**云端自己**返回 `-704042011`。默认仍是 1,现有调用方零变化。

**2. 定点查询读真机,全量冷查询读缓存**(`miot/service.py`)。分档线复用已有的 `user_specified`:传了 `iid` 的调用方是在**拿这个值当判据**,它需要知道读数活不活;不传 iid 的是面板那种全量冷查询,WebUI 一屏 30+ 台同时打,那边的注释已写明会撞上 MiOT 约 10 QPS 限频。事故那条定时任务的日志行是 `iid: prop.2.1`,走这一档之后判据自然为假,任务一个字都不用改。

**3. 幂等预检必须读真机**(`rule/runner.py`)。这是本仓库内更隐蔽的一处:缓存的陈旧值 == 目标值 → 报「已在目标态」跳过,而这个 return 在**所有** `_write_action_ledger` 之前 —— 断电后灯的缓存停在 `on`,一条「开灯」规则读到陈旧的 `on` 就永久跳过,台账一行都不写。ds=2 下云端返回 `-704042011`,已有的 `code == 0` 判据无需改动。

**4. 透出云端的 `updateTime`**(`miot/service.py`,CLI 换算 `age_s`)。云端每一行状态属性都带 `updateTime`,此前被丢弃 —— 于是一个 182 天前的读数与一个刚读到的读数在响应里完全同形。原样透传、不做换算;缺失给 `null` 而非 0(`siid=1` 静态元数据本就没有这个字段,给 0 会让调用方算出 56 年)。**它是 as-of 注解,不是「设备还活着吗」** —— 实测在线设备的读数也可以很老(净饮机 25.1 小时)。

**5. `SKILL.md` 收窄离线口径**。「离线设备照常下命令」被限定到**控制路径**,并补了查询侧规则。文档是事故的近因,不改会把前面几条抵消掉。

## 6. `ds=2` 的批量悬崖(第二个提交)

读真机是**全或无**的,有约 4.2s 的服务端截止时间。一次请求的属性数超过该设备能在时限内答完的数量,**整批**返回 `-704220043` 且不带 `updateTime` —— 一台健康在线的设备被整台报成「读不到」,**把响亮的假阳换成静默的假阴**,正是这个 PR 要避免的方向。

悬崖位置因设备而异、但对同一台设备是确定的(实测,重复扫边界一致):

```
空调    14 个 ok(369ms) → 15 个整批失败(4374ms)
净化器  16 个 ok(857ms) → 20 个整批失败(4739ms)
洗衣机  16 个 ok(368ms) → 20 个整批失败(4179ms)
```

而端点接受逗号分隔的多个 iid(`miot/router.py:316`),这个家里 33 台设备中 **11 台**可读属性 ≥15 个(其中 8 台此刻在线)。现按 **8** 分批(最低那条悬崖的一半,常量里写清了来历),**顺序发**、结果**按请求顺序拼接**,调用方照旧按 iid 对号。同三台设备、整套可读属性,改前 / 改后:

```
次卧全景  71 属性   6038ms  0/71  →  1400ms  71/71
书房全景  43 属性   4138ms  0/43  →   889ms  40/43
空调      42 属性   4198ms  0/42  →  1758ms  42/42
```

分批比不分批**更快** —— 注定失败的那次请求会把截止时间烧满。书房全景剩下的 3 个失败是云端逐属性给出的 `-704220008`,是整批失败此前一直盖住的真实答复。(71 属性那台相机整批失败时报的是 `-704083036` 而非 `-704220043`,同一个悬崖、不同的码。)

一批带着错误码回来**不会影响其它批**,该批的码原样返回 —— 只有云端真的返回过的码才算失败(#394),本地既不合成也不抹掉。传输层异常仍照常上抛:那意味着「没读到」,而一个悄悄少几行的响应正是这个 PR 要消灭的失败形态。

不并发的理由:对同一台设备开 6 路读回既加重设备负担,也更容易撞限频,而顺序分批本来就比「一次问完然后整批失败」更快。

## 代价(实测,真实账号)

ds=2 在线 15 属性 167~249ms(ds=1 为 61ms)、离线 67~90ms —— **不慢**,云端凭在线注册表秒拒,不等超时;30 台并发 290ms vs ds=1 的 356ms,未触发限频。

## 本 PR **不做**的

以下两处是同一根因的其它面 —— 存的是「上次已知」,端出去时是「当前」。证据已经有了,但改动性质不同(涉及订阅 / 刷新调度),**另开 PR 处理**:

1. **miloco 自己那份「谁在线」的快照不刷新。** 非相机设备既无周期刷新也不订阅上下线,实测最长冻结 **6h48m**;稳态下每天只在小米服务端 05:00 断线重连时更新一次。也正因为这样,本 PR **没有**、也不该拿 `online` 当闸门:实测抓到过反例 —— 33 台逐台比对漂移 1 台,恰好是事故那盏灯,缓存说离线,而真机读回来它活着、亮着。拿它当判决会把一个吵闹的假阳换成一个静默的假阴。
2. **相机唤醒态缓存**,实测冻结 **11h39m**。

WebUI 本次不需要改:它靠 `real.ts` 的 `if (!d.online)` 屏蔽了陈旧值(#441 立的规矩),陈旧值虽然进了 `Device.props`,但今天没有渲染方。

## 测试

- `backend/miloco/tests/test_miot_read_through_batching.py`(新):超过 chunk 的请求必须全部成功返回、顺序不变、单批失败不影响其它批且其错误码原样返回、`ds=1` 不被拆、不足一批不多花往返、chunk 值不得高于实测最低悬崖。(放在 miloco 的测试目录,是因为 `backend/pyproject.toml` 的 `norecursedirs = ["miot", ...]` 会让 `backend/miot/tests` 完全不被收集。)
- `test_miot_service_lru.py` / `test_rule.py` / `cli/tests/test_commands.py`:分档路由、`updated_at` 透传与缺失、云端码不被改写、不可达 ≠ 已在目标态、`age_s` 换算。
- 全绿:`backend` 2807 passed、`cli` 557 passed;`ruff check` 在改动文件上干净。
- 真机验证:上面所有数字都来自真实账号的只读探测(仅 `miotspec/prop/get`,未控制任何设备)。

## 开放问题

- **`ds=2` 会不会唤醒电池 / 休眠设备并耗电,没测**(本机 6 台温湿度计全在线,无可测样本)。这是最可能在别的部署里出问题的地方。
- **`updateTime` 的精确云端语义无文档**,我的解读(= 该值上次被写入的时刻)是反推的,所以只拿它做 as-of 注解,没让任何判断依赖它。
