### PR TITLE
feat(config): add CI environment variable audit module

### DIFF
--- a/backend/miloco/src/miloco/config/env_audit.py
+++ b/backend/miloco/src/miloco/config/env_audit.py
@@ -1,0 +1,79 @@
+# Copyright (C) 2025 Xiaomi Corporation
+# This software may be used and distributed according to the terms of the Xiaomi Miloco License Agreement.
+
+"""CI 环境校验工具。
+
+在 CI 流程或容器化部署中，环境变量可能因 Docker 层缓存、.env 文件遗漏
+或 systemd EnvironmentFile 配置错误而缺失。本模块提供轻量级校验函数，
+在 miloco 启动早期检测缺失/冲突的 ``MILOCO_*`` 变量，避免运行时静默降级。
+
+用法::
+
+    from miloco.config.env_audit import audit_env
+    issues = audit_env()
+    if issues:
+        logger.warning("环境配置问题: %s", issues)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+REQUIRED_VARS = [
+    "MILOCO_HOME",
+    "MILOCO_DEVICE_MODEL",
+]
+
+OPTIONAL_VARS = [
+    "MILOCO_LOG_LEVEL",
+    "MILOCO_STORAGE_ROOT",
+    "MILOCO_MIOT_CACHE_DIR",
+]
+
+_MILOCO_PREFIX = re.compile(r"^MILOCO_")
+
+
+def _read_proc_environ() -> dict[str, str]:
+    """从 /proc/self/environ 读取原始进程环境。
+
+    与 os.environ 不同，/proc/self/environ 反映进程启动时的原始变量，
+    不受运行时 os.environ 修改（如 dotenv 覆盖）影响。用于审计 CI
+    容器中实际注入的变量是否与预期一致。
+    """
+    try:
+        raw = Path("/proc/self/environ").read_bytes()
+        pairs = (entry.split(b"=", 1) for entry in raw.split(b"\0") if b"=" in entry)
+        return {k.decode(): v.decode() for k, v in pairs}
+    except (OSError, UnicodeDecodeError):
+        return {}
+
+
+def audit_env(*, use_proc: bool = False) -> list[str]:
+    """校验当前环境中的 MILOCO_* 变量。
+
+    Args:
+        use_proc: 为 True 时从 /proc/self/environ 读取，用于对比 os.environ
+                  以检测运行时覆盖。
+
+    Returns:
+        问题描述列表（空列表 = 无问题）。
+    """
+    source = _read_proc_environ() if use_proc else dict(os.environ)
+    issues: list[str] = []
+
+    for var in REQUIRED_VARS:
+        if var not in source:
+            issues.append(f"缺少必需变量: {var}")
+        elif not source[var].strip():
+            issues.append(f"变量为空: {var}")
+
+    miloco_vars = {k: v for k, v in source.items() if _MILOCO_PREFIX.match(k)}
+    if not miloco_vars:
+        issues.append("未发现任何 MILOCO_* 变量（可能未加载 .env 或 EnvironmentFile）")
+
+    return issues

--- a/backend/miloco/tests/test_env_audit.py
+++ b/backend/miloco/tests/test_env_audit.py
@@ -1,0 +1,50 @@
+# Copyright (C) 2025 Xiaomi Corporation
+# This software may be used and distributed according to the terms of the Xiaomi Miloco License Agreement.
+
+"""env_audit 模块测试。"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from miloco.config.env_audit import REQUIRED_VARS, audit_env
+
+
+class TestAuditEnv:
+    """audit_env() 单元测试。"""
+
+    def test_all_vars_present(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for var in REQUIRED_VARS:
+            monkeypatch.setenv(var, "test_value")
+        issues = audit_env()
+        assert issues == []
+
+    def test_missing_required_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("MILOCO_HOME", raising=False)
+        monkeypatch.delenv("MILOCO_DEVICE_MODEL", raising=False)
+        issues = audit_env()
+        assert any("MILOCO_HOME" in i for i in issues)
+
+    def test_empty_var_flagged(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MILOCO_HOME", "")
+        monkeypatch.setenv("MILOCO_DEVICE_MODEL", "test")
+        issues = audit_env()
+        assert any("为空" in i for i in issues)
+
+    def test_proc_environ_fallback(self) -> None:
+        """验证 use_proc=True 走 /proc/self/environ 路径。
+
+        CI 环境下 /proc/self/environ 应当可读；若因容器安全策略
+        不可读则降级到空 dict，不应抛异常。
+        """
+        issues = audit_env(use_proc=True)
+        assert isinstance(issues, list)
+
+    def test_no_miloco_vars_warning(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            monkeypatch.setenv("PATH", "/usr/bin")
+            issues = audit_env()
+            assert any("MILOCO_" in i for i in issues)


### PR DESCRIPTION
## 背景

CI 流水线和容器部署中，`MILOCO_*` 环境变量经常因 Docker 层缓存或 `.env` 遗漏导致运行时静默降级。目前没有启动早期的校验机制。

## 改动

- 新增 `miloco.config.env_audit` 模块，提供 `audit_env()` 函数
- 支持从 `os.environ` 或 `/proc/self/environ` 读取，后者用于对比 dotenv 覆盖前的原始注入变量
- 覆盖必需变量缺失、空值、无 `MILOCO_*` 前缀变量三类场景
- 配套单元测试

## 测试

```bash
cd backend && uv run pytest miloco/tests/test_env_audit.py -v
```