### PR TITLE
fix: 回环并入 NO_PROXY，防系统代理劫持本机调用（backend + CLI）

### DIFF
--- a/backend/miloco/src/miloco/main.py
+++ b/backend/miloco/src/miloco/main.py
@@ -69,7 +69,132 @@ from miloco.task_record.router import router as task_record_router
 from miloco.utils.common import escape_for_js_string
 from miloco.utils.paths import miloco_home
 
+# httpx 的 get_environment_proxies 遍历的三个键(all = 全协议出口,常见于 SOCKS)。
+_PROXY_SCHEMES = ("http", "https", "all")
+
+
+def _system_proxies() -> dict[str, str]:
+    """只读**系统**代理设置,绕开 getproxies() 的 env 短路。
+
+    平台专用函数(macOS 的 getproxies_macosx_sysconf / Windows 的
+    getproxies_registry)不看环境变量,正是 getproxies() 里 `or` 右侧那一半。
+    其它平台(Linux)本就只有 env 一个来源,返回空 dict 即可。
+    """
+    import urllib.request
+
+    for name in ("getproxies_macosx_sysconf", "getproxies_registry"):
+        fn = getattr(urllib.request, name, None)
+        if fn is None:
+            continue
+        try:
+            return fn()
+        except Exception:  # noqa: BLE001 - 平台 API 失败退回无代理
+            return {}
+    return {}
+
+
+def _ensure_no_proxy_for_local() -> None:
+    """把回环地址并入 NO_PROXY,防系统代理劫持本机调用。
+
+    macOS 上 urllib.getproxies() 会读**系统级代理设置**(不只环境变量),Clash
+    Verge 等开启系统代理后,httpx(trust_env 默认 True)会把打 localhost:8080
+    (本地推理)的请求也送进代理,代理回连失败返 502 → 感知全灭
+    (2026-07-29 实锅:15:07 起 local-gemma/local-qwen 全部 502)。
+
+    **写入前必须先把当前可见的代理快照导出到 env**:CPython 的 getproxies() 是
+    ``getproxies_environment() or getproxies_macosx_sysconf()``(Windows 同构走
+    注册表)——只要环境里存在任何 ``*_proxy`` 变量,前者返回非空 dict 并短路掉
+    系统代理查询。若不先快照就写 NO_PROXY,系统代理会被整体"影子化",云端 API
+    (openrouter 等)从此直连、墙内不可达。
+
+    **两个大小写必须写成同一个值**:CPython 把所有 ``*_proxy`` 折叠成一个 dict
+    时分两遍扫描,第二遍只认字面小写并覆盖第一遍(源码注释:"in order to prefer
+    lowercase variables, process environment in two passes"),故 httpx 最终只认
+    小写 ``no_proxy``。若两份各读各的现有值再各写各的,只设了大写 ``NO_PROXY``
+    的用户(Docker / K8s / 企业代理文档的通行写法)其排除项会被静默丢弃。这里
+    取两份的并集,再把同一个结果写回两份。
+
+    只列回环地址(localhost / 127.0.0.1 / ::1),**不列 RFC1918 网段**:
+    httpx(0.28.1)的 NO_PROXY 没有子网匹配——``192.168.0.0/16`` 会被转成 mount
+    key ``all://192.168.0.0/16``,URLPattern 解析后 host 精确匹配
+    ``192.168.0.0``、path ``/16`` 直接丢弃(httpx 自己的 tests/test_utils.py
+    固化了这个转换),只有字面等于 ``192.168.0.0`` 的目标才 bypass。局域网设备
+    (vLLM / Tailscale / 手机节点)的直连交给代理软件自己的 DIRECT 规则;若要在
+    miloco 内强制,得在 client 构造点按目标地址给 ``trust_env=False``。
+
+    三条已知边界(都不在本函数职责内,记在这里免得排障时抓瞎):
+
+    - **快照只在 import 期取一次**。backend 起来之后才打开系统代理的话,env 里
+      没有代理、NO_PROXY 又已写入,云端调用会静默直连,须重启 backend 才恢复。
+    - **对"env 里本就有裸 NO_PROXY"的用户,这是新开启代理**。改动前
+      getproxies() 被那个 NO_PROXY 短路,httpx 拿不到任何代理 → 云端直连;
+      改动后 _system_proxies() 兜回系统代理并落进 env → 云端改走代理。这正是
+      本 PR 想要的(墙内访问云 API 需要代理),但对"故意设 NO_PROXY 来禁用代理"
+      的用户是行为反转——他们应改用 no_proxy 精确列目标,或显式设空的
+      http_proxy/https_proxy 表达"不要代理"。
+    - **快照会扩大代理的作用范围,不止子进程**。系统代理只有"系统感知"的库
+      (urllib / httpx)会读;落地成 env 后,凡是认 ``*_proxy`` 的都会开始走代理:
+      ① backend spawn 的子进程(git、升级脚本里的 curl / uv);② **同进程**内经
+      ctypes 加载的原生库——如摄像头 SDK 内含的 libcurl,它读的是本进程 env,
+      其云侧出口会从直连变成走代理。排查「版本检查/自动升级/相机云端接口突然
+      连不上」时记得这一条。
+    """
+    import urllib.request
+
+    # 先快照——顺序不能反,理由见 docstring。
+    try:
+        snapshot = urllib.request.getproxies()
+        # getproxies() 自己也会被 env 短路:**裸 NO_PROXY 也是 *_proxy**,
+        # 折叠成 `no` 键即让 dict 非空。用户 .zshrc 里 `export NO_PROXY=...`、
+        # 或 .env 经 load_dotenv() 注入(它跑在本函数之前)时,快照会静默取空,
+        # 系统代理照旧被影子化。所以拿不到 http/https 时直接问系统设置一次。
+        if not any(snapshot.get(k) for k in _PROXY_SCHEMES):
+            snapshot = {**_system_proxies(), **snapshot}
+    except Exception:  # noqa: BLE001 - 取不到代理不该拖垮启动
+        snapshot = {}
+    # 判**存在**而非真值:空值是 curl / CPython 生态里"显式取消该 scheme 代理"
+    # 的通行约定(getproxies_environment 第二遍扫描对空值走 proxies.pop),
+    # 用真值判断会把 `export https_proxy=` 当成"没配"、反手把系统代理写上去,
+    # 恰好打掉 docstring 给出的那条退出办法。
+    # 用户已显式配过任一出口就整体不插手:只配了 ALL_PROXY 的纯 SOCKS 出口
+    # (v2ray / Clash / ssh -D 的通行写法,httpx 的 get_environment_proxies
+    # 遍历 http/https/all 三个键)若只查 http/https,会被系统代理顶掉 http/https
+    # 出口——与"只追加缺失项"相反。
+    user_configured = any(
+        f"{s}_proxy" in os.environ or f"{s.upper()}_PROXY" in os.environ
+        for s in _PROXY_SCHEMES
+    )
+    if not user_configured:
+        # 导出只做 http/https:平台函数的键集里没有 all(macOS _scproxy 给
+        # http/https/ftp/gopher/socks,Windows 注册表给协议名),唯一能产出 all 的是
+        # getproxies_environment(),而那种情况 user_configured 已为真、走不到这里。
+        for scheme in ("http", "https"):
+            proxied = snapshot.get(scheme)
+            if proxied:
+                os.environ[f"{scheme}_proxy"] = proxied
+                os.environ[f"{scheme.upper()}_PROXY"] = proxied
+
+    local_entries = ["localhost", "127.0.0.1", "::1"]
+    # 先并集再统一写回:保序去重(用户已设条目在前),两份大小写内容一致。
+    merged: list[str] = []
+    for var in ("NO_PROXY", "no_proxy"):
+        for entry in os.environ.get(var, "").split(","):
+            entry = entry.strip()
+            if entry and entry not in merged:
+                merged.append(entry)
+    merged += [e for e in local_entries if e not in merged]
+    value = ",".join(merged)
+    os.environ["NO_PROXY"] = value
+    os.environ["no_proxy"] = value
+
+
 load_dotenv()
+# 模块级调用,不要挪进 lifespan/函数:感知与 agent 的 httpx client 在首次
+# 请求时惰性构造,而 client 构造时读一次代理环境——必须在那之前生效。
+# 被重构掉时的退化表现是本机调用重新被系统代理劫持返 502,
+# tests/test_no_proxy_local.py::test_module_import_applies_no_proxy_end_to_end
+# 开子进程钉住这条链路。
+_ensure_no_proxy_for_local()
 
 logger = logging.getLogger(__name__)
 

