### PR TITLE
fix(shell): brace variable expansions that precede non-ASCII text

### DIFF
--- a/backend/miloco/tests/test_shell_var_braces.py
+++ b/backend/miloco/tests/test_shell_var_braces.py
@@ -1,0 +1,61 @@
+"""仓库体检：shell 脚本里紧跟中文的变量展开必须写花括号。
+
+macOS 自带的 /bin/bash（3.2.57，Apple 那份补丁版）在 UTF-8 locale 下会把紧跟变量名的
+多字节字符首字节当成变量名的一部分：
+
+    $ v=hi; echo "A（$v）B"          # LC_ALL=C.UTF-8, bash 3.2.57
+    bash: v?: unbound variable      # 查的是 "v\xef" 而不是 "v"
+
+`set -u` 下这会直接把脚本打断（本仓库的 shell 脚本基本都开了 `set -euo pipefail`），
+而且往往发生在"本来要打印一句人话"的错误分支上，把真正的报错替换成一句莫名其妙的
+unbound variable。LC_ALL=C 反而正常 —— 所以这不是靠 locale 能绕开的，唯一可靠写法是
+`"${VAR}中文"`。docker 里的 bash 3.2 / 4.4 / 5.2 都不复现，只有 Apple 那份会。
+
+这个测试只管纯 ASCII 边界上的坑，不碰注释（注释不参与展开）。
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[3]
+
+# 只查命名变量：$1 / $# / $? 这类特殊参数 bash 只吃一个字符，紧跟中文也不会跑偏。
+_BARE_VAR_BEFORE_NON_ASCII = re.compile(r"\$[A-Za-z_][A-Za-z0-9_]*(?=[^\x00-\x7f])")
+
+# 第三方/生成物不体检
+_SKIP_PARTS = {"node_modules", ".venv", "dist", "build", ".git"}
+
+
+def _repo_shell_scripts() -> list[Path]:
+    return sorted(
+        p
+        for p in _ROOT.rglob("*.sh")
+        if not _SKIP_PARTS.intersection(p.parts)
+    )
+
+
+def test_shell_scripts_found() -> None:
+    """先确认扫得到脚本，否则下面那条断言会因为"一个文件都没扫"而假绿。"""
+    scripts = _repo_shell_scripts()
+    assert len(scripts) >= 10, f"只扫到 {len(scripts)} 个 .sh，路径推导可能坏了：{_ROOT}"
+    names = {p.name for p in scripts}
+    assert {"build.sh", "local-ci.sh", "install-hermes.sh"} <= names, names
+
+
+def test_no_bare_var_before_non_ascii() -> None:
+    offenders: list[str] = []
+    for path in _repo_shell_scripts():
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for lineno, line in enumerate(text.splitlines(), 1):
+            if line.lstrip().startswith("#"):
+                continue
+            if _BARE_VAR_BEFORE_NON_ASCII.search(line):
+                rel = path.relative_to(_ROOT)
+                offenders.append(f"{rel}:{lineno}: {line.strip()}")
+
+    assert not offenders, (
+        "以下位置的变量紧跟非 ASCII 字符，macOS 自带 bash 3.2 会把它连进变量名，"
+        "set -u 下脚本会炸在这行。改成 ${VAR} 即可：\n  " + "\n  ".join(offenders)
+    )

--- a/backend/miloco/tests/test_shell_var_braces.py
+++ b/backend/miloco/tests/test_shell_var_braces.py
@@ -68,8 +68,15 @@ def _repo_shell_scripts() -> list[Path]:
             return found
     except (OSError, subprocess.SubprocessError):
         pass
+    # 后缀要和上面的 ls-files 一致：兜底只扫 *.sh 的话，将来有人加 foo.bash 会在源码包
+    # 场景下静默逃过门禁（不像"一个文件都没扫到"会被 test_shell_scripts_found 报红）。
+    # 比对 parts 前先 relative_to：否则 _ROOT 自身的祖先目录名也参与匹配，仓库 checkout
+    # 在某个叫 build/ 的目录下就会把一切都跳过。
     return sorted(
-        p for p in _ROOT.rglob("*.sh") if not _SKIP_PARTS.intersection(p.parts)
+        p
+        for pat in ("*.sh", "*.bash")
+        for p in _ROOT.rglob(pat)
+        if not _SKIP_PARTS.intersection(p.relative_to(_ROOT).parts)
     )
 
 

--- a/backend/miloco/tests/test_shell_var_braces.py
+++ b/backend/miloco/tests/test_shell_var_braces.py
@@ -1,45 +1,82 @@
-"""仓库体检：shell 脚本里紧跟中文的变量展开必须写花括号。
+# Copyright (C) 2025 Xiaomi Corporation
+# This software may be used and distributed according to the terms of the Xiaomi Miloco License Agreement.
+
+"""仓库体检：shell 脚本里紧跟非 ASCII 字符的变量展开必须写花括号。
 
 macOS 自带的 /bin/bash（3.2.57，Apple 那份补丁版）在 UTF-8 locale 下会把紧跟变量名的
-多字节字符首字节当成变量名的一部分：
+非 ASCII 字符首字节当成变量名的一部分：
 
     $ v=hi; echo "A（$v）B"          # LC_ALL=C.UTF-8, bash 3.2.57
-    bash: v?: unbound variable      # 查的是 "v\xef" 而不是 "v"
+    bash: v?: unbound variable      # 查的是 "v\\xef" 而不是 "v"
 
-`set -u` 下这会直接把脚本打断（本仓库的 shell 脚本基本都开了 `set -euo pipefail`），
-而且往往发生在"本来要打印一句人话"的错误分支上，把真正的报错替换成一句莫名其妙的
-unbound variable。LC_ALL=C 反而正常 —— 所以这不是靠 locale 能绕开的，唯一可靠写法是
-`"${VAR}中文"`。docker 里的 bash 3.2 / 4.4 / 5.2 都不复现，只有 Apple 那份会。
+不限于中文：`$vé` / `$v🙂` / `$v°C` 一样中招，判据就是「下一个字符不是 ASCII」。
+LC_ALL=C 反而正常（单字节模式下遇到 >=0x80 的字节就停止取名），所以这不是靠 locale
+能绕开的，唯一可靠写法是 `"${VAR}中文"`。
 
-这个测试只管纯 ASCII 边界上的坑，不碰注释（注释不参与展开）。
+两种失败形态：
+
+* 开了 `set -u`（本仓库跟踪的 shell 脚本目前全都开了）—— 直接 unbound variable 打断
+  脚本，而且往往发生在"本来要打印一句人话"的错误分支上，把真报错顶掉；
+* 没开 `set -u` —— 不报错，变量取空、后随字符首字节被吞掉，静默输出乱码（`A（??B`），
+  更难发现。
+
+docker 里的 bash 3.2 / 4.4 / 5.2 都不复现，只有 Apple 那份会。
+
+**覆盖范围**：只扫 git 跟踪的 `*.sh` / `*.bash`。以下不在范围内 ——
+
+* `.github/workflows/` 的内联 `run:` 块：跑在 ubuntu runner 的 bash 5 上，不受影响
+  （仓库目前没有 macos runner；哪天加了就得把那些 run: 块一起纳管）；
+* Python / TS 里的 shell 字符串（`subprocess(..., shell=True)`、`bash -c "…"` 字面量）：
+  macOS 的 /bin/sh 就是 bash 3.2 的 posix 模式，实测同样中招，所以它们理论上在射程内，
+  只是当前全仓 0 处，没为此加扫描。
 """
 
 from __future__ import annotations
 
 import re
