### PR TITLE
fix(omni): 熔断 OPEN_CONFIG 黑洞——补 audio format 根因 + 慢周期自动探测逃生通道

### DIFF
--- a/backend/miloco/src/miloco/admin/router.py
+++ b/backend/miloco/src/miloco/admin/router.py
@@ -1467,22 +1467,41 @@ async def retry_omni_probe(current_user: str = Depends(verify_token)):
         if elapsed_ms < int(RETRY_COOLDOWN_SEC * 1000):
             return NormalResponse(code=0, message="ok", data=_full_omni_payload())
 
-    await cb.retry_now()
-    omni = get_settings().model.omni
-    if not omni.api_key:
-        # 无 key:直接标记 probe 失败,回 OPEN_CONFIG
-        await cb.record_probe_result(
-            False,
-            ClassifiedError(
-                "no_key",
-                "未配置 API Key",
-                ErrorCategory.CONFIG,
-            ),
-        )
-        return NormalResponse(code=0, message="ok", data=_full_omni_payload())
-
     try:
-        result = await _probe.probe_omni(omni.model, omni.base_url, omni.api_key)
+        await cb.retry_now()
+        omni = get_settings().model.omni
+        if not omni.api_key:
+            # 无 key:直接标记 probe 失败,回 OPEN_CONFIG
+            await cb.record_probe_result(
+                False,
+                ClassifiedError(
+                    "no_key",
+                    "未配置 API Key",
+                    ErrorCategory.CONFIG,
+                ),
+            )
+        else:
+            result = await _probe.probe_omni(omni.model, omni.base_url, omni.api_key)
+            if result.get("ok"):
+                await cb.record_probe_result(True, None)
+            else:
+                code = result.get("code", "unreachable")
+                cat = (
+                    ErrorCategory.CONFIG
+                    if code in ("bad_key", "not_found", "rejected_authed")
+                    else ErrorCategory.RECOVERABLE
+                )
+                await cb.record_probe_result(
+                    False,
+                    ClassifiedError(
+                        code,
+                        result.get("message", ""),
+                        cat,
+                        # rate_limited 时 probe_chat 会在 result 里回带 retry_after_seconds,
+                        # 传给 _grow_backoff_locked 让 backoff 尊重 server Retry-After。
+                        result.get("retry_after_seconds"),
+                    ),
+                )
     except asyncio.CancelledError:
         # 客户端断开 HTTP(用户切页/关 tab/网络抖动)时 FastAPI 抛 CancelledError。
         # 此前 retry_now() 已把 state 置 HALF_OPEN,若不复位则 before_call 永久短路、
@@ -1497,26 +1516,21 @@ async def retry_omni_probe(current_user: str = Depends(verify_token)):
             ),
         )
         raise
-    if result.get("ok"):
-        await cb.record_probe_result(True, None)
-    else:
-        code = result.get("code", "unreachable")
-        cat = (
-            ErrorCategory.CONFIG
-            if code in ("bad_key", "not_found", "rejected_authed")
-            else ErrorCategory.RECOVERABLE
-        )
+    except Exception as exc:
+        # URL 解析等异常可能发生在 probe 内部 try 之前;仅清位仍会卡在 HALF_OPEN。
+        # 先按既有失败记账回落,同时保留探测代数校验,避免覆盖新配置的恢复状态。
         await cb.record_probe_result(
             False,
             ClassifiedError(
-                code,
-                result.get("message", ""),
-                cat,
-                # rate_limited 时 probe_chat 会在 result 里回带 retry_after_seconds,
-                # 传给 _grow_backoff_locked 让 backoff 尊重 server Retry-After。
-                result.get("retry_after_seconds"),
+                "unreachable",
+                f"probe 抛异常({type(exc).__name__})",
+                ErrorCategory.RECOVERABLE,
             ),
         )
+        raise
+    finally:
+        # 配置读取、无 key 分支及失败记账本身抛异常时,也必须释放探测占位。
+        cb.clear_probe_in_flight()
     return NormalResponse(code=0, message="ok", data=_full_omni_payload())
 
 