--- a/backend/miloco/src/miloco/main.py
+++ b/backend/miloco/src/miloco/main.py
@@ -70,7 +70,132 @@ from miloco.task_record.router import router as task_record_router
 from miloco.utils.common import escape_for_js_string
 from miloco.utils.paths import miloco_home
 
+# httpx 的 get_environment_proxies 遍历的三个键(all = 全协议出口,常见于 SOCKS)。
+_PROXY_SCHEMES = ("http", "https", "all")
+
+
+def _system_proxies() -> dict[str, str]:
+    """只读**系统**代理设置,绕开 getproxies() 的 env 短路。
+
+    平台专用函数(macOS 的 getproxies_macosx_sysconf / Windows 的
+    getproxies_registry)不看环境变量,正是 getproxies() 里 `or` 右侧那一半。
+    其它平台(Linux)本就只有 env 一个来源,返回空 dict 即可。
+    """
+    import urllib.request
+
+    for name in ("getproxies_macosx_sysconf", "getproxies_registry"):
+        fn = getattr(urllib.request, name, None)
+        if fn is None:
+            continue
+        try:
+            return fn()
+        except Exception:  # noqa: BLE001 - 平台 API 失败退回无代理
+            return {}
+    return {}
+
+
+def _ensure_no_proxy_for_local() -> None:
+    """把回环地址并入 NO_PROXY,防系统代理劫持本机调用。
+
+    macOS 上 urllib.getproxies() 会读**系统级代理设置**(不只环境变量),Clash
+    Verge 等开启系统代理后,httpx(trust_env 默认 True)会把打 localhost:8080
+    (本地推理)的请求也送进代理,代理回连失败返 502 → 感知全灭
+    (2026-07-29 实锅:15:07 起 local-gemma/local-qwen 全部 502)。
+
+    **写入前必须先把当前可见的代理快照导出到 env**:CPython 的 getproxies() 是
+    ``getproxies_environment() or getproxies_macosx_sysconf()``(Windows 同构走
+    注册表)——只要环境里存在任何 ``*_proxy`` 变量,前者返回非空 dict 并短路掉
+    系统代理查询。若不先快照就写 NO_PROXY,系统代理会被整体"影子化",云端 API
+    (openrouter 等)从此直连、墙内不可达。
+
+    **两个大小写必须写成同一个值**:CPython 把所有 ``*_proxy`` 折叠成一个 dict
+    时分两遍扫描,第二遍只认字面小写并覆盖第一遍(源码注释:"in order to prefer
+    lowercase variables, process environment in two passes"),故 httpx 最终只认
+    小写 ``no_proxy``。若两份各读各的现有值再各写各的,只设了大写 ``NO_PROXY``
+    的用户(Docker / K8s / 企业代理文档的通行写法)其排除项会被静默丢弃。这里
+    取两份的并集,再把同一个结果写回两份。
+
+    只列回环地址(localhost / 127.0.0.1 / ::1),**不列 RFC1918 网段**:
+    httpx(0.28.1)的 NO_PROXY 没有子网匹配——``192.168.0.0/16`` 会被转成 mount
+    key ``all://192.168.0.0/16``,URLPattern 解析后 host 精确匹配
+    ``192.168.0.0``、path ``/16`` 直接丢弃(httpx 自己的 tests/test_utils.py
+    固化了这个转换),只有字面等于 ``192.168.0.0`` 的目标才 bypass。局域网设备
+    (vLLM / Tailscale / 手机节点)的直连交给代理软件自己的 DIRECT 规则;若要在
+    miloco 内强制,得在 client 构造点按目标地址给 ``trust_env=False``。
+
+    三条已知边界(都不在本函数职责内,记在这里免得排障时抓瞎):
+
+    - **快照只在 import 期取一次**。backend 起来之后才打开系统代理的话,env 里
+      没有代理、NO_PROXY 又已写入,云端调用会静默直连,须重启 backend 才恢复。
+    - **对"env 里本就有裸 NO_PROXY"的用户,这是新开启代理**。改动前
+      getproxies() 被那个 NO_PROXY 短路,httpx 拿不到任何代理 → 云端直连;
+      改动后 _system_proxies() 兜回系统代理并落进 env → 云端改走代理。这正是
+      本 PR 想要的(墙内访问云 API 需要代理),但对"故意设 NO_PROXY 来禁用代理"
+      的用户是行为反转——他们应改用 no_proxy 精确列目标,或显式设空的
+      http_proxy/https_proxy 表达"不要代理"。
+    - **快照会扩大代理的作用范围,不止子进程**。系统代理只有"系统感知"的库
+      (urllib / httpx)会读;落地成 env 后,凡是认 ``*_proxy`` 的都会开始走代理:
+      ① backend spawn 的子进程(git、升级脚本里的 curl / uv);② **同进程**内经
+      ctypes 加载的原生库——如摄像头 SDK 内含的 libcurl,它读的是本进程 env,
+      其云侧出口会从直连变成走代理。排查「版本检查/自动升级/相机云端接口突然
+      连不上」时记得这一条。
+    """
+    import urllib.request
+
+    # 先快照——顺序不能反,理由见 docstring。
+    try:
+        snapshot = urllib.request.getproxies()
+        # getproxies() 自己也会被 env 短路:**裸 NO_PROXY 也是 *_proxy**,
+        # 折叠成 `no` 键即让 dict 非空。用户 .zshrc 里 `export NO_PROXY=...`、
+        # 或 .env 经 load_dotenv() 注入(它跑在本函数之前)时,快照会静默取空,
+        # 系统代理照旧被影子化。所以拿不到 http/https 时直接问系统设置一次。
+        if not any(snapshot.get(k) for k in _PROXY_SCHEMES):
+            snapshot = {**_system_proxies(), **snapshot}
+    except Exception:  # noqa: BLE001 - 取不到代理不该拖垮启动
+        snapshot = {}
+    # 判**存在**而非真值:空值是 curl / CPython 生态里"显式取消该 scheme 代理"
+    # 的通行约定(getproxies_environment 第二遍扫描对空值走 proxies.pop),
+    # 用真值判断会把 `export https_proxy=` 当成"没配"、反手把系统代理写上去,
+    # 恰好打掉 docstring 给出的那条退出办法。
+    # 用户已显式配过任一出口就整体不插手:只配了 ALL_PROXY 的纯 SOCKS 出口
+    # (v2ray / Clash / ssh -D 的通行写法,httpx 的 get_environment_proxies
+    # 遍历 http/https/all 三个键)若只查 http/https,会被系统代理顶掉 http/https
+    # 出口——与"只追加缺失项"相反。
+    user_configured = any(
+        f"{s}_proxy" in os.environ or f"{s.upper()}_PROXY" in os.environ
+        for s in _PROXY_SCHEMES
+    )
+    if not user_configured:
+        # 导出只做 http/https:平台函数的键集里没有 all(macOS _scproxy 给
+        # http/https/ftp/gopher/socks,Windows 注册表给协议名),唯一能产出 all 的是
+        # getproxies_environment(),而那种情况 user_configured 已为真、走不到这里。
+        for scheme in ("http", "https"):
+            proxied = snapshot.get(scheme)
+            if proxied:
+                os.environ[f"{scheme}_proxy"] = proxied
+                os.environ[f"{scheme.upper()}_PROXY"] = proxied
+
+    local_entries = ["localhost", "127.0.0.1", "::1"]
+    # 先并集再统一写回:保序去重(用户已设条目在前),两份大小写内容一致。
+    merged: list[str] = []
+    for var in ("NO_PROXY", "no_proxy"):
+        for entry in os.environ.get(var, "").split(","):
+            entry = entry.strip()
+            if entry and entry not in merged:
+                merged.append(entry)
+    merged += [e for e in local_entries if e not in merged]
+    value = ",".join(merged)
+    os.environ["NO_PROXY"] = value
+    os.environ["no_proxy"] = value
+
+
 load_dotenv()
+# 模块级调用,不要挪进 lifespan/函数:感知与 agent 的 httpx client 在首次
+# 请求时惰性构造,而 client 构造时读一次代理环境——必须在那之前生效。
+# 被重构掉时的退化表现是本机调用重新被系统代理劫持返 502,
+# tests/test_no_proxy_local.py::test_module_import_applies_no_proxy_end_to_end
+# 开子进程钉住这条链路。
+_ensure_no_proxy_for_local()
 
 logger = logging.getLogger(__name__)
 

--- a/backend/miloco/src/miloco/main.py
+++ b/backend/miloco/src/miloco/main.py
@@ -70,8 +70,8 @@ from miloco.task_record.router import router as task_record_router
 from miloco.utils.common import escape_for_js_string
 from miloco.utils.paths import miloco_home
 
