### PR TITLE
feat(perception): urgency filter for suggestion → agent dispatch

### DIFF
--- a/backend/miloco/src/miloco/admin/router.py
+++ b/backend/miloco/src/miloco/admin/router.py
@@ -14,6 +14,7 @@ import subprocess
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as pkg_version
 from pathlib import Path
+from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field, StrictBool
@@ -1079,6 +1080,13 @@ class PerceptionConfigBody(BaseModel):
     video_short_edge: int | None = Field(default=None, ge=64, le=2160)
     omni_fps: int | None = Field(default=None, ge=1, le=30)
     window_size: int | None = Field(default=None, ge=1, le=60)
+    min_suggestion_urgency: Literal["low", "medium", "high"] | None = Field(
+        default=None,
+        description=(
+            "把 urgency 低于该阈值的 suggestion 从 dispatch→agent 通路丢弃;"
+            "low=不过滤(默认),medium=丢弃 low,high=只保留 high"
+        ),
+    )
 
 
 def _perception_config_payload() -> dict:
@@ -1088,6 +1096,7 @@ def _perception_config_payload() -> dict:
         "video_short_edge": inp.get("video_short_edge", 512),
         "omni_fps": inp.get("omni_fps", 1),
         "window_size": s.perception.collect.window_size,
+        "min_suggestion_urgency": s.perception.min_suggestion_urgency,
     }
 
 
@@ -1113,6 +1122,11 @@ async def put_perception_config(body: PerceptionConfigBody, current_user: str = 
         update.setdefault("perception", {}).setdefault("engine", {}).setdefault("input", {})["omni_fps"] = body.omni_fps
     if body.window_size is not None:
         update.setdefault("perception", {}).setdefault("collect", {})["window_size"] = body.window_size
+    if body.min_suggestion_urgency is not None:
+        # 阈值热读:client.py 的 _filter_suggestions_by_min_urgency 每次 dispatch 前
+        # get_settings() 现读,update_shared_config 已含 reset_settings,下个 cycle 即生效,
+        # 不参与下方 restart_ok(不需要重启引擎)。
+        update.setdefault("perception", {})["min_suggestion_urgency"] = body.min_suggestion_urgency
     payload = _perception_config_payload()
     if update:
         # 三个参数生效路径各不同，按「新值 != 旧值」判断（前端 drawer 三字段一起 PUT）：

--- a/backend/miloco/src/miloco/config/settings.py
+++ b/backend/miloco/src/miloco/config/settings.py
@@ -17,7 +17,7 @@ import json
 import logging
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Literal
 
 import yaml
 from pydantic import BaseModel, Field, computed_field, field_validator, model_validator
@@ -307,6 +307,14 @@ class PerceptionSettings(BaseModel):
     """感知管线相关配置。"""
 
     log_ttl: int = Field(default=30, description="感知日志保留天数")
+    min_suggestion_urgency: Literal["low", "medium", "high"] = Field(
+        default="low",
+        description=(
+            "把 urgency 低于该阈值的 suggestion 从 dispatch→agent 通路丢弃;"
+            "low = 不过滤(默认,向后兼容),medium = 丢弃 low,high = 只保留 high。"
+            "result.suggestions 保留完整,timeline/dump/上下文不受影响,仅 agent 派发受限。"
+        ),
+    )
     event_ttl_days: int = Field(
         default=7,
         description=(

--- a/backend/miloco/src/miloco/config/settings.schema.json
+++ b/backend/miloco/src/miloco/config/settings.schema.json
@@ -154,6 +154,19 @@
           "description": "相同通知文案在此窗口（秒）内只发一次；<=0 = 关闭去重"
         }
       }
+    },
+    "perception": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "感知管线相关配置",
+      "properties": {
+        "min_suggestion_urgency": {
+          "type": "string",
+          "enum": ["low", "medium", "high"],
+          "default": "low",
+          "description": "把 urgency 低于该阈值的 suggestion 从 dispatch→agent 通路丢弃；low=不过滤（默认，向后兼容），medium=丢弃 low，high=只保留 high。result.suggestions 保留完整，仅 agent 派发受限"
+        }
+      }
     }
   },
   "required": ["debug", "server", "agent", "model"]

