### PR TITLE
fix(hermes): 修 trace 持久会话漏记账，suggestion 车道改持久会话

### DIFF
--- a/backend/miloco/src/miloco/agent_platform/base.py
+++ b/backend/miloco/src/miloco/agent_platform/base.py
@@ -12,7 +12,7 @@
 
 #11 trace 读盘约定:
 - Adapter 提供 :meth:`read_trace_meta` 方法,backend 的 ``agent_meta_poller`` 轮询
-  ``get_trace`` 时由 Adapter 实现读 ``MILOCO_HOME/trace/*.meta.json`` 返回。
+  ``get_trace`` 时由 Adapter 实现读 plugin 落盘的 meta 返回,落盘路径由各 plugin 自定。
 - 这是文件 IPC 通道(plugin 写、Adapter 读),避免跨进程 webhook get_trace。
 """
 
@@ -127,10 +127,14 @@ class AgentPlatformAdapter(ABC):
 
     @abstractmethod
     async def read_trace_meta(self, run_id: str) -> Optional[TraceMeta]:
-        """读 ``MILOCO_HOME/trace/<run_id>.meta.json``,返回 :class:`TraceMeta` 或 None。
+        """读 plugin trace 落盘的 meta,返回 :class:`TraceMeta` 或 None。
 
         Backend ``agent_meta_poller`` 轮询 ``get_trace`` 时由本方法读盘返回。
-        Plugin 端 trace.py 负责常写(meta.json),Adapter 不感知写入,只读取。
+        Plugin 端负责写,Adapter 只读。
+
+        注意 ``run_id`` 不一定是文件名——两侧 run_id 口径可能不同(hermes 侧
+        adapter 用 uuid、plugin 用 session_id),如何把 ``run_id`` 关联到盘上那份
+        meta 由各 Adapter 自己决定(hermes 用发送原文与 meta 的 query 前缀匹配)。
         """
 
     async def aclose(self) -> None:

--- a/knowledge/03-features/hermes-integration.md
+++ b/knowledge/03-features/hermes-integration.md
@@ -60,23 +60,23 @@ miloco 原本只通过 OpenClaw 插件（`plugins/openclaw/`）接入小米内�
 对外暴露三个方法（满足 AgentPlatformAdapter duck-typed 契约）：
 
 - `send_turn(ctx)` — 调 Hermes `/v1/chat/completions`（OpenAI 兼容端点），用 `X-Hermes-Session-Id: miloco:<sessionKey>:<lane>` 头维持会话连续；`build_system` 丢线程池执行（避免 catalog CLI 阻塞事件循环）。
-- `read_trace_meta(run_id)` — 读 `$MILOCO_HOME/trace/<run_id>.meta.json`（trace.py 常写，adapter 只读）。
+- `read_trace_meta(run_id)` — 读 `$MILOCO_HOME/trace/agent/<YYYYMMDD>/` 下的 `.meta.json`（trace.py 写，adapter 只读）。两侧 run_id 口径不同（adapter 用 uuid、trace.py 用 session_id），靠发送原文与 meta 的 `query` 前缀匹配关联。
 - `reset_sessions(routes)` — 切家庭时清理 Hermes 会话（调 `hermes sessions delete` CLI）。
 
 上下文溢出 best-effort 自愈：识别溢出关键词后，丢弃会话上下文用无 session 头的全新 turn 重试一次。
 
 ### 与 OpenClaw 集成的关键差异
 
-| 维度             | OpenClaw 版                                       | Hermes 版                                                                           |
-| ---------------- | ------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| 插件语言         | TypeScript                                        | Python                                                                              |
-| 上下文注入       | `before_prompt_build` → system prompt             | adapter.build_system → `<system>` 消息（丢线程池，不阻塞事件循环）                  |
-| 入站回调         | 插件内 `api.registerHttpRoute("/miloco/webhook")` | backend adapter 直调 Hermes `/v1/chat/completions`                                  |
-| 同步等 turn      | `api.runtime.subagent.run` + `waitForRun`         | adapter.send_turn 内 httpx POST `/v1/chat/completions`（sync，X-Hermes-Session-Id） |
-| get_trace        | 内存 trace buffer，后端反向轮询取 meta            | 文件 IPC：trace.py 写 `$MILOCO_HOME/trace/*.meta.json`，adapter 读盘                |
-| 溢出自愈         | `deleteSession({deleteTranscript:true})` + 重跑   | 丢弃会话上下文、无 session 头全新 turn 重试一次                                     |
-| 通知投递         | subagent run with deliver:true                    | adapter._deliver_response → `hermes send --json --to <platform:chat_id>`            |
-| backend 生命周期 | 有（`miloco-cli service restart/stop`）           | 有（supervisord 管理）                                                              |
+| 维度             | OpenClaw 版                                       | Hermes 版                                                                                                                       |
+| ---------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| 插件语言         | TypeScript                                        | Python                                                                                                                          |
+| 上下文注入       | `before_prompt_build` → system prompt             | adapter.build_system → `<system>` 消息（丢线程池，不阻塞事件循环）                                                              |
+| 入站回调         | 插件内 `api.registerHttpRoute("/miloco/webhook")` | backend adapter 直调 Hermes `/v1/chat/completions`                                                                              |
+| 同步等 turn      | `api.runtime.subagent.run` + `waitForRun`         | adapter.send_turn 内 httpx POST `/v1/chat/completions`（sync，X-Hermes-Session-Id）                                             |
+| get_trace        | 内存 trace buffer，后端反向轮询取 meta            | 文件 IPC：trace.py 按天写 `trace/agent/<YYYYMMDD>/*.meta.json`，adapter 读盘（hermes 插件不能注册 HTTP 路由，拿不到跨进程内存） |
+| 溢出自愈         | `deleteSession({deleteTranscript:true})` + 重跑   | 丢弃会话上下文、无 session 头全新 turn 重试一次                                                                                 |
+| 通知投递         | subagent run with deliver:true                    | adapter._deliver_response → `hermes send --json --to <platform:chat_id>`                                                        |
+| backend 生命周期 | 有（`miloco-cli service restart/stop`）           | 有（supervisord 管理）                                                                                                          |
 
 ### 配置共享
 

--- a/knowledge/05-external-deps/sdk-hermes.md
+++ b/knowledge/05-external-deps/sdk-hermes.md
@@ -31,7 +31,7 @@ miloco 通过 `plugins/hermes/` 接入 Hermes，作为 OpenClaw 之外的并列 
 **api_server 同步 chat**（`gateway/platforms/api_server.py`）：
 
 - `POST /v1/chat/completions`（OpenAI 兼容同步端点），body `{"messages":[{"role":"system","content":...},{"role":"user","content":...}]}`，响应 `{"choices":[{"message":{"role":"assistant","content":...}}],"usage":{}}`。
-- 会话连续：请求头 `X-Hermes-Session-Id: <id>` —— Hermes 从 state.db 加载该 session 的历史。adapter 用 `miloco:<sessionKey>:<lane>` 作 id。suggest 车道用 `miloco:<sessionKey>:<lane>:<uuid>` 唯一后缀（不复用历史，避免 token 累积）。
+- 会话连续：请求头 `X-Hermes-Session-Id: <id>` —— Hermes 从 state.db 加载该 session 的历史。adapter 用 `miloco:<sessionKey>:<lane>` 作 id，各车道（含 suggest）都复用同一个持久会话。
 - 鉴权：`Authorization: Bearer $API_SERVER_KEY`。`API_SERVER_KEY` 环境变量设置即自动启用 api_server 平台（默认端口 8642）。
 - 溢出自愈：adapter 识别溢出关键词后，用无 `X-Hermes-Session-Id` 的全新 turn 重试一次。
 

--- a/knowledge/05-external-deps/sdk-hermes.md
+++ b/knowledge/05-external-deps/sdk-hermes.md
@@ -33,7 +33,8 @@ miloco 通过 `plugins/hermes/` 接入 Hermes，作为 OpenClaw 之外的并列 
 - `POST /v1/chat/completions`（OpenAI 兼容同步端点），body `{"messages":[{"role":"system","content":...},{"role":"user","content":...}]}`，响应 `{"choices":[{"message":{"role":"assistant","content":...}}],"usage":{}}`。
 - 会话连续：请求头 `X-Hermes-Session-Id: <id>` —— Hermes 从 state.db 加载该 session 的历史。adapter 用 `miloco:<sessionKey>:<lane>` 作 id，各车道（含 suggest）都复用同一个持久会话。
 - 鉴权：`Authorization: Bearer $API_SERVER_KEY`。`API_SERVER_KEY` 环境变量设置即自动启用 api_server 平台（默认端口 8642）。
-- 溢出自愈：adapter 识别溢出关键词后，用无 `X-Hermes-Session-Id` 的全新 turn 重试一次。
+- 上下文压缩：Hermes 平台自带（`config.yaml::compression`，默认开，用量超阈值即压，另有按消息数的强制压缩），且遇到 payload 过大会循环压缩重试，压满次数才放弃。持久会话的历史增长由它兜底，miloco 侧不做裁剪、安装脚本也不改压缩配置。
+- 溢出自愈：adapter 识别溢出关键词后，用无 `X-Hermes-Session-Id` 的全新 turn 重试一次。能走到这一步说明平台压缩已经压不动了，此时删会话通常也救不回（主因是 system prompt 自身超预算）。已知代价：自愈那一轮的 session_id 没有 `miloco:` 前缀，trace 不落盘，该轮记账会丢。
 
 **cron**（`cron/jobs.py::create_job`）：
 

--- a/plugins/hermes/miloco-plugin/hermes_adapter/__init__.py
+++ b/plugins/hermes/miloco-plugin/hermes_adapter/__init__.py
@@ -9,6 +9,7 @@ backend 启动时按 ``settings.agent.platform == "hermes"`` 加载。
   分级,组装 OpenAI ``<system>`` 消息文本
 - ``send_turn(ctx)``: 同步 POST 到 Hermes ``/v1/chat/completions``,携带 system msg + user msg,
   带 ``X-Hermes-Session-Id`` 头做会话连续;溢出自愈沿用 PR #279 的 best-effort(无 session 重试)
-- ``read_trace_meta(run_id)``: 读 ``$MILOCO_HOME/trace/<run_id>.meta.json``(plugin trace.py 写);
+- ``read_trace_meta(run_id)``: 读 ``$MILOCO_HOME/trace/agent/<YYYYMMDD>/`` 下的 meta.json
+  (plugin trace.py 写);两侧 run_id 口径不同,按发送原文与 meta 的 query 前缀反查;
   文件不存在 / 解析失败 → 返回 None,backend poller 走超时分支
 """

--- a/plugins/hermes/miloco-plugin/hermes_adapter/adapter.py
+++ b/plugins/hermes/miloco-plugin/hermes_adapter/adapter.py
@@ -13,9 +13,9 @@ Hermes /v1/chat/completions 协议(OpenAI 兼容 Chat Completions API):
 溢出自愈(沿用 279): 识别错误文案含 ``_OVERFLOW_MARKERS`` 时,无 session 头重试一次
 (最佳努力,v0.10.0 api_server 无 session 删除/重置路由)。
 
-trace 文件 IPC(#11): plugin ``trace.py`` 写 ``$MILOCO_HOME/trace/<run_id>.meta.json``,
-本 adapter ``read_trace_meta`` 读盘返回。本 session 暂未重构 ``trace.py``,所以读盘
-通常返回 None —— backend meta_poller 走超时分支,不影响功能。
+trace 文件 IPC(#11): plugin ``trace.py`` 按天写 ``$MILOCO_HOME/trace/agent/<YYYYMMDD>/``
+下的 ``.meta.json``,本 adapter ``read_trace_meta`` 读盘返回。两侧 run_id 口径不同
+(adapter 用 uuid、trace.py 用 session_id),靠发送原文与 meta 的 query 前缀匹配关联。
 """
 
 from __future__ import annotations
@@ -271,13 +271,7 @@ class Adapter:
             session_id = None
             owner_chat = owner_session
         else:
-            # suggestion 每个事件独立评估，不用持久 session；
-            # 但需保留 miloco: 前缀让 trace hook 正常落盘。
-            import uuid as _uuid
-
-            session_id = _map_session(session_key, lane) if lane != "miloco-suggest" else (
-                f"{_map_session(session_key, lane)}:{_uuid.uuid4().hex[:8]}"
-            )
+            session_id = _map_session(session_key, lane)
         timeout_s = max(wait_timeout_ms / 1000.0, 1.0) + _HTTP_BUFFER_S
 
         # 组装 messages: <system>(可选) + <user>
@@ -454,6 +448,22 @@ class Adapter:
 
     # ---- read_trace_meta ----------------------------------------------
 
+    def _recent_meta_files(self) -> list[Path]:
+        """当天 + 昨天（跨零点的 turn）目录下的 meta 文件。
+
+        trace 目录按 YYYYMMDD 分天且没有保留期，全树扫描会随天数线性变慢，
+        而 poller 只可能读到刚落盘的那一批。
+        """
+        import datetime as _dt
+
+        today = _dt.date.today()
+        files: list[Path] = []
+        for day in (today, today - _dt.timedelta(days=1)):
+            day_dir = self._trace_dir / day.strftime("%Y%m%d")
+            if day_dir.is_dir():
+                files.extend(day_dir.glob("*.meta.json"))
+        return files
+
     async def read_trace_meta(self, run_id: str) -> Optional[Any]:
         """按发送原文反查 trace.py 落盘的 meta.json。
 
@@ -465,7 +475,7 @@ class Adapter:
         if not text:
             return None
         candidates = sorted(
-            self._trace_dir.rglob("*.meta.json"),
+            self._recent_meta_files(),
             key=lambda p: p.stat().st_mtime, reverse=True,
         )
         data: dict[str, Any] | None = None
@@ -506,15 +516,12 @@ class Adapter:
     ) -> dict[str, Any]:
         """切家庭时批量清理 Hermes 会话。按 (session_key, lane) 映射为 session_id 后逐个删。
 
-        返回 ``{"reset": [...], "failed": [...]}``。suggest 车道每次 turn
-        用一次性会话（带 uuid 后缀），无跨轮状态，跳过重置。
+        返回 ``{"reset": [...], "failed": [...]}``。
         """
         reset, failed, seen = [], [], set()
         import asyncio as _asyncio
         loop = _asyncio.get_running_loop()
         for session_key, lane in routes:
-            if lane == "miloco-suggest":
-                continue
             session_id = _map_session(session_key, lane)
             if session_id in seen:
                 continue

--- a/plugins/hermes/miloco-plugin/hermes_adapter/adapter.py
+++ b/plugins/hermes/miloco-plugin/hermes_adapter/adapter.py
@@ -112,6 +112,14 @@ def _new_run_id() -> str:
     return str(uuid.uuid4())
 
 
+def _mtime_or_zero(path: Path) -> float:
+    """取 mtime；文件刚被 trace.py 淘汰掉时当最旧处理，别让整次读盘抛出去。"""
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return 0.0
+
+
 def _resolve_trace_dir() -> Path:
     """``$MILOCO_HOME/trace/agent/`` —— plugin trace.py 写盘位置。
 
@@ -474,10 +482,7 @@ class Adapter:
         text = self._pending_texts.get(run_id)
         if not text:
             return None
-        candidates = sorted(
-            self._recent_meta_files(),
-            key=lambda p: p.stat().st_mtime, reverse=True,
-        )
+        candidates = sorted(self._recent_meta_files(), key=_mtime_or_zero, reverse=True)
         data: dict[str, Any] | None = None
         for meta_path in candidates[:50]:
             try:

--- a/plugins/hermes/miloco-plugin/tools_status.py
+++ b/plugins/hermes/miloco-plugin/tools_status.py
@@ -233,40 +233,60 @@ def _check_versions(ctx: Any) -> Dict[str, Any]:
 
 
 def _check_trace_hooks() -> Dict[str, Any]:
-    """trace.py 是否被 register 了——通过查 $MILOCO_HOME/trace/agent/ 目录近期活动。
+    """trace hook 有没有在写盘——查 $MILOCO_HOME/trace/agent/ 今天的 meta.json。
 
-    注意：trace 是 debug 开关，没开过不代表坏了。所以 trace 目录不存在时
-    返回 ``ok=True, note="trace debug 未启用"``，不进 failed_count。
+    meta.json 每个 miloco turn 都写，不受 debug 开关影响（它是 backend 记账的唯一
+    来源）；归 debug 管的只有 jsonl.gz 明细。所以「没有 meta」不能解释成 debug 没开，
+    只有两种可能：今天确实没派过 turn，或者 hook 没注册上。
     """
+    from datetime import datetime
+
+    from .trace import is_debug_enabled
+
     trace_dir = miloco_home() / "trace" / "agent"
+    debug = is_debug_enabled()
+    no_meta_fix = (
+        "先确认 backend 今天确实派过 turn（miloco-cli service status）。派过却没有 meta "
+        "就是 trace hook 没注册上：查 hermes gateway 日志里的 "
+        "'[miloco-trace] register ... failed'，或确认插件已加载"
+    )
     if not trace_dir.is_dir():
         return {
             "ok": True,
-            "note": "trace debug 未启用（没跑过 MILOCO_TRACE_DEBUG=1 的 turn）— 不算异常",
-            "enabled": False,
-            "fix": "需要 debug 时再 export MILOCO_TRACE_DEBUG=1 跑一个 turn",
+            "note": "trace/agent 目录还不存在——至今没有 miloco turn 落过 meta",
+            "debug_enabled": debug,
+            "trace_dir": str(trace_dir),
+            "fix": no_meta_fix,
         }
-    # 看今天有没有 meta.json 写过
-    from datetime import datetime
     today = trace_dir / datetime.now().strftime("%Y%m%d")
     if not today.is_dir():
         return {
             "ok": True,
-            "note": "trace 目录在但今天没 turn 跑过（首次跑会建目录 + meta.json）",
+            "note": "今天还没有 miloco turn 落过 meta",
+            "debug_enabled": debug,
             "trace_dir": str(trace_dir),
+            "fix": no_meta_fix,
         }
     metas = list(today.glob("*.meta.json"))
     if not metas:
+        # 今天的目录只由落盘时的 mkdir 建出来，所以目录在 = 至少一个 turn 走到了落盘。
+        # 走到了却没留下 meta，就是落盘失败，这一天的 agent 统计会全部丢。
         return {
-            "ok": True,
-            "note": "今天还没 turn 跑过（debug 模式需 MILOCO_TRACE_DEBUG=1）",
-            "trace_dir": str(trace_dir),
+            "ok": False,
+            "error": "今天的 trace 目录建了却没有一份 meta——落盘失败，当天 agent 统计会全丢",
+            "debug_enabled": debug,
+            "trace_dir": str(today),
+            "fix": (
+                "查 hermes gateway 日志里的 '[miloco-trace] flush failed'，"
+                "常见原因是磁盘写满或目录没有写权限；若恰好有 turn 正在跑，稍后重跑本自检"
+            ),
         }
     newest = max(metas, key=lambda p: p.stat().st_mtime)
     return {
         "ok": True,
-        "trace_files_today": len(list(today.glob("*.jsonl.gz"))),
         "meta_files_today": len(metas),
+        "jsonl_files_today": len(list(today.glob("*.jsonl.gz"))),  # debug 开时才有
+        "debug_enabled": debug,
         "newest_meta": newest.name,
     }
 

--- a/plugins/hermes/miloco-plugin/trace.py
+++ b/plugins/hermes/miloco-plugin/trace.py
@@ -48,12 +48,13 @@ TURNS_HARD_CAP = 20  # _turns 大小硬上限，兜底防泄漏
 # ── 状态 ────────────────────────────────────────────────────────────────
 
 class _TurnState:
-    __slots__ = ("buffer", "started_at", "query")
+    __slots__ = ("buffer", "started_at", "query", "last_seen")
 
     def __init__(self, started_at: int) -> None:
         self.buffer: List[Dict[str, Any]] = []
         self.started_at = started_at
         self.query: str = ""
+        self.last_seen = started_at
 
 
 # 进程内 registry：run_id → _TurnState（与 openclaw turns Map 等价）
@@ -110,17 +111,22 @@ def _sweep_stale_turns() -> None:
     正常 turn 在 on_session_end 就被 pop 掉。这里兜的是 hook 之间 run_id 口径不一致：
     ``on_session_start`` 只拿得到 session_id，其余 hook 优先用 task_id，两者不等时
     前者建的 state 永远等不到自己那次 session_end。
+
+    判据一律用「多久没有新事件」而不是「开了多久」——僵尸的特征是不再有人往里写，
+    而慢 turn 每条 hook 都会刷新，不该被当成僵尸清掉。
     """
     cutoff = _now_ms() - int(STUCK_TTL_S * 1000)
-    for run_id in [k for k, v in _turns.items() if v.started_at < cutoff]:
+    for run_id in [k for k, v in _turns.items() if v.last_seen < cutoff]:
         state = _turns.pop(run_id, None)
         if state is not None:
             logger.warning(
-                "[miloco-trace] stuck turn evicted: runId=%s age=%ds",
-                run_id, (_now_ms() - state.started_at) // 1000,
+                "[miloco-trace] stuck turn evicted: runId=%s idle=%ds",
+                run_id, (_now_ms() - state.last_seen) // 1000,
             )
     if len(_turns) > TURNS_HARD_CAP:
-        oldest = sorted(_turns.items(), key=lambda kv: kv[1].started_at)
+        # 按最后一次事件时间淘汰：还在跑的 turn 每条 hook 都会刷新 last_seen，只进不出的
+        # 僵尸不会。用 started_at 会先删掉跑得最久的那个活 turn。
+        oldest = sorted(_turns.items(), key=lambda kv: kv[1].last_seen)
         for run_id, _ in oldest[: len(_turns) - TURNS_HARD_CAP]:
             _turns.pop(run_id, None)
         logger.warning("[miloco-trace] turns over hard cap %d, evicted oldest", TURNS_HARD_CAP)
@@ -166,6 +172,7 @@ def _get_or_init(run_id: str) -> _TurnState:
 
 
 def _push_event(state: _TurnState, ev: Dict[str, Any]) -> None:
+    state.last_seen = _now_ms()
     if len(state.buffer) < BUFFER_MAX:
         state.buffer.append(ev)
     elif len(state.buffer) == BUFFER_MAX:
@@ -256,18 +263,23 @@ def _flush_to_disk(run_id: str, state: _TurnState, final_success: bool) -> None:
         stem = _truncate_bytes(f"{run_id}__{_sanitize_filename(state.query)}", _STEM_MAX_BYTES)
         jsonl_path: Optional[str] = None
         if is_debug_enabled():
-            existing = [p for p in dir_path.iterdir() if p.suffix == ".gz"]
-            if len(existing) >= DAILY_DUMP_MAX:
-                logger.warning(
-                    "[miloco-trace] daily cap reached: %d/%d, skip jsonl runId=%s",
-                    len(existing), DAILY_DUMP_MAX, run_id,
-                )
-            else:
-                filename = f"{stem}.jsonl.gz"
-                text = "\n".join(json.dumps(e, ensure_ascii=False) for e in state.buffer) + "\n"
-                with gzip.open(dir_path / filename, "wt", encoding="utf-8") as f:
-                    f.write(text)
-                jsonl_path = f"trace/agent/{dir_path.name}/{filename}"
+            # 明细只是诊断产物，它自己的 IO 失败绝不能连累下面的 meta 写入
+            # （磁盘写满时 meta 往往还写得下）。openclaw trace.ts 的 gzip 段同样自带一层。
+            try:
+                existing = [p for p in dir_path.iterdir() if p.suffix == ".gz"]
+                if len(existing) >= DAILY_DUMP_MAX:
+                    logger.warning(
+                        "[miloco-trace] daily cap reached: %d/%d, skip jsonl runId=%s",
+                        len(existing), DAILY_DUMP_MAX, run_id,
+                    )
+                else:
+                    filename = f"{stem}.jsonl.gz"
+                    text = "\n".join(json.dumps(e, ensure_ascii=False) for e in state.buffer) + "\n"
+                    with gzip.open(dir_path / filename, "wt", encoding="utf-8") as f:
+                        f.write(text)
+                    jsonl_path = f"trace/agent/{dir_path.name}/{filename}"
+            except OSError as exc:
+                logger.warning("[miloco-trace] jsonl write failed runId=%s: %s", run_id, exc)
         _evict_old_metas(dir_path)
         # meta 文件（adapter read_trace_meta 读这个）——小 JSON 包含聚合统计 + 路径。
         # 字段名统一 snake_case，与 adapter.py read_trace_meta 读盘侧一致。
@@ -360,7 +372,7 @@ def _hk_on_session_start(session_id, model, platform, **kwargs):
 
 
 def _hk_on_session_end(session_id, completed, interrupted, model, platform, **kwargs):
-    """对齐 OpenClaw agent_end——finalize turn：落盘后释放内存里的 turn state。"""
+    """对齐 OpenClaw agent_end——finalize turn：先释放内存里的 turn state，再落盘。"""
     run_id = _run_id_from_args(session_id=session_id, task_id=kwargs.get("task_id"))
     with _lock:
         state = _turns.get(run_id)
@@ -379,17 +391,17 @@ def _hk_on_session_end(session_id, completed, interrupted, model, platform, **kw
                 "durationMs": _now_ms() - state.started_at,
             },
         })
-        try:
-            # 只落 miloco 触发的 turn，普通 chat 直接丢。用 session_id 前缀判定而不是
-            # register_trace_link——后者跨进程调不到（_map_session 生成固定 "miloco:" 前缀）。
-            if (session_id or "").startswith("miloco:"):
-                _flush_to_disk(run_id, state, bool(completed))
-        finally:
-            # 持久会话下一轮复用同一个 run_id，这里不释放会让下一轮接着写本轮 buffer。
-            # 放 finally 是因为落盘一旦抛出，漏释放就是本模块修掉的那个 bug 原样复发。
-            _turns.pop(run_id, None)
-            _sweep_stale_turns()
-    pop_trace_link(run_id)
+        # 先摘下来：持久会话下一轮复用同一个 run_id，不释放会让下一轮接着写本轮 buffer。
+        # 摘完 state 只属于本次调用，落盘不必再占这把全局锁，也就没有"落盘抛错导致漏释放"。
+        _turns.pop(run_id, None)
+        _sweep_stale_turns()
+    try:
+        # 只落 miloco 触发的 turn，普通 chat 直接丢。用 session_id 前缀判定而不是
+        # register_trace_link——后者跨进程调不到（_map_session 生成固定 "miloco:" 前缀）。
+        if (session_id or "").startswith("miloco:"):
+            _flush_to_disk(run_id, state, bool(completed))
+    finally:
+        pop_trace_link(run_id)
 
 
 # ── 注册 ────────────────────────────────────────────────────────────────

--- a/plugins/hermes/miloco-plugin/trace.py
+++ b/plugins/hermes/miloco-plugin/trace.py
@@ -13,8 +13,10 @@ Hermes 没有 ``runId`` 概念——直接用 ``session_id`` 作为 turn id。tr
 ``miloco:<sessionKey>:<lane>`` 前缀的 session_id 推导（context_injection 时识别）。
 
 落盘：``$MILOCO_HOME/trace/agent/<YYYYMMDD>/<runId>__<query>.jsonl.gz`` + 同名
-``.meta.json``（adapter 的 read_trace_meta 读这个）。jsonl 有每日数量上限防撑爆
-磁盘，meta 不受限——它是 backend 记账的唯一来源。
+``.meta.json``（adapter 的 read_trace_meta 读这个）。
+
+jsonl 是诊断产物，与 openclaw 一样只在 debug 开时写、并有每日数量上限；meta 是
+backend 记账的唯一来源（openclaw 那边走内存 webhook），必须常写，超上限淘汰最老的。
 """
 
 from __future__ import annotations
@@ -34,7 +36,8 @@ logger = logging.getLogger(__name__)
 
 # ── 常量（与 openclaw trace.ts 对齐） ─────────────────────────────────────
 BUFFER_MAX = 5000  # 单 turn buffer 上限（events 数）；超出记 _truncated
-DAILY_DUMP_MAX = 300  # 每日 jsonl.gz 文件数 cap
+DAILY_DUMP_MAX = 300  # 每日 jsonl.gz 文件数 cap（debug 开时才落 jsonl）
+META_DAILY_MAX = 300  # 每日 meta.json 文件数上限，超出淘汰最老的
 QUERY_LEN_MAX = 80  # 文件名里 query 部分最大长度（字符）
 NAME_MAX_BYTES = 255  # POSIX 单个文件名字节上限
 _STEM_MAX_BYTES = NAME_MAX_BYTES - len(".meta.json")  # 后缀最长的那个
@@ -104,7 +107,9 @@ def _sanitize_filename(q: Optional[str]) -> str:
 def _sweep_stale_turns() -> None:
     """清理没走到 on_session_end 的僵尸 turn（对齐 openclaw ``gcExpiredTurns``）。
 
-    正常 turn 在 on_session_end 就被 pop 掉，这里只兜底 hook 缺席的情况。
+    正常 turn 在 on_session_end 就被 pop 掉。这里兜的是 hook 之间 run_id 口径不一致：
+    ``on_session_start`` 只拿得到 session_id，其余 hook 优先用 task_id，两者不等时
+    前者建的 state 永远等不到自己那次 session_end。
     """
     cutoff = _now_ms() - int(STUCK_TTL_S * 1000)
     for run_id in [k for k, v in _turns.items() if v.started_at < cutoff]:
@@ -223,28 +228,47 @@ def _reduce_meta(buffer: List[Dict[str, Any]]) -> Dict[str, Any]:
     }
 
 
+def _evict_old_metas(dir_path: Path) -> None:
+    """腾出一个 meta 名额：删最老的几个。
+
+    meta 是记账来源，撞上限只能淘汰旧的，不能像 jsonl 那样拒写。淘汰本身是尽力而为，
+    失败只记日志——让它冒出去会连累这一轮的 meta 写不成。
+    """
+    try:
+        metas = list(dir_path.glob("*.meta.json"))
+        if len(metas) < META_DAILY_MAX:
+            return
+        metas.sort(key=lambda p: p.stat().st_mtime)
+        for old in metas[: len(metas) - META_DAILY_MAX + 1]:
+            old.unlink(missing_ok=True)
+    except OSError as exc:
+        logger.warning("[miloco-trace] evict meta failed: %s", exc)
+
+
 def _flush_to_disk(run_id: str, state: _TurnState, final_success: bool) -> None:
     """落盘：``trace/agent/<YYYYMMDD>/<runId>__<query>.jsonl.gz`` + 同名 ``.meta.json``。
 
-    每日 cap 只挡体积大的 jsonl —— meta 是 backend 唯一的记账来源，撞 cap 也要写。
+    jsonl 跟着 debug 开关走（对齐 openclaw），meta 无论如何都要写 —— backend 靠它记账。
     """
     try:
         dir_path = _today_dir()
         dir_path.mkdir(parents=True, exist_ok=True)
         stem = _truncate_bytes(f"{run_id}__{_sanitize_filename(state.query)}", _STEM_MAX_BYTES)
         jsonl_path: Optional[str] = None
-        existing = [p for p in dir_path.iterdir() if p.suffix == ".gz"]
-        if len(existing) >= DAILY_DUMP_MAX:
-            logger.warning(
-                "[miloco-trace] daily cap reached: %d/%d, skip jsonl runId=%s",
-                len(existing), DAILY_DUMP_MAX, run_id,
-            )
-        else:
-            filename = f"{stem}.jsonl.gz"
-            text = "\n".join(json.dumps(e, ensure_ascii=False) for e in state.buffer) + "\n"
-            with gzip.open(dir_path / filename, "wt", encoding="utf-8") as f:
-                f.write(text)
-            jsonl_path = f"trace/agent/{dir_path.name}/{filename}"
+        if is_debug_enabled():
+            existing = [p for p in dir_path.iterdir() if p.suffix == ".gz"]
+            if len(existing) >= DAILY_DUMP_MAX:
+                logger.warning(
+                    "[miloco-trace] daily cap reached: %d/%d, skip jsonl runId=%s",
+                    len(existing), DAILY_DUMP_MAX, run_id,
+                )
+            else:
+                filename = f"{stem}.jsonl.gz"
+                text = "\n".join(json.dumps(e, ensure_ascii=False) for e in state.buffer) + "\n"
+                with gzip.open(dir_path / filename, "wt", encoding="utf-8") as f:
+                    f.write(text)
+                jsonl_path = f"trace/agent/{dir_path.name}/{filename}"
+        _evict_old_metas(dir_path)
         # meta 文件（adapter read_trace_meta 读这个）——小 JSON 包含聚合统计 + 路径。
         # 字段名统一 snake_case，与 adapter.py read_trace_meta 读盘侧一致。
         meta = _reduce_meta(state.buffer)
@@ -355,13 +379,16 @@ def _hk_on_session_end(session_id, completed, interrupted, model, platform, **kw
                 "durationMs": _now_ms() - state.started_at,
             },
         })
-        # 只落 miloco 触发的 turn，普通 chat 直接丢。用 session_id 前缀判定而不是
-        # register_trace_link——后者跨进程调不到（_map_session 生成固定 "miloco:" 前缀）。
-        if (session_id or "").startswith("miloco:"):
-            _flush_to_disk(run_id, state, bool(completed))
-        # 持久会话下一轮复用同一个 run_id，这里不释放会让下一轮接着写本轮 buffer。
-        _turns.pop(run_id, None)
-        _sweep_stale_turns()
+        try:
+            # 只落 miloco 触发的 turn，普通 chat 直接丢。用 session_id 前缀判定而不是
+            # register_trace_link——后者跨进程调不到（_map_session 生成固定 "miloco:" 前缀）。
+            if (session_id or "").startswith("miloco:"):
+                _flush_to_disk(run_id, state, bool(completed))
+        finally:
+            # 持久会话下一轮复用同一个 run_id，这里不释放会让下一轮接着写本轮 buffer。
+            # 放 finally 是因为落盘一旦抛出，漏释放就是本模块修掉的那个 bug 原样复发。
+            _turns.pop(run_id, None)
+            _sweep_stale_turns()
     pop_trace_link(run_id)
 
 

--- a/plugins/hermes/miloco-plugin/trace.py
+++ b/plugins/hermes/miloco-plugin/trace.py
@@ -13,9 +13,8 @@ Hermes 没有 ``runId`` 概念——直接用 ``session_id`` 作为 turn id。tr
 ``miloco:<sessionKey>:<lane>`` 前缀的 session_id 推导（context_injection 时识别）。
 
 落盘：``$MILOCO_HOME/trace/agent/<YYYYMMDD>/<runId>__<query>.jsonl.gz`` + 同名
-``.meta.json``（adapter 的 read_trace_meta 读这个）。
-
-每日 cap 300（超出 warn 跳过，防撑爆磁盘）—— 与 openclaw 完全一致。
+``.meta.json``（adapter 的 read_trace_meta 读这个）。jsonl 有每日数量上限防撑爆
+磁盘，meta 不受限——它是 backend 记账的唯一来源。
 """
 
 from __future__ import annotations
@@ -36,21 +35,22 @@ logger = logging.getLogger(__name__)
 # ── 常量（与 openclaw trace.ts 对齐） ─────────────────────────────────────
 BUFFER_MAX = 5000  # 单 turn buffer 上限（events 数）；超出记 _truncated
 DAILY_DUMP_MAX = 300  # 每日 jsonl.gz 文件数 cap
-QUERY_LEN_MAX = 80  # 文件名里 query 部分最大长度
-TRACE_DONE_TTL_S = 3600.0  # done turns 在内存保留 1h（adapter get_trace 轮询窗口）
+QUERY_LEN_MAX = 80  # 文件名里 query 部分最大长度（字符）
+NAME_MAX_BYTES = 255  # POSIX 单个文件名字节上限
+_STEM_MAX_BYTES = NAME_MAX_BYTES - len(".meta.json")  # 后缀最长的那个
+STUCK_TTL_S = 900.0  # 未结束 turn 超此时长强制清理（hook 没走到 session_end 的僵尸）
+TURNS_HARD_CAP = 20  # _turns 大小硬上限，兜底防泄漏
 
 
 # ── 状态 ────────────────────────────────────────────────────────────────
 
 class _TurnState:
-    __slots__ = ("buffer", "started_at", "query", "done", "done_at")
+    __slots__ = ("buffer", "started_at", "query")
 
     def __init__(self, started_at: int) -> None:
         self.buffer: List[Dict[str, Any]] = []
         self.started_at = started_at
         self.query: str = ""
-        self.done: Optional[Dict[str, Any]] = None
-        self.done_at: int = 0
 
 
 # 进程内 registry：run_id → _TurnState（与 openclaw turns Map 等价）
@@ -85,6 +85,11 @@ def _extract_user_query(prompt: Optional[str]) -> str:
     return cleaned.strip()
 
 
+def _truncate_bytes(s: str, limit: int) -> str:
+    """按 UTF-8 字节截断，不切碎多字节字符。"""
+    return s.encode("utf-8")[:limit].decode("utf-8", errors="ignore")
+
+
 def _sanitize_filename(q: Optional[str]) -> str:
     """与 openclaw sanitizeQueryForFilename 等价。"""
     if not q:
@@ -96,12 +101,24 @@ def _sanitize_filename(q: Optional[str]) -> str:
     return s or "system"
 
 
-def _gc_expired_turns() -> None:
-    """清理 done 超 1h 的 turn（释放内存）。"""
-    cutoff = _now_ms() - int(TRACE_DONE_TTL_S * 1000)
-    expired = [k for k, v in _turns.items() if v.done and v.done_at < cutoff]
-    for k in expired:
-        _turns.pop(k, None)
+def _sweep_stale_turns() -> None:
+    """清理没走到 on_session_end 的僵尸 turn（对齐 openclaw ``gcExpiredTurns``）。
+
+    正常 turn 在 on_session_end 就被 pop 掉，这里只兜底 hook 缺席的情况。
+    """
+    cutoff = _now_ms() - int(STUCK_TTL_S * 1000)
+    for run_id in [k for k, v in _turns.items() if v.started_at < cutoff]:
+        state = _turns.pop(run_id, None)
+        if state is not None:
+            logger.warning(
+                "[miloco-trace] stuck turn evicted: runId=%s age=%ds",
+                run_id, (_now_ms() - state.started_at) // 1000,
+            )
+    if len(_turns) > TURNS_HARD_CAP:
+        oldest = sorted(_turns.items(), key=lambda kv: kv[1].started_at)
+        for run_id, _ in oldest[: len(_turns) - TURNS_HARD_CAP]:
+            _turns.pop(run_id, None)
+        logger.warning("[miloco-trace] turns over hard cap %d, evicted oldest", TURNS_HARD_CAP)
 
 
 # ── 公共 API ────────────────────────────────────────────────────────────
@@ -133,29 +150,6 @@ def pop_trace_link(run_id: str) -> Optional[str]:
     with _lock:
         v = _trace_links.pop(run_id, None)
         return v
-
-
-def pop_done_turn(run_id: Optional[str]) -> Optional[Dict[str, Any]]:
-    """adapter 的 get_trace 调：取 done meta（原子，poll 完即清）。
-
-    ``run_id=None`` 时返回最新一个 done turn 的 meta（兜底，对应 backend 用
-    ``get_trace`` 不带 runId 的轮询）。
-    """
-    with _lock:
-        if run_id is None:
-            done = [(k, v.done, v.done_at) for k, v in _turns.items() if v.done]
-            if not done:
-                return None
-            done.sort(key=lambda x: x[2], reverse=True)
-            run_id, meta, _ = done[0]
-        else:
-            state = _turns.get(run_id)
-            meta = state.done if state else None
-        if meta is None:
-            return None
-        # pop（与 openclaw popDoneTurn 等价——meta 给 backend 后即清，避免重复消费）
-        _turns.pop(run_id, None)
-        return meta
 
 
 def _get_or_init(run_id: str) -> _TurnState:
@@ -229,26 +223,28 @@ def _reduce_meta(buffer: List[Dict[str, Any]]) -> Dict[str, Any]:
     }
 
 
-def _flush_to_disk(run_id: str, state: _TurnState, final_success: bool) -> Optional[str]:
+def _flush_to_disk(run_id: str, state: _TurnState, final_success: bool) -> None:
     """落盘：``trace/agent/<YYYYMMDD>/<runId>__<query>.jsonl.gz`` + 同名 ``.meta.json``。
 
-    返回 jsonl 相对路径（写进 meta 让 backend / 调试看到）；超出每日 cap 时 warn 跳过。
+    每日 cap 只挡体积大的 jsonl —— meta 是 backend 唯一的记账来源，撞 cap 也要写。
     """
     try:
         dir_path = _today_dir()
         dir_path.mkdir(parents=True, exist_ok=True)
+        stem = _truncate_bytes(f"{run_id}__{_sanitize_filename(state.query)}", _STEM_MAX_BYTES)
+        jsonl_path: Optional[str] = None
         existing = [p for p in dir_path.iterdir() if p.suffix == ".gz"]
         if len(existing) >= DAILY_DUMP_MAX:
             logger.warning(
-                "[miloco-trace] daily cap reached: %d/%d, skip dump runId=%s",
+                "[miloco-trace] daily cap reached: %d/%d, skip jsonl runId=%s",
                 len(existing), DAILY_DUMP_MAX, run_id,
             )
-            return None
-        filename = f"{run_id}__{_sanitize_filename(state.query)}.jsonl.gz"
-        full_path = dir_path / filename
-        text = "\n".join(json.dumps(e, ensure_ascii=False) for e in state.buffer) + "\n"
-        with gzip.open(full_path, "wt", encoding="utf-8") as f:
-            f.write(text)
+        else:
+            filename = f"{stem}.jsonl.gz"
+            text = "\n".join(json.dumps(e, ensure_ascii=False) for e in state.buffer) + "\n"
+            with gzip.open(dir_path / filename, "wt", encoding="utf-8") as f:
+                f.write(text)
+            jsonl_path = f"trace/agent/{dir_path.name}/{filename}"
         # meta 文件（adapter read_trace_meta 读这个）——小 JSON 包含聚合统计 + 路径。
         # 字段名统一 snake_case，与 adapter.py read_trace_meta 读盘侧一致。
         meta = _reduce_meta(state.buffer)
@@ -256,16 +252,15 @@ def _flush_to_disk(run_id: str, state: _TurnState, final_success: bool) -> Optio
         meta["trace_id"] = _trace_links.get(run_id)
         meta["query"] = state.query
         meta["success"] = final_success
-        meta["jsonl_path"] = f"trace/agent/{dir_path.name}/{filename}"
+        meta["jsonl_path"] = jsonl_path
         meta["started_at"] = state.started_at
         meta["done_at"] = _now_ms()
         meta["duration_ms"] = meta["done_at"] - meta["started_at"]
-        meta_path = dir_path / f"{run_id}__{_sanitize_filename(state.query)}.meta.json"
-        meta_path.write_text(json.dumps(meta, ensure_ascii=False, indent=2), encoding="utf-8")
-        return meta["jsonl_path"]
+        (dir_path / f"{stem}.meta.json").write_text(
+            json.dumps(meta, ensure_ascii=False, indent=2), encoding="utf-8",
+        )
     except OSError as exc:
         logger.warning("[miloco-trace] flush failed runId=%s: %s", run_id, exc)
-        return None
 
 
 # ── hook handlers ───────────────────────────────────────────────────────
@@ -341,11 +336,11 @@ def _hk_on_session_start(session_id, model, platform, **kwargs):
 
 
 def _hk_on_session_end(session_id, completed, interrupted, model, platform, **kwargs):
-    """对齐 OpenClaw agent_end——finalize turn，写盘 + 留 meta 给 backend 拉。"""
+    """对齐 OpenClaw agent_end——finalize turn：落盘后释放内存里的 turn state。"""
     run_id = _run_id_from_args(session_id=session_id, task_id=kwargs.get("task_id"))
     with _lock:
         state = _turns.get(run_id)
-        if not state or state.done:
+        if not state:
             return
         _push_event(state, {
             "ts": _now_iso(),
@@ -360,24 +355,13 @@ def _hk_on_session_end(session_id, completed, interrupted, model, platform, **kw
                 "durationMs": _now_ms() - state.started_at,
             },
         })
-        # session_id 不以 "miloco:" 开头 = 非 miloco 触发的 turn（普通 chat）→ GC，不落盘。
-        # 替代旧的 register_trace_link 跨进程机制：该函数在两个进程间无法调用，
-        # 用 session_id 前缀判定更可靠（_map_session 生成固定前缀 "miloco:<key>:<lane>"）。
-        if not (session_id or "").startswith("miloco:"):
-            _turns.pop(run_id, None)
-            _gc_expired_turns()
-            return
-        jsonl_path = _flush_to_disk(run_id, state, bool(completed))
-        meta = _reduce_meta(state.buffer)
-        meta["run_id"] = run_id
-        meta["trace_id"] = _trace_links.get(run_id)
-        meta["query"] = state.query
-        meta["duration_ms"] = _now_ms() - state.started_at
-        meta["success"] = bool(completed)
-        meta["jsonl_path"] = jsonl_path
-        state.done = meta
-        state.done_at = _now_ms()
-        _gc_expired_turns()
+        # 只落 miloco 触发的 turn，普通 chat 直接丢。用 session_id 前缀判定而不是
+        # register_trace_link——后者跨进程调不到（_map_session 生成固定 "miloco:" 前缀）。
+        if (session_id or "").startswith("miloco:"):
+            _flush_to_disk(run_id, state, bool(completed))
+        # 持久会话下一轮复用同一个 run_id，这里不释放会让下一轮接着写本轮 buffer。
+        _turns.pop(run_id, None)
+        _sweep_stale_turns()
     pop_trace_link(run_id)
 
 

--- a/plugins/hermes/tests/test_author_fix_regression.py
+++ b/plugins/hermes/tests/test_author_fix_regression.py
@@ -176,8 +176,7 @@ class TestTraceFieldAlignment:
 
         t[0] = 2000000  # advance time for done_at
 
-        jsonl_path = tr._flush_to_disk(run_id, state, final_success=True)
-        assert jsonl_path is not None, "trace 落盘失败——register_trace_link 可能没生效"
+        tr._flush_to_disk(run_id, state, final_success=True)
 
         # 现在读盘——模拟 adapter.read_trace_meta 逻辑
         from pathlib import Path

--- a/plugins/hermes/tests/test_author_fix_regression.py
+++ b/plugins/hermes/tests/test_author_fix_regression.py
@@ -160,6 +160,7 @@ class TestTraceFieldAlignment:
         from miloco_plugin_pkg import trace as tr
 
         monkeypatch.setenv("MILOCO_HOME", str(tmp_path))
+        monkeypatch.setenv("MILOCO_TRACE_DEBUG", "1")
         monkeypatch.setattr(tr, "_today_dir", lambda: tmp_path)
         t = [1000000]
         monkeypatch.setattr(tr, "_now_ms", lambda: t[0])

--- a/plugins/hermes/tests/test_hermes_adapter.py
+++ b/plugins/hermes/tests/test_hermes_adapter.py
@@ -488,3 +488,97 @@ def _fake_ctx(text: str, trace_id: str = "tr-test", lane: str = "miloco-interact
     ctx.profile = "minimal"
     ctx.extra = {}
     return ctx
+
+# ---------------------------------------------------------------------------
+# read_trace_meta
+# ---------------------------------------------------------------------------
+
+
+def _write_meta(trace_dir: Path, day: str, query: str) -> None:
+    day_dir = trace_dir / day
+    day_dir.mkdir(parents=True, exist_ok=True)
+    (day_dir / f"run__{query}.meta.json").write_text(
+        json.dumps({"query": query, "duration_ms": 1, "llm_call_count": 1}), encoding="utf-8",
+    )
+
+
+@pytest.mark.anyio
+async def test_read_trace_meta_matches_today_and_yesterday(tmp_path: Path):
+    """当天与昨天（跨零点的 turn）的 meta 都要能反查到。"""
+    from datetime import datetime, timedelta
+
+    from miloco_plugin_pkg.hermes_adapter.adapter import Adapter
+
+    _write_meta(tmp_path, datetime.now().strftime("%Y%m%d"), "今天的问题")
+    _write_meta(tmp_path, (datetime.now() - timedelta(days=1)).strftime("%Y%m%d"), "昨天的问题")
+
+    a = Adapter(trace_dir=tmp_path)
+    a._pending_texts["run-today"] = "今天的问题"
+    a._pending_texts["run-yesterday"] = "昨天的问题"
+
+    assert (await a.read_trace_meta("run-today")).query == "今天的问题"
+    assert (await a.read_trace_meta("run-yesterday")).query == "昨天的问题"
+
+
+@pytest.mark.anyio
+async def test_read_trace_meta_ignores_old_day_dirs(tmp_path: Path):
+    """只扫最近两天的目录：meta 按天累积不清理，poller 高频全树 stat 会拖垮 SBC 的 IO。"""
+    from datetime import datetime, timedelta
+
+    from miloco_plugin_pkg.hermes_adapter.adapter import Adapter
+
+    _write_meta(tmp_path, (datetime.now() - timedelta(days=30)).strftime("%Y%m%d"), "上个月的问题")
+
+    a = Adapter(trace_dir=tmp_path)
+    a._pending_texts["run-old"] = "上个月的问题"
+    assert await a.read_trace_meta("run-old") is None
+
+
+# ---------------------------------------------------------------------------
+# suggest 车道会话策略
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_suggest_lane_reuses_persistent_session(monkeypatch):
+    """suggest 车道与其他车道一样复用持久会话——同 (session_key, lane) 恒定 session id。"""
+    from miloco_plugin_pkg.hermes_adapter.adapter import Adapter
+    import httpx
+
+    seen: list[str] = []
+
+    async def fake_post(self, url, headers=None, **kw):
+        seen.append((headers or {}).get("X-Hermes-Session-Id"))
+        resp = mock.MagicMock()
+        resp.status_code = 200
+        return resp
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+    monkeypatch.setattr(httpx.AsyncClient, "aclose", mock.AsyncMock())
+
+    a = Adapter()
+    for _ in range(2):
+        ctx = _fake_ctx("有个建议", lane="miloco-suggest")
+        ctx.session_key = "agent:main:miloco-suggest"
+        await a.send_turn(ctx)
+
+    assert seen == ["miloco:agent:main:miloco-suggest:miloco-suggest"] * 2
+
+
+@pytest.mark.anyio
+async def test_reset_sessions_covers_suggest_lane(monkeypatch):
+    """切家庭要能清掉 suggest 会话，否则上一个家的对话历史留在里面。"""
+    from miloco_plugin_pkg.hermes_adapter import adapter as ad
+
+    deleted: list[str] = []
+    monkeypatch.setattr(
+        ad, "_delete_hermes_session", lambda sid, timeout=15.0: deleted.append(sid) or True,
+    )
+
+    a = ad.Adapter()
+    out = await a.reset_sessions([
+        ("agent:main:miloco-rule", "miloco-rule"),
+        ("agent:main:miloco-suggest", "miloco-suggest"),
+    ])
+    assert "miloco:agent:main:miloco-suggest:miloco-suggest" in deleted
+    assert len(out["reset"]) == 2

--- a/plugins/hermes/tests/test_integration.py
+++ b/plugins/hermes/tests/test_integration.py
@@ -85,29 +85,6 @@ def test_trace_full_write_read_cycle(tmp_path, monkeypatch):
     assert len(gz_files) == 1
 
 
-def test_trace_pop_done_turn_gives_meta(tmp_path, monkeypatch):
-    """pop_done_turn 返回完整 meta 给 backend adapter 读。"""
-    monkeypatch.setenv("MILOCO_HOME", str(tmp_path))
-    from miloco_plugin_pkg import trace as tr
-
-    tr._turns.clear()
-    tr._trace_links.clear()
-
-    sess = "miloco:test-pop"
-    tr.register_trace_link(sess, "trace-abc")
-    tr._hk_pre_llm_call(sess, "test query", [], True, "m", "p")
-    tr._hk_on_session_end(sess, True, False, "m", "p")
-
-    meta = tr.pop_done_turn(sess)
-    assert meta is not None
-    assert meta["run_id"] == sess
-    assert meta["trace_id"] == "trace-abc"
-    assert "llm_call_count" in meta
-    assert "tool_call_count" in meta
-
-    assert tr.pop_done_turn(sess) is None
-
-
 # ── notify 三级 fallback ────────────────────────────────────────────────────
 
 def test_notify_resolve_target_runtime_fallback(tmp_path, monkeypatch):

--- a/plugins/hermes/tests/test_integration.py
+++ b/plugins/hermes/tests/test_integration.py
@@ -55,8 +55,9 @@ def test_hermes_adapter_instantiable():
 # ── trace 读写全链路（文件 IPC） ────────────────────────────────────────────
 
 def test_trace_full_write_read_cycle(tmp_path, monkeypatch):
-    """trace.py 常写 → 读取，验证文件 IPC 链路。"""
+    """trace.py 写 → 读取，验证文件 IPC 链路（jsonl 部分要 debug 开）。"""
     monkeypatch.setenv("MILOCO_HOME", str(tmp_path))
+    monkeypatch.setenv("MILOCO_TRACE_DEBUG", "1")
     from miloco_plugin_pkg import trace as tr
 
     tr._turns.clear()

--- a/plugins/hermes/tests/test_tools_status.py
+++ b/plugins/hermes/tests/test_tools_status.py
@@ -218,24 +218,36 @@ def test_versions_mismatch_detected(tmp_path: Path):
 
 
 def test_trace_hooks_empty_trace_dir(tmp_path: Path, monkeypatch):
-    """trace 目录不存在 → ok=True + note（debug 没开过 ≠ 坏了，不进 failed）。"""
+    """trace 目录不存在 → ok=True，但不能归因到 debug（meta 不受 debug 管）。"""
     monkeypatch.setenv("MILOCO_HOME", str(tmp_path))
     out = ts._check_trace_hooks()
     assert out["ok"] is True
-    assert out["enabled"] is False
-    assert "trace debug 未启用" in out["note"]
+    assert "debug" not in out["note"]  # 别再把「没有 meta」说成 debug 没开
+    assert "没注册上" in out["fix"]
 
 
-def test_trace_hooks_today_dir_no_files(tmp_path: Path, monkeypatch):
-    """trace 目录有但今天没 turn → ok=True + note。"""
+def test_trace_hooks_no_today_dir(tmp_path: Path, monkeypatch):
+    """trace 目录在、今天的日期目录还没建 → ok=True（今天没派过 turn）。"""
+    monkeypatch.setenv("MILOCO_HOME", str(tmp_path))
+    (tmp_path / "trace" / "agent").mkdir(parents=True, exist_ok=True)
+    out = ts._check_trace_hooks()
+    assert out["ok"] is True
+    assert "今天还没有" in out["note"]
+
+
+def test_trace_hooks_today_dir_without_meta_is_failure(tmp_path: Path, monkeypatch):
+    """今天目录建了却没有 meta → ok=False。
+
+    该目录只由落盘时的 mkdir 建出来，所以目录在 = 有 turn 走到了落盘却没写成，
+    当天记账会全丢。自检必须报出来，不能盖章放行。
+    """
     from datetime import datetime
     monkeypatch.setenv("MILOCO_HOME", str(tmp_path))
-    trace_dir = tmp_path / "trace" / "agent"
-    today = trace_dir / datetime.now().strftime("%Y%m%d")
+    today = tmp_path / "trace" / "agent" / datetime.now().strftime("%Y%m%d")
     today.mkdir(parents=True, exist_ok=True)
     out = ts._check_trace_hooks()
-    assert out["ok"] is True
-    assert "今天还没" in out["note"]
+    assert out["ok"] is False
+    assert "落盘失败" in out["error"]
 
 
 def test_trace_hooks_today_has_files(tmp_path: Path, monkeypatch):
@@ -251,7 +263,7 @@ def test_trace_hooks_today_has_files(tmp_path: Path, monkeypatch):
     out = ts._check_trace_hooks()
     assert out["ok"] is True
     assert out["meta_files_today"] == 1
-    assert out["trace_files_today"] == 1
+    assert out["jsonl_files_today"] == 1
     assert out["newest_meta"] == "sess-1__test.meta.json"
 
 

--- a/plugins/hermes/tests/test_trace.py
+++ b/plugins/hermes/tests/test_trace.py
@@ -175,6 +175,12 @@ def test_pop_trace_link_missing_returns_none():
 MILOCO_SESSION = "miloco:agent:main:miloco-suggest:miloco-suggest"
 
 
+def _read_metas() -> list[dict]:
+    """读当前 MILOCO_HOME 下落盘的全部 meta.json。"""
+    root = Path(os.environ["MILOCO_HOME"]) / "trace" / "agent"
+    return [json.loads(p.read_text(encoding="utf-8")) for p in sorted(root.rglob("*.meta.json"))]
+
+
 def test_session_end_without_trace_id_drops():
     """非 miloco: 前缀的 session → 直接 GC，不留 meta、不落盘。"""
     tr._hk_pre_llm_call("sess-1", "hi", [], True, "m", "p")
@@ -182,58 +188,27 @@ def test_session_end_without_trace_id_drops():
     assert "sess-1" not in tr._turns
 
 
-def test_session_end_with_trace_id_keeps_done_meta():
-    """miloco: 前缀的 session → finalize，留 done meta 给 backend 拉。"""
+def test_session_end_writes_meta_to_disk():
+    """miloco: 前缀的 session → finalize 落盘 meta 给 backend 读。"""
     tr.register_trace_link(MILOCO_SESSION, "trace-abc")
     tr._hk_pre_llm_call(MILOCO_SESSION, "hi", [], True, "m", "p")
     tr._hk_post_llm_call(MILOCO_SESSION, "hi", "ans", [], "m", "p", duration_ms=500)
     tr._hk_on_session_end(MILOCO_SESSION, True, False, "m", "p")
-    state = tr._turns[MILOCO_SESSION]
-    assert state.done is not None
-    assert state.done["trace_id"] == "trace-abc"
-    assert state.done["success"] is True
-    assert state.done["llm_call_count"] == 1
+    metas = _read_metas()
+    assert len(metas) == 1
+    assert metas[0]["trace_id"] == "trace-abc"
+    assert metas[0]["success"] is True
+    assert metas[0]["llm_call_count"] == 1
     assert MILOCO_SESSION not in tr._trace_links
 
 
 def test_session_end_idempotent():
-    """同一 session end 调两次，第二次是 no-op。"""
+    """同一 turn 的 session_end 触发两次，第二次是 no-op（state 已释放）。"""
     tr.register_trace_link(MILOCO_SESSION, "trace-abc")
     tr._hk_pre_llm_call(MILOCO_SESSION, "hi", [], True, "m", "p")
     tr._hk_on_session_end(MILOCO_SESSION, True, False, "m", "p")
     tr._hk_on_session_end(MILOCO_SESSION, True, False, "m", "p")
-    state = tr._turns[MILOCO_SESSION]
-    end_events = [e for e in state.buffer if e["hook"] == "on_session_end"]
-    assert len(end_events) == 1
-
-
-# ── pop_done_turn（adapter get_trace 用） ─────────────────────────────────
-
-def test_pop_done_turn_specific_run_id():
-    tr.register_trace_link(MILOCO_SESSION, "trace-abc")
-    tr._hk_pre_llm_call(MILOCO_SESSION, "hi", [], True, "m", "p")
-    tr._hk_on_session_end(MILOCO_SESSION, True, False, "m", "p")
-    meta = tr.pop_done_turn(MILOCO_SESSION)
-    assert meta is not None
-    assert meta["trace_id"] == "trace-abc"
-    assert tr.pop_done_turn(MILOCO_SESSION) is None
-
-
-def test_pop_done_turn_latest():
-    """run_id=None 返最新一个 done turn。"""
-    sids = ["miloco:sess-1", "miloco:sess-2", "miloco:sess-3"]
-    for sid in sids:
-        tr.register_trace_link(sid, f"trace-{sid}")
-        tr._hk_pre_llm_call(sid, "hi", [], True, "m", "p")
-        tr._hk_on_session_end(sid, True, False, "m", "p")
-    meta = tr.pop_done_turn(None)
-    assert meta is not None
-    assert meta["run_id"] in sids
-
-
-def test_pop_done_turn_empty():
-    assert tr.pop_done_turn("nonexistent") is None
-    assert tr.pop_done_turn(None) is None
+    assert len(_read_metas()) == 1
 
 
 # ── debug 落盘 ────────────────────────────────────────────────────────────
@@ -244,12 +219,9 @@ def test_flush_writes_even_without_debug():
     tr.register_trace_link(sess, "trace-abc")
     tr._hk_pre_llm_call(sess, "hi", [], True, "m", "p")
     tr._hk_on_session_end(sess, True, False, "m", "p")
-    state = tr._turns[sess]
-    # 去 debug 门槛后常写，jsonl_path 不应为 None
-    assert state.done["jsonl_path"] is not None
-    # meta.json 应出现
-    today = Path(os.environ["MILOCO_HOME"]) / "trace" / "agent"
-    assert any(today.rglob("*.meta.json"))
+    metas = _read_metas()
+    assert len(metas) == 1
+    assert metas[0]["jsonl_path"] is not None
 
 
 def test_flush_enabled_writes_jsonl_and_meta(monkeypatch):
@@ -259,9 +231,6 @@ def test_flush_enabled_writes_jsonl_and_meta(monkeypatch):
     tr._hk_pre_llm_call(sess, "[Mon Jun 18 14:32:11 2026] 你好", [], True, "m", "p")
     tr._hk_post_tool_call("miloco_im_push", {}, "ok", sess, duration_ms=42)
     tr._hk_on_session_end(sess, True, False, "m", "p")
-
-    state = tr._turns[sess]
-    assert state.done["jsonl_path"] is not None
 
     today = Path(os.environ["MILOCO_HOME"]) / "trace" / "agent"
     jsonl_files = list(today.rglob("*.jsonl.gz"))
@@ -300,25 +269,92 @@ def test_daily_cap_skips_dump(monkeypatch):
     tr.register_trace_link(sess, "trace-abc")
     tr._hk_pre_llm_call(sess, "hi", [], True, "m", "p")
     tr._hk_on_session_end(sess, True, False, "m", "p")
-    state = tr._turns[sess]
-    assert state.done["jsonl_path"] is None  # 跳过落盘
+
+    # jsonl 跳过，但 meta 必须照写——否则 cap 一满记账整天静默停摆
+    assert not (today / f"{sess}__hi.jsonl.gz").exists()
+    metas = _read_metas()
+    assert len(metas) == 1
+    assert metas[0]["jsonl_path"] is None
 
 
-# ── GC ────────────────────────────────────────────────────────────────────
+# ── sweeper ───────────────────────────────────────────────────────────────
 
-def test_gc_removes_old_done_turns():
-    """done_at 超过 TTL 的 turn 被 GC。"""
-    sess_old = "miloco:old-1"
-    sess_new = "miloco:new-1"
-    tr.register_trace_link(sess_old, "trace-old")
-    tr._hk_pre_llm_call(sess_old, "hi", [], True, "m", "p")
-    tr._hk_on_session_end(sess_old, True, False, "m", "p")
-    # 把 done_at 改到很久以前
-    tr._turns[sess_old].done_at = 0  # epoch
-    # 加一个新鲜的
-    tr.register_trace_link(sess_new, "trace-new")
-    tr._hk_pre_llm_call(sess_new, "hi", [], True, "m", "p")
-    tr._hk_on_session_end(sess_new, True, False, "m", "p")
-    tr._gc_expired_turns()
-    assert sess_old not in tr._turns
-    assert sess_new in tr._turns
+def test_sweep_evicts_stuck_turn_keeps_fresh():
+    """没等到 session_end 的僵尸 turn 被清，进行中的新 turn 留着。"""
+    stuck, fresh = "miloco:stuck-1", "miloco:fresh-1"
+    tr._hk_pre_llm_call(stuck, "hi", [], True, "m", "p")
+    tr._hk_pre_llm_call(fresh, "hi", [], True, "m", "p")
+    tr._turns[stuck].started_at = 0  # epoch
+    tr._sweep_stale_turns()
+    assert stuck not in tr._turns
+    assert fresh in tr._turns
+
+
+def test_sweep_hard_cap_evicts_oldest():
+    """并发 turn 数超硬上限时按起始时间淘汰最老的。"""
+    for i in range(tr.TURNS_HARD_CAP + 5):
+        sid = f"miloco:sess-{i}"
+        tr._hk_pre_llm_call(sid, "hi", [], True, "m", "p")
+        tr._turns[sid].started_at = 10_000_000_000_000 + i  # 保证顺序，且不触发 stuck
+    tr._sweep_stale_turns()
+    assert len(tr._turns) == tr.TURNS_HARD_CAP
+    assert "miloco:sess-0" not in tr._turns
+    assert f"miloco:sess-{tr.TURNS_HARD_CAP + 4}" in tr._turns
+
+# ── 持久会话连续记账（本文件核心不变式） ──────────────────────────────────
+
+def _one_turn(session_id: str, query: str) -> None:
+    tr._hk_pre_llm_call(session_id, query, [], True, "m", "p")
+    tr._hk_post_llm_call(session_id, query, "ans", [], "m", "p", duration_ms=500)
+    tr._hk_on_session_end(session_id, True, False, "m", "p")
+
+
+def test_persistent_session_records_every_turn():
+    """同一 session_id 连跑多轮，每轮都要落一份 meta —— 持久会话（rule/suggest）的记账前提。"""
+    for i in range(3):
+        _one_turn(MILOCO_SESSION, f"第 {i} 轮问题")
+
+    metas = list((Path(os.environ["MILOCO_HOME"]) / "trace" / "agent").rglob("*.meta.json"))
+    assert len(metas) == 3
+    queries = sorted(json.loads(p.read_text(encoding="utf-8"))["query"] for p in metas)
+    assert queries == ["第 0 轮问题", "第 1 轮问题", "第 2 轮问题"]
+
+
+def test_turn_state_released_after_session_end():
+    """turn 结束后内存里的 state 必须释放，否则下一轮复用到旧 buffer。"""
+    _one_turn(MILOCO_SESSION, "问题")
+    assert MILOCO_SESSION not in tr._turns
+
+
+def test_second_turn_meta_excludes_first_turn_events():
+    """第二轮的 meta 只统计第二轮的事件，不累加第一轮。"""
+    tr._hk_pre_llm_call(MILOCO_SESSION, "第一轮", [], True, "m", "p")
+    tr._hk_post_llm_call(MILOCO_SESSION, "第一轮", "ans", [], "m", "p", duration_ms=500)
+    tr._hk_post_tool_call("tool_a", {}, "ok", MILOCO_SESSION, duration_ms=100)
+    tr._hk_on_session_end(MILOCO_SESSION, True, False, "m", "p")
+
+    tr._hk_pre_llm_call(MILOCO_SESSION, "第二轮", [], True, "m", "p")
+    tr._hk_post_llm_call(MILOCO_SESSION, "第二轮", "ans", [], "m", "p", duration_ms=700)
+    tr._hk_on_session_end(MILOCO_SESSION, True, False, "m", "p")
+
+    metas = {
+        json.loads(p.read_text(encoding="utf-8"))["query"]: json.loads(p.read_text(encoding="utf-8"))
+        for p in (Path(os.environ["MILOCO_HOME"]) / "trace" / "agent").rglob("*.meta.json")
+    }
+    assert metas["第二轮"]["llm_call_count"] == 1
+    assert metas["第二轮"]["tool_call_count"] == 0
+    assert metas["第二轮"]["llm_total_ms"] == 700
+
+
+def test_long_chinese_query_still_lands_on_disk():
+    """全中文长 query + 长 session_id 不能撑爆文件名字节上限，否则整轮记账静默丢失。"""
+    sess = "miloco:agent:main:miloco-suggest:miloco-suggest"
+    tr.register_trace_link(sess, "trace-abc")
+    tr._hk_pre_llm_call(sess, "客" * 200, [], True, "m", "p")
+    tr._hk_on_session_end(sess, True, False, "m", "p")
+
+    metas = _read_metas()
+    assert len(metas) == 1
+    for path in (Path(os.environ["MILOCO_HOME"]) / "trace" / "agent").rglob("*"):
+        if path.is_file():
+            assert len(path.name.encode("utf-8")) <= tr.NAME_MAX_BYTES

--- a/plugins/hermes/tests/test_trace.py
+++ b/plugins/hermes/tests/test_trace.py
@@ -181,11 +181,14 @@ def _read_metas() -> list[dict]:
     return [json.loads(p.read_text(encoding="utf-8")) for p in sorted(root.rglob("*.meta.json"))]
 
 
-def test_session_end_without_trace_id_drops():
-    """非 miloco: 前缀的 session → 直接 GC，不留 meta、不落盘。"""
-    tr._hk_pre_llm_call("sess-1", "hi", [], True, "m", "p")
+def test_session_end_without_trace_id_drops(monkeypatch):
+    """非 miloco: 前缀的 session 一个字都不落盘——那是车主自己的私聊，不该进 miloco trace。"""
+    monkeypatch.setenv("MILOCO_TRACE_DEBUG", "1")
+    tr._hk_pre_llm_call("sess-1", "我的私人问题", [], True, "m", "p")
     tr._hk_on_session_end("sess-1", True, False, "m", "p")
     assert "sess-1" not in tr._turns
+    assert not _read_metas()
+    assert not list((Path(os.environ["MILOCO_HOME"]) / "trace").rglob("*.jsonl.gz"))
 
 
 def test_session_end_writes_meta_to_disk():
@@ -213,15 +216,26 @@ def test_session_end_idempotent():
 
 # ── debug 落盘 ────────────────────────────────────────────────────────────
 
-def test_flush_writes_even_without_debug():
-    """debug 默认关时也常写 trace（已去 debug 门槛，对齐 hermes-pr.md §五 #11）。"""
+def test_meta_always_written_jsonl_needs_debug():
+    """debug 关时只写 meta 不写 jsonl —— meta 是 backend 记账的唯一来源，不能被开关掐掉。"""
     sess = "miloco:test-flush"
     tr.register_trace_link(sess, "trace-abc")
     tr._hk_pre_llm_call(sess, "hi", [], True, "m", "p")
     tr._hk_on_session_end(sess, True, False, "m", "p")
     metas = _read_metas()
     assert len(metas) == 1
-    assert metas[0]["jsonl_path"] is not None
+    assert metas[0]["jsonl_path"] is None
+    assert not list((Path(os.environ["MILOCO_HOME"]) / "trace" / "agent").rglob("*.jsonl.gz"))
+
+
+def test_meta_rolls_over_daily_cap(monkeypatch):
+    """meta 数达上限时淘汰最老的再写，不是拒写——拒写会让当天记账整天静默停摆。"""
+    monkeypatch.setattr(tr, "META_DAILY_MAX", 3)
+    for i in range(6):
+        _one_turn(MILOCO_SESSION, f"第 {i} 轮")
+
+    queries = sorted(m["query"] for m in _read_metas())
+    assert queries == ["第 3 轮", "第 4 轮", "第 5 轮"]
 
 
 def test_flush_enabled_writes_jsonl_and_meta(monkeypatch):
@@ -288,6 +302,15 @@ def test_sweep_evicts_stuck_turn_keeps_fresh():
     tr._sweep_stale_turns()
     assert stuck not in tr._turns
     assert fresh in tr._turns
+
+
+def test_session_end_triggers_sweep():
+    """sweeper 要真接在 turn 结束这条路径上，光有函数没人调等于没清。"""
+    zombie = "miloco:zombie-1"
+    tr._hk_pre_llm_call(zombie, "hi", [], True, "m", "p")
+    tr._turns[zombie].started_at = 0  # epoch
+    _one_turn(MILOCO_SESSION, "正常一轮")
+    assert zombie not in tr._turns
 
 
 def test_sweep_hard_cap_evicts_oldest():
@@ -358,3 +381,29 @@ def test_long_chinese_query_still_lands_on_disk():
     for path in (Path(os.environ["MILOCO_HOME"]) / "trace" / "agent").rglob("*"):
         if path.is_file():
             assert len(path.name.encode("utf-8")) <= tr.NAME_MAX_BYTES
+
+
+def test_state_released_even_if_flush_raises(monkeypatch):
+    """落盘抛错也要释放 state，否则下一轮接着写这轮 buffer——正是本模块修掉的那个形态。"""
+    def boom(*_a, **_kw):
+        raise RuntimeError("disk exploded")
+
+    monkeypatch.setattr(tr, "_flush_to_disk", boom)
+    tr._hk_pre_llm_call(MILOCO_SESSION, "hi", [], True, "m", "p")
+    with pytest.raises(RuntimeError):
+        tr._hk_on_session_end(MILOCO_SESSION, True, False, "m", "p")
+    assert MILOCO_SESSION not in tr._turns
+
+
+def test_meta_written_even_when_evict_fails(monkeypatch):
+    """淘汰只是尽力而为，它出错不能把这一轮的记账一起吃掉。"""
+    real_glob = Path.glob
+
+    def boom(self, pattern, **kwargs):
+        if pattern == "*.meta.json":  # 只打掉淘汰那一次，别影响测试自己读盘
+            raise OSError("permission denied")
+        return real_glob(self, pattern, **kwargs)
+
+    monkeypatch.setattr(Path, "glob", boom)
+    _one_turn(MILOCO_SESSION, "问题")
+    assert len(_read_metas()) == 1

--- a/plugins/hermes/tests/test_trace.py
+++ b/plugins/hermes/tests/test_trace.py
@@ -347,11 +347,15 @@ def test_sweep_hard_cap_keeps_active_over_idle():
 
 
 def test_sweep_hard_cap_evicts_oldest():
-    """并发 turn 数超硬上限时按起始时间淘汰最老的。"""
+    """并发 turn 数超硬上限时淘汰到上限为止，先淘汰最久没有动静的。
+
+    判据本身由 test_sweep_hard_cap_keeps_active_over_idle 区分；这里只钉数量收敛。
+    """
     for i in range(tr.TURNS_HARD_CAP + 5):
         sid = f"miloco:sess-{i}"
+        # 插入顺序天然让 last_seen 单调不减：建得最早 = 最久没动静。
+        # 僵尸判据同样看 last_seen，刚建的 turn 天然新鲜，不必覆写任何时间戳。
         tr._hk_pre_llm_call(sid, "hi", [], True, "m", "p")
-        tr._turns[sid].started_at = 10_000_000_000_000 + i  # 保证顺序，且不触发 stuck
     tr._sweep_stale_turns()
     assert len(tr._turns) == tr.TURNS_HARD_CAP
     assert "miloco:sess-0" not in tr._turns

--- a/plugins/hermes/tests/test_trace.py
+++ b/plugins/hermes/tests/test_trace.py
@@ -1,4 +1,5 @@
-"""trace.py 单测：buffer 累积、reduce_meta、debug 落盘、daily cap、GC。"""
+"""trace.py 单测：buffer 累积、reduce_meta、debug 门槛、daily cap 滚动淘汰、
+僵尸 turn 清理、持久会话连续记账（本文件核心不变式）。"""
 
 from __future__ import annotations
 
@@ -298,7 +299,7 @@ def test_sweep_evicts_stuck_turn_keeps_fresh():
     stuck, fresh = "miloco:stuck-1", "miloco:fresh-1"
     tr._hk_pre_llm_call(stuck, "hi", [], True, "m", "p")
     tr._hk_pre_llm_call(fresh, "hi", [], True, "m", "p")
-    tr._turns[stuck].started_at = 0  # epoch
+    tr._turns[stuck].last_seen = 0  # epoch 之后再没有事件
     tr._sweep_stale_turns()
     assert stuck not in tr._turns
     assert fresh in tr._turns
@@ -308,9 +309,41 @@ def test_session_end_triggers_sweep():
     """sweeper 要真接在 turn 结束这条路径上，光有函数没人调等于没清。"""
     zombie = "miloco:zombie-1"
     tr._hk_pre_llm_call(zombie, "hi", [], True, "m", "p")
-    tr._turns[zombie].started_at = 0  # epoch
+    tr._turns[zombie].last_seen = 0  # epoch 之后再没有事件
     _one_turn(MILOCO_SESSION, "正常一轮")
     assert zombie not in tr._turns
+
+
+def test_sweep_keeps_slow_but_active_turn():
+    """判据是「多久没动静」不是「开了多久」：慢 turn 只要还在出事件就不能被清。"""
+    slow = "miloco:slow-1"
+    tr._hk_pre_llm_call(slow, "hi", [], True, "m", "p")
+    tr._turns[slow].started_at = 0  # epoch 就开始了
+    tr._hk_post_llm_call(slow, "hi", "ans", [], "m", "p", duration_ms=1)  # 但刚刚还在出事件
+    tr._sweep_stale_turns()
+    assert slow in tr._turns
+
+
+def test_sweep_hard_cap_keeps_active_over_idle():
+    """撞硬上限时先淘汰最久没动静的，而不是开始得最早的。
+
+    所有 turn 的 last_seen 都要留在 stuck 窗口内，否则先被僵尸清理带走，
+    硬上限那段根本不会执行。
+    """
+    now = tr._now_ms()
+    active = "miloco:long-running"
+    tr._hk_pre_llm_call(active, "hi", [], True, "m", "p")
+    tr._turns[active].started_at = now - 600_000  # 全场开始最早
+    for i in range(tr.TURNS_HARD_CAP):
+        sid = f"miloco:idle-{i}"
+        tr._hk_pre_llm_call(sid, "hi", [], True, "m", "p")
+        tr._turns[sid].started_at = now - 300_000 + i
+        tr._turns[sid].last_seen = now - 300_000 + i  # 建完就没动静，但没到僵尸线
+    tr._turns[active].last_seen = now  # 活跃的刚刚还在出事件
+
+    tr._sweep_stale_turns()
+    assert active in tr._turns
+    assert "miloco:idle-0" not in tr._turns
 
 
 def test_sweep_hard_cap_evicts_oldest():
@@ -407,3 +440,18 @@ def test_meta_written_even_when_evict_fails(monkeypatch):
     monkeypatch.setattr(Path, "glob", boom)
     _one_turn(MILOCO_SESSION, "问题")
     assert len(_read_metas()) == 1
+
+
+def test_meta_written_even_when_jsonl_write_fails(monkeypatch):
+    """明细写失败不能连累统计——磁盘写满时 meta 往往还写得下。"""
+    monkeypatch.setenv("MILOCO_TRACE_DEBUG", "1")
+
+    def boom(*_a, **_kw):
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr(tr.gzip, "open", boom)
+    _one_turn(MILOCO_SESSION, "问题")
+
+    metas = _read_metas()
+    assert len(metas) == 1
+    assert metas[0]["jsonl_path"] is None


### PR DESCRIPTION
## 问题

`trace.py` 的 `on_session_end` 把 turn 标成「已完成、等人取」，但取的人 `pop_done_turn` 在 adapter 改成读盘之后就没有调用者了（全仓零调用，死代码）。持久会话每轮 run_id 相同，第二轮撞上这个标记直接 return，记账只能等 TTL 到期的 GC 放行。

mac 上实测 rule 车道：

| 日期 | `state.db` turns | `agent_runs` | 记账率 |
| --- | --- | --- | --- |
| 08-13 | 212 | 6 | 2.8% |
| 08-14 | 212 | 11 | 5.2% |

`agent_runs` 里相邻间隔 19 个样本中 18 个 ≥60 分钟，精确锁在 TTL 上——GC 是唯一放行通道。不影响功能，影响的是可观测性：rule 的耗时/工具分析建立在 5% 采样上，且偏差不随机（只取每小时首轮）。

## 改动

**1. turn 结束后释放 state**（`3a74c364`）

- 落盘后直接 `_turns.pop`，删掉 `done`/`done_at` 与死代码 `pop_done_turn`
- 原 `_gc_expired_turns` 只清 done，改完永不命中 → 换成 `_sweep_stale_turns`（僵尸 turn eviction + 数量硬上限，补回 openclaw `trace.ts` 里 hermes 移植时丢掉的那段）
- 每日文件数上限只挡 jsonl，meta 照写——它是 backend 唯一的记账来源。原先 cap 命中直接 `return`，meta 跟着不写，症状与本 bug 一模一样。修完 rule 一家 200+ 轮/天，几天内必然撞线
- 文件名按字节截断：最坏情况 run_id 47 + `__` + 80 个全中文 240 + 后缀 = 298 字节，超 `NAME_MAX` → `OSError` → 静默丢整轮

**2. suggestion 车道改持久会话 + 收窄 meta 扫描**（`441ef708`）

- 删掉 uuid 后缀分支，与其他车道一样复用 `miloco:<key>:<lane>`，对齐 openclaw（那边本来就是持久会话且在 reset 列表里）
- `reset_sessions` 不再跳过 suggest——切家庭时上一个家的对话历史原本清不掉
- `read_trace_meta` 原本全树 `rglob` + 逐文件 `stat` 排序，而 poller 是 3s 一轮、单 turn 最多 30 轮、并发 8；meta 不再受每日上限约束后会随天数增长，收窄到当天+昨天

代价：agent 会看到同车道的历史判断，连续误报与连续漏报都会被带偏。心跳/重复抑制在 pipeline 层事件链闸门已经做了，这里多拿到的只是「语义相关但属不同事件链」的连续骚扰抑制。

**3. jsonl 恢复 debug 门槛，meta 改滚动淘汰上限**（`106e3fd5`）

对齐 openclaw：它的 `isDebugEnabled()` 只包住 gzip 落盘那一段，meta 走内存 webhook 不受开关影响。hermes 是文件 IPC，meta 就是那条内存通道的等价物，debug 关掉记账会整个断掉——所以只给 jsonl 加门槛。meta 的上限只能是滚动淘汰（写前删最老的），拒写就是上面刚修掉的那个形态。

同批修掉审查发现的缺口：

- 落盘抛非 `OSError` 时不再跳过 state 释放（否则下一轮接着写上一轮 buffer，本 bug 原样复发）。这一版放在 `finally`，第 5 个 commit 又推进了一步，见下
- 淘汰失败只记日志，不连累这一轮的 meta 写入
- adapter 读盘排序的 `stat` 加兜底：meta 现在有删除者了，跨进程可能撞 `FileNotFoundError`
- `knowledge/03-features/hermes-integration.md` 的 meta 路径早就不对（写的是 `trace/<run_id>.meta.json`），补上按天目录与 query 前缀匹配的真实形态

**4. 明细写失败不再连累统计，落盘移出全局锁，清理判据改用最后活动时间**（`6d6a850`）

审查发现前三项的同一条设计原则在错误路径上还有漏网：

- jsonl 落盘段加内层 `try/except OSError`（对齐 openclaw `trace.ts` gzip 段自带的那层）。原先明细与统计共用一个 `except`、明细在前，debug 开着时磁盘写满会让当轮统计一个字都不写——症状与本 PR 修掉的漏记账一样
- `on_session_end` 锁内只剩「摘 state + sweep」，`_flush_to_disk` 整体移出那把所有车道共用的全局锁。释放先于落盘，比放 `finally` 更彻底——「落盘抛错导致漏释放」这条路径不复存在
- 僵尸与硬上限判据从 `started_at` 改为 `last_seen`：慢 turn 每条 hook 都会刷新，原判据下跑得久的**活** turn 会被当成僵尸清掉，硬上限也会先删掉开始得最早的那个

## 为什么不做成内存通道

`hermes_cli/plugins.py` 给插件的 ctx 有 18 个 `register_*`，没有注册 HTTP 路由的；`web_server.py` 的路由全是模块级装饰器写死的。openclaw 那条路成立是因为它有 `api.registerHttpRoute`，backend 能反向调进插件进程拿内存 Map。hermes 下 trace hook 在 gateway 进程、adapter 在 backend 进程，文件是当前插件 API 下唯一的通道。

（第三条路是反过来让插件主动 POST 给 backend，能顺带解掉 poller 90s 上限丢慢 turn 的问题，但那是换 IPC 通道，另开。）

## 测试

194 passed / 2 skipped。新增 13 条，核心是持久会话的三条不变式：多轮各落一份 meta、state 释放、第二轮不累加第一轮。

关键断言都做了变异校验（改坏实现确认对应测试变红）：去掉 pop → 5 红、cap 恢复拒写 → 1 红、去掉字节截断 → 1 红、非 miloco 会话也落盘 → 1 红、删掉 sweeper 接线 → 1 红、释放挪到落盘之后 → 1 红、淘汰不吞自己的错 → 1 红。

`jsonl_path` 变常态 None 的跨仓消费者查过：`agent_meta_poller` → `metrics_db` TEXT 列 → web `types.ts` 全链路本来就允许 null，web 侧只有类型声明无渲染使用。

## 待办

- **真机验证**：跑 ≥1 小时后对账 `state.db` turns vs `agent_runs`，记账率应到 ~100%。单测只能钉住「第二次 `on_session_end` 也会 flush」
- meta 跨天目录仍无保留期清理（本轮只做单日上限）
- `register_trace_link` / `pop_trace_link` / `_trace_links` 与 `pop_done_turn` 同源，也是生产零调用（`meta["trace_id"]` 恒为 None，poller 用自己那侧的 `job.trace_id`，不影响功能），清理另开
- 升级前创建的 suggest 一次性会话（`miloco:<key>:miloco-suggest:<uuid8>`）已无法枚举，state.db 里的存量残留不追溯清理（升级后不再增长，每条都是单轮会话）