-# httpx 的 get_environment_proxies 遍历的三个键(all = 全协议出口,常见于 SOCKS)。
-_PROXY_SCHEMES = ("http", "https", "all")
+# 只从系统快照补 HTTP(S);ALL_PROXY 由用户显式配置,不自动导出。
+_PROXY_SCHEMES = ("http", "https")
 
 
 def _system_proxies() -> dict[str, str]:
@@ -104,7 +104,7 @@ def _ensure_no_proxy_for_local() -> None:
 
     **写入前必须先把当前可见的代理快照导出到 env**:CPython 的 getproxies() 是
     ``getproxies_environment() or getproxies_macosx_sysconf()``(Windows 同构走
-    注册表)——只要环境里存在任何 ``*_proxy`` 变量,前者返回非空 dict 并短路掉
+    注册表)——只要环境代理解析结果非空(含单独的 ``no`` 键),就会短路掉
     系统代理查询。若不先快照就写 NO_PROXY,系统代理会被整体"影子化",云端 API
     (openrouter 等)从此直连、墙内不可达。
 
@@ -132,7 +132,10 @@ def _ensure_no_proxy_for_local() -> None:
       改动后 _system_proxies() 兜回系统代理并落进 env → 云端改走代理。这正是
       本 PR 想要的(墙内访问云 API 需要代理),但对"故意设 NO_PROXY 来禁用代理"
       的用户是行为反转——他们应改用 no_proxy 精确列目标,或显式设空的
-      http_proxy/https_proxy 表达"不要代理"。
+      http_proxy/https_proxy 表达"该协议不补系统代理"。未配置的另一协议仍补
+      系统代理;非空显式配置同样只影响自身协议。这是逐协议补齐的行为变化。
+      ALL_PROXY/all_proxy 存在时(含空值)则整体不补系统代理,保留用户默认出口;
+      若 ALL_PROXY 非空,单个协议设空仍可能落到该出口。全部直连应设 NO_PROXY=*。
     - **快照会扩大代理的作用范围,不止子进程**。系统代理只有"系统感知"的库
       (urllib / httpx)会读;落地成 env 后,凡是认 ``*_proxy`` 的都会开始走代理:
       ① backend spawn 的子进程(git、升级脚本里的 curl / uv);② **同进程**内经