--- a/backend/miloco/src/miloco/admin/router.py
+++ b/backend/miloco/src/miloco/admin/router.py
@@ -1292,8 +1292,8 @@ async def test_omni_config(
     result = await _probe.probe_omni(model, base_url, api_key)
     # 测通 + 三元组精确匹配当前 active + 熔断非 ok → 主动清熔断,与 put/activate/retry
     # 恢复路径对齐。护栏:测别的档案 / 未保存的新配置时不动状态。
-    # OPEN_CONFIG 下 tick 不会自动探测(只探 OPEN_RECOVERABLE),不清则用户测通了红条仍不消失,
-    # 只能靠横条上的「立即重试」或改配置重存才能恢复——「测通即恢复」是最直觉的路径。
+    # OPEN_CONFIG 下 tick 虽有慢周期自动探测(config_probe_interval_sec,默认 300s),但不清则
+    # 用户测通后最坏还要等一整个周期红条才消失——「测通即恢复」是最直觉的路径。
     if result.get("ok"):
         from miloco.perception.engine.omni.circuit_breaker import (
             get_omni_circuit_breaker,
@@ -1486,7 +1486,7 @@ async def retry_omni_probe(current_user: str = Depends(verify_token)):
     except asyncio.CancelledError:
         # 客户端断开 HTTP(用户切页/关 tab/网络抖动)时 FastAPI 抛 CancelledError。
         # 此前 retry_now() 已把 state 置 HALF_OPEN,若不复位则 before_call 永久短路、
-        # tick 只 arm OPEN_RECOVERABLE 也不会驱动新 probe,只能改配置或重启。
+        # tick 只 arm OPEN_*(HALF_OPEN 不在其列)也不会驱动新 probe,只能改配置或重启。
         # 走 record_probe_result(fail, RECOVERABLE) 回落到 OPEN_RECOVERABLE 让 tick 接管。
         await cb.record_probe_result(
             False,

--- a/backend/miloco/src/miloco/perception/engine/omni/circuit_breaker.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/circuit_breaker.py
@@ -71,7 +71,8 @@ class HealthSnapshot:
     next_probe_at_ms: int | None
     # 到下次 tick 探测的剩余秒数(monotonic 差算,不依赖两端时钟一致)。前端直接倒计时
     # 该值,避免 next_probe_at_ms(服务端 unix ms)与客户端 Date.now() 时钟偏差导致
-    # 倒计时不准(家用 NAS/容器场景常见)。CLOSED / OPEN_CONFIG / HALF_OPEN 时为 None。
+    # 倒计时不准(家用 NAS/容器场景常见)。CLOSED / HALF_OPEN 时为 None;
+    # OPEN_CONFIG 也有值(慢速自动探测周期,见 config_probe_interval_sec)。
     next_probe_in_seconds: float | None
     last_probe_at_ms: int | None
     last_probe_result: str | None  # "ok" | "fail" | None
@@ -102,6 +103,7 @@ class OmniCircuitBreaker:
         backoff_multiplier: float = 2.0,
         backoff_caps: dict[str, float] | None = None,
         jitter_ratio: float = 0.2,
+        config_probe_interval_sec: float = 300.0,
     ):
         self._consecutive_threshold = consecutive_threshold
         self._window_seconds = window_seconds
@@ -111,6 +113,12 @@ class OmniCircuitBreaker:
         self._backoff_multiplier = backoff_multiplier
         self._backoff_caps = backoff_caps or {"rate_limited": 60.0, "_default": 600.0}
         self._jitter_ratio = jitter_ratio
+        # OPEN_CONFIG 的慢速自动探测周期。原设计 OPEN_CONFIG 只等「配置变更 / 手动
+        # retry」,但分类误判(如 422 payload 错被当成 config 错)会把感知打进永不
+        # 自愈的黑洞(2026-07-29 实锅:12:14→14:45 全部 short-circuit,零重试)。
+        # 慢周期自动探测兜住误判,同时保持"不拿注定失败的 key 反复打 provider"的
+        # 初衷——5min 一次极简 ping 的代价可忽略。
+        self._config_probe_interval_sec = config_probe_interval_sec
 
         # RLock:允许 try_arm_probe 持锁调 probe_due (probe_due 单独调用时也持锁,
         # 嵌套 acquire 靠 RLock 兼容)。跨 loop / 跨线程访问全部通过它序列化,配合
@@ -228,9 +236,16 @@ class OmniCircuitBreaker:
         self._emit()
 
     def probe_due(self) -> bool:
-        """外部 tick 查询:是否到 HALF_OPEN 时刻(不改状态)。"""
+        """外部 tick 查询:是否到 HALF_OPEN 时刻(不改状态)。
+
+        OPEN_RECOVERABLE 走指数 backoff 周期;OPEN_CONFIG 也参与——走固定慢周期
+        (config_probe_interval_sec),防误判分类造成的永久黑洞。
+        """
         with self._lock:
-            if self._state != CircuitState.OPEN_RECOVERABLE:
+            if self._state not in (
+                CircuitState.OPEN_RECOVERABLE,
+                CircuitState.OPEN_CONFIG,
+            ):
                 return False
             return (
                 self._next_probe_at_monotonic is not None
@@ -238,7 +253,7 @@ class OmniCircuitBreaker:
             )
 
     def try_arm_probe(self) -> bool:
-        """tick 驱动占位:三条件齐(OPEN_RECOVERABLE + probe_due + 未 in-flight)时置
+        """tick 驱动占位:三条件齐(OPEN_* + probe_due + 未 in-flight)时置
         in-flight 位并返回 True。调用方拿到 True 后 spawn probe task,task 里必须走
         mark_half_open → probe_omni → record_probe_result(record_probe_result 会清位)。
 
@@ -246,7 +261,10 @@ class OmniCircuitBreaker:
         原子;并发调用只有一个能拿到 True。
         """
         with self._lock:
-            if self._state != CircuitState.OPEN_RECOVERABLE:
+            if self._state not in (
+                CircuitState.OPEN_RECOVERABLE,
+                CircuitState.OPEN_CONFIG,
+            ):
                 return False
             if self._probe_in_flight:
                 return False
@@ -276,7 +294,10 @@ class OmniCircuitBreaker:
     async def mark_half_open(self) -> None:
         """外部驱动:进入 HALF_OPEN(发起 probe 前调)。"""
         with self._lock:
-            if self._state == CircuitState.OPEN_RECOVERABLE:
+            if self._state in (
+                CircuitState.OPEN_RECOVERABLE,
+                CircuitState.OPEN_CONFIG,
+            ):
                 self._state = CircuitState.HALF_OPEN
         self._emit()
 
@@ -299,9 +320,9 @@ class OmniCircuitBreaker:
             mono_now = time.monotonic()
             next_ms: int | None = None
             next_in_s: float | None = None
-            if (
-                self._next_probe_at_monotonic is not None
-                and self._state == CircuitState.OPEN_RECOVERABLE
+            if self._next_probe_at_monotonic is not None and self._state in (
+                CircuitState.OPEN_RECOVERABLE,
+                CircuitState.OPEN_CONFIG,
             ):
                 delta_s = max(0.0, self._next_probe_at_monotonic - mono_now)
                 next_ms = now_ms + int(delta_s * 1000)
@@ -380,7 +401,12 @@ class OmniCircuitBreaker:
         self._state = CircuitState.OPEN_CONFIG
         self._state_since = time.monotonic()
         self._current_code, self._current_message = err.code, err.message
-        self._next_probe_at_monotonic = None
+        # 慢速自动探测逃生通道:固定周期(不指数增长——config 错不会因等得久而好转,
+        # 周期本身已经够长)。record_probe_result 失败仍是 CONFIG 时会重入本函数,
+        # 自动排下一次。
+        self._next_probe_at_monotonic = (
+            time.monotonic() + self._config_probe_interval_sec
+        )
         self._current_backoff = 0.0
 
     def _transition_to_closed_locked(self) -> None:

--- a/backend/miloco/src/miloco/perception/engine/omni/circuit_breaker.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/circuit_breaker.py
@@ -144,14 +144,14 @@ class OmniCircuitBreaker:
         self._probe_in_flight: bool = False
         # 探测代数:_transition_to_closed_locked 每次 +1;arm 探测(try_arm_probe /
         # retry_now / mark_half_open)时把当前值盖到 _probe_epoch。record_probe_result
-        # 发现两者不等,说明探测在飞期间发生过 CLOSED(改配置 / 测通 / 换档案),它测的
-        # 是旧配置,结果作废——否则迟到的 bad_key 会把刚修好的配置打回 OPEN_CONFIG 再锁
+        # 发现两者不等,说明探测在飞期间发生过 CLOSED(改配置 / 测通 / 换档案 / 并发成功),
+        # 结果已过期,应作废——否则迟到的 bad_key 会把刚修好的配置打回 OPEN_CONFIG 再锁
         # 一个慢周期。OPEN_CONFIG 参与自动探测之后,“后台探测在飞 + 用户正在改配置”
         # 恰是横条引导用户做的事,重叠不再是小概率。
         self._reset_epoch: int = 0
         self._probe_epoch: int = 0
-        # 进入 HALF_OPEN 前的来源态,仅供 snapshot() 决定 HALF_OPEN 的 UI 级别;
-        # 每次进 HALF_OPEN 都会重写,离开 HALF_OPEN 后的残值不会被读到。
+        # 进入 HALF_OPEN 前的来源态,供 UI 级别与配置故障重入时保留计时起点;
+        # 每次进 HALF_OPEN 都会重写,仅在当前状态为 HALF_OPEN 时读取,避免使用离开后的残值。
         self._half_open_from: CircuitState | None = None
         self._on_state_change: list[Callable[[HealthSnapshot], None]] = []
 
@@ -234,14 +234,14 @@ class OmniCircuitBreaker:
         with self._lock:
             self._last_probe_at = time.monotonic()
             self._last_probe_result = "ok" if ok else "fail"
-            # 过期探测:arm 之后发生过 CLOSED(reset_on_config_change 等),这次结果针对
-            # 的是旧配置,只做记账(last_probe_* / 清位),不改状态。只对 arm 过的探测
+            # 过期探测:arm 之后发生过 CLOSED(reset_on_config_change 等),这次结果
+            # 已过期,只做记账(last_probe_* / 清位),不改状态。只对 arm 过的探测
             # 判代数(_probe_in_flight 为 True 才盖过 _probe_epoch);未经 arm 直接调
             # 本方法的路径(仅测试)维持原语义。
             if self._probe_in_flight and self._probe_epoch != self._reset_epoch:
                 self._probe_in_flight = False
                 _emit_logger.info(
-                    "omni CB: 丢弃过期探测结果 ok=%s code=%s(探测期间配置已重置)",
+                    "omni CB: 丢弃过期探测结果 ok=%s code=%s(探测期间熔断已关闭或重置)",
                     ok,
                     err.code if err is not None else None,
                 )
@@ -447,8 +447,13 @@ class OmniCircuitBreaker:
         self._grow_backoff_locked(err)
 
     def _transition_to_open_config_locked(self, err: ClassifiedError) -> None:
+        continuing_config = self._state == CircuitState.OPEN_CONFIG or (
+            self._state == CircuitState.HALF_OPEN
+            and self._half_open_from == CircuitState.OPEN_CONFIG
+        )
+        if not continuing_config:
+            self._state_since = time.monotonic()
         self._state = CircuitState.OPEN_CONFIG
-        self._state_since = time.monotonic()
         self._current_code, self._current_message = err.code, err.message
         # 慢速自动探测逃生通道:固定周期(不指数增长——config 错不会因等得久而好转,
         # 周期本身已经够长)。record_probe_result 失败仍是 CONFIG 时会重入本函数,

--- a/backend/miloco/src/miloco/perception/engine/omni/circuit_breaker.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/circuit_breaker.py
@@ -117,10 +117,14 @@ class OmniCircuitBreaker:
         self._backoff_caps = backoff_caps or {"rate_limited": 60.0, "_default": 600.0}
         self._jitter_ratio = jitter_ratio
         # OPEN_CONFIG 的慢速自动探测周期。原设计 OPEN_CONFIG 只等“配置变更 / 手动
-        # retry」,但分类误判(如 422 payload 错被当成 config 错)会把感知打进永不
-        # 自愈的黑洞(2026-07-29 实锅:12:14→14:45 全部 short-circuit,零重试)。
-        # 慢周期自动探测兜住误判,同时保持"不拿注定失败的 key 反复打 provider"的
-        # 初衷——5min 一次极简 ping 的代价可忽略。
+        # retry”,但分类误判(如 422 payload 错被当成 config 错)会把感知打进永不
+        # 重试的黑洞(2026-07-29 实锅:12:14→14:45 全部 short-circuit,零重试)。
+        # 慢周期自动探测把“永久黑洞”降为“周期性重试”,同时保持"不拿注定失败的 key
+        # 反复打 provider"的初衷——5min 一次极简 ping 的代价可忽略。
+        # 分寸:探测是纯文本 ping,只对它能复现的配置错(bad_key / not_found /
+        # 服务端恢复)构成自愈;对媒体 / 请求体类 422 探测必成,CLOSED 后真流量再撞
+        # 失败才重开,且 _transition_to_closed_locked 会清掉累计证据——这类的完整
+        # 解法是 flap 计数升级(#542),不在本机制范围内。
         self._config_probe_interval_sec = config_probe_interval_sec
 
         # RLock:允许 try_arm_probe 持锁调 probe_due (probe_due 单独调用时也持锁,
@@ -138,6 +142,14 @@ class OmniCircuitBreaker:
         self._last_probe_at: float | None = None
         self._last_probe_result: str | None = None
         self._probe_in_flight: bool = False
+        # 探测代数:_transition_to_closed_locked 每次 +1;arm 探测(try_arm_probe /
+        # retry_now / mark_half_open)时把当前值盖到 _probe_epoch。record_probe_result
+        # 发现两者不等,说明探测在飞期间发生过 CLOSED(改配置 / 测通 / 换档案),它测的
+        # 是旧配置,结果作废——否则迟到的 bad_key 会把刚修好的配置打回 OPEN_CONFIG 再锁
+        # 一个慢周期。OPEN_CONFIG 参与自动探测之后,“后台探测在飞 + 用户正在改配置”
+        # 恰是横条引导用户做的事,重叠不再是小概率。
+        self._reset_epoch: int = 0
+        self._probe_epoch: int = 0
         # 进入 HALF_OPEN 前的来源态,仅供 snapshot() 决定 HALF_OPEN 的 UI 级别;
         # 每次进 HALF_OPEN 都会重写,离开 HALF_OPEN 后的残值不会被读到。
         self._half_open_from: CircuitState | None = None
@@ -222,6 +234,18 @@ class OmniCircuitBreaker:
         with self._lock:
             self._last_probe_at = time.monotonic()
             self._last_probe_result = "ok" if ok else "fail"
+            # 过期探测:arm 之后发生过 CLOSED(reset_on_config_change 等),这次结果针对
+            # 的是旧配置,只做记账(last_probe_* / 清位),不改状态。只对 arm 过的探测
+            # 判代数(_probe_in_flight 为 True 才盖过 _probe_epoch);未经 arm 直接调
+            # 本方法的路径(仅测试)维持原语义。
+            if self._probe_in_flight and self._probe_epoch != self._reset_epoch:
+                self._probe_in_flight = False
+                _emit_logger.info(
+                    "omni CB: 丢弃过期探测结果 ok=%s code=%s(探测期间配置已重置)",
+                    ok,
+                    err.code if err is not None else None,
+                )
+                return
             if ok:
                 self._transition_to_closed_locked()
             else:
@@ -280,6 +304,7 @@ class OmniCircuitBreaker:
             if not self.probe_due():
                 return False
             self._probe_in_flight = True
+            self._probe_epoch = self._reset_epoch
             return True
 
     def clear_probe_in_flight(self) -> None:
@@ -309,15 +334,22 @@ class OmniCircuitBreaker:
             ):
                 self._half_open_from = self._state
                 self._state = CircuitState.HALF_OPEN
+                self._probe_epoch = self._reset_epoch
         self._emit()
 
     async def retry_now(self) -> None:
-        """用户点「立即重试」;OPEN_RECOVERABLE / OPEN_CONFIG → HALF_OPEN。"""
+        """用户点「立即重试」;OPEN_RECOVERABLE / OPEN_CONFIG → HALF_OPEN。
+
+        同时置 in-flight 位并盖探测代数:retry 发起的 probe 与 tick 发起的一样会
+        经 record_probe_result 收尾,期间若配置被重置,结果同样要作废。
+        """
         with self._lock:
             if self._state in (CircuitState.OPEN_RECOVERABLE, CircuitState.OPEN_CONFIG):
                 self._half_open_from = self._state
                 self._state = CircuitState.HALF_OPEN
                 self._next_probe_at_monotonic = time.monotonic()
+                self._probe_in_flight = True
+                self._probe_epoch = self._reset_epoch
         self._emit()
 
     async def reset_on_config_change(self) -> None:
@@ -429,6 +461,8 @@ class OmniCircuitBreaker:
     def _transition_to_closed_locked(self) -> None:
         self._state = CircuitState.CLOSED
         self._state_since = time.monotonic()
+        # 在飞的探测(若有)自此作废,见 _reset_epoch 注释。
+        self._reset_epoch += 1
         self._current_code, self._current_message = None, ""
         self._consecutive_failures = 0
         self._samples.clear()

--- a/backend/miloco/src/miloco/perception/engine/omni/circuit_breaker.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/circuit_breaker.py
@@ -293,9 +293,9 @@ class OmniCircuitBreaker:
         """只读:是否有 probe 正在执行(tick 已 arm 但 record_probe_result 未回)。
 
         用于 router.retry_omni_probe:tick.try_arm_probe 已置 _probe_in_flight=True
-        但尚未 mark_half_open 的短暂窗口里,state 仍是 OPEN_RECOVERABLE,只判 state
-        的短路会漏掉这段,导致 retry 与 tick 双 probe 并发、record_probe_result 互相
-        覆盖引起横条闪跳。
+        但尚未 mark_half_open 的短暂窗口里,state 仍是 OPEN_RECOVERABLE / OPEN_CONFIG,
+        只判 state 的短路会漏掉这段,导致 retry 与 tick 双 probe 并发、record_probe_result
+        互相覆盖引起横条闪跳。
         """
         with self._lock:
             return self._probe_in_flight

--- a/backend/miloco/src/miloco/perception/engine/omni/circuit_breaker.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/circuit_breaker.py
@@ -38,6 +38,9 @@ class CircuitState(Enum):
     HALF_OPEN = "half_open"
 
 
+# HALF_OPEN 的 "warn" 只是缺省:snapshot() 会让 HALF_OPEN 沿用其来源态的级别
+# (从 OPEN_CONFIG 进入的探测期间仍报 "error"),否则 OPEN_CONFIG 每个慢周期探测
+# 一次就让红条闪一次黄、前端“到模型页修改”入口卸载又挂回。
 _STATE_TO_UI: dict[CircuitState, str] = {
     CircuitState.CLOSED: "ok",
     CircuitState.OPEN_RECOVERABLE: "warn",
@@ -71,7 +74,8 @@ class HealthSnapshot:
     next_probe_at_ms: int | None
     # 到下次 tick 探测的剩余秒数(monotonic 差算,不依赖两端时钟一致)。前端直接倒计时
     # 该值,避免 next_probe_at_ms(服务端 unix ms)与客户端 Date.now() 时钟偏差导致
-    # 倒计时不准(家用 NAS/容器场景常见)。CLOSED / OPEN_CONFIG / HALF_OPEN 时为 None。
+    # 倒计时不准(家用 NAS/容器场景常见)。CLOSED / HALF_OPEN 时为 None;
+    # OPEN_CONFIG 也有值(慢速自动探测周期,见 config_probe_interval_sec)。
     next_probe_in_seconds: float | None
     last_probe_at_ms: int | None
     last_probe_result: str | None  # "ok" | "fail" | None
@@ -102,6 +106,7 @@ class OmniCircuitBreaker:
         backoff_multiplier: float = 2.0,
         backoff_caps: dict[str, float] | None = None,
         jitter_ratio: float = 0.2,
+        config_probe_interval_sec: float = 300.0,
     ):
         self._consecutive_threshold = consecutive_threshold
         self._window_seconds = window_seconds
@@ -111,6 +116,12 @@ class OmniCircuitBreaker:
         self._backoff_multiplier = backoff_multiplier
         self._backoff_caps = backoff_caps or {"rate_limited": 60.0, "_default": 600.0}
         self._jitter_ratio = jitter_ratio
+        # OPEN_CONFIG 的慢速自动探测周期。原设计 OPEN_CONFIG 只等“配置变更 / 手动
+        # retry」,但分类误判(如 422 payload 错被当成 config 错)会把感知打进永不
+        # 自愈的黑洞(2026-07-29 实锅:12:14→14:45 全部 short-circuit,零重试)。
+        # 慢周期自动探测兜住误判,同时保持"不拿注定失败的 key 反复打 provider"的
+        # 初衷——5min 一次极简 ping 的代价可忽略。
+        self._config_probe_interval_sec = config_probe_interval_sec
 
         # RLock:允许 try_arm_probe 持锁调 probe_due (probe_due 单独调用时也持锁,
         # 嵌套 acquire 靠 RLock 兼容)。跨 loop / 跨线程访问全部通过它序列化,配合
@@ -127,6 +138,9 @@ class OmniCircuitBreaker:
         self._last_probe_at: float | None = None
         self._last_probe_result: str | None = None
         self._probe_in_flight: bool = False
+        # 进入 HALF_OPEN 前的来源态,仅供 snapshot() 决定 HALF_OPEN 的 UI 级别;
+        # 每次进 HALF_OPEN 都会重写,离开 HALF_OPEN 后的残值不会被读到。
+        self._half_open_from: CircuitState | None = None
         self._on_state_change: list[Callable[[HealthSnapshot], None]] = []
 
     def register_listener(self, cb: Callable[[HealthSnapshot], None]) -> None:
@@ -215,22 +229,32 @@ class OmniCircuitBreaker:
                 if err.category == ErrorCategory.CONFIG:
                     self._transition_to_open_config_locked(err)
                 else:
-                    self._grow_backoff_locked(err)
                     # 守卫 OPEN_CONFIG:try_arm_probe 通过后到 probe 完成之间的 await
                     # 窗口里,并发 record_failure(CONFIG) 可能把 state 推到 OPEN_CONFIG
                     # (真 auth failure)。若这里无条件设 OPEN_RECOVERABLE 会把它抹回
                     # "自动退避重试",tick 继续探测注定失败的 key,浪费 backoff 周期。
                     # 只有 state 不是 OPEN_CONFIG 时才降级到 OPEN_RECOVERABLE。
+                    # _grow_backoff_locked 也必须在守卫之内:它会把 next_probe 排到
+                    # ~backoff_start 秒后,若在守卫之前执行会覆盖 OPEN_CONFIG 刚排好的
+                    # 慢周期(OPEN_CONFIG 参与 probe_due 之后这不再是死数据)。
                     if self._state != CircuitState.OPEN_CONFIG:
+                        self._grow_backoff_locked(err)
                         self._state = CircuitState.OPEN_RECOVERABLE
                         self._current_code, self._current_message = err.code, err.message
             self._probe_in_flight = False
         self._emit()
 
     def probe_due(self) -> bool:
-        """外部 tick 查询:是否到 HALF_OPEN 时刻(不改状态)。"""
+        """外部 tick 查询:是否到 HALF_OPEN 时刻(不改状态)。
+
+        OPEN_RECOVERABLE 走指数 backoff 周期;OPEN_CONFIG 也参与——走固定慢周期
+        (config_probe_interval_sec),防误判分类造成的永久黑洞。
+        """
         with self._lock:
-            if self._state != CircuitState.OPEN_RECOVERABLE:
+            if self._state not in (
+                CircuitState.OPEN_RECOVERABLE,
+                CircuitState.OPEN_CONFIG,
+            ):
                 return False
             return (
                 self._next_probe_at_monotonic is not None
@@ -238,7 +262,7 @@ class OmniCircuitBreaker:
             )
 
     def try_arm_probe(self) -> bool:
-        """tick 驱动占位:三条件齐(OPEN_RECOVERABLE + probe_due + 未 in-flight)时置
+        """tick 驱动占位:三条件齐(OPEN_* + probe_due + 未 in-flight)时置
         in-flight 位并返回 True。调用方拿到 True 后 spawn probe task,task 里必须走
         mark_half_open → probe_omni → record_probe_result(record_probe_result 会清位)。
 
@@ -246,7 +270,10 @@ class OmniCircuitBreaker:
         原子;并发调用只有一个能拿到 True。
         """
         with self._lock:
-            if self._state != CircuitState.OPEN_RECOVERABLE:
+            if self._state not in (
+                CircuitState.OPEN_RECOVERABLE,
+                CircuitState.OPEN_CONFIG,
+            ):
                 return False
             if self._probe_in_flight:
                 return False
@@ -276,7 +303,11 @@ class OmniCircuitBreaker:
     async def mark_half_open(self) -> None:
         """外部驱动:进入 HALF_OPEN(发起 probe 前调)。"""
         with self._lock:
-            if self._state == CircuitState.OPEN_RECOVERABLE:
+            if self._state in (
+                CircuitState.OPEN_RECOVERABLE,
+                CircuitState.OPEN_CONFIG,
+            ):
+                self._half_open_from = self._state
                 self._state = CircuitState.HALF_OPEN
         self._emit()
 
@@ -284,6 +315,7 @@ class OmniCircuitBreaker:
         """用户点「立即重试」;OPEN_RECOVERABLE / OPEN_CONFIG → HALF_OPEN。"""
         with self._lock:
             if self._state in (CircuitState.OPEN_RECOVERABLE, CircuitState.OPEN_CONFIG):
+                self._half_open_from = self._state
                 self._state = CircuitState.HALF_OPEN
                 self._next_probe_at_monotonic = time.monotonic()
         self._emit()
@@ -299,9 +331,9 @@ class OmniCircuitBreaker:
             mono_now = time.monotonic()
             next_ms: int | None = None
             next_in_s: float | None = None
-            if (
-                self._next_probe_at_monotonic is not None
-                and self._state == CircuitState.OPEN_RECOVERABLE
+            if self._next_probe_at_monotonic is not None and self._state in (
+                CircuitState.OPEN_RECOVERABLE,
+                CircuitState.OPEN_CONFIG,
             ):
                 delta_s = max(0.0, self._next_probe_at_monotonic - mono_now)
                 next_ms = now_ms + int(delta_s * 1000)
@@ -315,8 +347,14 @@ class OmniCircuitBreaker:
             since_ms = 0
             if self._state != CircuitState.CLOSED:
                 since_ms = now_ms - int((mono_now - self._state_since) * 1000)
+            ui_state = _STATE_TO_UI[self._state]
+            if (
+                self._state == CircuitState.HALF_OPEN
+                and self._half_open_from == CircuitState.OPEN_CONFIG
+            ):
+                ui_state = _STATE_TO_UI[CircuitState.OPEN_CONFIG]
             return HealthSnapshot(
-                state=_STATE_TO_UI[self._state],
+                state=ui_state,
                 code=self._current_code,
                 message=self._current_message,
                 since_ms=since_ms,
@@ -380,7 +418,12 @@ class OmniCircuitBreaker:
         self._state = CircuitState.OPEN_CONFIG
         self._state_since = time.monotonic()
         self._current_code, self._current_message = err.code, err.message
-        self._next_probe_at_monotonic = None
+        # 慢速自动探测逃生通道:固定周期(不指数增长——config 错不会因等得久而好转,
+        # 周期本身已经够长)。record_probe_result 失败仍是 CONFIG 时会重入本函数,
+        # 自动排下一次。
+        self._next_probe_at_monotonic = (
+            time.monotonic() + self._config_probe_interval_sec
+        )
         self._current_backoff = 0.0
 
     def _transition_to_closed_locked(self) -> None:

--- a/backend/miloco/src/miloco/perception/engine/omni/error_classifier.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/error_classifier.py
@@ -51,7 +51,7 @@ _MESSAGES: dict[str, str] = {
     "bad_key": "API Key 无效或无权限",
     "no_key": "未配置 API Key",
     "not_found": "模型或地址不存在",
-    "rejected_authed": "已连接，但请求被拒绝（模型名或 API Key 可能有误）",
+    "rejected_authed": "已连接，但请求被拒绝（请求体/媒体数据、模型名或 API Key 可能有误）",
     "bad_response": "omni 响应格式异常",
     "cancelled": "重试被中断",
 }
@@ -88,8 +88,13 @@ def classify_response(resp: httpx.Response) -> ClassifiedError | None:
             "not_found", _MESSAGES["not_found"], ErrorCategory.CONFIG
         )
     if s in (400, 422):
+        # 运行时语境的 400/422 绝大多数是**单次请求体问题**(坏帧、媒体编码、缺字段
+        # ——2026-07-29 实锅:audio 路由 input_audio 缺 format 字段打本地 mlx server
+        # 422×3 → OPEN_CONFIG 黑洞,感知停摆 2.5h)。归 RECOVERABLE 让熔断走
+        # backoff+自动探测(probe 是极简文本 ping,配置真有问题探测自己会失败);
+        # 真·key/模型名错误主要走 401/403/404 分支,不依赖这里。
         return ClassifiedError(
-            "rejected_authed", _MESSAGES["rejected_authed"], ErrorCategory.CONFIG
+            "rejected_authed", _MESSAGES["rejected_authed"], ErrorCategory.RECOVERABLE
         )
     if s == 429:
         retry_after = _parse_retry_after(resp.headers.get("Retry-After"))

--- a/backend/miloco/src/miloco/perception/engine/omni/error_classifier.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/error_classifier.py
@@ -16,7 +16,7 @@ import httpx
 
 class ErrorCategory(Enum):
     RECOVERABLE = "recoverable"  # 进指数退避熔断
-    CONFIG = "config"  # 直接软停,等用户改配置
+    CONFIG = "config"  # 软停等用户改配置;熔断器另有慢周期探测(默认 300s)兜误判
 
 
 @dataclass(frozen=True)

--- a/backend/miloco/src/miloco/perception/engine/omni/provider.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/provider.py
@@ -132,9 +132,15 @@ class MiMoAdapter(OpenAICompatAdapter):
         }
 
     def build_audio_block(self, audio_base64: str, media: LocalMediaInfo) -> dict[str, Any]:
+        # OpenAI 规范 input_audio 的 data+format 均必填——本地 mlx-vlm server 严格
+        # 校验,缺 format 直接 422(2026-07-29 感知停摆根因);宽松 provider 忽略
+        # 多余字段无副作用。载荷是 audio-only mp4(AAC),format 报容器名。
         return {
             "type": "input_audio",
-            "input_audio": {"data": f"data:audio/m4a;base64,{audio_base64}"},
+            "input_audio": {
+                "data": f"data:audio/m4a;base64,{audio_base64}",
+                "format": "mp4",
+            },
         }
 
     def build_request_body(

--- a/backend/miloco/src/miloco/perception/engine/omni/provider.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/provider.py
@@ -132,9 +132,16 @@ class MiMoAdapter(OpenAICompatAdapter):
         }
 
     def build_audio_block(self, audio_base64: str, media: LocalMediaInfo) -> dict[str, Any]:
+        # OpenAI 规范 input_audio 的 data+format 均必填——本地 mlx-vlm server 严格
+        # 校验,缺 format 直接 422(2026-07-29 感知停摆根因);宽松 provider 忽略
+        # 多余字段无副作用。载荷是 prompt_builder._encode_audio_only_mp4 产出的真 m4a
+        # 容器(ftyp="M4A "),format 报 "m4a",与 data 的 mime 及 QwenOmniAdapter 一致。
         return {
             "type": "input_audio",
-            "input_audio": {"data": f"data:audio/m4a;base64,{audio_base64}"},
+            "input_audio": {
+                "data": f"data:audio/m4a;base64,{audio_base64}",
+                "format": "m4a",
+            },
         }
 
     def build_request_body(

--- a/backend/miloco/src/miloco/perception/processor.py
+++ b/backend/miloco/src/miloco/perception/processor.py
@@ -230,9 +230,10 @@ class PipelineProcessor:
     def drive_omni_probe(self) -> None:
         """tick 入口驱动 omni 熔断器自动探测。
 
-        三条件齐(state==OPEN_RECOVERABLE + backoff 到期 + 无 in-flight)时 fire-and-forget
-        spawn 一次 probe task;否则 sync 判断后立即返回。CLOSED 稳态开销 = 一次 sync 读,
-        可忽略。
+        三条件齐(state∈{OPEN_RECOVERABLE, OPEN_CONFIG} + 探测周期到期 + 无 in-flight)时
+        fire-and-forget spawn 一次 probe task;否则 sync 判断后立即返回。OPEN_CONFIG 走
+        固定慢周期(config_probe_interval_sec),是误判分类的逃生通道。CLOSED 稳态开销 =
+        一次 sync 读,可忽略。
 
         单飞位由熔断器内部维护(try_arm_probe 原子占位、record_probe_result 释放),
         并发 tick / 多相机 batch 场景下同一时刻只会有一个 probe in-flight。

--- a/backend/miloco/src/miloco/perception/processor.py
+++ b/backend/miloco/src/miloco/perception/processor.py
@@ -72,7 +72,7 @@ _GATE_TOTAL_RE = re.compile(r"^gate_[^_]+_ms$")
 
 
 async def _run_omni_probe() -> None:
-    """OPEN_RECOVERABLE + backoff 到期时的自动探测协程。
+    """OPEN_*(RECOVERABLE backoff 到期 / CONFIG 慢周期到期)时的自动探测协程。
 
     走 mark_half_open → probe_omni(bypass before_call) → record_probe_result 三步。
     record_probe_result 会清 in-flight 位;探测本身异常也走一次失败记录,保证 in-flight
@@ -126,7 +126,7 @@ async def _run_omni_probe() -> None:
     except asyncio.CancelledError:
         # CancelledError 是 BaseException 子类,进不了 except Exception。
         # mark_half_open 后被 cancel (runner.stop / loop 关闭 / task.cancel 等) 若不复位,
-        # state 会卡在 HALF_OPEN:tick 只 arm OPEN_RECOVERABLE、before_call 短路一切、
+        # state 会卡在 HALF_OPEN:tick 只 arm OPEN_*(HALF_OPEN 不在其列)、before_call 短路一切、
         # retry_now 对 HALF_OPEN no-op → 永久卡死,只能重启进程。走一次
         # record_probe_result(fail, RECOVERABLE) 回落到 OPEN_RECOVERABLE 让 tick 接管;
         # 之后 re-raise 让 cancel 语义正确传播(task 状态标记为 cancelled)。

--- a/backend/miloco/src/miloco/perception/runner.py
+++ b/backend/miloco/src/miloco/perception/runner.py
@@ -158,12 +158,13 @@ class PerceptionRunner:
 
     async def _tick(self) -> None:
         """Drain all ready windows and infer sequentially."""
-        # 每 tick 驱动一次 omni 熔断器自动探测:OPEN_RECOVERABLE + backoff 到期时 spawn
-        # 一次后台 probe。无外部驱动时 probe_due 归零后状态永远不动,provider 恢复后感知
-        # 也不会自愈,只能靠用户手动点「立即重试」。sync 判断 + 后台 spawn,tick 不阻塞。
+        # 每 tick 驱动一次 omni 熔断器自动探测:OPEN_RECOVERABLE(backoff 到期)或
+        # OPEN_CONFIG(慢周期到期,防分类误判黑洞)时 spawn 一次后台 probe。无外部驱动时
+        # probe_due 归零后状态永远不动,provider 恢复后感知也不会自愈,只能靠用户手动点
+        # 「立即重试」。sync 判断 + 后台 spawn,tick 不阻塞。
         # 前置到 active_sources 判断之前:无摄像头联调 / 摄像头全部掉线场景下也要能自愈,
         # 否则 backoff 到期后 next_probe_at_monotonic 卡在过去、SSE 快照持续显示"0 秒后下次探测"。
-        # 非 OPEN_RECOVERABLE 时 try_arm_probe 零开销直接返 False,前置安全。
+        # CLOSED / HALF_OPEN 时 try_arm_probe 零开销直接返 False,前置安全。
         self._pipeline.drive_omni_probe()
 
         if not self._collector.get_all_active_sources():

--- a/backend/miloco/src/miloco/perception/runner.py
+++ b/backend/miloco/src/miloco/perception/runner.py
@@ -158,12 +158,13 @@ class PerceptionRunner:
 
     async def _tick(self) -> None:
         """Drain all ready windows and infer sequentially."""
-        # 每 tick 驱动一次 omni 熔断器自动探测:OPEN_RECOVERABLE + backoff 到期时 spawn
-        # 一次后台 probe。无外部驱动时 probe_due 归零后状态永远不动,provider 恢复后感知
-        # 也不会自愈,只能靠用户手动点「立即重试」。sync 判断 + 后台 spawn,tick 不阻塞。
+        # 每 tick 驱动一次 omni 熔断器自动探测:OPEN_RECOVERABLE(backoff 到期)或
+        # OPEN_CONFIG(慢周期到期,防分类误判黑洞)时 spawn 一次后台 probe。无外部驱动时
+        # probe_due 归零后状态永远不动,provider 恢复后感知也不会自愈,只能靠用户手动点
+        # “立即重试”。sync 判断 + 后台 spawn,tick 不阻塞。
         # 前置到 active_sources 判断之前:无摄像头联调 / 摄像头全部掉线场景下也要能自愈,
         # 否则 backoff 到期后 next_probe_at_monotonic 卡在过去、SSE 快照持续显示"0 秒后下次探测"。
-        # 非 OPEN_RECOVERABLE 时 try_arm_probe 零开销直接返 False,前置安全。
+        # CLOSED / HALF_OPEN 时 try_arm_probe 零开销直接返 False,前置安全。
         self._pipeline.drive_omni_probe()
 
         if not self._collector.get_all_active_sources():

--- a/backend/miloco/tests/admin/test_omni_config.py
+++ b/backend/miloco/tests/admin/test_omni_config.py
@@ -958,7 +958,8 @@ def _force_breaker_open_config():
 
 def test_test_connection_ok_matching_active_clears_breaker(client):
     """测通 + 三元组与当前 active 完全一致 → 熔断从 OPEN_CONFIG 回 CLOSED。
-    这是「测通即恢复」的最直觉路径,OPEN_CONFIG 下 tick 不自动探测,不清则用户困在红条上。"""
+    这是「测通即恢复」的最直觉路径,OPEN_CONFIG 下 tick 只有慢周期(默认 300s)自动探测,
+    不清则用户测通后最坏还要困在红条上一整个周期。"""
     from miloco.perception.engine.omni.circuit_breaker import (
         get_omni_circuit_breaker,
     )

--- a/backend/miloco/tests/admin/test_omni_config_preflight.py
+++ b/backend/miloco/tests/admin/test_omni_config_preflight.py
@@ -507,7 +507,7 @@ def test_snapshot_carries_relative_seconds_and_cooldown(client):
 async def test_retry_probe_cancelled_falls_back_to_open_recoverable(monkeypatch):
     """review Finding 4:retry_now() 已把 state 置 HALF_OPEN,若 probe_omni 期间
     客户端断开(CancelledError),必须回落 OPEN_RECOVERABLE,让 tick 能重新驱动 probe。
-    修复前:HALF_OPEN 卡死,tick 只 arm OPEN_RECOVERABLE,before_call 又永远短路。"""
+    修复前:HALF_OPEN 卡死,tick 只 arm OPEN_*(HALF_OPEN 不在其列),before_call 又永远短路。"""
     import asyncio
 
     from miloco.admin import router as admin_router

--- a/backend/miloco/tests/admin/test_omni_config_preflight.py
+++ b/backend/miloco/tests/admin/test_omni_config_preflight.py
@@ -759,3 +759,79 @@ def test_activate_endpoint_resets_open_config_breaker(client, mock_probe):
     r = client.post("/api/admin/omni-config/activate", json={"label": "乙"})
     assert r.status_code == 200
     assert cb.state_for_test() == CircuitState.CLOSED
+
+
+@pytest.mark.parametrize("failure", ["malformed_url", "settings_error", "reset_then_error"])
+async def test_retry_unexpected_error_releases_slot_and_allows_recovery(monkeypatch, failure):
+    """真实 URL 解析异常与配置读取异常不留 HALF_OPEN;旧探测异常不覆盖新配置。"""
+    from types import SimpleNamespace
+
+    from miloco.admin import router as admin_router
+    from miloco.config.settings import OmniModelSettings
+    from miloco.perception.engine.omni.circuit_breaker import (
+        CircuitState,
+        get_omni_circuit_breaker,
+    )
+    from miloco.perception.engine.omni.error_classifier import (
+        ClassifiedError,
+        ErrorCategory,
+    )
+
+    cb = get_omni_circuit_breaker()
+    for _ in range(3):
+        await cb.record_failure(ClassifiedError("bad_key", "test", ErrorCategory.CONFIG))
+    # str 校验接受不配对的 IPv6 方括号;真实 probe 在 urlparse 处抛 ValueError。
+    omni = OmniModelSettings(base_url="http://[::1", api_key="test-placeholder")
+    monkeypatch.setattr(admin_router, "get_settings", lambda: SimpleNamespace(model=SimpleNamespace(omni=omni)))
+    expected = ValueError
+    if failure == "settings_error":
+        def broken_settings():
+            raise RuntimeError("settings unavailable")
+        monkeypatch.setattr(admin_router, "get_settings", broken_settings)
+        expected = RuntimeError
+    elif failure == "reset_then_error":
+        async def old_probe(*args):
+            await cb.reset_on_config_change()
+            raise ValueError("old probe failed")
+        monkeypatch.setattr(admin_router._probe, "probe_omni", old_probe)
+
+    with pytest.raises(expected):
+        await admin_router.retry_omni_probe(current_user="test")
+    assert cb.probe_in_flight() is False
+    if failure == "reset_then_error":
+        assert cb.state_for_test() == CircuitState.CLOSED
+        assert cb.snapshot().code is None
+    else:
+        assert cb.state_for_test() == CircuitState.OPEN_RECOVERABLE
+        assert cb.snapshot().code == "unreachable"
+        import time
+        now = time.monotonic()
+        monkeypatch.setattr(time, "monotonic", lambda: now + 601)
+        assert cb.try_arm_probe() is True
+
+
+async def test_retry_result_recording_error_still_releases_slot(monkeypatch):
+    """失败记账本身抛异常时,finally 仍必须清除探测占位。"""
+    from types import SimpleNamespace
+
+    from miloco.admin import router as admin_router
+    from miloco.config.settings import OmniModelSettings
+    from miloco.perception.engine.omni.circuit_breaker import get_omni_circuit_breaker
+    from miloco.perception.engine.omni.error_classifier import (
+        ClassifiedError,
+        ErrorCategory,
+    )
+
+    cb = get_omni_circuit_breaker()
+    for _ in range(3):
+        await cb.record_failure(ClassifiedError("bad_key", "test", ErrorCategory.CONFIG))
+    omni = OmniModelSettings(api_key="")
+    monkeypatch.setattr(admin_router, "get_settings", lambda: SimpleNamespace(model=SimpleNamespace(omni=omni)))
+
+    async def broken_record(*args):
+        raise RuntimeError("recording unavailable")
+
+    monkeypatch.setattr(cb, "record_probe_result", broken_record)
+    with pytest.raises(RuntimeError, match="recording unavailable"):
+        await admin_router.retry_omni_probe(current_user="test")
+    assert cb.probe_in_flight() is False

--- a/backend/miloco/tests/perception/engine/omni/test_circuit_breaker.py
+++ b/backend/miloco/tests/perception/engine/omni/test_circuit_breaker.py
@@ -156,6 +156,44 @@ async def test_open_config_refreshes_code_on_subsequent_config_error(cb):
     assert cb.snapshot().code == "not_found"
 
 
+# ─── OPEN_CONFIG 逃生通道(慢速自动探测)───────────────────────────────────────
+#
+# 这三条守护本 PR 的核心新增:OPEN_CONFIG 不再是永久黑洞。缺了它们,谁把
+# probe_due / try_arm_probe 里的 OPEN_CONFIG 分支删掉都不会有测试变红——
+# 上方 test_try_arm_probe_false_when_open_config 仍会因"周期未到"而 pass。
+# cb fixture 未传 config_probe_interval_sec,走默认 300s。
+
+
+async def test_open_config_probe_due_after_interval(cb, frozen_time):
+    """OPEN_CONFIG 慢速自动探测:config_probe_interval_sec 到期后 probe_due 返 True。"""
+    for _ in range(3):
+        await cb.record_failure(_cfg("bad_key"))
+    assert cb.state_for_test() == CircuitState.OPEN_CONFIG
+    assert cb.probe_due() is False  # 刚进 OPEN_CONFIG,300s 未到
+    frozen_time.tick(301)
+    assert cb.probe_due() is True
+
+
+async def test_open_config_try_arm_probe_after_interval(cb, frozen_time):
+    """逃生通道生效:周期到期后 tick 能 arm 到探测,不再永久卡死。"""
+    for _ in range(3):
+        await cb.record_failure(_cfg("bad_key"))
+    assert cb.try_arm_probe() is False
+    frozen_time.tick(301)
+    assert cb.try_arm_probe() is True
+
+
+async def test_open_config_snapshot_shows_next_probe(cb):
+    """OPEN_CONFIG snapshot 携带 next_probe 字段,前端能显示"下次自动重试"倒计时。"""
+    for _ in range(3):
+        await cb.record_failure(_cfg("bad_key"))
+    snap = cb.snapshot()
+    assert snap.state == "error"
+    assert snap.next_probe_at_ms is not None
+    assert snap.next_probe_in_seconds is not None
+    assert 299 <= snap.next_probe_in_seconds <= 300
+
+
 # ─── 指数退避 ───────────────────────────────────────────────────────────────
 
 
@@ -360,6 +398,8 @@ async def test_try_arm_probe_false_when_closed(cb):
 
 
 async def test_try_arm_probe_false_when_open_config(cb):
+    """刚进 OPEN_CONFIG 时 arm 不到——原因是慢速探测周期未到,**不是**
+    OPEN_CONFIG 本身阻塞 arm(周期到期后能 arm,见下方逃生通道用例)。"""
     for _ in range(3):
         await cb.record_failure(_cfg("bad_key"))
     assert cb.try_arm_probe() is False

--- a/backend/miloco/tests/perception/engine/omni/test_circuit_breaker.py
+++ b/backend/miloco/tests/perception/engine/omni/test_circuit_breaker.py
@@ -733,3 +733,92 @@ async def test_probe_result_recoverable_fail_still_reopens_from_half_open(
     await cb.record_probe_result(False, _rec("unreachable"))
     assert cb.state_for_test() == CircuitState.OPEN_RECOVERABLE
     assert cb.snapshot().code == "unreachable"
+
+
+# ─── 过期探测结果:探测在飞期间配置被重置,结果作废 (review 🟡2) ─────────────
+
+
+async def _open_config_probe_in_flight(cb, frozen_time) -> None:
+    for _ in range(3):
+        await cb.record_failure(_cfg("bad_key"))
+    assert cb.state_for_test() == CircuitState.OPEN_CONFIG
+    frozen_time.tick(301)
+    assert cb.try_arm_probe() is True
+    await cb.mark_half_open()
+    assert cb.state_for_test() == CircuitState.HALF_OPEN
+
+
+async def test_stale_config_probe_after_reset_is_discarded(cb, frozen_time):
+    """OPEN_CONFIG(bad_key) 到期后台 arm 并读到旧 key;探测在飞的几秒内用户保存了
+    正确 key(reset_on_config_change → CLOSED)。旧探测带着 bad_key 回来不得把刚修好
+    的配置打回 OPEN_CONFIG 再锁 300s。"""
+    await _open_config_probe_in_flight(cb, frozen_time)
+    seen: list = []
+    cb.register_listener(lambda snap: seen.append(snap.state))
+
+    await cb.reset_on_config_change()
+    assert cb.state_for_test() == CircuitState.CLOSED
+
+    await cb.record_probe_result(False, _cfg("bad_key"))
+    assert cb.state_for_test() == CircuitState.CLOSED
+    snap = cb.snapshot()
+    assert snap.state == "ok"
+    assert snap.code is None
+    assert snap.next_probe_in_seconds is None
+    # 记账仍要发生:单飞位释放、last_probe_* 落点
+    assert cb.probe_in_flight() is False
+    assert snap.last_probe_result == "fail"
+    # 过期结果不触发状态广播:reset 之后 listener 只看到那一次 "ok"
+    assert seen == ["ok"]
+    await cb.before_call()  # 放行
+
+
+async def test_stale_ok_probe_after_reset_and_reopen_is_discarded(cb, frozen_time):
+    """反向:reset 后新配置的真流量又攒够失败重开(不同错误码),旧探测的“成功”迟到
+    不得把真开着的熔断合上;旧探测的“失败”也不得覆盖新错误码。"""
+    await _open_config_probe_in_flight(cb, frozen_time)
+    await cb.reset_on_config_change()
+    for _ in range(3):
+        await cb.record_failure(_cfg("not_found"))
+    assert cb.state_for_test() == CircuitState.OPEN_CONFIG
+    assert cb.snapshot().code == "not_found"
+
+    await cb.record_probe_result(True, None)
+    assert cb.state_for_test() == CircuitState.OPEN_CONFIG
+    assert cb.snapshot().code == "not_found"
+    assert cb.probe_in_flight() is False
+
+    # 单飞位已释放,新一轮探测照常可 arm(不会因过期结果卡死)
+    frozen_time.tick(301)
+    assert cb.try_arm_probe() is True
+    await cb.mark_half_open()
+    await cb.record_probe_result(False, _cfg("not_found"))
+    assert cb.state_for_test() == CircuitState.OPEN_CONFIG
+
+
+async def test_stale_retry_probe_after_reset_is_discarded(cb, frozen_time):
+    """「立即重试」发起的探测同样受代数保护:retry_now 置 in-flight 并盖代数,期间
+    走「测试连接 / 保存档案」把熔断清掉后,retry 的旧结果作废。"""
+    for _ in range(3):
+        await cb.record_failure(_cfg("bad_key"))
+    await cb.retry_now()
+    assert cb.state_for_test() == CircuitState.HALF_OPEN
+    assert cb.probe_in_flight() is True
+
+    await cb.reset_on_config_change()
+    await cb.record_probe_result(False, _cfg("bad_key"))
+    assert cb.state_for_test() == CircuitState.CLOSED
+    assert cb.snapshot().state == "ok"
+    assert cb.probe_in_flight() is False
+
+
+async def test_probe_result_without_reset_still_applies(cb, frozen_time):
+    """对照:探测在飞期间没有 CLOSED 发生,结果照常生效(代数一致)。"""
+    await _open_config_probe_in_flight(cb, frozen_time)
+    await cb.record_probe_result(True, None)
+    assert cb.state_for_test() == CircuitState.CLOSED
+
+    await _open_config_probe_in_flight(cb, frozen_time)
+    await cb.record_probe_result(False, _cfg("bad_key"))
+    assert cb.state_for_test() == CircuitState.OPEN_CONFIG
+    assert 299 <= cb.snapshot().next_probe_in_seconds <= 300

--- a/backend/miloco/tests/perception/engine/omni/test_circuit_breaker.py
+++ b/backend/miloco/tests/perception/engine/omni/test_circuit_breaker.py
@@ -156,6 +156,133 @@ async def test_open_config_refreshes_code_on_subsequent_config_error(cb):
     assert cb.snapshot().code == "not_found"
 
 
+# ─── OPEN_CONFIG 逃生通道(慢速自动探测)───────────────────────────────────────
+#
+# 这三条守护本 PR 的核心新增:OPEN_CONFIG 不再是永久黑洞。缺了它们,谁把
+# probe_due / try_arm_probe 里的 OPEN_CONFIG 分支删掉都不会有测试变红——
+# 上方 test_try_arm_probe_false_when_open_config 仍会因"周期未到"而 pass。
+# cb fixture 未传 config_probe_interval_sec,走默认 300s。
+
+
+async def test_open_config_probe_due_after_interval(cb, frozen_time):
+    """OPEN_CONFIG 慢速自动探测:config_probe_interval_sec 到期后 probe_due 返 True。"""
+    for _ in range(3):
+        await cb.record_failure(_cfg("bad_key"))
+    assert cb.state_for_test() == CircuitState.OPEN_CONFIG
+    assert cb.probe_due() is False  # 刚进 OPEN_CONFIG,300s 未到
+    frozen_time.tick(301)
+    assert cb.probe_due() is True
+
+
+async def test_open_config_try_arm_probe_after_interval(cb, frozen_time):
+    """逃生通道生效:周期到期后 tick 能 arm 到探测,不再永久卡死。"""
+    for _ in range(3):
+        await cb.record_failure(_cfg("bad_key"))
+    assert cb.try_arm_probe() is False
+    frozen_time.tick(301)
+    assert cb.try_arm_probe() is True
+
+
+async def test_open_config_snapshot_shows_next_probe(cb):
+    """OPEN_CONFIG snapshot 携带 next_probe 字段,前端能显示"下次自动重试"倒计时。"""
+    for _ in range(3):
+        await cb.record_failure(_cfg("bad_key"))
+    snap = cb.snapshot()
+    assert snap.state == "error"
+    assert snap.next_probe_at_ms is not None
+    assert snap.next_probe_in_seconds is not None
+    assert 299 <= snap.next_probe_in_seconds <= 300
+
+
+async def test_open_config_probe_fail_config_rearms_interval(cb, frozen_time):
+    """黑洞不残留:OPEN_CONFIG 到期 → 探测仍是 CONFIG 错 → 留在 OPEN_CONFIG 且重排
+    下一个慢周期;第二轮到期照样能 arm。"""
+    for _ in range(3):
+        await cb.record_failure(_cfg("bad_key"))
+    frozen_time.tick(301)
+    assert cb.try_arm_probe() is True
+    await cb.mark_half_open()
+    assert cb.state_for_test() == CircuitState.HALF_OPEN
+    await cb.record_probe_result(False, _cfg("bad_key"))
+    assert cb.state_for_test() == CircuitState.OPEN_CONFIG
+    assert cb.probe_in_flight() is False
+    assert cb.probe_due() is False
+    frozen_time.tick(299)
+    assert cb.probe_due() is False
+    frozen_time.tick(2)
+    assert cb.try_arm_probe() is True
+
+
+async def test_open_config_probe_success_closes(cb, frozen_time):
+    """误判分类的自愈路径:OPEN_CONFIG 到期探测成功 → CLOSED,before_call 放行。"""
+    for _ in range(3):
+        await cb.record_failure(_cfg("bad_key"))
+    frozen_time.tick(301)
+    assert cb.try_arm_probe() is True
+    await cb.mark_half_open()
+    await cb.record_probe_result(True, None)
+    assert cb.state_for_test() == CircuitState.CLOSED
+    assert cb.snapshot().state == "ok"
+    await cb.before_call()  # 不抛
+
+
+async def test_open_config_probe_fail_recoverable_downgrades_to_backoff(cb, frozen_time):
+    """OPEN_CONFIG 到期探测遇到 RECOVERABLE 错(如网络不通):降级 OPEN_RECOVERABLE,
+    从 backoff_start 起走指数退避,不再等 300s。"""
+    for _ in range(3):
+        await cb.record_failure(_cfg("bad_key"))
+    frozen_time.tick(301)
+    assert cb.try_arm_probe() is True
+    await cb.mark_half_open()
+    await cb.record_probe_result(False, _rec("unreachable"))
+    assert cb.state_for_test() == CircuitState.OPEN_RECOVERABLE
+    snap = cb.snapshot()
+    assert snap.code == "unreachable"
+    assert snap.next_probe_in_seconds == 1.0  # backoff_start
+
+
+async def test_concurrent_config_failure_during_probe_keeps_config_interval(cb, frozen_time):
+    """探测在飞期间并发 record_failure(CONFIG) 把 state 推到 OPEN_CONFIG,随后探测以
+    RECOVERABLE 失败收尾:_grow_backoff_locked 不得跑在 OPEN_CONFIG 守卫之前,否则会把
+    刚排好的慢周期覆盖成 ~backoff_start 秒(OPEN_CONFIG 参与 probe_due 后这就是活数据)。"""
+    for _ in range(3):
+        await cb.record_failure(_rec())
+    assert cb.state_for_test() == CircuitState.OPEN_RECOVERABLE
+    frozen_time.tick(2)
+    assert cb.try_arm_probe() is True
+    await cb.mark_half_open()
+    for _ in range(3):  # 探测 await 窗口里的并发 CONFIG 失败(真 key 错)
+        await cb.record_failure(_cfg("bad_key"))
+    assert cb.state_for_test() == CircuitState.OPEN_CONFIG
+    await cb.record_probe_result(False, _rec("timeout"))
+    assert cb.state_for_test() == CircuitState.OPEN_CONFIG
+    snap = cb.snapshot()
+    assert snap.code == "bad_key"
+    assert 299 <= snap.next_probe_in_seconds <= 300
+
+
+async def test_half_open_from_open_config_keeps_error_ui(cb, frozen_time):
+    """OPEN_CONFIG 的慢周期探测期间横条不闪:HALF_OPEN 沿用来源态的 UI 级别(error),
+    前端“到模型页修改”入口不会每 300s 卸载又挂回。"""
+    for _ in range(3):
+        await cb.record_failure(_cfg("bad_key"))
+    frozen_time.tick(301)
+    assert cb.try_arm_probe() is True
+    await cb.mark_half_open()
+    assert cb.state_for_test() == CircuitState.HALF_OPEN
+    assert cb.snapshot().state == "error"
+
+
+async def test_half_open_from_open_recoverable_stays_warn(cb, frozen_time):
+    """对照:从 OPEN_RECOVERABLE 进入的 HALF_OPEN 仍是 warn,行为不变。"""
+    for _ in range(3):
+        await cb.record_failure(_rec())
+    frozen_time.tick(2)
+    assert cb.try_arm_probe() is True
+    await cb.mark_half_open()
+    assert cb.snapshot().state == "warn"
+
+
 # ─── 指数退避 ───────────────────────────────────────────────────────────────
 
 
@@ -360,6 +487,8 @@ async def test_try_arm_probe_false_when_closed(cb):
 
 
 async def test_try_arm_probe_false_when_open_config(cb):
+    """刚进 OPEN_CONFIG 时 arm 不到——原因是慢速探测周期未到,**不是**
+    OPEN_CONFIG 本身阻塞 arm(周期到期后能 arm,见下方逃生通道用例)。"""
     for _ in range(3):
         await cb.record_failure(_cfg("bad_key"))
     assert cb.try_arm_probe() is False

--- a/backend/miloco/tests/perception/engine/omni/test_circuit_breaker.py
+++ b/backend/miloco/tests/perception/engine/omni/test_circuit_breaker.py
@@ -158,7 +158,7 @@ async def test_open_config_refreshes_code_on_subsequent_config_error(cb):
 
 # ─── OPEN_CONFIG 逃生通道(慢速自动探测)───────────────────────────────────────
 #
-# 这三条守护本 PR 的核心新增:OPEN_CONFIG 不再是永久黑洞。缺了它们,谁把
+# 以下用例守护本 PR 的核心新增:OPEN_CONFIG 不再是永久黑洞。缺了它们,谁把
 # probe_due / try_arm_probe 里的 OPEN_CONFIG 分支删掉都不会有测试变红——
 # 上方 test_try_arm_probe_false_when_open_config 仍会因"周期未到"而 pass。
 # cb fixture 未传 config_probe_interval_sec,走默认 300s。
@@ -822,3 +822,50 @@ async def test_probe_result_without_reset_still_applies(cb, frozen_time):
     await cb.record_probe_result(False, _cfg("bad_key"))
     assert cb.state_for_test() == CircuitState.OPEN_CONFIG
     assert 299 <= cb.snapshot().next_probe_in_seconds <= 300
+
+
+@pytest.mark.parametrize("manual", [False, True])
+async def test_config_probe_reentry_preserves_episode_start(cb, frozen_time, monkeypatch, manual):
+    """同一轮配置故障连续探测失败,起点保留且每次续排完整慢周期。"""
+    monkeypatch.setattr(time, "time", lambda: frozen_time.now + 1000)
+    for _ in range(3):
+        await cb.record_failure(_cfg())
+    since = cb.snapshot().since_ms
+    for _ in range(2):
+        frozen_time.tick(301)
+        if manual:
+            await cb.retry_now()
+        else:
+            assert cb.try_arm_probe()
+            await cb.mark_half_open()
+        frozen_time.tick(2)
+        await cb.record_probe_result(False, _cfg())
+        assert cb.snapshot().since_ms == since
+        assert cb.snapshot().next_probe_in_seconds == 300
+
+
+async def test_new_config_episode_ignores_stale_half_open_origin(cb, frozen_time, monkeypatch):
+    """跨 CLOSED 的新故障重新计时,不读取上一轮 HALF_OPEN 的残值。"""
+    monkeypatch.setattr(time, "time", lambda: frozen_time.now + 1000)
+    for _ in range(3):
+        await cb.record_failure(_cfg())
+    old_since = cb.snapshot().since_ms
+    await cb.retry_now()
+    await cb.record_probe_result(True, None)
+    frozen_time.tick(100)
+    for _ in range(3):
+        await cb.record_failure(_cfg())
+    assert cb.snapshot().since_ms == old_since + 100_000
+
+
+async def test_recoverable_probe_to_config_starts_new_config_episode(cb, frozen_time, monkeypatch):
+    """从可恢复故障探出配置错误,配置故障起点从本次确认时计。"""
+    monkeypatch.setattr(time, "time", lambda: frozen_time.now + 1000)
+    for _ in range(3):
+        await cb.record_failure(_rec())
+    old_since = cb.snapshot().since_ms
+    frozen_time.tick(10)
+    assert cb.try_arm_probe()
+    await cb.mark_half_open()
+    await cb.record_probe_result(False, _cfg())
+    assert cb.snapshot().since_ms == old_since + 10_000

--- a/backend/miloco/tests/perception/engine/omni/test_circuit_breaker.py
+++ b/backend/miloco/tests/perception/engine/omni/test_circuit_breaker.py
@@ -184,7 +184,7 @@ async def test_open_config_try_arm_probe_after_interval(cb, frozen_time):
 
 
 async def test_open_config_snapshot_shows_next_probe(cb):
-    """OPEN_CONFIG snapshot 携带 next_probe 字段,前端能显示"下次自动重试"倒计时。"""
+    """OPEN_CONFIG snapshot 携带 next_probe 字段,供前端消费倒计时(前端接线见 #544)。"""
     for _ in range(3):
         await cb.record_failure(_cfg("bad_key"))
     snap = cb.snapshot()

--- a/backend/miloco/tests/perception/engine/omni/test_error_classifier.py
+++ b/backend/miloco/tests/perception/engine/omni/test_error_classifier.py
@@ -83,12 +83,16 @@ def test_404_is_not_found_config():
 
 
 def test_400_is_rejected_authed():
+    # 400/422 归 RECOVERABLE 而非 CONFIG:运行时语境下绝大多数是单次请求体
+    # 问题(坏帧/媒体编码/缺字段),该走 backoff 自动探测;归 CONFIG 会进
+    # OPEN_CONFIG 且永不自动重试(2026-07-29 感知停摆 2.5h 的放大器)。
     r = classify_response(_resp(400))
-    assert r.code == "rejected_authed" and r.category == ErrorCategory.CONFIG
+    assert r.code == "rejected_authed" and r.category == ErrorCategory.RECOVERABLE
 
 
 def test_422_is_rejected_authed():
-    assert classify_response(_resp(422)).code == "rejected_authed"
+    r = classify_response(_resp(422))
+    assert r.code == "rejected_authed" and r.category == ErrorCategory.RECOVERABLE
 
 
 def test_429_is_rate_limited_recoverable():

--- a/backend/miloco/tests/perception/engine/omni/test_provider.py
+++ b/backend/miloco/tests/perception/engine/omni/test_provider.py
@@ -68,9 +68,11 @@ class TestMiMoAdapter:
         assert block["media_resolution"] == "max"
         assert block["video_url"]["url"].startswith("data:video/mp4;base64,")
 
-    def test_audio_block(self):
+    def test_audio_block_has_format(self):
+        """根因回归守护:audio 块缺 format 是 2026-07-29 422×3 → OPEN_CONFIG 停摆的起点。"""
         block = self.adapter.build_audio_block("BBBB", _AUDIO_MEDIA)
         assert block["type"] == "input_audio"
+        assert block["input_audio"]["format"] == "mp4"
         assert block["input_audio"]["data"].startswith("data:audio/m4a;base64,")
 
     def test_request_body_non_stream(self):

--- a/backend/miloco/tests/perception/engine/omni/test_provider.py
+++ b/backend/miloco/tests/perception/engine/omni/test_provider.py
@@ -68,9 +68,11 @@ class TestMiMoAdapter:
         assert block["media_resolution"] == "max"
         assert block["video_url"]["url"].startswith("data:video/mp4;base64,")
 
-    def test_audio_block(self):
+    def test_audio_block_has_format(self):
+        """根因回归守护:audio 块缺 format 是 2026-07-29 422×3 → OPEN_CONFIG 停摆的起点。"""
         block = self.adapter.build_audio_block("BBBB", _AUDIO_MEDIA)
         assert block["type"] == "input_audio"
+        assert block["input_audio"]["format"] == "m4a"
         assert block["input_audio"]["data"].startswith("data:audio/m4a;base64,")
 
     def test_request_body_non_stream(self):


### PR DESCRIPTION
## 问题

音频请求的 `input_audio` 缺少 `format` 字段，严格校验的服务端会拒绝请求。此类错误归为 CONFIG 后，原 OPEN_CONFIG 不自动探测，感知只能等待人工介入。

## 修复

1. **音频格式字段**：`MiMoAdapter.build_audio_block` 补 `format: "m4a"`，与编码器生成的 m4a 容器、data MIME 以及 Qwen 适配器的取值一致。
2. **慢周期探测**：OPEN_CONFIG 参与 tick 自动探测，默认每 300 秒一次。仍为 CONFIG 错误时续排完整慢周期；同一轮配置故障的起点保留，HALF_OPEN 继承来源态的 UI 级别。并发 CONFIG 失败刚排好的慢周期不会被 recoverable backoff 覆盖。
3. **探测生命周期**：配置重置或并发成功使熔断关闭后，迟到的探测结果按 generation 作废。人工重试的占位、配置读取和探测结果处理纳入异常保护：取消或普通异常通过现有失败记账退出 HALF_OPEN，finally 兜底释放占位；异常继续向上抛出。

## 行为边界与后续

- 探测使用纯文本 ping。对探测本身能复现的故障，服务或配置恢复后可自动恢复；对于仅媒体 / 请求体触发的 400/422，提供的是周期性重试，不能承诺 5 分钟内修复。
- 400/422 分类继续保持 CONFIG。跨 CLOSED 的持续拒绝统计与 flap 升级由 #542 处理；本次保留计时仅覆盖同一轮 OPEN_CONFIG 探测失败重入。
- 主动告警见 #543；OPEN_CONFIG 的前端倒计时见 #544。网络错误导致配置红条降级、过期探测记账后的冷却同步继续作为后续设计项。
- 本次未扩大 provider 格式支持范围，m4a 字段测试不代表所有 OpenAI-compatible 服务均支持 m4a。

## 验证

- omni 套件、tick drive、health SSE、admin omni config 与 preflight：532 passed。
- 新增 8 条用例覆盖真实畸形 URL 异常、配置读取异常、重置后迟到异常、记账失败清位、自动/人工探测重入计时，以及两条新故障重新计时的对照；原 head 上 6 failed / 2 passed，补丁后全部通过。
- 四个改动文件的 ruff check 与 git diff --check 通过。
- 本轮未重跑全量 backend；不将此前的全量失败集合对比作为本次验证结果。