+import subprocess
 from pathlib import Path
 
 _ROOT = Path(__file__).resolve().parents[3]
 
-# 只查命名变量：$1 / $# / $? 这类特殊参数 bash 只吃一个字符，紧跟中文也不会跑偏。
+# 只查命名变量：$1 / $# / $? 这类特殊参数 bash 只吃一个字符，紧跟非 ASCII 也不会跑偏。
 _BARE_VAR_BEFORE_NON_ASCII = re.compile(r"\$[A-Za-z_][A-Za-z0-9_]*(?=[^\x00-\x7f])")
 
-# 第三方/生成物不体检
+# 无 git 时的兜底扫描要跳过的目录（第三方 / 生成物）
 _SKIP_PARTS = {"node_modules", ".venv", "dist", "build", ".git"}
 
 
 def _repo_shell_scripts() -> list[Path]:
+    """仓库里**被 git 跟踪的** shell 脚本。
+
+    走 git ls-files 而不是 rglob：rglob 会把 .gitignore 掉的东西也扫进来（例如 .claude/
+    下各人自己的小工具），等于拿仓库门禁去管别人机器上的私货，且脚本数会随各人工作树
+    浮动。git 不可用时（源码包解压、没有 .git）退回 rglob + 跳过清单。
+    """
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(_ROOT), "ls-files", "-z", "*.sh", "*.bash"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=30,
+        ).stdout
+        tracked = [_ROOT / rel for rel in out.split("\0") if rel]
+        # 只留工作树里真实存在的（git 记录里可能有刚被删还没提交的）
+        found = sorted(p for p in tracked if p.is_file())
+        if found:
+            return found
+    except (OSError, subprocess.SubprocessError):
+        pass
     return sorted(
-        p
-        for p in _ROOT.rglob("*.sh")
-        if not _SKIP_PARTS.intersection(p.parts)
+        p for p in _ROOT.rglob("*.sh") if not _SKIP_PARTS.intersection(p.parts)
     )
 
 
 def test_shell_scripts_found() -> None:
     """先确认扫得到脚本，否则下面那条断言会因为"一个文件都没扫"而假绿。"""
     scripts = _repo_shell_scripts()