@@ -142,34 +145,23 @@ def _ensure_no_proxy_for_local() -> None:
     """
     import urllib.request
 
-    # 先快照——顺序不能反,理由见 docstring。
-    try:
-        snapshot = urllib.request.getproxies()
-        # getproxies() 自己也会被 env 短路:**裸 NO_PROXY 也是 *_proxy**,
-        # 折叠成 `no` 键即让 dict 非空。用户 .zshrc 里 `export NO_PROXY=...`、
-        # 或 .env 经 load_dotenv() 注入(它跑在本函数之前)时,快照会静默取空,
-        # 系统代理照旧被影子化。所以拿不到 http/https 时直接问系统设置一次。
-        if not any(snapshot.get(k) for k in _PROXY_SCHEMES):
-            snapshot = {**_system_proxies(), **snapshot}
-    except Exception:  # noqa: BLE001 - 取不到代理不该拖垮启动
-        snapshot = {}
-    # 判**存在**而非真值:空值是 curl / CPython 生态里"显式取消该 scheme 代理"
-    # 的通行约定(getproxies_environment 第二遍扫描对空值走 proxies.pop),
-    # 用真值判断会把 `export https_proxy=` 当成"没配"、反手把系统代理写上去,
-    # 恰好打掉 docstring 给出的那条退出办法。
-    # 用户已显式配过任一出口就整体不插手:只配了 ALL_PROXY 的纯 SOCKS 出口
-    # (v2ray / Clash / ssh -D 的通行写法,httpx 的 get_environment_proxies
-    # 遍历 http/https/all 三个键)若只查 http/https,会被系统代理顶掉 http/https
-    # 出口——与"只追加缺失项"相反。
-    user_configured = any(
-        f"{s}_proxy" in os.environ or f"{s.upper()}_PROXY" in os.environ
-        for s in _PROXY_SCHEMES
+    # ALL_PROXY(含空值)表示用户掌管默认出口;否则仅补未配置的协议。
+    # 按变量存在性判断,保留显式空值及 CPython 的大小写优先级。
+    proxy_env_keys = {key.lower() for key in os.environ}
+    missing_schemes = (
+        [] if "all_proxy" in proxy_env_keys else
+        [s for s in _PROXY_SCHEMES if f"{s}_proxy" not in proxy_env_keys]
     )
-    if not user_configured:
-        # 导出只做 http/https:平台函数的键集里没有 all(macOS _scproxy 给
-        # http/https/ftp/gopher/socks,Windows 注册表给协议名),唯一能产出 all 的是
-        # getproxies_environment(),而那种情况 user_configured 已为真、走不到这里。
-        for scheme in ("http", "https"):
+    if missing_schemes:
+        # 必须先快照再写 NO_PROXY。裸 NO_PROXY 或仅配置一个协议,都会让
+        # getproxies() 短路系统设置;对缺失协议单独检查是否需要系统回退。
+        try:
+            snapshot = urllib.request.getproxies()
+            if any(not snapshot.get(s) for s in missing_schemes):
+                snapshot = {**_system_proxies(), **snapshot}
+        except Exception:  # noqa: BLE001 - 取不到代理不该拖垮启动
+            snapshot = {}
+        for scheme in missing_schemes:
             proxied = snapshot.get(scheme)
             if proxied:
                 os.environ[f"{scheme}_proxy"] = proxied

--- a/backend/miloco/tests/test_no_proxy_local.py
+++ b/backend/miloco/tests/test_no_proxy_local.py
@@ -1,0 +1,223 @@
+# Copyright (C) 2025 Xiaomi Corporation
+# This software may be used and distributed according to the terms of the Xiaomi Miloco License Agreement.
+
+"""``_ensure_no_proxy_for_local`` 单测。
+
+守护两条容易回归、且回归后**静默**的性质:
+1. 写 NO_PROXY 前必须先把系统代理快照进 env——否则 CPython 的
+   ``getproxies_environment() or <系统代理>`` 短路会让系统代理整体消失,
+   云端 API 直连、墙内不可达(症状在本地开发机上完全看不出来)。
+2. 不写 RFC1918 CIDR——httpx 不做子网匹配,写了也只是无效条目。
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+# 必须在 import miloco.main **之前**快照:该模块在模块级就调用了
+# _ensure_no_proxy_for_local(),import 的一瞬间就会把系统代理写进 os.environ,
+# 早于任何 fixture。不在这里记下原始值,这些变量会泄漏到同一次 pytest 会话的
+# 后续测试(且失败带顺序依赖,最难查那类)。
+_PROXY_ENV_AT_IMPORT = {
+    k: v for k, v in os.environ.items() if k.lower().endswith("_proxy")
+}
+
+from miloco.main import _ensure_no_proxy_for_local  # noqa: E402
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _restore_proxy_env_after_module():
+    """本模块跑完把 *_proxy 恢复到 import 前的样子(含 import 期的副作用)。"""
+    yield
+    for key in [k for k in os.environ if k.lower().endswith("_proxy")]:
+        del os.environ[key]
+    os.environ.update(_PROXY_ENV_AT_IMPORT)
+
+
+@pytest.fixture
+def clean_proxy_env(monkeypatch):
+    """清掉所有 *_proxy,模拟「纯系统代理、环境无代理变量」的事故环境。
+
+    还原用显式快照而**不是** monkeypatch.delenv:被测函数直接写 os.environ、
+    不经 monkeypatch,而 delenv 对**当时不存在**的 key 什么都不记录
+    (pytest 的 delitem: ``if name not in dic: ...else: 记录``),于是函数新写入
+    的 http_proxy / HTTPS_PROXY 等在 teardown 时无人还原,泄漏进同一次 pytest
+    会话的后续测试——且失败带顺序依赖(单跑此文件绿、全量才红),最难查那类。
+    这里退出时先清空所有 *_proxy 再灌回快照,与函数写了什么无关。
+    """
+    saved = {k: v for k, v in os.environ.items() if k.lower().endswith("_proxy")}
+    for key in saved:
+        del os.environ[key]
+    yield monkeypatch
+    for key in [k for k in os.environ if k.lower().endswith("_proxy")]:
+        del os.environ[key]
+    os.environ.update(saved)
+
+
+def test_loopback_entries_appended(clean_proxy_env):
+    _ensure_no_proxy_for_local()
+    entries = os.environ["NO_PROXY"].split(",")
+    assert "localhost" in entries
+    assert "127.0.0.1" in entries
+    assert "::1" in entries
+    # 大小写两份都要写:httpx 读 no_proxy,部分工具读 NO_PROXY
+    assert os.environ["no_proxy"] == os.environ["NO_PROXY"]
+
+
+def test_no_cidr_entries(clean_proxy_env):
+    """httpx 不做子网匹配,CIDR 条目形同虚设——不写,免得看着生效实则无效。"""
+    _ensure_no_proxy_for_local()
+    assert "/" not in os.environ["NO_PROXY"]
+
+
+def test_system_proxy_snapshotted_before_write(clean_proxy_env):
+    """🔴 回归守护:系统代理必须先快照进 env,否则写 NO_PROXY 会把它影子化。
+
+    模拟 macOS「系统代理开着、shell 无 *_proxy 变量」——即本 PR 的事故环境。
+    """
+    clean_proxy_env.setattr(
+        "urllib.request.getproxies",
+        lambda: {"http": "http://127.0.0.1:7897", "https": "http://127.0.0.1:7897"},
+    )
+    _ensure_no_proxy_for_local()
+    assert os.environ["http_proxy"] == "http://127.0.0.1:7897"
+    assert os.environ["HTTPS_PROXY"] == "http://127.0.0.1:7897"
+
+
+def test_existing_proxy_env_not_overwritten(clean_proxy_env):
+    """代理本就配在 env(Linux Clash 典型):快照不该覆盖用户的显式配置。"""
+    clean_proxy_env.setenv("https_proxy", "http://user-set:1080")
+    clean_proxy_env.setattr(
+        "urllib.request.getproxies", lambda: {"https": "http://snapshot:9999"}
+    )
+    _ensure_no_proxy_for_local()
+    assert os.environ["https_proxy"] == "http://user-set:1080"
+
+
+def test_existing_no_proxy_entries_preserved(clean_proxy_env):
+    """setdefault 语义:只追加缺失项,用户已设条目原样保留。"""
+    clean_proxy_env.setenv("NO_PROXY", "example.com,127.0.0.1")
+    _ensure_no_proxy_for_local()
+    entries = os.environ["NO_PROXY"].split(",")
+    assert entries[0] == "example.com"
+    assert entries.count("127.0.0.1") == 1  # 已存在的不重复追加
+
+
+def test_uppercase_only_no_proxy_not_dropped(clean_proxy_env):
+    """只设大写 NO_PROXY(Docker/K8s/企业代理通行写法)时,排除项不能丢。
+
+    回归守护:CPython 折叠 *_proxy 时小写胜出,若两份各读各的现有值再各写各的,
+    小写那份不含 example.com,httpx 实际采纳的就是缺了它的版本——静默丢配置。
+    """
+    clean_proxy_env.setenv("NO_PROXY", "api.internal.corp")
+    _ensure_no_proxy_for_local()
+    assert "api.internal.corp" in os.environ["no_proxy"]
+    assert os.environ["no_proxy"] == os.environ["NO_PROXY"]
+
+
+def test_lowercase_only_no_proxy_not_dropped(clean_proxy_env):
+    """对称场景:只设小写 no_proxy 时同样不丢。"""
+    clean_proxy_env.setenv("no_proxy", "api.internal.corp")
+    _ensure_no_proxy_for_local()
+    assert "api.internal.corp" in os.environ["NO_PROXY"]
+    assert os.environ["no_proxy"] == os.environ["NO_PROXY"]
+
+
+def test_getproxies_failure_does_not_break_startup(clean_proxy_env):
+    """取代理抛异常时仍要写好 NO_PROXY——本函数在 import 期跑,不能拖垮启动。"""
+    def boom():
+        raise OSError("SystemConfiguration unavailable")
+
+    clean_proxy_env.setattr("urllib.request.getproxies", boom)
+    _ensure_no_proxy_for_local()
+    assert "127.0.0.1" in os.environ["NO_PROXY"]
+
+
+def test_snapshot_survives_preexisting_bare_no_proxy(clean_proxy_env):
+    """env 里事先就有裸 NO_PROXY 时,快照不能被短路成空。
+
+    回归守护:NO_PROXY 自己也是 *_proxy,折叠成 `no` 键即让
+    getproxies_environment() 非空 → getproxies() 不再查系统设置。用户 .zshrc
+    里 `export NO_PROXY=localhost`、或 .env 经 load_dotenv() 注入(跑在被测
+    函数之前)都会命中。此时必须回退到只读系统设置的平台函数。
+
+    刻意**不 mock getproxies**——上一版 8 条用例全把它整个 mock 掉,结构性
+    抓不到这个洞;这里只 mock 系统侧函数,让真实的 env 短路逻辑参与进来。
+    """
+    clean_proxy_env.setenv("NO_PROXY", "preexisting.example")
+    clean_proxy_env.setattr(
+        "miloco.main._system_proxies",
+        lambda: {"http": "http://sys:7897", "https": "http://sys:7897"},
+    )
+    _ensure_no_proxy_for_local()
+    assert os.environ["https_proxy"] == "http://sys:7897"
+    # 用户原有条目仍在
+    assert "preexisting.example" in os.environ["no_proxy"]
+
+
+def test_env_proxy_wins_over_system(clean_proxy_env):
+    """env 已显式配了代理时,不去问系统设置(env 是更强的用户意图)。"""
+    clean_proxy_env.setenv("https_proxy", "http://env-set:1080")
+    clean_proxy_env.setattr(
+        "miloco.main._system_proxies",
+        lambda: pytest.fail("env 已有代理时不该回退问系统"),
+    )
+    _ensure_no_proxy_for_local()
+    assert os.environ["https_proxy"] == "http://env-set:1080"
+
+
+def test_all_proxy_only_user_not_overridden(clean_proxy_env):
+    """只配 ALL_PROXY(纯 SOCKS 出口的通行写法)时,不能被系统代理顶掉。
+
+    回归守护:httpx 的 get_environment_proxies 遍历 http/https/all 三个键。
+    若「用户是否已配代理」的 guard 只查 http/https,系统代理会被写进
+    http_proxy/https_proxy,把用户想全走 SOCKS 的意图静默改掉——与本函数
+    "只追加缺失项"的原则相反。
+    """
+    clean_proxy_env.setenv("ALL_PROXY", "socks5://127.0.0.1:7891")
+    clean_proxy_env.setattr(
+        "miloco.main._system_proxies",
+        lambda: {"http": "http://sys:7890", "https": "http://sys:7890"},
+    )
+    _ensure_no_proxy_for_local()
+    assert os.environ["ALL_PROXY"] == "socks5://127.0.0.1:7891"
+    assert "http_proxy" not in os.environ
+    assert "https_proxy" not in os.environ
+
+
+def test_module_import_applies_no_proxy_end_to_end():
+    """开子进程 import miloco.main,验证注入链路真的生效。
+
+    其余用例都直接 import 被测函数,结构上抓不到"函数写对了但没人调用"——
+    backend 的注入是 main.py 里一句模块级语句,被重构掉时 11 个用例全绿,
+    而失效后果比 CLI 更大(整个感知链路的本机调用重新被代理劫持)。
+    与 CLI 侧 test_entrypoint_applies_no_proxy_end_to_end 对称。
+    """
+    import subprocess
+    import sys
+
+    env = {k: v for k, v in os.environ.items() if not k.lower().endswith("_proxy")}
+    out = subprocess.run(
+        [sys.executable, "-c",
+         "import miloco.main, os; print(os.environ.get('NO_PROXY', ''))"],
+        capture_output=True, text=True, env=env, timeout=120,
+    )
+    assert out.returncode == 0, out.stderr[-2000:]
+    entries = out.stdout.strip().splitlines()[-1].split(",")
+    assert {"localhost", "127.0.0.1", "::1"} <= set(entries), out.stdout
+
+
+def test_empty_proxy_value_treated_as_explicit_opt_out(clean_proxy_env):
+    """空值 = 显式取消该 scheme 代理(curl / CPython 通行约定),不该被系统代理覆盖。
+
+    回归守护:守门若判真值而非存在性,`export https_proxy=` 会被当成"没配",
+    系统代理反手写上去——正好打掉 docstring 给出的那条退出办法。
+    """
+    clean_proxy_env.setenv("https_proxy", "")
+    clean_proxy_env.setattr(
+        "miloco.main._system_proxies", lambda: {"https": "http://sys:9999"}
+    )
+    _ensure_no_proxy_for_local()
+    assert os.environ["https_proxy"] == ""

--- a/backend/miloco/tests/test_no_proxy_local.py
+++ b/backend/miloco/tests/test_no_proxy_local.py
@@ -13,8 +13,11 @@
 from __future__ import annotations
 
 import os
+import urllib.request
 
+import httpx
 import pytest