--- a/backend/miloco/src/miloco/perception/client.py
+++ b/backend/miloco/src/miloco/perception/client.py
@@ -44,6 +44,7 @@ from miloco.perception.snapshot_context import (
     event_artifacts_scope,
 )
 from miloco.perception.types import (
+    URGENCY_RANK,
     CaptionEntry,
     MatchedRule,
     OnDemandPerceptionResult,
@@ -68,6 +69,51 @@ def _publish_perception_event(event_type: str, source: str, payload: dict) -> No
     if client is None:
         return
     client.publish_event(event_type=event_type, source=source, payload=payload)
+
+
+def _filter_suggestions_by_min_urgency(
+    suggestions: list[Suggestion],
+) -> tuple[list[Suggestion], list[Suggestion], str]:
+    """按 ``settings.perception.min_suggestion_urgency`` 拆分 (kept, dropped, threshold)。
+
+    threshold=low(默认)时 dropped 恒空——URGENCY_RANK 里 low 是最低分,任何合法档位
+    都 >= 它,不引入过滤开销。settings 字段是 Literal["low","medium","high"],pydantic
+    ValidationError 已挡脏值,故 URGENCY_RANK[threshold] 直接下标;s.urgency 是 str
+    需保留 .get 兜底(模型偶发输出未定义档时退化为 low 分)。
+    result.suggestions 由调用方保留不动,本函数只切分派发对象。
+    """
+    threshold = get_settings().perception.min_suggestion_urgency
+    cutoff = URGENCY_RANK[threshold]
+    kept: list[Suggestion] = []
+    dropped: list[Suggestion] = []
+    for s in suggestions:
+        if URGENCY_RANK.get(s.urgency, 0) >= cutoff:
+            kept.append(s)
+        else:
+            dropped.append(s)
+    return kept, dropped, threshold
+
+
+def _log_dropped_suggestions(
+    dropped: list[Suggestion], threshold: str, phase: str
+) -> None:
+    """把本 cycle 被 min_urgency 拦下的 suggestion 汇总打一行 info log。
+
+    刻意不逐条打:threshold=high 时家庭场景每天可拦几千条 low,逐条会淹没其它 info。
+    汇总带前 5 条摘要,足够肉眼 grep 出分布;要看全量走 debug 或复现场景。
+    phase 区分早送(``early``)与合批(``merged``)路径。
+    """
+    if not dropped:
+        return
+    # event 是模型自由文本,理论上可能含换行——把换行折成空格保住"每 cycle 一行"grep 契约。
+    preview = ", ".join(
+        f"{s.event.replace(chr(10), ' ')}({s.urgency})" for s in dropped[:5]
+    )
+    more = f" (+{len(dropped) - 5} more)" if len(dropped) > 5 else ""
+    logger.info(
+        "[urgency-filter] dropped %d suggestion(s) phase=%s threshold=%s: %s%s",
+        len(dropped), phase, threshold, preview, more,
+    )
 
 
 if TYPE_CHECKING:
@@ -499,14 +545,23 @@ class PerceptionEngineProxy:
             # 剔除 engine 内部字段（id）后外发。
             for s in suggestions:
                 if s.id is not None:
-                    early_sent_sugg_ids.add(s.id)  # 终态 merge 会把同一新链保留进 result，发送侧据此跳过
+                    # early_sent_sugg_ids 记「已早处理」(不论是否过 min_urgency 过滤);
+                    # merged 路径据此跳过同一新链,避免对 Agent 重发或重复打拦截 log。
+                    early_sent_sugg_ids.add(s.id)
                 _publish_perception_event(
                     "suggestion", s.event, {"action": s.action},
                 )
+            # urgency 过滤只影响 agent 派发通路:_publish 与 early_sent_sugg_ids 已按
+            # 全量执行,dispatch_event 仅拿到 kept 子集,保证 result.suggestions 完整、
+            # timeline 不受影响。
+            kept, dropped, threshold = _filter_suggestions_by_min_urgency(suggestions)
+            _log_dropped_suggestions(dropped, threshold, phase="early")
+            if not kept:
+                return
             # B2 单源真值:文本构造延迟到 drainer；urgency 仅作淘汰用的条目级优先级
             await dispatch_event(
-                "suggestion", suggestions, build_suggestions_text,
-                intra_priority=suggestion_intra_priority(suggestions),
+                "suggestion", kept, build_suggestions_text,
+                intra_priority=suggestion_intra_priority(kept),
             )
 
         # --- Pipeline timing ---
@@ -837,11 +892,19 @@ class PerceptionEngineProxy:
                 _publish_perception_event(
                     "suggestion", s.event, {"action": s.action},
                 )
-            # B2 单源真值:文本构造延迟到 drainer；urgency 仅作淘汰用的条目级优先级
-            await dispatch_event(
-                "suggestion", pending_suggestions, build_suggestions_text,
-                intra_priority=suggestion_intra_priority(pending_suggestions),
+            # urgency 过滤:见 _on_early_suggestions 同名段落。batch 模式下这里是唯一
+            # 派发点;per-omni 模式下早送已把新链 id 记入 early_sent_sugg_ids,pending
+            # 通常为空,不会重复打拦截 log。
+            kept, dropped, threshold = _filter_suggestions_by_min_urgency(
+                pending_suggestions,
             )
+            _log_dropped_suggestions(dropped, threshold, phase="merged")
+            if kept:
+                # B2 单源真值:文本构造延迟到 drainer；urgency 仅作淘汰用的条目级优先级
+                await dispatch_event(
+                    "suggestion", kept, build_suggestions_text,
+                    intra_priority=suggestion_intra_priority(kept),
+                )
 
         # handle speeches (skip those already sent via streaming early callback)
         speeches: list[Speech] = []

--- a/backend/miloco/tests/admin/test_perception_config_dispatch.py
+++ b/backend/miloco/tests/admin/test_perception_config_dispatch.py
@@ -94,3 +94,51 @@ def test_unchanged_omni_fps_is_noop(client):
     assert resp.status_code == 200
     svc.apply_omni_fps_live.assert_not_awaited()
     svc.apply_config_restart.assert_not_awaited()
+
+
+def test_min_urgency_change_writes_config_no_restart(client):
+    """min_suggestion_urgency 走热读路径:落盘即生效,不参与 restart 分派。"""
+    c, svc = client
+    resp = c.put(
+        "/api/admin/perception-config",
+        json={"min_suggestion_urgency": "medium"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["min_suggestion_urgency"] == "medium"
+    svc.apply_omni_fps_live.assert_not_awaited()
+    svc.apply_config_restart.assert_not_awaited()
+
+
+def test_min_urgency_get_returns_current(client):
+    c, _ = client
+    resp = c.get("/api/admin/perception-config")
+    assert resp.status_code == 200
+    # 默认值 low(与 backend Literal default 对齐,fixture 未写此字段)
+    assert resp.json()["data"]["min_suggestion_urgency"] == "low"
+
+
+def test_min_urgency_rejects_bogus_value(client):
+    """Literal 类型校验:非 low/medium/high 应被 pydantic 拒(422)。"""
+    c, _ = client
+    resp = c.put(
+        "/api/admin/perception-config",
+        json={"min_suggestion_urgency": "urgent"},
+    )
+    assert resp.status_code == 422
+
+
+def test_min_urgency_mixed_with_omni_fps(client):
+    """混合 PUT:同时改 omni_fps + min_urgency,前者走 hot-reload,后者走 hot-read,
+    互不干扰——apply_omni_fps_live 被调 1 次(omni_fps),apply_config_restart 不调。"""
+    c, svc = client
+    resp = c.put(
+        "/api/admin/perception-config",
+        json={"omni_fps": 2, "min_suggestion_urgency": "high"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["omni_fps"] == 2
+    assert data["min_suggestion_urgency"] == "high"
+    svc.apply_omni_fps_live.assert_awaited_once_with(2)
+    svc.apply_config_restart.assert_not_awaited()

--- a/backend/miloco/tests/test_perception_client.py
+++ b/backend/miloco/tests/test_perception_client.py
@@ -300,6 +300,195 @@ async def test_handle_realtime_sends_all_when_no_early_sent(proxy):
     assert [s.id for s in disp.await_args.args[1]] == [1]
 
 
+# ─── min_suggestion_urgency 过滤(dispatch→agent 通路)─────────────────────────
+
+
+def _urgency_settings(min_urgency: str) -> MagicMock:
+    """构造一个只关心 perception.min_suggestion_urgency 的 settings mock。"""
+    s = MagicMock()
+    s.perception.min_suggestion_urgency = min_urgency
+    return s
+
+
+def test_filter_helper_splits_by_threshold():
+    """纯 helper:按阈值切分 kept/dropped/threshold,不依赖协程/引擎。"""
+    from miloco.perception.client import _filter_suggestions_by_min_urgency
+    from miloco.perception.types import Suggestion
+
+    s_low = Suggestion(event="水龙头没关", action="提醒", urgency="low", id=1)
+    s_med = Suggestion(event="有人敲门", action="查看", urgency="medium", id=2)
+    s_high = Suggestion(event="老人摔倒", action="紧急", urgency="high", id=3)
+
+    with patch(
+        "miloco.perception.client.get_settings",
+        return_value=_urgency_settings("medium"),
+    ):
+        kept, dropped, threshold = _filter_suggestions_by_min_urgency(
+            [s_low, s_med, s_high]
+        )
+    assert threshold == "medium"
+    assert [s.id for s in kept] == [2, 3]
+    assert [s.id for s in dropped] == [1]
+
+
+def test_filter_helper_low_threshold_is_noop():
+    """默认阈值 low:所有档位都 >= low,dropped 恒空(向后兼容:不引入过滤)。"""
+    from miloco.perception.client import _filter_suggestions_by_min_urgency
+    from miloco.perception.types import Suggestion
+
+    items = [
+        Suggestion(event="a", action="a", urgency="low"),
+        Suggestion(event="b", action="b", urgency="medium"),
+        Suggestion(event="c", action="c", urgency="high"),
+    ]
+    with patch(
+        "miloco.perception.client.get_settings",
+        return_value=_urgency_settings("low"),
+    ):
+        kept, dropped, threshold = _filter_suggestions_by_min_urgency(items)
+    assert threshold == "low"
+    assert len(kept) == 3
+    assert dropped == []
+
+
+async def test_handle_realtime_urgency_filter_drops_below_threshold(proxy):
+    """合批路径:threshold=medium 时 low 不进 dispatch;result.suggestions 保留完整。"""
+    from unittest.mock import AsyncMock
+
+    from miloco.perception.types import Suggestion
+
+    result = RealtimePerceptionResult(
+        suggestions=[
+            Suggestion(event="水龙头没关", action="提醒", urgency="low", id=1),
+            Suggestion(event="有人敲门", action="查看", urgency="medium", id=2),
+            Suggestion(event="老人摔倒", action="紧急", urgency="high", id=3),
+        ],
+    )
+    fake_mgr = MagicMock()
+
+    async def _noop_update(*a, **k):
+        ...
+
+    fake_mgr.rule_service.update_state = _noop_update
+    fake_mgr.rule_service.get_enabled_rule_ids = MagicMock(return_value=[])
+
+    with patch("miloco.manager.get_manager", return_value=fake_mgr), \
+         patch("miloco.perception.client.dispatch_event",
+               new_callable=AsyncMock) as disp, \
+         patch("miloco.perception.client.get_settings",
+               return_value=_urgency_settings("medium")):
+        await proxy.handle_realtime_perception_result(result)
+
+    disp.assert_awaited_once()
+    # 只发 medium + high;low 被拦
+    assert [s.id for s in disp.await_args.args[1]] == [2, 3]
+    # result 保持完整,timeline / dump / 上下文不受影响
+    assert [s.id for s in result.suggestions] == [1, 2, 3]
+
+
+async def test_handle_realtime_urgency_filter_high_only(proxy):
+    """threshold=high 时仅 high 通过;若全部被拦则不 dispatch。"""
+    from unittest.mock import AsyncMock
+
+    from miloco.perception.types import Suggestion
+
+    result = RealtimePerceptionResult(
+        suggestions=[
+            Suggestion(event="水龙头没关", action="提醒", urgency="low", id=1),
+            Suggestion(event="有人敲门", action="查看", urgency="medium", id=2),
+        ],
+    )
+    fake_mgr = MagicMock()
+
+    async def _noop_update(*a, **k):
+        ...
+
+    fake_mgr.rule_service.update_state = _noop_update
+    fake_mgr.rule_service.get_enabled_rule_ids = MagicMock(return_value=[])
+
+    with patch("miloco.manager.get_manager", return_value=fake_mgr), \
+         patch("miloco.perception.client.dispatch_event",
+               new_callable=AsyncMock) as disp, \
+         patch("miloco.perception.client.get_settings",
+               return_value=_urgency_settings("high")):
+        await proxy.handle_realtime_perception_result(result)
+
+    disp.assert_not_awaited()
+    assert [s.id for s in result.suggestions] == [1, 2]
+
+
+async def test_early_suggestions_urgency_filter(proxy):
+    """早出路径:_on_early_suggestions 内 dispatch 仅收到 >= 阈值的 kept 子集;
+    _publish 与 early_sent_sugg_ids 对全量执行(timeline / dedup 不受影响)。"""
+    from unittest.mock import AsyncMock
+
+    from miloco.perception.types import Suggestion
+
+    main_loop = asyncio.get_running_loop()
+    published: list[tuple[str, str, dict]] = []
+
+    def _fake_publish(event_type, source, payload):
+        published.append((event_type, source, payload))
+
+    async def engine_realtime(*args, **kwargs):
+        await kwargs["on_early_suggestions"]([
+            Suggestion(event="水龙头没关", action="提醒", urgency="low", id=1),
+            Suggestion(event="有人敲门", action="查看", urgency="medium", id=2),
+            Suggestion(event="老人摔倒", action="紧急", urgency="high", id=3),
+        ])
+        return _empty_result()
+
+    proxy.perception_engine.realtime_perceive = engine_realtime
+
+    with patch("miloco.perception.client.dispatch_event",
+               new_callable=AsyncMock) as disp, \
+         patch("miloco.perception.client._publish_perception_event",
+               side_effect=_fake_publish), \
+         patch("miloco.perception.client.get_settings",
+               return_value=_urgency_settings("medium")):
+        _, _, _, early_ids = await proxy._realtime_perceive_impl(
+            _stub_snapshot(), [], 0, 0.0, main_loop, [],
+        )
+
+    # dispatch 只见 medium + high
+    disp.assert_awaited_once()
+    assert [s.id for s in disp.await_args.args[1]] == [2, 3]
+    # _publish 对全量执行,timeline 全部见得到
+    assert [p[1] for p in published] == ["水龙头没关", "有人敲门", "老人摔倒"]
+    # early_sent_sugg_ids 含全部三个 id(不论过滤与否),让 merged 路径不重复处理
+    assert early_ids == {1, 2, 3}
+
+
+async def test_early_suggestions_default_low_is_noop(proxy):
+    """默认阈值 low:早出路径不引入过滤(向后兼容),全量 dispatch。"""
+    from unittest.mock import AsyncMock
+
+    from miloco.perception.types import Suggestion
+
+    main_loop = asyncio.get_running_loop()
+
+    async def engine_realtime(*args, **kwargs):
+        await kwargs["on_early_suggestions"]([
+            Suggestion(event="a", action="a", urgency="low", id=1),
+            Suggestion(event="b", action="b", urgency="medium", id=2),
+        ])
+        return _empty_result()
+
+    proxy.perception_engine.realtime_perceive = engine_realtime
+
+    with patch("miloco.perception.client.dispatch_event",
+               new_callable=AsyncMock) as disp, \
+         patch("miloco.perception.client._publish_perception_event"), \
+         patch("miloco.perception.client.get_settings",
+               return_value=_urgency_settings("low")):
+        await proxy._realtime_perceive_impl(
+            _stub_snapshot(), [], 0, 0.0, main_loop, [],
+        )
+
+    disp.assert_awaited_once()
+    assert [s.id for s in disp.await_args.args[1]] == [1, 2]
+
+
 # test_unmatched_enabled_rules_get_false_each_cycle / test_unmatched_skips_early_sent_rules
 # 已迁移到 test_perception_client_rule_dispatch.py(per-device 状态机重构后,
 # false 广播改为按 device_rule_map 精确推退,旧 case 的全集 enabled rule 模型不再适用)。

--- a/cli/src/miloco_cli/config.py
+++ b/cli/src/miloco_cli/config.py
@@ -128,6 +128,13 @@ _SCHEMA_PATHS: dict[str, tuple[type, Any, str]] = {
         "宠物参考图多样性选择（默认开）：视频注册时用人体 ReID 特征距离贪心选最不相似的 ≤3 张"
         "多姿态；关或模型不可用时回退感知哈希 dHash。仅在 pet_recognition 开启时有意义；内部调优，一般无需改动",
     ),
+    "perception.min_suggestion_urgency": (
+        str,
+        "low",
+        "把 urgency 低于该阈值的 suggestion 从 dispatch→agent 通路丢弃；"
+        "值域 low|medium|high；low=不过滤（默认，向后兼容）。"
+        "result.suggestions 保留完整，仅 agent 派发受限；下个感知周期即生效",
+    ),
 }
 
 # ─── 基础读写 ────────────────────────────────────────────────────────────────
@@ -291,6 +298,15 @@ def _coerce(path: str, raw: str) -> Any:
             raise ValueError(
                 f"{path} 仅支持 low / high（留空=默认 low），收到 {raw!r}。"
                 f"注：Gemini media_resolution 有效档位只有 low/high，medium 等同 low。"
+            )
+        return norm
+    # min_suggestion_urgency 与 backend PerceptionSettings 的 Literal 对齐——CLI 先兜住,
+    # 让脏值在写盘前就报错,不必等 backend 启动 ValidationError。
+    if path == "perception.min_suggestion_urgency":
+        norm = raw.strip().lower()
+        if norm not in ("low", "medium", "high"):
+            raise ValueError(
+                f"{path} 仅支持 low / medium / high，收到 {raw!r}"
             )
         return norm
     return raw  # str

--- a/cli/tests/test_config.py
+++ b/cli/tests/test_config.py
@@ -127,6 +127,25 @@ def test_set_value_rejects_bad_bool():
         set_value("server.tls_verify", "maybe")
 
 
+def test_min_suggestion_urgency_accepts_valid_values(isolated_config):
+    """low / medium / high 三档均可写入(大小写不敏感由 _coerce 归一)。"""
+    for v in ("low", "MEDIUM", "High"):
+        set_value("perception.min_suggestion_urgency", v)
+        data = json.loads(isolated_config.read_text())
+        assert data["perception"]["min_suggestion_urgency"] == v.lower()
+
+
+def test_min_suggestion_urgency_rejects_bogus():
+    with pytest.raises(ValueError, match="min_suggestion_urgency"):
+        set_value("perception.min_suggestion_urgency", "urgent")
+
+
+def test_min_suggestion_urgency_default_is_low():
+    """默认值 low = 不过滤,与 backend PerceptionSettings.Literal default 对齐。"""
+    cfg = load_config()
+    assert cfg["perception"]["min_suggestion_urgency"] == "low"
+
+
 def test_get_value_reads_persisted(isolated_config):
     set_value("model.omni.api_key", "sk-xxx")
     assert get_value("model.omni.api_key") == "sk-xxx"

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -689,10 +689,15 @@ export async function getMemorySeries(
 
 // ─── Perception Config ─────────────────────────────────────────────────
 
+export type MinSuggestionUrgency = "low" | "medium" | "high";
+
 export interface PerceptionConfig {
   video_short_edge: number;
   omni_fps: number;
   window_size: number;
+  // 老 backend(<0.10.x)不返此字段,前端在读取处 ?? DEFAULTS.min_suggestion_urgency 回退。
+  // 声明成可选是为了把这层运行时兼容语义显式化,别让未来维护者把 ?? 当成死代码删。
+  min_suggestion_urgency?: MinSuggestionUrgency;
 }
 
 export async function getPerceptionConfig(): Promise<PerceptionConfig> {

--- a/web/src/components/SettingsDrawer.tsx
+++ b/web/src/components/SettingsDrawer.tsx
@@ -27,7 +27,8 @@ const SHORT_EDGE_OPTIONS = [360, 512, 768, 1080] as const;
 const FPS_OPTIONS = [1, 2, 3] as const;
 const WINDOW_MIN = 2;
 const WINDOW_MAX = 10;
-const URGENCY_OPTIONS: MinSuggestionUrgency[] = ["low", "medium", "high"];
+// slider 顺序即 URGENCY_RANK,index == pydantic Literal 顺序 → 双向 O(1) 映射。
+const URGENCY_LEVELS: readonly MinSuggestionUrgency[] = ["low", "medium", "high"] as const;
 
 interface Props {
   open: boolean;
@@ -312,25 +313,39 @@ export function SettingsDrawer({ open, onClose }: Props) {
                 </div>
               </div>
 
-              {/* Agent 干扰阈值 —— urgency 过滤 */}
+              {/* 事件提醒 —— urgency 过滤(3-stop slider,与感知窗口视觉对齐) */}
               <div className="space-y-2.5">
-                <label className="text-body font-medium text-text-primary block">
-                  {t("settings.minUrgency")}
-                </label>
-                <div className="flex gap-2">
-                  {URGENCY_OPTIONS.map((v) => (
-                    <button
-                      key={v}
-                      type="button"
-                      onClick={() => setMinUrgency(v)}
-                      className={`flex-1 py-2.5 rounded-xl text-body transition-colors ${
-                        minUrgency === v
-                          ? "bg-brand-primary text-white shadow-sm"
-                          : "bg-bg-primary border border-border text-text-primary hover:border-brand-primary"
-                      }`}
-                    >
-                      {t(`settings.minUrgencyOption.${v}`)}
-                    </button>
+                <div className="flex items-center justify-between">
+                  <label className="text-body font-medium text-text-primary">
+                    {t("settings.minUrgency")}
+                  </label>
+                  <span className="text-body text-text-primary font-semibold">
+                    {t(`settings.minUrgencyStatus.${minUrgency}`)}
+                  </span>
+                </div>
+                {(() => {
+                  const idx = URGENCY_LEVELS.indexOf(minUrgency);
+                  const pct = (idx / (URGENCY_LEVELS.length - 1)) * 100;
+                  return (
+                    <input
+                      type="range"
+                      min={0}
+                      max={URGENCY_LEVELS.length - 1}
+                      step={1}
+                      value={idx}
+                      onChange={(e) =>
+                        setMinUrgency(URGENCY_LEVELS[Number(e.target.value)])
+                      }
+                      className="settings-slider w-full"
+                      style={{
+                        background: `linear-gradient(to right, var(--color-brand-primary, #ff6900) ${pct}%, var(--color-border, #e5e5e5) ${pct}%)`,
+                      }}
+                    />
+                  );
+                })()}
+                <div className="flex justify-between text-caption text-text-tertiary">
+                  {URGENCY_LEVELS.map((v) => (
+                    <span key={v}>{t(`settings.minUrgencyTick.${v}`)}</span>
                   ))}
                 </div>
                 <p className="text-caption text-text-tertiary">

--- a/web/src/components/SettingsDrawer.tsx
+++ b/web/src/components/SettingsDrawer.tsx
@@ -5,18 +5,29 @@ import {
   getSchedulerConfig,
   updatePerceptionConfig,
   updateSchedulerConfig,
+  type MinSuggestionUrgency,
   type PerceptionConfig,
 } from "@/api";
 import { useEscClose } from "@/hooks/useEscClose";
 import { toast } from "./Toast";
 
+// PerceptionConfig 里 min_suggestion_urgency 声明为可选(老 backend 不返此字段);
+// 但组件 state 需要确定值,单独拎一个具体类型的默认常量兜住:接口"可能没"、控件"永远有"。
+const DEFAULT_MIN_URGENCY: MinSuggestionUrgency = "low";
+
 // 与 backend settings.yaml perception.engine.input + perception.collect.window_size 对齐
-const DEFAULTS: PerceptionConfig = { video_short_edge: 512, omni_fps: 1, window_size: 4 };
+const DEFAULTS: PerceptionConfig = {
+  video_short_edge: 512,
+  omni_fps: 1,
+  window_size: 4,
+  min_suggestion_urgency: DEFAULT_MIN_URGENCY,
+};
 
 const SHORT_EDGE_OPTIONS = [360, 512, 768, 1080] as const;
 const FPS_OPTIONS = [1, 2, 3] as const;
 const WINDOW_MIN = 2;
 const WINDOW_MAX = 10;
+const URGENCY_OPTIONS: MinSuggestionUrgency[] = ["low", "medium", "high"];
 
 interface Props {
   open: boolean;
@@ -32,6 +43,9 @@ export function SettingsDrawer({ open, onClose }: Props) {
   const [videoShortEdge, setVideoShortEdge] = useState(DEFAULTS.video_short_edge);
   const [omniFps, setOmniFps] = useState(DEFAULTS.omni_fps);
   const [windowSize, setWindowSize] = useState(DEFAULTS.window_size);
+  const [minUrgency, setMinUrgency] = useState<MinSuggestionUrgency>(
+    DEFAULT_MIN_URGENCY,
+  );
 
   // 内置定时任务自动管理开关（scheduler.enabled）。缺省 true = 自动管理。
   const [schedulerLoaded, setSchedulerLoaded] = useState<boolean | null>(null);
@@ -58,6 +72,9 @@ export function SettingsDrawer({ open, onClose }: Props) {
         setVideoShortEdge(c.video_short_edge);
         setOmniFps(c.omni_fps);
         setWindowSize(c.window_size);
+        // 老 backend 若不返 min_suggestion_urgency 时回退到"不过滤"默认,与 backend 的
+        // Literal default 对齐,不误导用户以为拿到了远端值。
+        setMinUrgency(c.min_suggestion_urgency ?? DEFAULT_MIN_URGENCY);
       }),
       getSchedulerConfig().then((s) => {
         setSchedulerLoaded(s.enabled);
@@ -80,7 +97,9 @@ export function SettingsDrawer({ open, onClose }: Props) {
     config != null &&
     (videoShortEdge !== config.video_short_edge ||
       omniFps !== config.omni_fps ||
-      windowSize !== config.window_size);
+      windowSize !== config.window_size ||
+      minUrgency !==
+        (config.min_suggestion_urgency ?? DEFAULT_MIN_URGENCY));
   // schedulerLoaded === null 表示这次没读到服务端值（接口缺失 / 版本错位）：
   // 此时 schedulerDirty 恒 false，拨动开关不会写盘，故置灰禁用避免呈现「看着能动、
   // 实则静默丢弃」的控件。
@@ -110,6 +129,7 @@ export function SettingsDrawer({ open, onClose }: Props) {
           video_short_edge: videoShortEdge,
           omni_fps: omniFps,
           window_size: windowSize,
+          min_suggestion_urgency: minUrgency,
         });
         setConfig(updated);
         if (updated.restart_ok === false) {
@@ -144,6 +164,7 @@ export function SettingsDrawer({ open, onClose }: Props) {
     setVideoShortEdge(DEFAULTS.video_short_edge);
     setOmniFps(DEFAULTS.omni_fps);
     setWindowSize(DEFAULTS.window_size);
+    setMinUrgency(DEFAULT_MIN_URGENCY);
     // 仅在开关可配置时才回默认 ON；不可用（schedulerLoaded===null，置灰）时保持
     // 当前视觉，避免把置灰的开关拨到 ON 且 schedulerDirty 恒 false 无从写盘。
     if (schedulerAvailable) setSchedulerEnabled(true);
@@ -289,6 +310,32 @@ export function SettingsDrawer({ open, onClose }: Props) {
                   <span>{WINDOW_MIN} {t("settings.windowSizeUnit")}</span>
                   <span>{WINDOW_MAX} {t("settings.windowSizeUnit")}</span>
                 </div>
+              </div>
+
+              {/* Agent 干扰阈值 —— urgency 过滤 */}
+              <div className="space-y-2.5">
+                <label className="text-body font-medium text-text-primary block">
+                  {t("settings.minUrgency")}
+                </label>
+                <div className="flex gap-2">
+                  {URGENCY_OPTIONS.map((v) => (
+                    <button
+                      key={v}
+                      type="button"
+                      onClick={() => setMinUrgency(v)}
+                      className={`flex-1 py-2.5 rounded-xl text-body transition-colors ${
+                        minUrgency === v
+                          ? "bg-brand-primary text-white shadow-sm"
+                          : "bg-bg-primary border border-border text-text-primary hover:border-brand-primary"
+                      }`}
+                    >
+                      {t(`settings.minUrgencyOption.${v}`)}
+                    </button>
+                  ))}
+                </div>
+                <p className="text-caption text-text-tertiary">
+                  {t("settings.minUrgencyHint")}
+                </p>
               </div>
 
               {/* 内置定时任务自动管理开关 */}

--- a/web/src/i18n/locales/en/settings.json
+++ b/web/src/i18n/locales/en/settings.json
@@ -18,6 +18,13 @@
     "schedulerSaved": "Saved. Takes effect after the next agent gateway restart.",
     "autoSchedule": "Auto scheduled tasks",
     "autoScheduleHint": "When on, miloco auto-creates and maintains its built-in scheduled tasks (perception digest / home patrol / memory dreaming / habit insights). When off, those tasks are removed and not recreated. Takes effect after the next agent gateway restart.",
-    "autoScheduleUnavailable": "This backend doesn't support this toggle (version may be too old); not configurable for now."
+    "autoScheduleUnavailable": "This backend doesn't support this toggle (version may be too old); not configurable for now.",
+    "minUrgency": "Agent interruption threshold",
+    "minUrgencyHint": "Suggestions are sent to the main agent only when the omni-judged urgency is at or above this level. Filtered events still appear in the perception timeline.",
+    "minUrgencyOption": {
+      "low": "All",
+      "medium": "Medium & high",
+      "high": "High only"
+    }
   }
 }

--- a/web/src/i18n/locales/en/settings.json
+++ b/web/src/i18n/locales/en/settings.json
@@ -19,12 +19,17 @@
     "autoSchedule": "Auto scheduled tasks",
     "autoScheduleHint": "When on, miloco auto-creates and maintains its built-in scheduled tasks (perception digest / home patrol / memory dreaming / habit insights). When off, those tasks are removed and not recreated. Takes effect after the next agent gateway restart.",
     "autoScheduleUnavailable": "This backend doesn't support this toggle (version may be too old); not configurable for now.",
-    "minUrgency": "Agent interruption threshold",
-    "minUrgencyHint": "Suggestions are sent to the main agent only when the omni-judged urgency is at or above this level. Filtered events still appear in the perception timeline.",
-    "minUrgencyOption": {
-      "low": "All",
-      "medium": "Medium & high",
-      "high": "High only"
+    "minUrgency": "Alert filter",
+    "minUrgencyHint": "Filtered events still show up in the activity log; the main agent is not notified.",
+    "minUrgencyTick": {
+      "low": "Low",
+      "medium": "Med",
+      "high": "High"
+    },
+    "minUrgencyStatus": {
+      "low": "Receive all events",
+      "medium": "Receive medium & high urgency",
+      "high": "Receive high urgency only"
     }
   }
 }

--- a/web/src/i18n/locales/zh/settings.json
+++ b/web/src/i18n/locales/zh/settings.json
@@ -19,12 +19,17 @@
     "autoSchedule": "自动定时任务",
     "autoScheduleHint": "开启后 miloco 自动创建并维护内置定时任务（感知摘要 / 家庭巡检 / 记忆整理 / 习惯洞察）；关闭后将清除这些任务且不再重建。改动在 agent 网关下次重启后生效。",
     "autoScheduleUnavailable": "当前后端不支持此开关（可能版本过旧），暂不可配置",
-    "minUrgency": "Agent 干扰阈值",
-    "minUrgencyHint": "仅当 omni 判定的紧急度不低于该阈值时才提醒主 agent；被过滤的事件仍会写入感知记录，不影响 timeline",
-    "minUrgencyOption": {
-      "low": "全部",
-      "medium": "中 / 高",
-      "high": "仅高"
+    "minUrgency": "事件提醒过滤",
+    "minUrgencyHint": "被过滤的事件仍会显示在日志里，但不提醒主 Agent",
+    "minUrgencyTick": {
+      "low": "低",
+      "medium": "中",
+      "high": "高"
+    },
+    "minUrgencyStatus": {
+      "low": "接收所有事件",
+      "medium": "接收中高紧急事件",
+      "high": "仅接收高紧急事件"
     }
   }
 }

--- a/web/src/i18n/locales/zh/settings.json
+++ b/web/src/i18n/locales/zh/settings.json
@@ -18,6 +18,13 @@
     "schedulerSaved": "已保存，agent 网关下次重启后生效",
     "autoSchedule": "自动定时任务",
     "autoScheduleHint": "开启后 miloco 自动创建并维护内置定时任务（感知摘要 / 家庭巡检 / 记忆整理 / 习惯洞察）；关闭后将清除这些任务且不再重建。改动在 agent 网关下次重启后生效。",
-    "autoScheduleUnavailable": "当前后端不支持此开关（可能版本过旧），暂不可配置"
+    "autoScheduleUnavailable": "当前后端不支持此开关（可能版本过旧），暂不可配置",
+    "minUrgency": "Agent 干扰阈值",
+    "minUrgencyHint": "仅当 omni 判定的紧急度不低于该阈值时才提醒主 agent；被过滤的事件仍会写入感知记录，不影响 timeline",
+    "minUrgencyOption": {
+      "low": "全部",
+      "medium": "中 / 高",
+      "high": "仅高"
+    }
   }
 }


### PR DESCRIPTION
## 背景

omni 输出的 suggestion 三档 urgency（low/medium/high）目前无差别送主 agent，
低紧急度提醒（灯没关、水龙头没关等）容易造成对话打断。本 PR 提供一个全局阈值
`perception.min_suggestion_urgency`，仅当 `urgency ≥ 阈值` 时才 dispatch 给
agent；被过滤的仍然写入 `result.suggestions`，timeline / dump / meaningful_events
观测面完整，不受影响。

## 改动

- **backend/perception**：`PerceptionSettings.min_suggestion_urgency:
  Literal["low","medium","high"]`（默认 `low` = 不过滤，老部署零副作用）。
  早送 (`_on_early_suggestions`) 与合批 (`handle_realtime_perception_result`)
  两条 dispatch 通路前各拦一刀，`_publish_perception_event` 与
  `early_sent_sugg_ids` 全走全量。
- **backend/logging**：被拦下的每 cycle 汇总一行 `[urgency-filter] dropped ...`
  info log（前 5 条摘要 + 溢出计数），便于阈值调优 grep。
- **backend/admin API**：`GET/PUT /api/admin/perception-config` 加此字段；
  阈值 hot-read（每次 dispatch 前 `get_settings()`）配合
  `update_shared_config` 的 `reset_settings`，写盘即下一 cycle 生效，不重启引擎。
- **CLI**：`miloco-cli config set perception.min_suggestion_urgency <low|medium|high>`；
  `_coerce` 前置 strip+lower+enum 校验。
- **Web**：设置抽屉「事件提醒过滤」3-stop 滑条:低 / 中 / 高。右上角实时反馈
  当前挡位对应的接收范围；fill 越多 = 过滤越强 = 越少事件通过，与"门槛"语义
  一致。hint "被过滤的事件仍会显示在日志里，但不提醒主 Agent" 提示数据不丢。
  兼容老 backend（字段可选，读侧回退到 `low`）。

## 前端
<img width="321" height="860" alt="Screenshot 2026-08-04 at 10 33 43 AM" src="https://github.com/user-attachments/assets/d47585b6-7903-4256-a393-682e6939fab7" />


## 生效路径与不变量

- `result.suggestions` 全程未改；`_persist_meaningful_event` / classify / dump /
  timeline 都拿到全量
- `_filter_suggestions_by_min_urgency` 每 dispatch cycle 现读 settings，不缓存
- 默认 `"low"` 时 `URGENCY_RANK["low"]=0`，dropped 恒空 → 向后兼容零副作用
- 早/合批两条通路的 `early_sent_sugg_ids` 均记「已早处理」，merged 不重复处理

## 已验过

- 单测：`test_perception_client.py` helper + 早/合批两条路径 + default noop
- 单测：`test_perception_config_dispatch.py` GET/PUT + Literal 拒 + 混合 PUT + no-restart
- 单测：`cli test_config.py` 低/中/高三档（含大小写归一）+ 拒非法 + default
- 本地全绿：backend 1228 passed / cli 27 passed / tsc clean
- 实机：CLI `config get / set / 拒 bogus` 往返
- 实机：Admin `GET/PUT perception-config` 热读生效不重启

## 实机验证 checklist（合并前跑一次）

- [x] 设置抽屉切档 → 保存 → 关抽屉 → 重开确认持久化（纯前端 UI 闭环）
- [x] 阈值=high 跑 5–10 分钟感知，\`grep '\[urgency-filter\] dropped' log\` 看到
      汇总行（实场景触发时 log 格式肉眼确认）