-    assert len(scripts) >= 10, f"只扫到 {len(scripts)} 个 .sh，路径推导可能坏了：{_ROOT}"
+    assert len(scripts) >= 10, f"只扫到 {len(scripts)} 个脚本，路径推导可能坏了：{_ROOT}"
     names = {p.name for p in scripts}
     assert {"build.sh", "local-ci.sh", "install-hermes.sh"} <= names, names
 
@@ -56,6 +93,7 @@ def test_no_bare_var_before_non_ascii() -> None:
                 offenders.append(f"{rel}:{lineno}: {line.strip()}")
 
     assert not offenders, (
-        "以下位置的变量紧跟非 ASCII 字符，macOS 自带 bash 3.2 会把它连进变量名，"
-        "set -u 下脚本会炸在这行。改成 ${VAR} 即可：\n  " + "\n  ".join(offenders)
+        "以下位置的变量紧跟非 ASCII 字符（中文 / emoji / 带音标字母都算），macOS 自带 "
+        "bash 3.2 会把它连进变量名：set -u 下脚本炸在这行，没 set -u 则静默输出乱码。"
+        "改成 ${VAR} 即可：\n  " + "\n  ".join(offenders)
     )

--- a/knowledge/06-dev-guide/dev-guide.md
+++ b/knowledge/06-dev-guide/dev-guide.md
@@ -424,8 +424,9 @@ bash scripts/install.sh --dev
 
 - **Python**：Ruff（lint + format），配置在 `backend/pyproject.toml`
 - **TypeScript**：Biome，配置在 `plugins/openclaw/`