+from httpx._utils import get_environment_proxies
 
 # 必须在 import miloco.main **之前**快照:该模块在模块级就调用了
 # _ensure_no_proxy_for_local(),import 的一瞬间就会把系统代理写进 os.environ,
@@ -50,6 +53,9 @@ def clean_proxy_env(monkeypatch):
     saved = {k: v for k, v in os.environ.items() if k.lower().endswith("_proxy")}
     for key in saved:
         del os.environ[key]
+    # 不读取开发机系统代理;具体场景再显式注入系统设置。
+    for name in ("getproxies_macosx_sysconf", "getproxies_registry"):
+        monkeypatch.setattr(urllib.request, name, lambda: {}, raising=False)
     yield monkeypatch
     for key in [k for k in os.environ if k.lower().endswith("_proxy")]:
         del os.environ[key]
@@ -158,7 +164,8 @@ def test_snapshot_survives_preexisting_bare_no_proxy(clean_proxy_env):
 
 
 def test_env_proxy_wins_over_system(clean_proxy_env):
-    """env 已显式配了代理时,不去问系统设置(env 是更强的用户意图)。"""
+    """两个协议均已显式配置时,不读取系统设置。"""
+    clean_proxy_env.setenv("http_proxy", "http://env-set:1080")
     clean_proxy_env.setenv("https_proxy", "http://env-set:1080")
     clean_proxy_env.setattr(
         "miloco.main._system_proxies",
@@ -221,3 +228,87 @@ def test_empty_proxy_value_treated_as_explicit_opt_out(clean_proxy_env):
     )
     _ensure_no_proxy_for_local()
     assert os.environ["https_proxy"] == ""
+
+
+@pytest.mark.parametrize(
+    ("proxy_env", "expected_proxies"),
+    [
+        ({}, {"http://": "http://sys:7897", "https://": "http://sys:7897"}),
+        ({"http_proxy": ""}, {"https://": "http://sys:7897"}),
+        ({"HTTP_PROXY": ""}, {"https://": "http://sys:7897"}),
+        ({"https_proxy": ""}, {"http://": "http://sys:7897"}),
+        ({"HTTPS_PROXY": ""}, {"http://": "http://sys:7897"}),
+        ({"http_proxy": "http://user:1080"},
+         {"http://": "http://user:1080", "https://": "http://sys:7897"}),
+        ({"https_proxy": "http://user:1080"},
+         {"http://": "http://sys:7897", "https://": "http://user:1080"}),
+        ({"http_proxy": "", "https_proxy": ""}, {}),
+        ({"HTTP_PROXY": "http://upper:1080", "http_proxy": ""},
+         {"https://": "http://sys:7897"}),
+        ({"HTTPS_PROXY": "http://upper:1080", "https_proxy": "http://lower:1080"},
+         {"http://": "http://sys:7897", "https://": "http://lower:1080"}),
+        ({"ALL_PROXY": "socks5://user:1080"}, {"all://": "socks5://user:1080"}),
+        ({"all_proxy": "socks5://user:1080"}, {"all://": "socks5://user:1080"}),
+        ({"ALL_PROXY": ""}, {}),
+        ({"all_proxy": "", "https_proxy": "http://user:1080"},
+         {"https://": "http://user:1080"}),
+        ({"ALL_PROXY": "socks5://user:1080", "https_proxy": "http://user:1081"},
+         {"all://": "socks5://user:1080", "https://": "http://user:1081"}),
+    ],
+    ids=["system", "empty-http", "empty-HTTP", "empty-https", "empty-HTTPS",
+         "partial-http", "partial-https", "both-empty", "lowercase-empty-wins",
+         "lowercase-value-wins", "ALL-socks", "all-socks", "empty-ALL",
+         "empty-all-explicit-https", "ALL-with-explicit-https"],
+)
+def test_httpx_proxy_routes(clean_proxy_env, proxy_env, expected_proxies):
+    """只替换系统设置来源,让真实 urllib 和 httpx 解析最终环境及路由。"""
+    for name in ("getproxies_macosx_sysconf", "getproxies_registry"):
+        clean_proxy_env.setattr(
+            urllib.request, name,
+            lambda: {"http": "http://sys:7897", "https": "http://sys:7897"},
+            raising=False,
+        )
+    for key, value in proxy_env.items():
+        clean_proxy_env.setenv(key, value)
+    clean_proxy_env.setenv("NO_PROXY", "upper.example,localhost")
+    clean_proxy_env.setenv("no_proxy", "lower.example,localhost")
+
+    _ensure_no_proxy_for_local()
+
+    # 完整字典相等也守护条数,避免通配条目意外把整张代理表清空。
+    expected = {
+        **expected_proxies,
+        "all://*upper.example": None,
+        "all://*lower.example": None,
+        "all://localhost": None,
+        "all://127.0.0.1": None,
+        "all://[::1]": None,
+    }
+    assert get_environment_proxies() == expected
+    for key, value in proxy_env.items():
+        assert os.environ[key] == value
+    # 启动初始化重复执行不会改变已经确定的出口。
+    _ensure_no_proxy_for_local()
+    assert get_environment_proxies() == expected
+
+
+def test_httpx_client_selects_loopback_direct_and_cloud_proxy(clean_proxy_env):
+    """真实 Client 的 transport 选择;不发网络请求、不依赖本机代理服务。"""
+    clean_proxy_env.setenv("https_proxy", "http://proxy.invalid:7897")
+    clean_proxy_env.setenv("http_proxy", "http://proxy.invalid:7897")
+    _ensure_no_proxy_for_local()
+    with httpx.Client() as client:
+        for scheme in ("http", "https"):
+            for host in ("localhost", "127.0.0.1", "[::1]"):
+                url = httpx.URL(f"{scheme}://{host}:1810")
+                assert client._transport_for_url(url) is client._transport
+            cloud = httpx.URL(f"{scheme}://cloud.example")
+            assert client._transport_for_url(cloud) is not client._transport
+
+
+def test_httpx_explicit_wildcard_bypasses_all(clean_proxy_env):
+    """用户主动指定 NO_PROXY=* 时,仍应允许整表为空。"""
+    clean_proxy_env.setenv("https_proxy", "http://user:1080")
+    clean_proxy_env.setenv("NO_PROXY", "*")
+    _ensure_no_proxy_for_local()
+    assert get_environment_proxies() == {}

--- a/cli/src/miloco_cli/client.py
+++ b/cli/src/miloco_cli/client.py
@@ -6,12 +6,74 @@
 """
 
 import json
+import os
 import sys
+import urllib.request
 from typing import NoReturn
 
 import httpx
 
 from miloco_cli.config import load_config
+
+# httpx 的 get_environment_proxies 遍历的三个键(all = 全协议出口,常见于 SOCKS)。
+_PROXY_SCHEMES = ("http", "https", "all")
+
+
+def _system_proxies() -> dict[str, str]:
+    """只读系统代理设置,绕开 getproxies() 的 env 短路(裸 NO_PROXY 也会短路它)。"""
+    for name in ("getproxies_macosx_sysconf", "getproxies_registry"):
+        fn = getattr(urllib.request, name, None)
+        if fn is None:
+            continue
+        try:
+            return fn()
+        except Exception:  # noqa: BLE001
+            return {}
+    return {}
+
+
+def ensure_no_proxy_for_local() -> None:
+    """把回环并入 NO_PROXY,防系统代理劫持 CLI→后端(127.0.0.1:1810)的调用。
+
+    与 backend 的 ``main._ensure_no_proxy_for_local`` 同口径(先快照、快照本身防
+    env 短路、守门看三个 scheme 且判**存在性**而非真值、两个大小写写同值、
+    不列 CIDR),详见那边 docstring 的完整推理。
+    两个包互不依赖故各留一份;本函数刻意包成函数而非模块级裸语句——模块级
+    ``for`` 在 Python 里不是块作用域,循环变量会挂在模块命名空间上,且无法在
+    测试里重复调用。
+    """
+    try:
+        snapshot = urllib.request.getproxies()
+        if not any(snapshot.get(k) for k in _PROXY_SCHEMES):
+            snapshot = {**_system_proxies(), **snapshot}
+    except Exception:  # noqa: BLE001
+        snapshot = {}
+    user_configured = any(
+        f"{s}_proxy" in os.environ or f"{s.upper()}_PROXY" in os.environ
+        for s in _PROXY_SCHEMES
+    )
+    if not user_configured:
+        # 导出只做 http/https:平台函数的键集里没有 all(macOS _scproxy 给
+        # http/https/ftp/gopher/socks,Windows 注册表给协议名),唯一能产出 all 的是
+        # getproxies_environment(),而那种情况 user_configured 已为真、走不到这里。
+        for scheme in ("http", "https"):
+            proxied = snapshot.get(scheme)
+            if proxied:
+                os.environ[f"{scheme}_proxy"] = proxied
+                os.environ[f"{scheme.upper()}_PROXY"] = proxied
+
+    merged: list[str] = []
+    for var in ("NO_PROXY", "no_proxy"):
+        for entry in os.environ.get(var, "").split(","):
+            entry = entry.strip()
+            if entry and entry not in merged:
+                merged.append(entry)
+    merged += [e for e in ("localhost", "127.0.0.1", "::1") if e not in merged]
+    os.environ["NO_PROXY"] = os.environ["no_proxy"] = ",".join(merged)
+
+
+# 调用点在 miloco_cli.main(声明的入口点),不在这里自动执行——依赖 import
+# 副作用会让「谁 import 了本模块」变成隐式契约。
 
 
 def _get_client(cfg: dict) -> httpx.Client:

--- a/cli/src/miloco_cli/client.py
+++ b/cli/src/miloco_cli/client.py
@@ -15,8 +15,8 @@ import httpx
 
 from miloco_cli.config import load_config
 
-# httpx 的 get_environment_proxies 遍历的三个键(all = 全协议出口,常见于 SOCKS)。
-_PROXY_SCHEMES = ("http", "https", "all")
+# 只从系统快照补 HTTP(S);ALL_PROXY 由用户显式配置,不自动导出。
+_PROXY_SCHEMES = ("http", "https")
 
 
 def _system_proxies() -> dict[str, str]:
@@ -36,27 +36,29 @@ def ensure_no_proxy_for_local() -> None:
     """把回环并入 NO_PROXY,防系统代理劫持 CLI→后端(127.0.0.1:1810)的调用。
 
     与 backend 的 ``main._ensure_no_proxy_for_local`` 同口径(先快照、快照本身防
-    env 短路、守门看三个 scheme 且判**存在性**而非真值、两个大小写写同值、
+    env 短路、ALL_PROXY 整体守门、HTTP(S) 分别按存在性守门、两个大小写写同值、
     不列 CIDR),详见那边 docstring 的完整推理。
     两个包互不依赖故各留一份;本函数刻意包成函数而非模块级裸语句——模块级
     ``for`` 在 Python 里不是块作用域,循环变量会挂在模块命名空间上,且无法在
     测试里重复调用。
     """
-    try:
-        snapshot = urllib.request.getproxies()
-        if not any(snapshot.get(k) for k in _PROXY_SCHEMES):
-            snapshot = {**_system_proxies(), **snapshot}
-    except Exception:  # noqa: BLE001
-        snapshot = {}
-    user_configured = any(
-        f"{s}_proxy" in os.environ or f"{s.upper()}_PROXY" in os.environ
-        for s in _PROXY_SCHEMES
+    # ALL_PROXY(含空值)表示用户掌管默认出口;否则仅补未配置的协议。
+    # 按变量存在性判断,保留显式空值及 CPython 的大小写优先级。
+    proxy_env_keys = {key.lower() for key in os.environ}
+    missing_schemes = (
+        [] if "all_proxy" in proxy_env_keys else
+        [s for s in _PROXY_SCHEMES if f"{s}_proxy" not in proxy_env_keys]
     )
-    if not user_configured:
-        # 导出只做 http/https:平台函数的键集里没有 all(macOS _scproxy 给
-        # http/https/ftp/gopher/socks,Windows 注册表给协议名),唯一能产出 all 的是
-        # getproxies_environment(),而那种情况 user_configured 已为真、走不到这里。
-        for scheme in ("http", "https"):
+    if missing_schemes:
+        # 必须先快照再写 NO_PROXY。裸 NO_PROXY 或仅配置一个协议,都会让
+        # getproxies() 短路系统设置;对缺失协议单独检查是否需要系统回退。
+        try:
+            snapshot = urllib.request.getproxies()
+            if any(not snapshot.get(s) for s in missing_schemes):
+                snapshot = {**_system_proxies(), **snapshot}
+        except Exception:  # noqa: BLE001 - 取不到代理不该拖垮启动
+            snapshot = {}
+        for scheme in missing_schemes:
             proxied = snapshot.get(scheme)
             if proxied:
                 os.environ[f"{scheme}_proxy"] = proxied

--- a/cli/src/miloco_cli/main.py
+++ b/cli/src/miloco_cli/main.py
@@ -13,29 +13,39 @@ from datetime import datetime, timezone
 
 import click
 
-from miloco_cli.commands.account import account_group
-from miloco_cli.commands.actions import actions_group
-from miloco_cli.commands.admin import admin_group
-from miloco_cli.commands.config import config_group
-from miloco_cli.commands.cron import cron_group
-from miloco_cli.commands.dashboard import dashboard_cmd
-from miloco_cli.commands.debug import debug_group
-from miloco_cli.commands.device import device_group
-from miloco_cli.commands.doctor import doctor_cmd
-from miloco_cli.commands.habit import habit_group
-from miloco_cli.commands.home_profile import home_profile_group
-from miloco_cli.commands.identity import identity_group
-from miloco_cli.commands.monitor import monitor_group
-from miloco_cli.commands.notify import notify_group
-from miloco_cli.commands.perceive import perceive_group
-from miloco_cli.commands.person import person_group
-from miloco_cli.commands.pet import pet_group
-from miloco_cli.commands.rule import rule_group
-from miloco_cli.commands.scene import scene_group
-from miloco_cli.commands.scope import scope_group
-from miloco_cli.commands.service import service_group
-from miloco_cli.commands.task import task_group
-from miloco_cli.commands.time_compute import time_compute_cmd
+# 必须在任何命令模块 import 之前执行:它们各自现构造 httpx client,而 client
+# 在构造时读一次代理环境。此前这个副作用挂在 commands/scope.py 的模块级
+# `from miloco_cli.client import ...` 上——全仓 18 个命令模块里唯一一个那么写
+# 的,把它改成惰性 import(一次纯粹的一致性清理)就会让整条链路静默失效,
+# 退化表现正是本修复要消灭的 502。钉在声明的入口点上,不依赖任何模块的
+# import 顺序。
+from miloco_cli.client import ensure_no_proxy_for_local
+
+ensure_no_proxy_for_local()
+
+from miloco_cli.commands.account import account_group  # noqa: E402
+from miloco_cli.commands.actions import actions_group  # noqa: E402
+from miloco_cli.commands.admin import admin_group  # noqa: E402
+from miloco_cli.commands.config import config_group  # noqa: E402
+from miloco_cli.commands.cron import cron_group  # noqa: E402
+from miloco_cli.commands.dashboard import dashboard_cmd  # noqa: E402
+from miloco_cli.commands.debug import debug_group  # noqa: E402
+from miloco_cli.commands.device import device_group  # noqa: E402
+from miloco_cli.commands.doctor import doctor_cmd  # noqa: E402
+from miloco_cli.commands.habit import habit_group  # noqa: E402
+from miloco_cli.commands.home_profile import home_profile_group  # noqa: E402
+from miloco_cli.commands.identity import identity_group  # noqa: E402
+from miloco_cli.commands.monitor import monitor_group  # noqa: E402
+from miloco_cli.commands.notify import notify_group  # noqa: E402
+from miloco_cli.commands.perceive import perceive_group  # noqa: E402
+from miloco_cli.commands.person import person_group  # noqa: E402
+from miloco_cli.commands.pet import pet_group  # noqa: E402
+from miloco_cli.commands.rule import rule_group  # noqa: E402
+from miloco_cli.commands.scene import scene_group  # noqa: E402
+from miloco_cli.commands.scope import scope_group  # noqa: E402
+from miloco_cli.commands.service import service_group  # noqa: E402
+from miloco_cli.commands.task import task_group  # noqa: E402
+from miloco_cli.commands.time_compute import time_compute_cmd  # noqa: E402
 
 
 @functools.lru_cache(maxsize=1)

--- a/cli/src/miloco_cli/main.py
+++ b/cli/src/miloco_cli/main.py
@@ -13,12 +13,13 @@ from datetime import datetime, timezone
 
 import click
 
-# 必须在任何命令模块 import 之前执行:它们各自现构造 httpx client,而 client
-# 在构造时读一次代理环境。此前这个副作用挂在 commands/scope.py 的模块级
-# `from miloco_cli.client import ...` 上——全仓 18 个命令模块里唯一一个那么写
-# 的,把它改成惰性 import(一次纯粹的一致性清理)就会让整条链路静默失效,
-# 退化表现正是本修复要消灭的 502。钉在声明的入口点上,不依赖任何模块的
-# import 顺序。
+# 钉在声明的入口点上,先于所有命令模块 import——只需要早于 main() 执行(命令
+# 模块当前全部在函数体内惰性构造 httpx client,而 client 构造时读一次代理环境),
+# 排在最前面是防御性的:将来谁加了模块级 client 也不会踩到"名单还没写好"的窗口。
+# 此前这个副作用挂在 commands/scope.py 的模块级 `from miloco_cli.client
+# import ...` 上——17 个引用 client 的命令模块里唯一一个在模块级 import 的,
+# 把它改成和其余 16 个一致的函数内 import(一次纯粹的一致性清理)就会让整条
+# 链路静默失效,退化表现正是本修复要消灭的 502。
 from miloco_cli.client import ensure_no_proxy_for_local
 
 ensure_no_proxy_for_local()

--- a/cli/tests/test_no_proxy_local.py
+++ b/cli/tests/test_no_proxy_local.py
@@ -1,0 +1,116 @@
+"""``miloco_cli.client.ensure_no_proxy_for_local`` 单测。
+
+与 backend 的 test_no_proxy_local.py 对称——两个包互不依赖、各留一份实现,
+若只有一侧有回归守护,另一侧被改坏时 CI 全绿、故障表现却是 miloco-cli 打
+127.0.0.1:1810 又开始走代理返 502。
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+# 在 import 被测模块**之前**快照:虽然 client.py 已不再自带 import 副作用
+# (调用挪到了 miloco_cli.main),但本文件的子进程用例会 import main、而 main
+# 一 import 就写 env;保留快照+还原,免得泄漏进同会话后续测试。
+_PROXY_ENV_AT_IMPORT = {
+    k: v for k, v in os.environ.items() if k.lower().endswith("_proxy")
+}
+
+from miloco_cli.client import ensure_no_proxy_for_local  # noqa: E402
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _restore_proxy_env_after_module():
+    yield
+    for key in [k for k in os.environ if k.lower().endswith("_proxy")]:
+        del os.environ[key]
+    os.environ.update(_PROXY_ENV_AT_IMPORT)
+
+
+@pytest.fixture
+def clean_proxy_env(monkeypatch):
+    """清掉所有 *_proxy;退出时按快照还原(被测函数直接写 os.environ,
+    monkeypatch 对当时不存在的 key 不记录、无从还原)。"""
+    saved = {k: v for k, v in os.environ.items() if k.lower().endswith("_proxy")}
+    for key in saved:
+        del os.environ[key]
+    yield monkeypatch
+    for key in [k for k in os.environ if k.lower().endswith("_proxy")]:
+        del os.environ[key]
+    os.environ.update(saved)
+
+
+def test_loopback_appended_and_cases_identical(clean_proxy_env):
+    ensure_no_proxy_for_local()
+    entries = os.environ["NO_PROXY"].split(",")
+    assert {"localhost", "127.0.0.1", "::1"} <= set(entries)
+    assert os.environ["no_proxy"] == os.environ["NO_PROXY"]
+
+
+def test_no_cidr_entries(clean_proxy_env):
+    ensure_no_proxy_for_local()
+    assert "/" not in os.environ["NO_PROXY"]
+
+
+def test_uppercase_only_no_proxy_not_dropped(clean_proxy_env):
+    """只设大写 NO_PROXY 时排除项不能丢(CPython 折叠时小写胜出)。"""
+    clean_proxy_env.setenv("NO_PROXY", "api.internal.corp")
+    ensure_no_proxy_for_local()
+    assert "api.internal.corp" in os.environ["no_proxy"]
+    assert os.environ["no_proxy"] == os.environ["NO_PROXY"]
+
+
+def test_snapshot_survives_preexisting_bare_no_proxy(clean_proxy_env):
+    """env 里事先有裸 NO_PROXY 时,快照不能被 getproxies 的 env 短路成空。"""
+    clean_proxy_env.setenv("NO_PROXY", "preexisting.example")
+    clean_proxy_env.setattr(
+        "miloco_cli.client._system_proxies",
+        lambda: {"https": "http://sys:7897"},
+    )
+    ensure_no_proxy_for_local()
+    assert os.environ["https_proxy"] == "http://sys:7897"
+    assert "preexisting.example" in os.environ["no_proxy"]
+
+
+def test_all_proxy_only_user_not_overridden(clean_proxy_env):
+    """只配 ALL_PROXY(纯 SOCKS 出口)时不被系统代理顶掉。"""
+    clean_proxy_env.setenv("ALL_PROXY", "socks5://127.0.0.1:7891")
+    clean_proxy_env.setattr(
+        "miloco_cli.client._system_proxies", lambda: {"http": "http://sys:7890"}
+    )
+    ensure_no_proxy_for_local()
+    assert "http_proxy" not in os.environ
+
+
+def test_getproxies_failure_does_not_break_startup(clean_proxy_env):
+    def boom():
+        raise OSError("SystemConfiguration unavailable")
+
+    clean_proxy_env.setattr("urllib.request.getproxies", boom)
+    ensure_no_proxy_for_local()
+    assert "127.0.0.1" in os.environ["NO_PROXY"]
+
+
+def test_entrypoint_applies_no_proxy_end_to_end():
+    """开子进程跑真实入口点,验证整条链路真的生效。
+
+    其余用例都直接 import 被测函数,结构上抓不到"函数写对了但没人调用"这类
+    失效——CLI 侧的注入此前挂在 commands/scope.py 的模块级 import 副作用上
+    (18 个命令模块里唯一一个那么写的),把它改惰性就整条静默失效,退化表现
+    正是本修复要消灭的 502。这里用子进程还原真实执行路径:干净 env 起
+    miloco_cli.main,再看 NO_PROXY 有没有被写进去。
+    """
+    import subprocess
+    import sys
+
+    env = {k: v for k, v in os.environ.items() if not k.lower().endswith("_proxy")}
+    out = subprocess.run(
+        [sys.executable, "-c",
+         "import miloco_cli.main, os; print(os.environ.get('NO_PROXY', ''))"],
+        capture_output=True, text=True, env=env, timeout=60,
+    )
+    assert out.returncode == 0, out.stderr
+    entries = out.stdout.strip().split(",")
+    assert {"localhost", "127.0.0.1", "::1"} <= set(entries), out.stdout