-- **Shell**：`set -euo pipefail`；中文文案里的变量一律写 `${VAR}` 而非裸 `$VAR` —— macOS
-  自带的 bash 3.2 在 UTF-8 locale 下会把紧跟变量的中文首字节并进变量名，`set -u` 下那行
-  直接炸成 `unbound variable`（`backend/miloco/tests/test_shell_var_braces.py` 兜底）
+- **Shell**：`set -euo pipefail`；变量后面紧跟非 ASCII 字符（中文 / emoji / 带音标字母都算）
+  时一律写 `${VAR}` 而非裸 `$VAR` —— macOS 自带的 bash 3.2 在 UTF-8 locale 下会把那个字符的
+  首字节并进变量名：开了 `set -u` 就直接炸成 `unbound variable`，没开则不报错但静默输出乱码
+  （变量取空、后随字符首字节被吞）（`backend/miloco/tests/test_shell_var_braces.py` 兜底）
 - **测试**：pytest / vitest
 - **Commit**：遵循项目 git log 中的提交风格

--- a/knowledge/06-dev-guide/dev-guide.md
+++ b/knowledge/06-dev-guide/dev-guide.md
@@ -424,5 +424,8 @@ bash scripts/install.sh --dev
 
 - **Python**：Ruff（lint + format），配置在 `backend/pyproject.toml`
 - **TypeScript**：Biome，配置在 `plugins/openclaw/`
+- **Shell**：`set -euo pipefail`；中文文案里的变量一律写 `${VAR}` 而非裸 `$VAR` —— macOS
+  自带的 bash 3.2 在 UTF-8 locale 下会把紧跟变量的中文首字节并进变量名，`set -u` 下那行
+  直接炸成 `unbound variable`（`backend/miloco/tests/test_shell_var_braces.py` 兜底）
 - **测试**：pytest / vitest
 - **Commit**：遵循项目 git log 中的提交风格

--- a/plugins/hermes/install-hermes.sh
+++ b/plugins/hermes/install-hermes.sh
@@ -20,7 +20,8 @@ set -euo pipefail
 
 # 强制 UTF-8 + POSIX 字符类：中文提示/日志按字符而非字节处理，grep/sed/awk 行为一致。
 # 注意它防不住 "$VAR中文" —— 那个坑恰恰要 UTF-8 locale 才触发（macOS 自带 bash 3.2 在
-# UTF-8 下会把紧跟变量的多字节字符首字节并进变量名，set -u 直接报 unbound variable）。
+# UTF-8 下会把紧跟变量的非 ASCII 字符（中文 / emoji / 带音标字母都算）首字节并进变量名，
+# set -u 直接报 unbound variable，没 set -u 则静默输出乱码）。
 # 唯一可靠的写法是花括号 "${VAR}中文"，由 backend/miloco/tests/test_shell_var_braces.py 兜底。
 export LANG=C.UTF-8 LC_ALL=C.UTF-8
 

--- a/plugins/hermes/install-hermes.sh
+++ b/plugins/hermes/install-hermes.sh
@@ -18,7 +18,10 @@
 
 set -euo pipefail
 
-# 强制 UTF-8 + POSIX 字符类，防止 "$VAR中文" 被 bash 误识别为变量名延续
+# 强制 UTF-8 + POSIX 字符类：中文提示/日志按字符而非字节处理，grep/sed/awk 行为一致。
+# 注意它防不住 "$VAR中文" —— 那个坑恰恰要 UTF-8 locale 才触发（macOS 自带 bash 3.2 在
+# UTF-8 下会把紧跟变量的多字节字符首字节并进变量名，set -u 直接报 unbound variable）。
+# 唯一可靠的写法是花括号 "${VAR}中文"，由 backend/miloco/tests/test_shell_var_braces.py 兜底。
 export LANG=C.UTF-8 LC_ALL=C.UTF-8
 
 # --- CLI 参数解析（--diagnose / --no-start-backend / --post-install / -h） ---
@@ -48,7 +51,7 @@ EOF
       exit 0
       ;;
     *)
-      warn "未知参数: $arg（可用: --diagnose, --no-start-backend, -h）"
+      warn "未知参数: ${arg}（可用: --diagnose, --no-start-backend, -h）"
       ;;
   esac
 done