--- a/cli/tests/test_no_proxy_local.py
+++ b/cli/tests/test_no_proxy_local.py
@@ -8,8 +8,11 @@
 from __future__ import annotations
 
 import os
+import urllib.request
 
+import httpx
 import pytest
+from httpx._utils import get_environment_proxies
 
 # 在 import 被测模块**之前**快照:虽然 client.py 已不再自带 import 副作用
 # (调用挪到了 miloco_cli.main),但本文件的子进程用例会 import main、而 main
@@ -36,6 +39,9 @@ def clean_proxy_env(monkeypatch):
     saved = {k: v for k, v in os.environ.items() if k.lower().endswith("_proxy")}
     for key in saved:
         del os.environ[key]
+    # 不读取开发机系统代理;具体场景再显式注入系统设置。
+    for name in ("getproxies_macosx_sysconf", "getproxies_registry"):
+        monkeypatch.setattr(urllib.request, name, lambda: {}, raising=False)
     yield monkeypatch
     for key in [k for k in os.environ if k.lower().endswith("_proxy")]:
         del os.environ[key]
@@ -99,7 +105,8 @@ def test_empty_proxy_value_treated_as_explicit_opt_out(clean_proxy_env):
 
 
 def test_env_proxy_wins_over_system(clean_proxy_env):
-    """env 已显式配了代理时,不去问系统设置(env 是更强的用户意图)。"""
+    """两个协议均已显式配置时,不读取系统设置。"""
+    clean_proxy_env.setenv("http_proxy", "http://env-set:1080")
     clean_proxy_env.setenv("https_proxy", "http://env-set:1080")
     clean_proxy_env.setattr(
         "miloco_cli.client._system_proxies",
@@ -139,3 +146,87 @@ def test_entrypoint_applies_no_proxy_end_to_end():
     assert out.returncode == 0, out.stderr
     entries = out.stdout.strip().split(",")
     assert {"localhost", "127.0.0.1", "::1"} <= set(entries), out.stdout
+
+
+@pytest.mark.parametrize(
+    ("proxy_env", "expected_proxies"),
+    [
+        ({}, {"http://": "http://sys:7897", "https://": "http://sys:7897"}),
+        ({"http_proxy": ""}, {"https://": "http://sys:7897"}),
+        ({"HTTP_PROXY": ""}, {"https://": "http://sys:7897"}),
+        ({"https_proxy": ""}, {"http://": "http://sys:7897"}),
+        ({"HTTPS_PROXY": ""}, {"http://": "http://sys:7897"}),
+        ({"http_proxy": "http://user:1080"},
+         {"http://": "http://user:1080", "https://": "http://sys:7897"}),
+        ({"https_proxy": "http://user:1080"},
+         {"http://": "http://sys:7897", "https://": "http://user:1080"}),
+        ({"http_proxy": "", "https_proxy": ""}, {}),
+        ({"HTTP_PROXY": "http://upper:1080", "http_proxy": ""},
+         {"https://": "http://sys:7897"}),
+        ({"HTTPS_PROXY": "http://upper:1080", "https_proxy": "http://lower:1080"},
+         {"http://": "http://sys:7897", "https://": "http://lower:1080"}),
+        ({"ALL_PROXY": "socks5://user:1080"}, {"all://": "socks5://user:1080"}),
+        ({"all_proxy": "socks5://user:1080"}, {"all://": "socks5://user:1080"}),
+        ({"ALL_PROXY": ""}, {}),
+        ({"all_proxy": "", "https_proxy": "http://user:1080"},
+         {"https://": "http://user:1080"}),
+        ({"ALL_PROXY": "socks5://user:1080", "https_proxy": "http://user:1081"},
+         {"all://": "socks5://user:1080", "https://": "http://user:1081"}),
+    ],
+    ids=["system", "empty-http", "empty-HTTP", "empty-https", "empty-HTTPS",
+         "partial-http", "partial-https", "both-empty", "lowercase-empty-wins",
+         "lowercase-value-wins", "ALL-socks", "all-socks", "empty-ALL",
+         "empty-all-explicit-https", "ALL-with-explicit-https"],
+)
+def test_httpx_proxy_routes(clean_proxy_env, proxy_env, expected_proxies):
+    """只替换系统设置来源,让真实 urllib 和 httpx 解析最终环境及路由。"""
+    for name in ("getproxies_macosx_sysconf", "getproxies_registry"):
+        clean_proxy_env.setattr(
+            urllib.request, name,
+            lambda: {"http": "http://sys:7897", "https": "http://sys:7897"},
+            raising=False,
+        )
+    for key, value in proxy_env.items():
+        clean_proxy_env.setenv(key, value)
+    clean_proxy_env.setenv("NO_PROXY", "upper.example,localhost")
+    clean_proxy_env.setenv("no_proxy", "lower.example,localhost")
+
+    ensure_no_proxy_for_local()
+
+    # 完整字典相等也守护条数,避免通配条目意外把整张代理表清空。
+    expected = {
+        **expected_proxies,
+        "all://*upper.example": None,
+        "all://*lower.example": None,
+        "all://localhost": None,
+        "all://127.0.0.1": None,
+        "all://[::1]": None,
+    }
+    assert get_environment_proxies() == expected
+    for key, value in proxy_env.items():
+        assert os.environ[key] == value
+    # 启动初始化重复执行不会改变已经确定的出口。
+    ensure_no_proxy_for_local()
+    assert get_environment_proxies() == expected
+
+
+def test_httpx_client_selects_loopback_direct_and_cloud_proxy(clean_proxy_env):
+    """真实 Client 的 transport 选择;不发网络请求、不依赖本机代理服务。"""
+    clean_proxy_env.setenv("https_proxy", "http://proxy.invalid:7897")
+    clean_proxy_env.setenv("http_proxy", "http://proxy.invalid:7897")
+    ensure_no_proxy_for_local()
+    with httpx.Client() as client:
+        for scheme in ("http", "https"):
+            for host in ("localhost", "127.0.0.1", "[::1]"):
+                url = httpx.URL(f"{scheme}://{host}:1810")
+                assert client._transport_for_url(url) is client._transport
+            cloud = httpx.URL(f"{scheme}://cloud.example")
+            assert client._transport_for_url(cloud) is not client._transport
+
+
+def test_httpx_explicit_wildcard_bypasses_all(clean_proxy_env):
+    """用户主动指定 NO_PROXY=* 时,仍应允许整表为空。"""
+    clean_proxy_env.setenv("https_proxy", "http://user:1080")
+    clean_proxy_env.setenv("NO_PROXY", "*")
+    ensure_no_proxy_for_local()
+    assert get_environment_proxies() == {}

--- a/cli/tests/test_no_proxy_local.py
+++ b/cli/tests/test_no_proxy_local.py
@@ -84,6 +84,31 @@ def test_all_proxy_only_user_not_overridden(clean_proxy_env):
     assert "http_proxy" not in os.environ
 
 
+def test_empty_proxy_value_treated_as_explicit_opt_out(clean_proxy_env):
+    """空值 = 显式取消该 scheme 代理(curl / CPython 通行约定),不该被系统代理覆盖。
+
+    与 backend::test_empty_proxy_value_treated_as_explicit_opt_out 对称:两侧是
+    逐行镜像的实现,守门只在一侧钉住的话,另一侧退回真值判断时 CI 全绿。
+    """
+    clean_proxy_env.setenv("https_proxy", "")
+    clean_proxy_env.setattr(
+        "miloco_cli.client._system_proxies", lambda: {"https": "http://sys:9999"}
+    )
+    ensure_no_proxy_for_local()
+    assert os.environ["https_proxy"] == ""
+
+
+def test_env_proxy_wins_over_system(clean_proxy_env):
+    """env 已显式配了代理时,不去问系统设置(env 是更强的用户意图)。"""
+    clean_proxy_env.setenv("https_proxy", "http://env-set:1080")
+    clean_proxy_env.setattr(
+        "miloco_cli.client._system_proxies",
+        lambda: pytest.fail("env 已有代理时不该回退问系统"),
+    )
+    ensure_no_proxy_for_local()
+    assert os.environ["https_proxy"] == "http://env-set:1080"
+
+
 def test_getproxies_failure_does_not_break_startup(clean_proxy_env):
     def boom():
         raise OSError("SystemConfiguration unavailable")


### PR DESCRIPTION
## 问题

macOS/Windows 系统代理开启时，httpx 默认读取系统代理，本地推理服务和 CLI→后端的回环请求也可能进入代理并返回 502。直接追加 NO_PROXY 又会使 urllib 的环境解析结果非空，从而屏蔽系统代理，导致云端请求意外直连。

## 修复

backend 启动加载 .env 后，以及 CLI 入口导入命令前，先保留所需系统代理快照，再把 localhost、127.0.0.1、::1 合入 NO_PROXY/no_proxy。用户已有排除项保留，两种大小写写回相同并集。

代理配置规则：

| 启动环境 | HTTP | HTTPS |
|---|---|---|
| 无代理变量，或仅有 NO_PROXY | 补系统 HTTP 代理 | 补系统 HTTPS 代理 |
| 仅 `http_proxy=` | 保持空值 | 补系统 HTTPS 代理 |
| 仅 `https_proxy=` | 补系统 HTTP 代理 | 保持空值 |
| 仅一个协议有非空配置 | 保留该协议配置；未配置协议补系统代理 | 同左 |
| 两个协议均已显式配置（含空值） | 保留配置 | 保留配置 |
| ALL_PROXY/all_proxy 存在（含空值） | 不补系统代理，遵循用户环境配置 | 同左 |
| NO_PROXY=* | 全部直连 | 全部直连 |

缺失协议的系统快照不受裸 NO_PROXY 或另一协议环境变量短路影响；仅导出 HTTP/HTTPS。显式变量按存在性判断，保留空值和 urllib 的大小写优先级。

## 行为边界

- 对仅有 NO_PROXY 或只配置一个协议的用户，未配置协议可能从直连变为使用系统代理，这是有意的逐协议补齐。ALL_PROXY 非空时，单协议空值仍可能回退到 ALL_PROXY；全部直连使用 NO_PROXY=*。
- 快照在启动时读取，运行中修改系统代理需重启进程。
- 导出进程环境后，读取代理环境变量的原生库和子进程也会受到影响。
- 仅追加三种回环地址，不追加私网 CIDR；局域网直连策略不属于本次改动。

## 验证

- 后端代理专项 30 passed；CLI 代理专项 26 passed，全量 615 passed。
- 两侧各 15 种配置使用真实 urllib/httpx 解析，断言完整代理表，覆盖空值、单协议配置、大小写、ALL_PROXY、用户排除项及幂等性。
- 真实 httpx.Client 对两种协议下的三种回环地址选择直连 transport，对云端地址选择代理 transport；NO_PROXY=* 单独验证。
- 保留两侧入口点子进程验证，防止初始化调用在重构中失效。
- 相关文件 Ruff / git diff --check 通过。后端全量 3736 passed / 4 failed；4 个失败项（macOS 资源监控 3 例、ReID 加载耗时阈值 1 例）均已在未修改的 PR head `a079de26` 上复现。

本轮验证代理解析与 transport 选择，未请求真实云端服务。未修改依赖约束及锁文件。