--- a/plugins/hermes/scripts/install.sh
+++ b/plugins/hermes/scripts/install.sh
@@ -37,7 +37,7 @@ if ! command -v miloco-cli >/dev/null 2>&1; then
 fi
 
 if [ ! -d "$HERMES_HOME" ]; then
-  err "找不到 Hermes 目录 $HERMES_HOME，请先安装 Hermes Agent"
+  err "找不到 Hermes 目录 ${HERMES_HOME}，请先安装 Hermes Agent"
   exit 1
 fi
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -263,7 +263,7 @@ build_web() {
     # watch.html 也是必需真文件(从 web/dist 落,缺了 /watch 页 503),这里硬校验防漏拷。
     if [[ ! -f "$web_static/index.html" || ! -d "$web_static/assets" \
           || ! -d "$web_static/fonts" || ! -f "$web_static/watch.html" ]]; then
-        die 5 "web build 产物缺失（$web_static），wheel 会带上残缺 web"
+        die 5 "web build 产物缺失（${web_static}），wheel 会带上残缺 web"
     fi
 }
 
@@ -346,7 +346,7 @@ pack_platform_bundles() {
     # 否则 sync-to-remote.sh --packages <子集> 这类 dev 工作流会被 set -e 中断。
     # 全量构建（默认 / CI）时缺文件仍走硬失败，暴露 CI 打包异常。
     if [[ "$PACKAGES" != "$ALL_PACKAGES" ]]; then
-        log "子集构建（--packages=$PACKAGES），跳过平台归档打包"
+        log "子集构建（--packages=${PACKAGES}），跳过平台归档打包"
         return
     fi
 

--- a/scripts/local-ci.sh
+++ b/scripts/local-ci.sh
@@ -176,7 +176,7 @@ except: pass
 " 2>/dev/null)
     fi
     if command -v claude &>/dev/null && [[ -n "$anthropic_key" ]]; then
-        info "本地 Claude 审查 PR #$pr_num（~5-10 分钟）…"
+        info "本地 Claude 审查 PR #${pr_num}（~5-10 分钟）…"
         _run_claude_review "$pr_num" "$repo" "$anthropic_key"
         return
     fi


### PR DESCRIPTION
## 背景

macOS 自带的 `/bin/bash`（3.2.57，Apple 那份补丁版）在 UTF-8 locale 下，会把紧跟变量名的**非 ASCII 字符**首字节当成变量名的一部分：

```console
$ LC_ALL=C.UTF-8 /bin/bash -uc 'v=hi; echo "A（$v）B"'
/bin/bash: v?: unbound variable      # 它查的是 "v\xef"，不是 "v"
```

不限于中文，判据就是「下一个字符不是 ASCII」—— `$vé` / `$v🙂` / `$v°C` 实测一样中招。

两种失败形态：

- **开了 `set -u`**（本仓库跟踪的 shell 脚本目前全都开了）：直接打断脚本，而且多半发生在"本来要打印一句人话"的分支上 —— 真正的报错被一句莫名其妙的 `unbound variable` 顶掉；
- **没开 `set -u`**：不报错，变量取空 + 吞掉后随字符首字节，静默输出乱码（`od -c` 看是 `A （ ** ** 274 211 B`），比直接炸更难查。

顺带一个反直觉的点：`LC_ALL=C` 下这么写是**正常**的（单字节模式下 bash 遇到 ≥0x80 的字节就停止取名），是 UTF-8 locale 才把这个 bug 打开。所以这不是"设对 locale 就能绕开"的问题，唯一可靠写法是花括号 `"${VAR}中文"`。

## 改了什么

### 1. 清掉全部 5 处裸写法（注释里的不算，注释不参与展开）

| 位置 | 内容 | 是否错误路径 |
|---|---|---|
| `scripts/build.sh:266` | web 产物缺失的 `die` | 是 |
| `scripts/build.sh:349` | 子集构建跳过平台归档的 `log` | **否** |
| `plugins/hermes/install-hermes.sh:51` | 未知参数 `warn` | 是 |
| `plugins/hermes/scripts/install.sh:40` | 找不到 Hermes 目录的 `err` | 是 |
| `scripts/local-ci.sh:179` | 本地 Claude 审查提示 | **否** |

后两行标"否"的是**正常分支**，也就是说 macOS 上 `bash scripts/build.sh --packages <子集>`（`sync-to-remote.sh` 走这条）每次都会死在 349 行，而不是等某个错误发生才炸。

### 2. 修掉一句说反了的注释

`install-hermes.sh:21` 原文写着 `export LANG=C.UTF-8 LC_ALL=C.UTF-8` 是为了「防止 `"$VAR中文"` 被 bash 误识别为变量名延续」—— 实测恰恰相反，是这行 export 把 bug 打开的。

那行 export 有别的正当用处（中文按字符而非字节处理、`grep`/`sed`/`awk` 的 POSIX 字符类行为一致），所以**保留**，只把注释改成实情并指向真正的解法。

### 3. 加回归门禁 `backend/miloco/tests/test_shell_var_braces.py`

- 跟着仓库既有的扫仓库体检测试放（`test_cross_end_alignment.py` / `test_version_normalize.py` 是同类），CI 的 `backend-test` 自动带上，**不新增 CI 面、不新增脚本、不依赖 `grep -P`**
- 只查命名变量：`$1` / `$#` / `$?` 这类特殊参数 bash 只吃一个字符，紧跟非 ASCII 也不会跑偏（已实测）
- 扫描集走 `git ls-files '*.sh' '*.bash'` 而非 `rglob`：后者会把 gitignore 掉的个人脚本（`.claude/*.sh`）也纳入门禁，等于拿仓库测试去管别人机器上的私货，脚本数还随各人工作树浮动。git 不可用时（源码包解压）回落 rglob
- 跳过注释行；另有一条 `test_shell_scripts_found` 防"一个文件都没扫到"式假绿

**覆盖边界**（docstring 里写明）：只扫 git 跟踪的 `*.sh` / `*.bash`。`.github/workflows/` 的内联 `run:` 块跑在 ubuntu runner 的 bash 5 上，不受影响（仓库目前没有 macos runner，哪天加了得一起纳管）；Python / TS 里的 shell 字符串（`subprocess(..., shell=True)`、`bash -c "…"` 字面量）理论上在射程内 —— macOS 的 `/bin/sh` 就是这份 bash 3.2 的 posix 模式，实测同样复现 —— 但当前全仓 0 处，没为此加扫描。

### 4. `knowledge/06-dev-guide/dev-guide.md` 的「代码规范」补一条 Shell 约定

## 验证

全部在 Apple bash 3.2 + `LC_ALL=C.UTF-8` 下跑：

- **5 处逐条对比**（改前后的原文从 git 里取出来跑，不是照着重写）：改前一律 `<name>?: unbound variable`，改后正常打出中文
- **端到端**：抽出真实的 `pack_platform_bundles` 跑 `--packages miloco`
  - 改前：`PACKAGES?: unbound variable`，`EXIT=1`，一个字都没打
  - 改后：`[build] 子集构建（--packages=miloco），跳过平台归档打包`，`EXIT=0`
- **新测试**：当前绿；临时往 `scripts/` 塞一处裸写法立刻变红并报出 `文件:行号`
- 跟踪的 15 个 `.sh` 全部 `bash -n` 通过；backend `ruff check .` 全绿

## 影响范围 / 说明

- 纯字符串写法修正，**没有行为变化**（除了原本会崩的分支现在能正常打印）
- docker 里的 bash **3.2 / 4.4 / 5.2 都不复现**，只有 Apple 那份会 —— 所以 GitHub ubuntu runner 上的 workflow 内联 shell 不受影响，`.github/workflows/` 未改（那边有 2 处同类写法，留在原地）
- 与 #492 无冲突：#492 只动 `build.sh` 的 `pack_models` 区段，本 PR 动 266 / 349 行

Refs #492（那个 PR 的 review 过程中发现的）
