### PR TITLE
fix(perception): identities 选版跟随实际渲染的 gallery——修 spec 与 prompt 分叉

### DIFF
--- a/backend/miloco/src/miloco/perception/engine/identity/library.py
+++ b/backend/miloco/src/miloco/perception/engine/identity/library.py
@@ -607,7 +607,7 @@ class IdentityLibrary:
           - Tier A 优先；不足时补 Tier C 最近样本
           - body_attr_text 字段当前永远 None（功能未实施）
 
-        ⚠️  ``prompt_builder._build_fused_user_content`` 已切到 ``get_gallery_composites_for_omni``
+        ⚠️  ``prompt_builder._prepare_gallery_entries`` 已切到 ``get_gallery_composites_for_omni``
         新出口（带缓存）。本方法仅保留给那些显式需要 ``body_crops`` / ``face_crops``
         ndarray 的调用方（例如离线分析脚本）；正常 omni 派发路径**不再走**这里。
         """

--- a/backend/miloco/src/miloco/perception/engine/identity/library.py
+++ b/backend/miloco/src/miloco/perception/engine/identity/library.py
@@ -578,7 +578,8 @@ class IdentityLibrary:
         """只写一张 face_*.png + sidecar, 绕过 add_tier_a_sample 的"必须有 body"约束。
 
         web 批量注册里用户可能只勾 face(纯人脸); add_tier_a_sample 以 body_crop 必填, 直接调
-        会被迫多写一张冗余 body。本方法保持与正常 face 样本同格式(omni gallery 仍能识别)。
+        会被迫多写一张冗余 body。本方法保持与正常 face 样本同格式；当前 omni gallery
+        仍要求 body composite，仅有 face 样本的成员不会进入 gallery。
         face 容量(tier_a_max // 2)已满返 False。
         """
         tier_a_dir = self.persons_dir / person_id / "tier_a"

--- a/backend/miloco/src/miloco/perception/engine/omni/constants.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/constants.py
@@ -105,11 +105,14 @@ _EXAMPLE_CHAIN = """\
 输出（speeches 无故省略）：
 {"caption":"小明坐在电脑前操作鼠标键盘，屏幕显示游戏画面","env_sounds":"重物倒地声","suggestions":[{"event":"听到重物倒地声","action":"提醒用户确认房间情况","urgency":"medium"}]}"""
 
-# 身份库为空（identity_library_empty）时用的实例 B 变体：把示范专名换成泛称。只有库空
-# 才满足"本轮不可能产出任何成员名"（名册必然是「已识别人物：无」），caption 示范才不该叫
-# 专名——与 caption 字段说明「没识别出的人写 某人 / 陌生人」一致。判据是库空、不是
-# identity_match_disabled：库非空但本轮无参考图时，名册仍渲染已确认成员真名，示范叫
-# "某人"会把他们一并带塌。从 _EXAMPLE_CHAIN 派生而非另写一份，避免两份实例将来漂移；
+# 身份库为空（identity_library_empty）时用的实例 B 变体：把示范专名换成泛称。库空是
+# "本轮不可能产出任何成员名"的**充分**条件（名册必然是「已识别人物：无」），caption 示范
+# 因此不该叫专名——与 caption 字段说明「没识别出的人写 某人 / 陌生人」一致。反向不成立：
+# 库非空 + 本轮无参考图 + 名册恰好也没有已确认成员，同样产不出成员名，但仍走带名版（已知
+# 残留窗口，见 _render_examples）。判据取"库空"而非 identity_match_disabled 是权衡后的
+# 粗判：库非空但本轮无参考图时名册**常常**仍渲染已确认成员真名，示范叫"某人"会把他们一并
+# 带塌；那个代价比"名册也空时多示范了一个专名"更贵。要消掉残留窗口须把"名册里有没有成员
+# 名"一并纳入判据。从 _EXAMPLE_CHAIN 派生而非另写一份，避免两份实例将来漂移；
 # assert 兜住「示范专名被改名致 replace 静默失效」。
 _EXAMPLE_CHAIN_NO_NAME = _EXAMPLE_CHAIN.replace("小明", "某人")
 assert "小明" not in _EXAMPLE_CHAIN_NO_NAME

--- a/backend/miloco/src/miloco/perception/engine/omni/constants.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/constants.py
@@ -105,10 +105,11 @@ _EXAMPLE_CHAIN = """\
 输出（speeches 无故省略）：
 {"caption":"小明坐在电脑前操作鼠标键盘，屏幕显示游戏画面","env_sounds":"重物倒地声","suggestions":[{"event":"听到重物倒地声","action":"提醒用户确认房间情况","urgency":"medium"}]}"""
 
-# 本轮无成员参考图（identity_match_disabled：库空 / 无可用样本 / 「全或无」放弃）时用的
-# 实例 B 变体：把示范专名换成泛称。无参考图窗口没有成员匹配铺垫（实例 A 已被 gate 掉），
-# caption 示范不该叫专名——与 caption 字段说明「没识别出的人写 某人 / 陌生人」一致。
-# 从 _EXAMPLE_CHAIN 派生而非另写一份，避免两份实例将来漂移；
+# 身份库为空（identity_library_empty）时用的实例 B 变体：把示范专名换成泛称。只有库空
+# 才满足"本轮不可能产出任何成员名"（名册必然是「已识别人物：无」），caption 示范才不该叫
+# 专名——与 caption 字段说明「没识别出的人写 某人 / 陌生人」一致。判据是库空、不是
+# identity_match_disabled：库非空但本轮无参考图时，名册仍渲染已确认成员真名，示范叫
+# "某人"会把他们一并带塌。从 _EXAMPLE_CHAIN 派生而非另写一份，避免两份实例将来漂移；
 # assert 兜住「示范专名被改名致 replace 静默失效」。
 _EXAMPLE_CHAIN_NO_NAME = _EXAMPLE_CHAIN.replace("小明", "某人")
 assert "小明" not in _EXAMPLE_CHAIN_NO_NAME

--- a/backend/miloco/src/miloco/perception/engine/omni/constants.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/constants.py
@@ -105,9 +105,10 @@ _EXAMPLE_CHAIN = """\
 输出（speeches 无故省略）：
 {"caption":"小明坐在电脑前操作鼠标键盘，屏幕显示游戏画面","env_sounds":"重物倒地声","suggestions":[{"event":"听到重物倒地声","action":"提醒用户确认房间情况","urgency":"medium"}]}"""
 
-# 身份库为空（identity_match_disabled）时用的实例 B 变体：把示范专名换成泛称。库空窗口没有
-# 成员铺垫（实例 A 已被 gate 掉），caption 示范不该叫专名——与 caption 字段说明「没识别出的
-# 人写 某人 / 陌生人」一致。从 _EXAMPLE_CHAIN 派生而非另写一份，避免两份实例将来漂移；
+# 本轮无成员参考图（identity_match_disabled：库空 / 无可用样本 / 「全或无」放弃）时用的
+# 实例 B 变体：把示范专名换成泛称。无参考图窗口没有成员匹配铺垫（实例 A 已被 gate 掉），
+# caption 示范不该叫专名——与 caption 字段说明「没识别出的人写 某人 / 陌生人」一致。
+# 从 _EXAMPLE_CHAIN 派生而非另写一份，避免两份实例将来漂移；
 # assert 兜住「示范专名被改名致 replace 静默失效」。
 _EXAMPLE_CHAIN_NO_NAME = _EXAMPLE_CHAIN.replace("小明", "某人")
 assert "小明" not in _EXAMPLE_CHAIN_NO_NAME

--- a/backend/miloco/src/miloco/perception/engine/omni/constants.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/constants.py
@@ -105,14 +105,10 @@ _EXAMPLE_CHAIN = """\
 输出（speeches 无故省略）：
 {"caption":"小明坐在电脑前操作鼠标键盘，屏幕显示游戏画面","env_sounds":"重物倒地声","suggestions":[{"event":"听到重物倒地声","action":"提醒用户确认房间情况","urgency":"medium"}]}"""
 
-# 身份库为空（identity_library_empty）时用的实例 B 变体：把示范专名换成泛称。库空是
-# "本轮不可能产出任何成员名"的**充分**条件（名册必然是「已识别人物：无」），caption 示范
-# 因此不该叫专名——与 caption 字段说明「没识别出的人写 某人 / 陌生人」一致。反向不成立：
-# 库非空 + 本轮无参考图 + 名册恰好也没有已确认成员，同样产不出成员名，但仍走带名版（已知
-# 残留窗口，见 _render_examples）。判据取"库空"而非 identity_match_disabled 是权衡后的
-# 粗判：库非空但本轮无参考图时名册**常常**仍渲染已确认成员真名，示范叫"某人"会把他们一并
-# 带塌；那个代价比"名册也空时多示范了一个专名"更贵。要消掉残留窗口须把"名册里有没有成员
-# 名"一并纳入判据。从 _EXAMPLE_CHAIN 派生而非另写一份，避免两份实例将来漂移；
+# member_names_unavailable 时用的实例 B 变体：把示范专名换成泛称。有候选时依据实际
+# 名册姓名与 gallery 是否可用，不能用库非空代替——纯 face 注册可持久处于无 body
+# 参考图的状态。无候选窗口保留按库是否为空选版的兼容例外，见 SceneDescriptor。
+# 从 _EXAMPLE_CHAIN 派生而非另写一份，避免两份实例将来漂移；
 # assert 兜住「示范专名被改名致 replace 静默失效」。
 _EXAMPLE_CHAIN_NO_NAME = _EXAMPLE_CHAIN.replace("小明", "某人")
 assert "小明" not in _EXAMPLE_CHAIN_NO_NAME

--- a/backend/miloco/src/miloco/perception/engine/omni/field_registry.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/field_registry.py
@@ -227,11 +227,12 @@ class SceneDescriptor:
         ``prompt_builder.build_fused_payload`` 的 gallery pre-flight）；参考图可用时为
         False，用完整匹配版 ``IDENTITY``。
     identity_library_empty —— 身份库本身为空（``list_persons()`` 为 0 条，即 omni.py 传进
-        来的 ``matching_moot``）。**只**驱动「# 输出实例」里实例 B 的专名 / 泛称选版：泛称
-        版的前提是"本轮不可能产出任何成员名"，而这只有库空才成立——库非空、仅本轮无参考图
-        时名册照样渲染 ``已识别人物：张三[bbox=…]``，此时示范 caption 叫"某人"会把已确认
-        成员一并带塌。不要拿 ``identity_match_disabled`` 代替它（后者还含"库非空但无参考
-        图"两个来源）。
+        来的 ``matching_moot``）。**只**驱动「# 输出实例」里实例 B 的专名 / 泛称选版：库空
+        是"本轮不可能产出任何成员名"的充分条件（名册必然是「已识别人物：无」），示范才该改
+        叫泛称；库非空、仅本轮无参考图时名册**常常**仍渲染 ``已识别人物：张三[bbox=…]``，
+        此时示范 caption 叫"某人"会把已确认成员一并带塌（名册恰好也空的残留窗口仍走带名版，
+        属已知权衡，见 constants._EXAMPLE_CHAIN_NO_NAME 的注释）。不要拿
+        ``identity_match_disabled`` 代替它（后者还含"库非空但无参考图"两个来源）。
     """
 
     route: Literal["video", "audio"]

--- a/backend/miloco/src/miloco/perception/engine/omni/field_registry.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/field_registry.py
@@ -90,18 +90,23 @@ PET_IDENTITIES = FieldSpec(
     requires_pets=True,
 )
 
-# 精简版 identity 字段：身份库为空（无任何注册成员）时用。此时"对上 gallery 成员"不可能，
-# 整套面部逐项核对规则都是死重（徒增 prompt token 与模型认知负担、并产出误导性的"无法与库中
-# 成员匹配"reason）。只保留 unknown↔no_person 这一判定——no_person（非人误检抑制）不依赖 gallery，
-# 是身份库为空时仍需保住的能力（name 仍走 <unknown|no_person>，下游 no_person 解析/落定链路不变）。
+# 精简版 identity 字段：本轮拿不到任何成员参考图（<gallery> 不会出现在 prompt 里）时用——
+# 库空、库非空但无可用样本、「全或无」放弃三种来源同解（见 SceneDescriptor.identity_match_disabled）。
+# 此时"对上 gallery 成员"不可能，整套面部逐项核对规则都是死重（徒增 prompt token 与模型认知
+# 负担、并产出误导性的"无法与库中成员匹配"reason）。只保留 unknown↔no_person 这一判定——
+# no_person（非人误检抑制）不依赖 gallery，是无参考图窗口仍需保住的能力（name 仍走
+# <unknown|no_person>，下游 no_person 解析/落定链路不变）。
+# 措辞注意：不得写"本轮无注册成员"——库非空的来源下这是假话，会与同一 prompt 里的
+# 「# 家庭档案」成员名 / 名册行「已识别人物：X[bbox=…]」当场矛盾；判据只能是"没有参考图"。
 IDENTITY_NO_MATCH = FieldSpec(
     name="identities",
     schema_literal='"identities":[{"track_id":<int>,"name":"<unknown|no_person>","confidence":0-1,"reason":"≤20字"}]',
     spec_md="""## identities
-- 本轮无注册成员、不做成员匹配：只判每个"待识别 track"是「确有人体」还是「非人误检」，覆盖所有 track_id、不遗漏不新增
+- 本轮未提供任何成员参考图、不做成员匹配：只判每个"待识别 track"是「确有人体」还是「非人误检」，覆盖所有 track_id、不遗漏不新增
 - 确有人体（哪怕背影/侧身/局部/遮挡/模糊）→ name 填 "unknown"
 - 框内没有真实人体、只是家中非人物体被误框成人（如 3D 打印机、落地扇、衣帽架或搭挂/晾晒的衣物、落地绿植、纸箱行李堆 等外形易被误当成人的物体）→ name 填 "no_person"，纵使轮廓像人
 - 分不清是人还是物时倾向 unknown（别把真人误判成没人）
+- 即使「# 家庭档案」或上方名册里出现了成员姓名，本轮也不得据此给"待识别 track"安名——没有参考图就无从核对本人
 - confidence = 对"是人 / 不是人"这一判断的把握；reason ≤20 字简述依据""",
     requires_video=True,
     requires_identity=True,
@@ -214,9 +219,13 @@ class SceneDescriptor:
     has_pets     —— ``pet_recognition`` 开启且花名册非空（判据见 home_profile_loader，
         **不**看 profile.md 的「## 宠物」标题：那段会被 token 预算归档等路径抹掉）。为真且
         video 路由时，在「# 字段说明」追加「## 宠物命名」纪律（宠物命名是视觉判断，故只 video）。
-    identity_match_disabled —— 身份库为空（无任何注册成员）时为 True：``identities`` 字段
-        改用精简版 ``IDENTITY_NO_MATCH``（只判 unknown↔no_person、不做成员匹配）。仅在
-        ``has_identity=True`` 时有意义；库非空时为 False，用完整匹配版 ``IDENTITY``。
+    identity_match_disabled —— 本轮拿不到任何成员参考图（<gallery> 不会出现在 prompt 里）
+        时为 True：``identities`` 字段改用精简版 ``IDENTITY_NO_MATCH``（只判 unknown↔
+        no_person、不做成员匹配）。三个来源同解——① 身份库为空（无任何注册成员）；
+        ② 库非空但本轮 gallery_snapshot 为空（成员无可用样本）；③ 「全或无」放弃（某候选
+        person 的 body composite 取不到）。②③ 仅在 ``has_identity=True`` 时置位（判据见
+        ``prompt_builder.build_fused_payload`` 的 gallery pre-flight）；参考图可用时为
+        False，用完整匹配版 ``IDENTITY``。
     """
 
     route: Literal["video", "audio"]

--- a/backend/miloco/src/miloco/perception/engine/omni/field_registry.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/field_registry.py
@@ -226,6 +226,12 @@ class SceneDescriptor:
         person 的 body composite 取不到）。②③ 仅在 ``has_identity=True`` 时置位（判据见
         ``prompt_builder.build_fused_payload`` 的 gallery pre-flight）；参考图可用时为
         False，用完整匹配版 ``IDENTITY``。
+    identity_library_empty —— 身份库本身为空（``list_persons()`` 为 0 条，即 omni.py 传进
+        来的 ``matching_moot``）。**只**驱动「# 输出实例」里实例 B 的专名 / 泛称选版：泛称
+        版的前提是"本轮不可能产出任何成员名"，而这只有库空才成立——库非空、仅本轮无参考图
+        时名册照样渲染 ``已识别人物：张三[bbox=…]``，此时示范 caption 叫"某人"会把已确认
+        成员一并带塌。不要拿 ``identity_match_disabled`` 代替它（后者还含"库非空但无参考
+        图"两个来源）。
     """
 
     route: Literal["video", "audio"]
@@ -235,6 +241,7 @@ class SceneDescriptor:
     has_speech: bool = True
     has_pets: bool = False
     identity_match_disabled: bool = False
+    identity_library_empty: bool = False
 
     def selected_fields(self) -> list[FieldSpec]:
         order = _ORDER_STREAM if self.stream else _ORDER_NORMAL
@@ -248,8 +255,10 @@ class SceneDescriptor:
         if not self.has_pets:
             fields = [f for f in fields if not f.requires_pets]
         if self.has_identity:
-            # 库空 → 精简版（不做成员匹配、只判 unknown/no_person）；两者 name 同为 "identities",
-            # 故 render_schema / render_field_spec / 解析层都无感。
+            # 本轮无成员参考图（库空 / 无可用样本 / 「全或无」放弃，三来源同解，见上方
+            # identity_match_disabled 字段说明）→ 精简版（不做成员匹配、只判
+            # unknown/no_person）；两者 name 同为 "identities"，故 render_schema /
+            # render_field_spec / 解析层都无感。
             ident = IDENTITY_NO_MATCH if self.identity_match_disabled else _REGISTRY["identities"]
             fields = [ident, *fields]
         return fields

--- a/backend/miloco/src/miloco/perception/engine/omni/field_registry.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/field_registry.py
@@ -226,13 +226,12 @@ class SceneDescriptor:
         person 的 body composite 取不到）。②③ 仅在 ``has_identity=True`` 时置位（判据见
         ``prompt_builder.build_fused_payload`` 的 gallery pre-flight）；参考图可用时为
         False，用完整匹配版 ``IDENTITY``。
-    identity_library_empty —— 身份库本身为空（``list_persons()`` 为 0 条，即 omni.py 传进
-        来的 ``matching_moot``）。**只**驱动「# 输出实例」里实例 B 的专名 / 泛称选版：库空
-        是"本轮不可能产出任何成员名"的充分条件（名册必然是「已识别人物：无」），示范才该改
-        叫泛称；库非空、仅本轮无参考图时名册**常常**仍渲染 ``已识别人物：张三[bbox=…]``，
-        此时示范 caption 叫"某人"会把已确认成员一并带塌（名册恰好也空的残留窗口仍走带名版，
-        属已知权衡，见 constants._EXAMPLE_CHAIN_NO_NAME 的注释）。不要拿
-        ``identity_match_disabled`` 代替它（后者还含"库非空但无参考图"两个来源）。
+    member_names_unavailable —— **只**驱动实例 B 的专名 / 泛称选版。有候选时，实际
+        名册无有效姓名且本轮 gallery 未渲染 → True，实例 B 用泛称；任一来源可用则带名。
+        名册须排除待重审和 suppress_as_prior 目标，裸 person_id 不算姓名。它与
+        ``identity_match_disabled`` 独立：本轮无参考图，名册仍可能含前几窗已确认的姓名。
+        兼容例外：无候选窗口沿用 ``matching_moot``（库空不空）；库非空但名册无姓名时
+        仍用带名版，本次不改变这些窗口。非 fused 调用沿用默认 False。
     """
 
     route: Literal["video", "audio"]
@@ -242,7 +241,7 @@ class SceneDescriptor:
     has_speech: bool = True
     has_pets: bool = False
     identity_match_disabled: bool = False
-    identity_library_empty: bool = False
+    member_names_unavailable: bool = False
 
     def selected_fields(self) -> list[FieldSpec]:
         order = _ORDER_STREAM if self.stream else _ORDER_NORMAL

--- a/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import base64
 import logging
+from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
@@ -226,7 +227,8 @@ def build_fused_payload(
                            的实际结果（``_PreparedGallery.entries``）决定——库非空但样本
                            取不到、或「全或无」放弃时同样降级为精简版（只判
                            unknown/no_person），保证 spec 与 prompt 里有没有 <gallery>
-                           恒一致。no_person 判定链路不变（见 field_registry.IDENTITY_NO_MATCH）。
+                           恒一致。无候选窗口还用它保留实例 B 按库是否为空选版的旧行为。
+                           no_person 判定链路不变（见 field_registry.IDENTITY_NO_MATCH）。
 
     Returns:
         dict，含字段：
@@ -373,6 +375,17 @@ def build_fused_payload(
         if candidates and not matching_moot
         else _PreparedGallery(entries=[])
     )
+    if candidates:
+        # 无参考图时，名册中仍可能有前几窗已确认的姓名；库非空本身不保证这一点。
+        candidate_tids = {c.track_id for c in candidates}
+        member_names_unavailable = not (
+            _roster_will_name_members(packets, label_lookup, candidate_tids)
+            or bool(prepared_gallery.entries)
+        )
+    else:
+        # 兼容例外：无候选窗口不跑 gallery pre-flight，实例 B 保留按库空不空选版。
+        # 即使本轮名册无姓名，库非空仍用带名版；本次只收敛有候选窗口。
+        member_names_unavailable = matching_moot
 
     # has_speech 只由本轮 VAD 决定：本轮真有人声（含 pending 的延续语音）→ VAD 自然过、
     # 保留 speeches、模型把 <pending_speech> 拼成完整句；本轮无人声 → 剥 speeches，挂着的
@@ -387,10 +400,7 @@ def build_fused_payload(
         # has_identity=bool(candidates) 这道闸，无候选窗口置位与否不外显；留着是为了
         # has_identity 将来与 candidates 解耦时不出意外。
         identity_match_disabled=matching_moot or (bool(candidates) and not prepared_gallery.entries),
-        # 实例 B 的专名 / 泛称只跟"库空不空"：库非空时名册仍渲染真名（label_lookup 来自
-        # list_persons()，不看 gallery_snapshot），示范 caption 叫"某人"会把已确认成员一起
-        # 带塌——他们的在场结论来自前几窗落定的 state，不依赖本轮 gallery。
-        identity_library_empty=matching_moot,
+        member_names_unavailable=member_names_unavailable,
     )
     system_prompt = build_system_prompt(scene, include_home_profile=False, camera_prompt=context.camera_prompt)
     user_content = _build_fused_user_content(
@@ -658,22 +668,18 @@ def _render_examples(scene: SceneDescriptor) -> str:
     时同样不附实例 A：它演示的是成员匹配（摆 ``<gallery>`` 成员、输出成员名 + 五官匹配
     reason），与精简版 identities spec / schema（只判 unknown/no_person、无 gallery）自相
     矛盾，且抵消精简省 token 的目标；身份任务已由精简版「## identities」充分约束。
-    实例 B 无 identities 字段、照常附——但其专名 / 泛称跟 ``identity_library_empty``
-    （库空不空），不跟本标志：两者判据不同，见 SceneDescriptor 字段说明。
+    实例 B 无 identities 字段、照常附——其专名 / 泛称跟 ``member_names_unavailable``，
+    与本标志独立：无参考图时名册仍可能提供已确认姓名，见 SceneDescriptor 字段说明。
     """
     if scene.route == "audio" or not scene.has_audio:
         return ""
     examples = []
     if scene.has_identity and scene.has_speech and not scene.identity_match_disabled:
         examples.append(_EXAMPLE_IDENTITY)
-    # 库空时实例 B 用泛称版：此窗**不可能**产出任何成员名（名册必然是「已识别人物：无」），
-    # caption 示范不该叫专名。库非空照旧用带名版——哪怕本轮无参考图、identities 已收敛成
-    # unknown/no_person，名册里已确认成员仍该被 caption 叫真名（他们的在场结论来自前几窗
-    # 落定的 state，不依赖本轮 gallery）。
-    # 残留窗口：库非空 + 本轮无参考图 + 名册恰好也没有已确认成员时，此窗同样产不出成员名，
-    # 却仍走带名版。属已知权衡（判据不看名册），代价与理由见 constants._EXAMPLE_CHAIN_NO_NAME。
+    # 有候选时，无有效名册姓名且无 gallery → 泛称；名册已确认姓名不因无图而被一并降级。
+    # 无候选窗口保留按库是否为空选版的兼容行为，判据在 build_fused_payload 统一计算。
     examples.append(
-        _EXAMPLE_CHAIN_NO_NAME if scene.identity_library_empty else _EXAMPLE_CHAIN
+        _EXAMPLE_CHAIN_NO_NAME if scene.member_names_unavailable else _EXAMPLE_CHAIN
     )
     return "# 输出实例\n\n" + "\n\n".join(examples)
 
@@ -736,13 +742,11 @@ def _build_user_content(
 class _PreparedGallery:
     """本窗口 gallery 段的预备结果——「渲染」与「identities spec 选版」共用的唯一判据。
 
-    ``entries`` 非空 ⟺ 本轮 prompt 里真会出现 ``<gallery>`` 块。空有三种来源，对
-    调用方而言同解（本轮无参考图可比对 → 用精简版）：「全或无」放弃（某候选 person 的
-    body composite 取不到，原因已打进 ``event=fused_gallery_giveup`` 日志）、
-    ``gallery_snapshot`` 本就为空（库非空但无可用样本），以及 ``build_fused_payload``
-    在无候选 / 身份库为空时直接构造空实例、连 pre-flight 都不跑（与
-    ``SceneDescriptor.identity_match_disabled`` 字段说明的三来源对应）。调用方不据来源
-    分流，故不携带放弃原因字段——只写不读的状态会误导读者以为有人消费它。
+    ``entries`` 非空 ⟺ 本轮 prompt 里真会出现 ``<gallery>`` 块。有候选时，库空、
+    snapshot 空或「全或无」放弃均使 entries 为空，identities 因此使用精简版。
+    无候选时也直接构造空实例、不跑 pre-flight，但不下发 identities 字段；实例 B
+    此时保留按库是否为空选版的兼容行为，不能把空 entries 当作身份库为空。
+    放弃原因已打进 ``event=fused_gallery_giveup`` 日志，不再携带未被消费的原因字段。
     """
 
     entries: list[tuple[str, str, bytes, "bytes | None"]]  # (pid, label, body_jpg, face_jpg|None)
@@ -981,6 +985,34 @@ def _is_confirmed_member_pid(pid: str) -> bool:
     return not _is_stranger_pid(pid)
 
 
+def _iter_roster_targets(
+    packet: IdentityPacket,
+    candidate_tids: set[int] | frozenset[int],
+) -> Iterator[IdentityTarget]:
+    """名册渲染与示例选版共用的先验过滤；身份分桶仍由 person_id 决定。"""
+    for target in packet.targets:
+        # 重审候选及翻身份黏旧名期目标不能以旧身份作为本轮识别先验。
+        if target.track_id not in candidate_tids and not target.suppress_as_prior:
+            yield target
+
+
+def _roster_will_name_members(
+    packets: list[IdentityPacket],
+    label_lookup: dict[str, str] | None,
+    candidate_tids: set[int] | frozenset[int],
+) -> bool:
+    """本轮名册会渲染至少一个已确认姓名；反查缺失时的裸 person_id 不算姓名。
+
+    不要求 bbox：名册允许无框或 crop 坐标换算失败时只显示姓名。
+    """
+    lookup = label_lookup or {}
+    return any(
+        _is_confirmed_member_pid(target.person_id) and bool(lookup.get(target.person_id))
+        for packet in packets
+        for target in _iter_roster_targets(packet, candidate_tids)
+    )
+
+
 def _drop_bbox(_b: tuple[int, int, int, int]) -> tuple[int, int, int, int] | None:
     """恒撤掉 bbox 的 remap 回调：crop 已生效、但换算基准不适用于当前 packet 时用。
 
@@ -1053,11 +1085,7 @@ def _build_device_header(
     def _bucket(ep: IdentityPacket) -> tuple[list[str], list[str]]:
         members: list[str] = []
         strangers: list[str] = []
-        for t in ep.targets:
-            # candidate_tids（本窗派发重审）+ suppress_as_prior（翻身份黏旧名 track，
-            # coasting 窗不在 candidate_tids 内）均剔出名册，避免旧/当前身份当先验锚定 omni
-            if t.track_id in candidate_tids or t.suppress_as_prior:
-                continue
+        for t in _iter_roster_targets(ep, candidate_tids):
             if _is_confirmed_member_pid(t.person_id):
                 members.append(_render_roster_entry(t, label_lookup, bbox_remap))
             elif _is_stranger_pid(t.person_id):

--- a/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
@@ -382,12 +382,14 @@ def build_fused_payload(
         has_audio=_batch_video_has_audio(packets),
         has_speech=_batch_video_has_speech(packets),
         has_pets=_has_pets_for_scene(),
-        # 仅"本轮有候选却没渲染出 gallery"时额外置位；无候选窗口保持 matching_moot 原语义。
+        # 有候选却没渲染出 gallery → 置位。bool(candidates) 目前是防御性的：本标志的
+        # 三个消费方（selected_fields /「# 任务」身份行 / 实例 A 的 gate）都已先过
+        # has_identity=bool(candidates) 这道闸，无候选窗口置位与否不外显；留着是为了
+        # has_identity 将来与 candidates 解耦时不出意外。
         identity_match_disabled=matching_moot or (bool(candidates) and not prepared_gallery.entries),
         # 实例 B 的专名 / 泛称只跟"库空不空"：库非空时名册仍渲染真名（label_lookup 来自
         # list_persons()，不看 gallery_snapshot），示范 caption 叫"某人"会把已确认成员一起
-        # 带塌——他们的在场结论来自前几窗落定的 state，不依赖本轮 gallery。上一行的
-        # bool(candidates) 只挡住"无候选"那一半，挡不住"有候选 + 名册有名 + 本轮无参考图"。
+        # 带塌——他们的在场结论来自前几窗落定的 state，不依赖本轮 gallery。
         identity_library_empty=matching_moot,
     )
     system_prompt = build_system_prompt(scene, include_home_profile=False, camera_prompt=context.camera_prompt)

--- a/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
@@ -382,10 +382,13 @@ def build_fused_payload(
         has_audio=_batch_video_has_audio(packets),
         has_speech=_batch_video_has_speech(packets),
         has_pets=_has_pets_for_scene(),
-        # 仅"本轮有候选却没渲染出 gallery"时额外置位；无候选窗口保持 matching_moot 原语义
-        # （identity_match_disabled 还被 _render_examples 的 chain 变体读取，且那处不看
-        # has_identity——无候选时跟着翻会把名册里有名字的窗口也降级成泛称示例）。
+        # 仅"本轮有候选却没渲染出 gallery"时额外置位；无候选窗口保持 matching_moot 原语义。
         identity_match_disabled=matching_moot or (bool(candidates) and not prepared_gallery.entries),
+        # 实例 B 的专名 / 泛称只跟"库空不空"：库非空时名册仍渲染真名（label_lookup 来自
+        # list_persons()，不看 gallery_snapshot），示范 caption 叫"某人"会把已确认成员一起
+        # 带塌——他们的在场结论来自前几窗落定的 state，不依赖本轮 gallery。上一行的
+        # bool(candidates) 只挡住"无候选"那一半，挡不住"有候选 + 名册有名 + 本轮无参考图"。
+        identity_library_empty=matching_moot,
     )
     system_prompt = build_system_prompt(scene, include_home_profile=False, camera_prompt=context.camera_prompt)
     user_content = _build_fused_user_content(
@@ -653,18 +656,20 @@ def _render_examples(scene: SceneDescriptor) -> str:
     时同样不附实例 A：它演示的是成员匹配（摆 ``<gallery>`` 成员、输出成员名 + 五官匹配
     reason），与精简版 identities spec / schema（只判 unknown/no_person、无 gallery）自相
     矛盾，且抵消精简省 token 的目标；身份任务已由精简版「## identities」充分约束。
-    实例 B 无 identities 字段、照常附。
+    实例 B 无 identities 字段、照常附——但其专名 / 泛称跟 ``identity_library_empty``
+    （库空不空），不跟本标志：两者判据不同，见 SceneDescriptor 字段说明。
     """
     if scene.route == "audio" or not scene.has_audio:
         return ""
     examples = []
     if scene.has_identity and scene.has_speech and not scene.identity_match_disabled:
         examples.append(_EXAMPLE_IDENTITY)
-    # 无参考图窗口实例 B 用泛称版：此窗无成员匹配铺垫（实例 A 已 gate 掉），caption 示范
-    # 不该叫专名，与「无参考图不产成员名」收敛一致。参考图可用时照旧用带名版
-    # （其"小明"由上方实例 A 的 gallery 铺垫）。
+    # 库空时实例 B 用泛称版：此窗**不可能**产出任何成员名（名册必然是「已识别人物：无」），
+    # caption 示范不该叫专名。库非空照旧用带名版——哪怕本轮无参考图、identities 已收敛成
+    # unknown/no_person，名册里已确认成员仍该被 caption 叫真名（他们的在场结论来自前几窗
+    # 落定的 state，不依赖本轮 gallery）。
     examples.append(
-        _EXAMPLE_CHAIN_NO_NAME if scene.identity_match_disabled else _EXAMPLE_CHAIN
+        _EXAMPLE_CHAIN_NO_NAME if scene.identity_library_empty else _EXAMPLE_CHAIN
     )
     return "# 输出实例\n\n" + "\n\n".join(examples)
 

--- a/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
@@ -221,9 +221,12 @@ def build_fused_payload(
         config:            FusedPromptConfig；None 走默认值
         label_lookup:      person_id → 姓名/标签 反查表（供 ``_build_device_header`` 渲染人名）；
                            None 时由本函数自动从 gallery_snapshot 构造
-        matching_moot:     身份库为空（无注册成员）→ 成员匹配不可能。True 时 identities 字段
-                           改精简版（只判 unknown/no_person）、gallery 段整段不渲染。no_person
-                           判定链路不变（见 field_registry.IDENTITY_NO_MATCH）。
+        matching_moot:     身份库为空（无注册成员）→ 成员匹配不可能，直接跳过 gallery
+                           pre-flight。注意 identities 选版不只看它：本函数据 pre-flight
+                           的实际结果（``_PreparedGallery.entries``）决定——库非空但样本
+                           取不到、或「全或无」放弃时同样降级为精简版（只判
+                           unknown/no_person），保证 spec 与 prompt 里有没有 <gallery>
+                           恒一致。no_person 判定链路不变（见 field_registry.IDENTITY_NO_MATCH）。
 
     Returns:
         dict，含字段：
@@ -360,6 +363,17 @@ def build_fused_payload(
             packets, short_edge=_effective_panorama_short_edge()
         )
 
+    # gallery pre-flight 必须先于 SceneDescriptor：identities 用完整版还是精简版，判据是
+    # 「本轮 prompt 里真会出现 <gallery> 吗」，不是「库里有没有登记成员」。二者会分叉——
+    # 库非空但样本取不到（gallery_snapshot 为空）、或「全或无」放弃——此时完整版 spec 会指着
+    # 一个并不存在的 <gallery> 让模型做成员匹配，而「# 家庭档案」里的成员名就在同一个 prompt
+    # 里，等于把"别从档案取名安到没识别出的人身上"这条纪律推到最难守的位置。
+    prepared_gallery = (
+        _prepare_gallery_entries(gallery_snapshot, cfg)
+        if candidates and not matching_moot
+        else _PreparedGallery(entries=[])
+    )
+
     # has_speech 只由本轮 VAD 决定：本轮真有人声（含 pending 的延续语音）→ VAD 自然过、
     # 保留 speeches、模型把 <pending_speech> 拼成完整句；本轮无人声 → 剥 speeches，挂着的
     # pending 半句不强行补全（否则模型会就着噪声脑补出一个完成句，正是要根除的幻觉）。
@@ -368,14 +382,17 @@ def build_fused_payload(
         has_audio=_batch_video_has_audio(packets),
         has_speech=_batch_video_has_speech(packets),
         has_pets=_has_pets_for_scene(),
-        identity_match_disabled=matching_moot,
+        # 仅"本轮有候选却没渲染出 gallery"时额外置位；无候选窗口保持 matching_moot 原语义
+        # （identity_match_disabled 还被 _render_examples 的 chain 变体读取，且那处不看
+        # has_identity——无候选时跟着翻会把名册里有名字的窗口也降级成泛称示例）。
+        identity_match_disabled=matching_moot or (bool(candidates) and not prepared_gallery.entries),
     )
     system_prompt = build_system_prompt(scene, include_home_profile=False, camera_prompt=context.camera_prompt)
     user_content = _build_fused_user_content(
         packets=packets,
         context=context,
         candidates=candidates,
-        gallery_snapshot=gallery_snapshot,
+        prepared_gallery=prepared_gallery,
         video_b64=video_b64,
         media_info=media_info,
         ref_image_jpeg=ref_image_jpeg,
@@ -384,7 +401,6 @@ def build_fused_payload(
         cfg=cfg,
         label_lookup=label_lookup,
         has_pets=scene.has_pets,  # 复用 scene 已算好的 has_pets，避免注入点再读一次 profile.md
-        matching_moot=matching_moot,
     )
 
     messages = _assemble_fused_messages(
@@ -703,12 +719,91 @@ def _build_user_content(
     return text
 
 
+@dataclass(frozen=True)
+class _PreparedGallery:
+    """本窗口 gallery 段的预备结果——「渲染」与「identities spec 选版」共用的唯一判据。
+
+    ``entries`` 非空 ⟺ 本轮 prompt 里真会出现 ``<gallery>`` 块。空有两种来源，对
+    identities spec 而言是同一件事（本轮无参考图可比对 → 用精简版）：
+
+    - ``give_up_reason`` 非 None：「全或无」放弃（某候选 person 的 body composite 取不到）
+    - ``give_up_reason`` 为 None：``gallery_snapshot`` 本就为空（库非空但无可用样本）
+    """
+
+    entries: list[tuple[str, str, bytes, "bytes | None"]]  # (pid, label, body_jpg, face_jpg|None)
+    give_up_reason: str | None = None
+
+
+def _prepare_gallery_entries(
+    gallery_snapshot: dict[str, "GallerySamples"],
+    cfg: FusedPromptConfig,
+) -> _PreparedGallery:
+    """gallery 段 pre-flight：解析每人 body/face composite，判定本窗口能否渲染。
+
+    「全或无」语义：任一候选 person 的 body composite 全套兜底都失败，本窗口放弃整个
+    gallery 段。原因：少注入一个人，画面里若真有该人，omni 容易把他的脸贴到 gallery 里
+    最相似的另一位 → 错认（caption/speeches 全跟着错），代价比"漏识别"高一个量级。
+    face 是 nice-to-have，单人 face 失败不触发放弃。
+
+    除日志外无副作用（不产 prompt 块、不落 snapshot），故可在选 identities spec 之前调用
+    ——这正是本函数从 ``_build_fused_user_content`` 里抽出来的原因。
+    """
+    if not gallery_snapshot:
+        return _PreparedGallery(entries=[])
+
+    # 渲染上限保护：超出 cfg.max_gallery_persons 仅取前 N 人，避免 prompt token 爆
+    gallery_items = list(gallery_snapshot.items())
+    if len(gallery_items) > cfg.max_gallery_persons:
+        logger.warning(
+            "gallery person count %d > max_gallery_persons=%d，仅渲染前 %d 人",
+            len(gallery_items), cfg.max_gallery_persons, cfg.max_gallery_persons,
+        )
+        gallery_items = gallery_items[: cfg.max_gallery_persons]
+
+    prepared: list[tuple[str, str, bytes, "bytes | None"]] = []
+    for pid, samples in gallery_items:
+        body_jpg = _resolve_person_body_jpg(samples, cfg)
+        # 同时拦 None / empty / "非 None 但 size 异常小" 的坏 bytes (后者
+        # 通常是 library 缓存里的半截损坏 jpeg, 直接进 payload 会让 omni
+        # 服务端 400 Multimodal data is corrupted)
+        if not body_jpg or len(body_jpg) < _MIN_JPEG_BYTES:
+            give_up_reason = (
+                f"person_id={pid} name={samples.name!r} "
+                f"body composite 全部兜底来源均失败 "
+                f"(jpg={len(body_jpg) if body_jpg else 0} bytes)"
+            )
+            logger.warning(
+                "event=fused_gallery_giveup 触发整 gallery 放弃（全或无）：%s；"
+                "本窗口跳过 gallery 段，identities 改用精简版（只判 unknown/no_person），避免错认",
+                give_up_reason,
+            )
+            return _PreparedGallery(entries=[], give_up_reason=give_up_reason)
+        face_jpg = (
+            _resolve_person_face_jpg(samples, cfg)
+            if cfg.include_face_composite else None
+        )
+        # face 是 nice-to-have, size 不达标降级为 None (跳过本人 face 块,
+        # 其他人 body/face 仍渲染), 不触发整 gallery 放弃。
+        if face_jpg and len(face_jpg) < _MIN_JPEG_BYTES:
+            logger.warning(
+                "event=fused_face_jpg_too_short person_id=%s name=%r "
+                "size=%d 字节 (< %d), 跳过该人 face 块",
+                pid, samples.name, len(face_jpg), _MIN_JPEG_BYTES,
+            )
+            face_jpg = None
+        # 名册/gallery/输出统一用纯真名（角色上下文在「# 家庭档案」里）；
+        # name_to_pid 对纯名有 key，omni 输出 name 即可反查回 UUID
+        prepared.append((pid, samples.name or pid, body_jpg, face_jpg))
+
+    return _PreparedGallery(entries=prepared)
+
+
 def _build_fused_user_content(
     *,
     packets: list[IdentityPacket],
     context: OmniContext,
     candidates: list["IdentityQueryItem"],
-    gallery_snapshot: dict[str, "GallerySamples"],
+    prepared_gallery: _PreparedGallery,
     video_b64: str | None,
     media_info: LocalMediaInfo | None,
     ref_image_jpeg: bytes | None = None,
@@ -717,95 +812,40 @@ def _build_fused_user_content(
     cfg: FusedPromptConfig,
     label_lookup: "dict[str, str] | None" = None,
     has_pets: bool = False,
-    matching_moot: bool = False,
 ) -> list[dict]:
     """构建 user 消息的 content 列表（text/image_url/video_url 块交错）。
 
     fused 模式专用：与纯文本版 ``_build_user_content`` 不同，本函数返回
     ``list[dict]``（OpenAI 多模态 content array），不是 ``str``。
 
-    ``matching_moot=True``（身份库为空）时整个 gallery 段不渲染——库空无成员可比对，
-    identities 已由精简版 spec 指示"只判 unknown/no_person"（见 build_fused_payload），
-    此处不再塞"<gallery>库为空…"这类无用文本。待识别 track 列表仍照常渲染（no_person 判定按 track 给结论）。
+    gallery 段渲不渲染由调用方给的 ``prepared_gallery`` 单方面决定（``entries`` 空即整段
+    跳过），本函数不再自己做 pre-flight——判据必须与 ``build_fused_payload`` 选 identities
+    spec 时用的那一份完全同源，否则会出现"spec 让模型对着 <gallery> 做成员匹配、prompt 里
+    却没有 <gallery>"的分叉。空 gallery 时也不塞"<gallery>库为空…"这类占位文本：精简版
+    spec 已把任务收敛成 unknown/no_person，占位文本纯属噪声。
+
+    待识别 track 列表照常渲染（no_person 判定按 track 给结论，不依赖 gallery）。
     """
     gallery_content: list[dict] = []
 
-    # === gallery refs（仅当本轮有 candidate 时渲染；U4 顺序里置于"待识别 track"之后、video 之前）===
-    # 「全或无」语义：任一候选 person 的 body composite 全套兜底都失败，本窗口放弃
-    # 整个 gallery 段（等价无 gallery 主调用）。原因：少注入一个人，画面里若真有该
-    # 人，omni 容易把他的脸贴到 gallery 里最相似的另一位 → 错认（caption/speeches
-    # 全跟着错），代价比"漏识别"高一个量级。face 是 nice-to-have，单人 face 失败不
-    # 触发放弃。
-    #
-    # matching_moot（身份库为空）→ 整段跳过：库空无成员可比对，精简版 identities spec 已
-    # 指示只判 unknown/no_person，不需要 gallery 图，也不再塞"库为空"占位文本。
-    if candidates and not matching_moot:
-        if gallery_snapshot:
-            # 渲染上限保护：超出 cfg.max_gallery_persons 仅取前 N 人，避免 prompt token 爆
-            gallery_items = list(gallery_snapshot.items())
-            if len(gallery_items) > cfg.max_gallery_persons:
-                logger.warning(
-                    "gallery person count %d > max_gallery_persons=%d，仅渲染前 %d 人",
-                    len(gallery_items), cfg.max_gallery_persons, cfg.max_gallery_persons,
-                )
-                gallery_items = gallery_items[: cfg.max_gallery_persons]
+    # === gallery refs（U4 顺序里置于"待识别 track"之后、video 之前）===
+    # entries 为空 → 整段不渲染（库空 / 无可用样本 / 「全或无」放弃三种来源同解），
+    # 且不塞占位文本：调用方已据同一份 prepared_gallery 把 identities 收敛成精简版。
+    if prepared_gallery.entries:
+        gallery_content.append({"type": "text", "text": "下方 gallery 为候选成员参考图；图中衣着仅样本采集当时所穿、不保证与本轮一致——衣着只作辅助参考、不作决定性判据，以面部/体型/发型为主"})
+        from miloco.perception.snapshot_context import push_gallery_image
 
-            # 两段式：先 pre-flight 每人都能拿到 body_jpg，全过才进入渲染段
-            prepared: list[tuple[str, str, bytes, "bytes | None"]] = []  # (pid, label, body_jpg, face_jpg|None)
-            give_up_reason: str | None = None
-            for pid, samples in gallery_items:
-                body_jpg = _resolve_person_body_jpg(samples, cfg)
-                # 同时拦 None / empty / "非 None 但 size 异常小" 的坏 bytes (后者
-                # 通常是 library 缓存里的半截损坏 jpeg, 直接进 payload 会让 omni
-                # 服务端 400 Multimodal data is corrupted)
-                if not body_jpg or len(body_jpg) < _MIN_JPEG_BYTES:
-                    give_up_reason = (
-                        f"person_id={pid} name={samples.name!r} "
-                        f"body composite 全部兜底来源均失败 "
-                        f"(jpg={len(body_jpg) if body_jpg else 0} bytes)"
-                    )
-                    break
-                face_jpg = (
-                    _resolve_person_face_jpg(samples, cfg)
-                    if cfg.include_face_composite else None
-                )
-                # face 是 nice-to-have, size 不达标降级为 None (跳过本人 face 块,
-                # 其他人 body/face 仍渲染), 不触发整 gallery 放弃。
-                if face_jpg and len(face_jpg) < _MIN_JPEG_BYTES:
-                    logger.warning(
-                        "event=fused_face_jpg_too_short person_id=%s name=%r "
-                        "size=%d 字节 (< %d), 跳过该人 face 块",
-                        pid, samples.name, len(face_jpg), _MIN_JPEG_BYTES,
-                    )
-                    face_jpg = None
-                # 名册/gallery/输出统一用纯真名（角色上下文在「# 家庭档案」里）；
-                # name_to_pid 对纯名有 key，omni 输出 name 即可反查回 UUID
-                prepared.append((pid, samples.name or pid, body_jpg, face_jpg))
-
-            if give_up_reason is not None:
-                # 整 gallery 放弃 —— 不渲染 gallery 段，本窗口等价于无 gallery 主调用
-                logger.warning(
-                    "event=fused_gallery_giveup 触发整 gallery 放弃（全或无）：%s；"
-                    "本窗口跳过 gallery 段，identity 信息退化为 unknown，避免错认",
-                    give_up_reason,
-                )
-            else:
-                gallery_content.append({"type": "text", "text": "下方 gallery 为候选成员参考图；图中衣着仅样本采集当时所穿、不保证与本轮一致——衣着只作辅助参考、不作决定性判据，以面部/体型/发型为主"})
-                from miloco.perception.snapshot_context import push_gallery_image
-
-                gallery_content.append({"type": "text", "text": "<gallery>"})
-                for pid, label, body_jpg, face_jpg in prepared:
-                    gallery_content.append({"type": "text", "text": f"【{label}】"})
-                    gallery_content.append({"type": "text", "text": "体型/全身参考："})
-                    gallery_content.append(_png_block(body_jpg))
-                    push_gallery_image(pid, "body", body_jpg)
-                    if face_jpg:
-                        gallery_content.append({"type": "text", "text": "面部参考："})
-                        gallery_content.append(_png_block(face_jpg))
-                        push_gallery_image(pid, "face", face_jpg)
-                gallery_content.append({"type": "text", "text": "</gallery>"})
-        else:
-            gallery_content.append({"type": "text", "text": "<gallery>库为空，所有 track 应输出 unknown</gallery>"})
+        gallery_content.append({"type": "text", "text": "<gallery>"})
+        for pid, label, body_jpg, face_jpg in prepared_gallery.entries:
+            gallery_content.append({"type": "text", "text": f"【{label}】"})
+            gallery_content.append({"type": "text", "text": "体型/全身参考："})
+            gallery_content.append(_png_block(body_jpg))
+            push_gallery_image(pid, "body", body_jpg)
+            if face_jpg:
+                gallery_content.append({"type": "text", "text": "面部参考："})
+                gallery_content.append(_png_block(face_jpg))
+                push_gallery_image(pid, "face", face_jpg)
+        gallery_content.append({"type": "text", "text": "</gallery>"})
 
     # 按 U4 顺序组装：当前时间 → 已识别人物 → 待识别 track → gallery → video → identities 约束。
     # 历史参考（pending_speech）与待判断规则已抽到独立 user 消息
@@ -1222,7 +1262,7 @@ def _resolve_person_body_jpg(
 
     任一层成功即返回。全部失败返回 None —— 调用方据此触发"整 gallery 放弃"。
 
-    NOTE: omni 主路径(``_build_fused_user_content``)调用方走的 ``GallerySamples``
+    NOTE: omni 主路径(``_prepare_gallery_entries``)调用方走的 ``GallerySamples``
     来自 ``library.get_gallery_composites_for_omni`` 新出口,只填 ``body_composite_jpeg``
     不填 ``body_crops``,且 library 出口已过滤掉 ``body_composite_jpeg=None`` 的 person。
     所以新主路径下永远在层 1 命中,层 2/3 实际是 dead code。**层 2/3 保留是为了适配

--- a/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
@@ -670,6 +670,8 @@ def _render_examples(scene: SceneDescriptor) -> str:
     # caption 示范不该叫专名。库非空照旧用带名版——哪怕本轮无参考图、identities 已收敛成
     # unknown/no_person，名册里已确认成员仍该被 caption 叫真名（他们的在场结论来自前几窗
     # 落定的 state，不依赖本轮 gallery）。
+    # 残留窗口：库非空 + 本轮无参考图 + 名册恰好也没有已确认成员时，此窗同样产不出成员名，
+    # 却仍走带名版。属已知权衡（判据不看名册），代价与理由见 constants._EXAMPLE_CHAIN_NO_NAME。
     examples.append(
         _EXAMPLE_CHAIN_NO_NAME if scene.identity_library_empty else _EXAMPLE_CHAIN
     )
@@ -734,11 +736,13 @@ def _build_user_content(
 class _PreparedGallery:
     """本窗口 gallery 段的预备结果——「渲染」与「identities spec 选版」共用的唯一判据。
 
-    ``entries`` 非空 ⟺ 本轮 prompt 里真会出现 ``<gallery>`` 块。空有两种来源，对
+    ``entries`` 非空 ⟺ 本轮 prompt 里真会出现 ``<gallery>`` 块。空有三种来源，对
     调用方而言同解（本轮无参考图可比对 → 用精简版）：「全或无」放弃（某候选 person 的
-    body composite 取不到，原因已打进 ``event=fused_gallery_giveup`` 日志），以及
-    ``gallery_snapshot`` 本就为空（库非空但无可用样本）。调用方不据来源分流，故不携带
-    放弃原因字段——只写不读的状态会误导读者以为有人消费它。
+    body composite 取不到，原因已打进 ``event=fused_gallery_giveup`` 日志）、
+    ``gallery_snapshot`` 本就为空（库非空但无可用样本），以及 ``build_fused_payload``
+    在无候选 / 身份库为空时直接构造空实例、连 pre-flight 都不跑（与
+    ``SceneDescriptor.identity_match_disabled`` 字段说明的三来源对应）。调用方不据来源
+    分流，故不携带放弃原因字段——只写不读的状态会误导读者以为有人消费它。
     """
 
     entries: list[tuple[str, str, bytes, "bytes | None"]]  # (pid, label, body_jpg, face_jpg|None)

--- a/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
@@ -612,9 +612,11 @@ def _render_task_list(scene: SceneDescriptor) -> str:
     items: list[str] = []
     if scene.has_identity:
         if scene.identity_match_disabled:
-            # 库空：没有成员可对照，任务收敛为「判真人 / 非人误检」，与精简版 identities spec 一致，
-            # 不再写「对照图片库…库中哪一位」这类成员匹配任务（否则与精简 spec 自相矛盾、白占 token）。
-            items.append("身份识别：判断画面中每个目标是真人还是被误检成人的非人物体（本轮无注册成员，不做成员匹配）")
+            # 本轮无参考图（库空 / 无可用样本 / 「全或无」放弃）：没有可对照的成员图，任务收敛为
+            # 「判真人 / 非人误检」，与精简版 identities spec 一致，不再写「对照图片库…库中哪一位」
+            # 这类成员匹配任务（否则与精简 spec 自相矛盾、白占 token）。措辞不得写"无注册成员"——
+            # 库非空的来源下会与同一 prompt 里的家庭档案 / 名册姓名矛盾。
+            items.append("身份识别：判断画面中每个目标是真人还是被误检成人的非人物体（本轮未提供成员参考图，不做成员匹配）")
         else:
             items.append("身份识别：对照图片库，识别画面中的人对应库中哪一位（或都不是）")
     if scene.route == "video":
@@ -647,18 +649,20 @@ def _render_examples(scene: SceneDescriptor) -> str:
     needs_response 指令），留着会与剥掉的 schema 矛盾、并重新诱导脑补人声指令，故不附
     实例 A（身份判定已由「## identities」充分约束）；实例 B 无 speeches、照常附。
 
-    identity_match_disabled=True（库空）时同样不附实例 A：它演示的是成员匹配（摆
-    ``<gallery>`` 成员、输出成员名 + 五官匹配 reason），与库空的精简版 identities
-    spec / schema（只判 unknown/no_person、无 gallery）自相矛盾，且抵消库空省 token 的
-    目标；身份任务已由精简版「## identities」充分约束。实例 B 无 identities 字段、照常附。
+    identity_match_disabled=True（本轮无成员参考图：库空 / 无可用样本 / 「全或无」放弃）
+    时同样不附实例 A：它演示的是成员匹配（摆 ``<gallery>`` 成员、输出成员名 + 五官匹配
+    reason），与精简版 identities spec / schema（只判 unknown/no_person、无 gallery）自相
+    矛盾，且抵消精简省 token 的目标；身份任务已由精简版「## identities」充分约束。
+    实例 B 无 identities 字段、照常附。
     """
     if scene.route == "audio" or not scene.has_audio:
         return ""
     examples = []
     if scene.has_identity and scene.has_speech and not scene.identity_match_disabled:
         examples.append(_EXAMPLE_IDENTITY)
-    # 库空时实例 B 用泛称版：此窗无成员铺垫（实例 A 已 gate 掉），caption 示范不该叫专名，
-    # 与「库空不产成员名」收敛一致。库非空照旧用带名版（其"小明"由上方实例 A 的 gallery 铺垫）。
+    # 无参考图窗口实例 B 用泛称版：此窗无成员匹配铺垫（实例 A 已 gate 掉），caption 示范
+    # 不该叫专名，与「无参考图不产成员名」收敛一致。参考图可用时照旧用带名版
+    # （其"小明"由上方实例 A 的 gallery 铺垫）。
     examples.append(
         _EXAMPLE_CHAIN_NO_NAME if scene.identity_match_disabled else _EXAMPLE_CHAIN
     )
@@ -724,14 +728,13 @@ class _PreparedGallery:
     """本窗口 gallery 段的预备结果——「渲染」与「identities spec 选版」共用的唯一判据。
 
     ``entries`` 非空 ⟺ 本轮 prompt 里真会出现 ``<gallery>`` 块。空有两种来源，对
-    identities spec 而言是同一件事（本轮无参考图可比对 → 用精简版）：
-
-    - ``give_up_reason`` 非 None：「全或无」放弃（某候选 person 的 body composite 取不到）
-    - ``give_up_reason`` 为 None：``gallery_snapshot`` 本就为空（库非空但无可用样本）
+    调用方而言同解（本轮无参考图可比对 → 用精简版）：「全或无」放弃（某候选 person 的
+    body composite 取不到，原因已打进 ``event=fused_gallery_giveup`` 日志），以及
+    ``gallery_snapshot`` 本就为空（库非空但无可用样本）。调用方不据来源分流，故不携带
+    放弃原因字段——只写不读的状态会误导读者以为有人消费它。
     """
 
     entries: list[tuple[str, str, bytes, "bytes | None"]]  # (pid, label, body_jpg, face_jpg|None)
-    give_up_reason: str | None = None
 
 
 def _prepare_gallery_entries(
@@ -777,7 +780,7 @@ def _prepare_gallery_entries(
                 "本窗口跳过 gallery 段，identities 改用精简版（只判 unknown/no_person），避免错认",
                 give_up_reason,
             )
-            return _PreparedGallery(entries=[], give_up_reason=give_up_reason)
+            return _PreparedGallery(entries=[])
         face_jpg = (
             _resolve_person_face_jpg(samples, cfg)
             if cfg.include_face_composite else None

--- a/backend/miloco/tests/perception/engine/omni/test_prompt_builder.py
+++ b/backend/miloco/tests/perception/engine/omni/test_prompt_builder.py
@@ -1631,7 +1631,7 @@ class TestGalleryPreflightDrivesIdentitySpec:
 
     # ---- pre-flight 纯函数 ----
 
-    def test_preflight_empty_snapshot_no_entries_no_giveup(self):
+    def test_preflight_empty_snapshot_no_entries(self):
         from miloco.perception.engine.omni.prompt_builder import (
             FusedPromptConfig,
             _prepare_gallery_entries,
@@ -1639,10 +1639,14 @@ class TestGalleryPreflightDrivesIdentitySpec:
 
         got = _prepare_gallery_entries({}, FusedPromptConfig())
         assert got.entries == []
-        assert got.give_up_reason is None
 
-    def test_preflight_bad_body_gives_up_whole_gallery(self):
-        """「全或无」：一人 body composite 取不到 → 整段放弃（不能只少注入一个人）。"""
+    def test_preflight_bad_body_gives_up_whole_gallery(self, caplog):
+        """「全或无」：一人 body composite 取不到 → 整段放弃（不能只少注入一个人）。
+
+        放弃原因只进 ``event=fused_gallery_giveup`` 日志（结构体不携带只写不读的字段），
+        故经 caplog 断言原因里点到了取不到样本的那个人。"""
+        import logging
+
         from miloco.perception.engine.omni.prompt_builder import (
             FusedPromptConfig,
             _prepare_gallery_entries,
@@ -1652,10 +1656,13 @@ class TestGalleryPreflightDrivesIdentitySpec:
             "pid-1": self._samples("pid-1", "张三"),
             "pid-2": self._samples("pid-2", "李四", body=b""),
         }
-        got = _prepare_gallery_entries(snapshot, FusedPromptConfig())
+        with caplog.at_level(logging.WARNING):
+            got = _prepare_gallery_entries(snapshot, FusedPromptConfig())
         assert got.entries == []
-        assert got.give_up_reason is not None
-        assert "pid-2" in got.give_up_reason
+        assert any(
+            "fused_gallery_giveup" in r.message and "pid-2" in r.message
+            for r in caplog.records
+        )
 
     def test_preflight_short_face_degrades_only_that_person(self):
         """face 是 nice-to-have：size 不达标只置 None，不触发整段放弃。"""
@@ -1666,7 +1673,6 @@ class TestGalleryPreflightDrivesIdentitySpec:
 
         got = _prepare_gallery_entries(
             {"pid-1": self._samples(face=b"tiny")}, FusedPromptConfig())
-        assert got.give_up_reason is None
         assert len(got.entries) == 1
         pid, label, body_jpg, face_jpg = got.entries[0]
         assert (pid, label) == ("pid-1", "张三")
@@ -1703,6 +1709,29 @@ class TestGalleryPreflightDrivesIdentitySpec:
         assert "<gallery>" not in main_text
         assert "张三" not in main_text          # 放弃后不残留半截 gallery
         assert "待识别 track" in main_text      # no_person 判定仍按 track 走
+        assert self._NO_MATCH_MARKER in system_prompt
+        assert self._MATCH_ONLY_MARKER not in system_prompt
+
+    def test_slim_spec_wording_consistent_with_profile_present(self):
+        """库非空 + 档案里有成员名 + 本轮渲不出 gallery：精简版措辞不得断言"无注册成员"。
+
+        这句话在旧的唯一触发条件（库空）下是事实；复用到库非空的新路径上就与同一 prompt
+        里的「# 家庭档案」成员名 / 名册行当场矛盾——模型要么把在场成员当"没有成员"处理，
+        要么不采信规范、从档案取名安给待识别 track（正是要防的错认）。判据只能是"没有参考图"。"""
+        from miloco.perception.engine.omni.prompt_builder import build_fused_payload
+
+        with patch(
+            "miloco.perception.engine.omni.prompt_builder.get_home_profile_prefix",
+            return_value="# 家庭档案\n## 成员\n- 张三（爸爸）",
+        ):
+            fused = build_fused_payload(
+                packets=[_video_route_packet()], context=OmniContext(),
+                candidates=[self._candidate()], gallery_snapshot={},
+            )
+        system_prompt = fused["messages"][0]["content"]
+        assert "本轮无注册成员" not in system_prompt
+        assert "未提供" in system_prompt          # 新措辞：按"没有参考图"陈述
+        assert "不得据此" in system_prompt        # 护栏：禁止从档案/名册取名安给待识别 track
         assert self._NO_MATCH_MARKER in system_prompt
         assert self._MATCH_ONLY_MARKER not in system_prompt
 

--- a/backend/miloco/tests/perception/engine/omni/test_prompt_builder.py
+++ b/backend/miloco/tests/perception/engine/omni/test_prompt_builder.py
@@ -1316,11 +1316,12 @@ class TestNoAudioPromptDropsAudioFieldRefs:
 # 本轮无成员参考图 → identity 精简为 no_person-only（matching_moot / identity_match_disabled）
 # =============================================================================
 class TestIdentityMatchDisabled:
-    """库空时 identities 字段改精简版（只判 unknown/no_person、不做成员匹配）。
+    """本轮拿不到任何成员参考图时 identities 改精简版（只判 unknown/no_person、不做成员匹配）。
 
-    这是"gallery 为空不该激活成员匹配"修复的 prompt 侧断言：schema 的 name 域收成
+    这是"没有 gallery 就不该激活成员匹配"修复的 prompt 侧断言：schema 的 name 域收成
     <unknown|no_person>、字段说明砍掉全套面部匹配规则、gallery 段整段不渲染；no_person
-    判定链路不动（name 仍走 no_person）。库非空（默认 matching_moot=False）行为不变。
+    判定链路不动（name 仍走 no_person）。三个来源同解——库空（matching_moot=True）、
+    库非空但快照无可用样本、「全或无」放弃；参考图真渲出来时（默认路径）行为不变。
     """
 
     _MATCH_ONLY_MARKER = "本人正向吻合"   # 只在完整版 IDENTITY spec 里出现
@@ -1383,6 +1384,11 @@ class TestIdentityMatchDisabled:
         # system prompt：用精简版 identity spec
         assert self._NO_MATCH_MARKER in system_prompt
         assert self._MATCH_ONLY_MARKER not in system_prompt
+        # 库空 → 实例 B 用泛称版。这两行钉住 build_fused_payload 里
+        # identity_library_empty=matching_moot 那根接线：删掉它本条会红，
+        # 而只喂 SceneDescriptor 的单元用例不会。
+        assert "某人坐在电脑前" in system_prompt
+        assert "小明坐在电脑前" not in system_prompt
 
     def test_empty_snapshot_slims_spec_even_without_matching_moot(self):
         """库非空但本轮 gallery_snapshot 为空（成员一个可用样本都没有）→ 同样走精简版。
@@ -1410,6 +1416,11 @@ class TestIdentityMatchDisabled:
         assert "待识别 track" in main_text
         assert self._NO_MATCH_MARKER in system_prompt
         assert self._MATCH_ONLY_MARKER not in system_prompt
+        # 反向对照：库非空、仅本轮无参考图 → 规范降精简版，但实例 B 仍带名。
+        # 与 test_matching_moot_skips_gallery_block_keeps_track_list 合起来
+        # 钉住"两个字段没被重新合并成一个"。
+        assert "小明坐在电脑前" in system_prompt
+        assert "某人坐在电脑前" not in system_prompt
 
     # ---- follow-up（PR #407 code review）：库空时「任务描述 / 示例」也须收敛，非只 gallery/字段说明 ----
     _TASK_MATCH_MARKER = "对照图片库"    # 只在完整版「# 任务」身份行里出现
@@ -1627,7 +1638,7 @@ class TestGalleryPreflightDrivesIdentitySpec:
         )
 
     @staticmethod
-    def _build(gallery_snapshot, candidates):
+    def _build(gallery_snapshot, candidates, *, matching_moot=False):
         from miloco.perception.engine.omni.prompt_builder import build_fused_payload
 
         with patch(
@@ -1637,6 +1648,7 @@ class TestGalleryPreflightDrivesIdentitySpec:
             fused = build_fused_payload(
                 packets=[_video_route_packet()], context=OmniContext(),
                 candidates=candidates, gallery_snapshot=gallery_snapshot,
+                matching_moot=matching_moot,
             )
         messages = fused["messages"]
         main = _multimodal_user_content(messages)
@@ -1749,11 +1761,15 @@ class TestGalleryPreflightDrivesIdentitySpec:
         assert self._NO_MATCH_MARKER in system_prompt
         assert self._MATCH_ONLY_MARKER not in system_prompt
 
-    def test_no_candidate_window_keeps_named_example(self):
-        """无候选窗口不受影响：identity_match_disabled 还被 _render_examples 读取，
-        且那处不看 has_identity——跟着翻会把"名册里有名字"的窗口也降级成泛称示例。"""
-        system_prompt, _ = self._build({"pid-1": self._samples()}, [])
-        assert "小明" in system_prompt          # 带名版 _EXAMPLE_CHAIN
+    def test_no_candidate_window_example_b_follows_library_emptiness(self):
+        """无候选窗口的实例 B 只跟"库空不空"：库非空 → 带名版，库空 → 泛称版。
+
+        （identity_match_disabled 在无候选窗口取什么值都不外显：它的三个消费方
+        都先过 has_identity=bool(candidates) 这道闸。）"""
+        named, _ = self._build({"pid-1": self._samples()}, [])
+        assert "小明坐在电脑前" in named
+        moot, _ = self._build({}, [], matching_moot=True)
+        assert "某人坐在电脑前" in moot
 
 class TestAdaptiveResolution:
     """Smart Crop(智能裁切增强)在 fused 路径的接线。

--- a/backend/miloco/tests/perception/engine/omni/test_prompt_builder.py
+++ b/backend/miloco/tests/perception/engine/omni/test_prompt_builder.py
@@ -1384,8 +1384,13 @@ class TestIdentityMatchDisabled:
         assert self._NO_MATCH_MARKER in system_prompt
         assert self._MATCH_ONLY_MARKER not in system_prompt
 
-    def test_default_matching_moot_false_keeps_empty_gallery_placeholder(self):
-        """回归保护：matching_moot 默认 False 时，库空仍走旧行为（塞"库为空"占位 + 完整匹配 spec）。"""
+    def test_empty_snapshot_slims_spec_even_without_matching_moot(self):
+        """库非空但本轮 gallery_snapshot 为空（成员一个可用样本都没有）→ 同样走精简版。
+
+        取代旧的 ``test_default_matching_moot_false_keeps_empty_gallery_placeholder``：
+        那条钉的是"spec 让模型对着 <gallery> 做成员匹配、prompt 里却只有一句「库为空」
+        占位"的分叉行为。现在选版判据换成 gallery pre-flight 的实际结果，占位文本一并去掉。
+        """
         from miloco.perception.engine.omni.prompt_builder import build_fused_payload
 
         with patch(
@@ -1400,8 +1405,11 @@ class TestIdentityMatchDisabled:
         system_prompt = messages[0]["content"]
         main = _multimodal_user_content(messages)
         main_text = "\n".join(b.get("text", "") for b in main if b.get("type") == "text")
-        assert "库为空" in main_text
-        assert self._MATCH_ONLY_MARKER in system_prompt
+        assert "库为空" not in main_text
+        assert "<gallery>" not in main_text
+        assert "待识别 track" in main_text
+        assert self._NO_MATCH_MARKER in system_prompt
+        assert self._MATCH_ONLY_MARKER not in system_prompt
 
     # ---- follow-up（PR #407 code review）：库空时「任务描述 / 示例」也须收敛，非只 gallery/字段说明 ----
     _TASK_MATCH_MARKER = "对照图片库"    # 只在完整版「# 任务」身份行里出现
@@ -1571,6 +1579,138 @@ def _adaptive_packet(
         main_det_boxes=main_det_boxes,
     )
 
+
+
+# =============================================================================
+# gallery pre-flight 决定 identities 选版（库非空但本轮没渲染出 gallery 的分叉）
+# =============================================================================
+class TestGalleryPreflightDrivesIdentitySpec:
+    """identities 用完整版还是精简版，判据是「本轮 prompt 里真出现 <gallery> 了吗」。
+
+    库非空但 gallery 渲不出来有两条路径——``gallery_snapshot`` 为空、以及「全或无」
+    放弃（某候选 person 的 body composite 取不到）。旧实现只看「库空不空」，这两条路径
+    下会下发完整匹配版 spec 去对照一个并不存在的 <gallery>，而「# 家庭档案」里的成员名
+    就在同一个 prompt 里，等于把"别从档案取名安到没识别出的人身上"推到最难守的位置。
+    """
+
+    _MATCH_ONLY_MARKER = "本人正向吻合"   # 只在完整版 IDENTITY spec 里出现
+    _NO_MATCH_MARKER = "不做成员匹配"     # 只在精简版 IDENTITY_NO_MATCH spec 里出现
+
+    @staticmethod
+    def _candidate():
+        from miloco.perception.engine.identity.dispatcher import IdentityQueryItem
+
+        return IdentityQueryItem(
+            track_id=7, bbox_xyxy_norm=(100, 100, 200, 400), face_visible=False)
+
+    @staticmethod
+    def _samples(pid="pid-1", name="张三", body=b"P" * 400, face=b"F" * 400):
+        from miloco.perception.engine.identity.library import GallerySamples
+
+        return GallerySamples(
+            person_id=pid, name=name, role=None,
+            body_composite_jpeg=body, face_composite_jpeg=face,
+        )
+
+    @staticmethod
+    def _build(gallery_snapshot, candidates):
+        from miloco.perception.engine.omni.prompt_builder import build_fused_payload
+
+        with patch(
+            "miloco.perception.engine.omni.prompt_builder.get_home_profile_prefix",
+            return_value="",
+        ):
+            fused = build_fused_payload(
+                packets=[_video_route_packet()], context=OmniContext(),
+                candidates=candidates, gallery_snapshot=gallery_snapshot,
+            )
+        messages = fused["messages"]
+        main = _multimodal_user_content(messages)
+        main_text = "\n".join(b.get("text", "") for b in main if b.get("type") == "text")
+        return messages[0]["content"], main_text
+
+    # ---- pre-flight 纯函数 ----
+
+    def test_preflight_empty_snapshot_no_entries_no_giveup(self):
+        from miloco.perception.engine.omni.prompt_builder import (
+            FusedPromptConfig,
+            _prepare_gallery_entries,
+        )
+
+        got = _prepare_gallery_entries({}, FusedPromptConfig())
+        assert got.entries == []
+        assert got.give_up_reason is None
+
+    def test_preflight_bad_body_gives_up_whole_gallery(self):
+        """「全或无」：一人 body composite 取不到 → 整段放弃（不能只少注入一个人）。"""
+        from miloco.perception.engine.omni.prompt_builder import (
+            FusedPromptConfig,
+            _prepare_gallery_entries,
+        )
+
+        snapshot = {
+            "pid-1": self._samples("pid-1", "张三"),
+            "pid-2": self._samples("pid-2", "李四", body=b""),
+        }
+        got = _prepare_gallery_entries(snapshot, FusedPromptConfig())
+        assert got.entries == []
+        assert got.give_up_reason is not None
+        assert "pid-2" in got.give_up_reason
+
+    def test_preflight_short_face_degrades_only_that_person(self):
+        """face 是 nice-to-have：size 不达标只置 None，不触发整段放弃。"""
+        from miloco.perception.engine.omni.prompt_builder import (
+            FusedPromptConfig,
+            _prepare_gallery_entries,
+        )
+
+        got = _prepare_gallery_entries(
+            {"pid-1": self._samples(face=b"tiny")}, FusedPromptConfig())
+        assert got.give_up_reason is None
+        assert len(got.entries) == 1
+        pid, label, body_jpg, face_jpg = got.entries[0]
+        assert (pid, label) == ("pid-1", "张三")
+        assert body_jpg and face_jpg is None
+
+    def test_preflight_truncates_to_max_persons(self):
+        from miloco.perception.engine.omni.prompt_builder import (
+            FusedPromptConfig,
+            _prepare_gallery_entries,
+        )
+
+        snapshot = {f"pid-{i}": self._samples(f"pid-{i}", f"人{i}") for i in range(12)}
+        got = _prepare_gallery_entries(snapshot, FusedPromptConfig(max_gallery_persons=3))
+        assert len(got.entries) == 3
+
+    # ---- pre-flight 结果驱动 spec ----
+
+    def test_renderable_gallery_keeps_full_matching_spec(self):
+        """回归保护：正常渲染得出 gallery → 完整匹配版 spec 照旧。"""
+        system_prompt, main_text = self._build(
+            {"pid-1": self._samples()}, [self._candidate()])
+        assert "<gallery>" in main_text
+        assert "【张三】" in main_text
+        assert self._MATCH_ONLY_MARKER in system_prompt
+        assert self._NO_MATCH_MARKER not in system_prompt
+
+    def test_giveup_falls_back_to_slim_spec(self):
+        """「全或无」放弃 → spec 跟着降级；不能只撤图不撤匹配纪律。"""
+        snapshot = {
+            "pid-1": self._samples("pid-1", "张三"),
+            "pid-2": self._samples("pid-2", "李四", body=b""),
+        }
+        system_prompt, main_text = self._build(snapshot, [self._candidate()])
+        assert "<gallery>" not in main_text
+        assert "张三" not in main_text          # 放弃后不残留半截 gallery
+        assert "待识别 track" in main_text      # no_person 判定仍按 track 走
+        assert self._NO_MATCH_MARKER in system_prompt
+        assert self._MATCH_ONLY_MARKER not in system_prompt
+
+    def test_no_candidate_window_keeps_named_example(self):
+        """无候选窗口不受影响：identity_match_disabled 还被 _render_examples 读取，
+        且那处不看 has_identity——跟着翻会把"名册里有名字"的窗口也降级成泛称示例。"""
+        system_prompt, _ = self._build({"pid-1": self._samples()}, [])
+        assert "小明" in system_prompt          # 带名版 _EXAMPLE_CHAIN
 
 class TestAdaptiveResolution:
     """Smart Crop(智能裁切增强)在 fused 路径的接线。

--- a/backend/miloco/tests/perception/engine/omni/test_prompt_builder.py
+++ b/backend/miloco/tests/perception/engine/omni/test_prompt_builder.py
@@ -1313,7 +1313,7 @@ class TestNoAudioPromptDropsAudioFieldRefs:
 
 
 # =============================================================================
-# 身份库为空 → identity 精简为 no_person-only（matching_moot / identity_match_disabled）
+# 本轮无成员参考图 → identity 精简为 no_person-only（matching_moot / identity_match_disabled）
 # =============================================================================
 class TestIdentityMatchDisabled:
     """库空时 identities 字段改精简版（只判 unknown/no_person、不做成员匹配）。
@@ -1442,12 +1442,26 @@ class TestIdentityMatchDisabled:
         # has_speech=True：未修复时实例 A 本会注入，确保断言有意义
         out = _render_examples(SceneDescriptor(
             route="video", has_identity=True, has_audio=True, has_speech=True,
-            identity_match_disabled=True))
+            identity_match_disabled=True, identity_library_empty=True))
         assert self._EXAMPLE_A_MARKER not in out   # 成员匹配 few-shot 不注入
         assert "实例 B" in out                       # 通用观察 few-shot 照常
         # 库空实例 B 用泛称版：无成员铺垫的窗口不示范 caption 叫专名
         assert "小明" not in out
         assert "某人坐在电脑前" in out
+
+    def test_no_reference_image_window_keeps_named_example_when_library_nonempty(self):
+        """库非空 + 本轮渲不出 gallery：实例 A 撤掉（无 gallery 可示范），但实例 B 仍用
+        带名版——名册里的已确认成员照样该被 caption 叫真名（他们的在场结论来自前几窗落定
+        的 state，不依赖本轮 gallery）。泛称示例只属于"不可能产出成员名"的库空窗口。"""
+        from miloco.perception.engine.omni.field_registry import SceneDescriptor
+        from miloco.perception.engine.omni.prompt_builder import _render_examples
+
+        out = _render_examples(SceneDescriptor(
+            route="video", has_identity=True, has_audio=True, has_speech=True,
+            identity_match_disabled=True, identity_library_empty=False))
+        assert self._EXAMPLE_A_MARKER not in out
+        assert "小明坐在电脑前" in out
+        assert "某人坐在电脑前" not in out
 
     def test_example_a_present_when_gallery_present(self):
         from miloco.perception.engine.omni.field_registry import SceneDescriptor
@@ -1470,7 +1484,7 @@ class TestIdentityMatchDisabled:
 
         moot = SceneDescriptor(
             route="video", has_identity=True, has_audio=True, has_speech=True,
-            identity_match_disabled=True)
+            identity_match_disabled=True, identity_library_empty=True)
         sp = build_system_prompt(moot, include_home_profile=False)
         for leak in (self._TASK_MATCH_MARKER, "库中哪一位",
                      self._EXAMPLE_A_MARKER, self._MATCH_ONLY_MARKER):

--- a/backend/miloco/tests/perception/engine/omni/test_prompt_builder.py
+++ b/backend/miloco/tests/perception/engine/omni/test_prompt_builder.py
@@ -1605,7 +1605,6 @@ def _adaptive_packet(
     )
 
 
-
 # =============================================================================
 # gallery pre-flight 决定 identities 选版（库非空但本轮没渲染出 gallery 的分叉）
 # =============================================================================
@@ -1755,6 +1754,13 @@ class TestGalleryPreflightDrivesIdentitySpec:
                 candidates=[self._candidate()], gallery_snapshot={},
             )
         system_prompt = fused["messages"][0]["content"]
+        # 档案不在 system（build_system_prompt 传的是 include_home_profile=False），
+        # 而是 system 之后的独立 user 消息——不断言它，"共存"这个前提就是空转的
+        profile_msgs = [
+            m for m in fused["messages"][1:] if "# 家庭档案" in str(m["content"])
+        ]
+        assert len(profile_msgs) == 1
+        assert "张三" in str(profile_msgs[0]["content"])
         assert "本轮无注册成员" not in system_prompt
         assert "未提供" in system_prompt          # 新措辞：按"没有参考图"陈述
         assert "不得据此" in system_prompt        # 护栏：禁止从档案/名册取名安给待识别 track
@@ -1770,6 +1776,7 @@ class TestGalleryPreflightDrivesIdentitySpec:
         assert "小明坐在电脑前" in named
         moot, _ = self._build({}, [], matching_moot=True)
         assert "某人坐在电脑前" in moot
+
 
 class TestAdaptiveResolution:
     """Smart Crop(智能裁切增强)在 fused 路径的接线。

--- a/backend/miloco/tests/perception/engine/omni/test_prompt_builder.py
+++ b/backend/miloco/tests/perception/engine/omni/test_prompt_builder.py
@@ -1384,13 +1384,12 @@ class TestIdentityMatchDisabled:
         # system prompt：用精简版 identity spec
         assert self._NO_MATCH_MARKER in system_prompt
         assert self._MATCH_ONLY_MARKER not in system_prompt
-        # 库空 → 实例 B 用泛称版。这两行钉住 build_fused_payload 里
-        # identity_library_empty=matching_moot 那根接线：删掉它本条会红，
-        # 而只喂 SceneDescriptor 的单元用例不会。
+        # 库空且名册无有效姓名 → 实例 B 用泛称版，验证生产路径的标志接线。
         assert "某人坐在电脑前" in system_prompt
         assert "小明坐在电脑前" not in system_prompt
 
-    def test_empty_snapshot_slims_spec_even_without_matching_moot(self):
+    @pytest.mark.parametrize("has_roster_name", [False, True], ids=["no-name", "named-roster"])
+    def test_empty_snapshot_slims_spec_even_without_matching_moot(self, has_roster_name):
         """库非空但本轮 gallery_snapshot 为空（成员一个可用样本都没有）→ 同样走精简版。
 
         取代旧的 ``test_default_matching_moot_false_keeps_empty_gallery_placeholder``：
@@ -1406,6 +1405,7 @@ class TestIdentityMatchDisabled:
             fused = build_fused_payload(
                 packets=[_video_route_packet()], context=OmniContext(),
                 candidates=[self._candidate()], gallery_snapshot={},
+                label_lookup={"wangshihao": "张三"} if has_roster_name else {},
             )
         messages = fused["messages"]
         system_prompt = messages[0]["content"]
@@ -1416,11 +1416,10 @@ class TestIdentityMatchDisabled:
         assert "待识别 track" in main_text
         assert self._NO_MATCH_MARKER in system_prompt
         assert self._MATCH_ONLY_MARKER not in system_prompt
-        # 反向对照：库非空、仅本轮无参考图 → 规范降精简版，但实例 B 仍带名。
-        # 与 test_matching_moot_skips_gallery_block_keeps_track_list 合起来
-        # 钉住"两个字段没被重新合并成一个"。
-        assert "小明坐在电脑前" in system_prompt
-        assert "某人坐在电脑前" not in system_prompt
+        # 同样无图，名册有真名才带名；只有裸 person_id 不算可引用姓名。
+        assert ("已识别人物：张三" in main_text) == has_roster_name
+        assert ("小明坐在电脑前" in system_prompt) == has_roster_name
+        assert ("某人坐在电脑前" in system_prompt) == (not has_roster_name)
 
     # ---- follow-up（PR #407 code review）：库空时「任务描述 / 示例」也须收敛，非只 gallery/字段说明 ----
     _TASK_MATCH_MARKER = "对照图片库"    # 只在完整版「# 任务」身份行里出现
@@ -1453,23 +1452,21 @@ class TestIdentityMatchDisabled:
         # has_speech=True：未修复时实例 A 本会注入，确保断言有意义
         out = _render_examples(SceneDescriptor(
             route="video", has_identity=True, has_audio=True, has_speech=True,
-            identity_match_disabled=True, identity_library_empty=True))
+            identity_match_disabled=True, member_names_unavailable=True))
         assert self._EXAMPLE_A_MARKER not in out   # 成员匹配 few-shot 不注入
         assert "实例 B" in out                       # 通用观察 few-shot 照常
         # 库空实例 B 用泛称版：无成员铺垫的窗口不示范 caption 叫专名
         assert "小明" not in out
         assert "某人坐在电脑前" in out
 
-    def test_no_reference_image_window_keeps_named_example_when_library_nonempty(self):
-        """库非空 + 本轮渲不出 gallery：实例 A 撤掉（无 gallery 可示范），但实例 B 仍用
-        带名版——名册里的已确认成员照样该被 caption 叫真名（他们的在场结论来自前几窗落定
-        的 state，不依赖本轮 gallery）。泛称示例只属于"不可能产出成员名"的库空窗口。"""
+    def test_no_reference_image_window_keeps_named_example_when_roster_names_available(self):
+        """本轮无 gallery 但名册提供已确认姓名：实例 A 撤掉，实例 B 保留带名版。"""
         from miloco.perception.engine.omni.field_registry import SceneDescriptor
         from miloco.perception.engine.omni.prompt_builder import _render_examples
 
         out = _render_examples(SceneDescriptor(
             route="video", has_identity=True, has_audio=True, has_speech=True,
-            identity_match_disabled=True, identity_library_empty=False))
+            identity_match_disabled=True, member_names_unavailable=False))
         assert self._EXAMPLE_A_MARKER not in out
         assert "小明坐在电脑前" in out
         assert "某人坐在电脑前" not in out
@@ -1495,7 +1492,7 @@ class TestIdentityMatchDisabled:
 
         moot = SceneDescriptor(
             route="video", has_identity=True, has_audio=True, has_speech=True,
-            identity_match_disabled=True, identity_library_empty=True)
+            identity_match_disabled=True, member_names_unavailable=True)
         sp = build_system_prompt(moot, include_home_profile=False)
         for leak in (self._TASK_MATCH_MARKER, "库中哪一位",
                      self._EXAMPLE_A_MARKER, self._MATCH_ONLY_MARKER):
@@ -1637,7 +1634,7 @@ class TestGalleryPreflightDrivesIdentitySpec:
         )
 
     @staticmethod
-    def _build(gallery_snapshot, candidates, *, matching_moot=False):
+    def _build(gallery_snapshot, candidates, *, matching_moot=False, packets=None, label_lookup=None):
         from miloco.perception.engine.omni.prompt_builder import build_fused_payload
 
         with patch(
@@ -1645,9 +1642,9 @@ class TestGalleryPreflightDrivesIdentitySpec:
             return_value="",
         ):
             fused = build_fused_payload(
-                packets=[_video_route_packet()], context=OmniContext(),
+                packets=packets if packets is not None else [_video_route_packet()], context=OmniContext(),
                 candidates=candidates, gallery_snapshot=gallery_snapshot,
-                matching_moot=matching_moot,
+                matching_moot=matching_moot, label_lookup=label_lookup,
             )
         messages = fused["messages"]
         main = _multimodal_user_content(messages)
@@ -1723,19 +1720,27 @@ class TestGalleryPreflightDrivesIdentitySpec:
         assert "【张三】" in main_text
         assert self._MATCH_ONLY_MARKER in system_prompt
         assert self._NO_MATCH_MARKER not in system_prompt
+        assert "小明坐在电脑前" in system_prompt
 
-    def test_giveup_falls_back_to_slim_spec(self):
+    @pytest.mark.parametrize("has_roster_name", [False, True], ids=["no-name", "named-roster"])
+    def test_giveup_falls_back_to_slim_spec(self, has_roster_name):
         """「全或无」放弃 → spec 跟着降级；不能只撤图不撤匹配纪律。"""
         snapshot = {
             "pid-1": self._samples("pid-1", "张三"),
             "pid-2": self._samples("pid-2", "李四", body=b""),
         }
-        system_prompt, main_text = self._build(snapshot, [self._candidate()])
+        system_prompt, main_text = self._build(
+            snapshot, [self._candidate()],
+            label_lookup={"wangshihao": "王五"} if has_roster_name else {},
+        )
         assert "<gallery>" not in main_text
         assert "张三" not in main_text          # 放弃后不残留半截 gallery
         assert "待识别 track" in main_text      # no_person 判定仍按 track 走
         assert self._NO_MATCH_MARKER in system_prompt
         assert self._MATCH_ONLY_MARKER not in system_prompt
+        assert ("已识别人物：王五" in main_text) == has_roster_name
+        assert ("小明坐在电脑前" in system_prompt) == has_roster_name
+        assert ("某人坐在电脑前" in system_prompt) == (not has_roster_name)
 
     def test_slim_spec_wording_consistent_with_profile_present(self):
         """库非空 + 档案里有成员名 + 本轮渲不出 gallery：精简版措辞不得断言"无注册成员"。
@@ -1772,10 +1777,98 @@ class TestGalleryPreflightDrivesIdentitySpec:
 
         （identity_match_disabled 在无候选窗口取什么值都不外显：它的三个消费方
         都先过 has_identity=bool(candidates) 这道闸。）"""
-        named, _ = self._build({"pid-1": self._samples()}, [])
+        named, main_text = self._build({}, [], label_lookup={})
         assert "小明坐在电脑前" in named
+        assert "<gallery>" not in main_text
         moot, _ = self._build({}, [], matching_moot=True)
         assert "某人坐在电脑前" in moot
+
+    @pytest.mark.parametrize(
+        "person_id,track_id,suppress,label_lookup,expect_name",
+        [
+            ("pid-1", 1, False, {"pid-1": "张三"}, True),
+            ("pid-1", 7, False, {"pid-1": "张三"}, False),
+            ("pid-1", 1, True, {"pid-1": "张三"}, False),
+            ("pid-1", 1, False, {}, False),
+            ("pid-1", 1, False, {"pid-1": ""}, False),
+            ("none", 1, False, {"none": "张三"}, False),
+            ("", 1, False, {"": "张三"}, False),
+            ("pending", 1, False, {"pending": "张三"}, False),
+            ("pending:pid-1", 1, False, {"pending:pid-1": "张三"}, False),
+            ("unknown", 1, False, {"unknown": "张三"}, False),
+            ("unknown_1", 1, False, {"unknown_1": "张三"}, False),
+        ],
+        ids=["named-without-bbox", "recheck", "suppressed", "missing-label", "empty-label",
+             "none", "empty-pid", "pending", "pending-member", "stranger", "numbered-stranger"],
+    )
+    def test_example_b_follows_rendered_roster(
+        self, person_id, track_id, suppress, label_lookup, expect_name,
+    ):
+        packet = _video_route_packet()
+        target = packet.targets[0]
+        target.person_id = person_id
+        target.track_id = track_id
+        target.suppress_as_prior = suppress
+        target.bbox_xyxy_norm = None
+        system_prompt, main_text = self._build(
+            {}, [self._candidate()], packets=[packet], label_lookup=label_lookup,
+        )
+        assert ("已识别人物：张三" in main_text) == expect_name
+        assert ("小明坐在电脑前" in system_prompt) == expect_name
+        assert ("某人坐在电脑前" in system_prompt) == (not expect_name)
+        assert "待识别 track" in main_text
+        assert "<gallery>" not in main_text
+        assert self._NO_MATCH_MARKER in system_prompt
+
+    def test_named_roster_in_second_packet_keeps_named_example(self):
+        first, second = _video_route_packet(), _video_route_packet()
+        first.targets[0].person_id = "none"
+        second.targets[0].person_id = "pid-2"
+        second.targets[0].track_id = 2
+        system_prompt, main_text = self._build(
+            {}, [self._candidate()], packets=[first, second], label_lookup={"pid-2": "李四"},
+        )
+        assert "--- 设备 2 ---" in main_text
+        assert "已识别人物：李四" in main_text
+        assert "小明坐在电脑前" in system_prompt
+
+    def test_no_candidates_keeps_library_policy_even_with_stale_named_target(self):
+        """无候选兼容分支不随名册变化；即使输入携带已删除成员的旧标签。"""
+        system_prompt, main_text = self._build(
+            {}, [], matching_moot=True, label_lookup={"wangshihao": "张三"},
+        )
+        assert "已识别人物：张三" in main_text
+        assert "某人坐在电脑前" in system_prompt
+
+    def test_face_only_registration_after_reopen_uses_generic_example(self, tmp_path):
+        """真实持久路径：只写 face，库非空但无 body gallery，不能示范安成员名。"""
+        from miloco.perception.engine.identity.library import IdentityLibrary
+
+        root = tmp_path / "identity"
+        library = IdentityLibrary(root)
+        pid = "11111111-1111-4111-8111-111111111111"
+        assert library.add_face_only_sample(pid, np.zeros((64, 64, 3), dtype=np.uint8))
+        library.set_meta(pid, name="张三")
+
+        reopened = IdentityLibrary(root)
+        persons = reopened.list_persons()
+        assert len(persons) == 1
+        assert not persons[0].has_tier_a
+        snapshot = reopened.get_gallery_composites_for_omni()
+        assert snapshot == {}
+        packet = _video_route_packet()
+        packet.targets[0].person_id = "none"
+        packet.targets[0].track_id = 7
+        system_prompt, main_text = self._build(
+            snapshot, [self._candidate()], matching_moot=not persons,
+            packets=[packet], label_lookup={ref.person_id: ref.name for ref in persons if ref.name},
+        )
+        assert "已识别人物：无" in main_text
+        assert "待识别 track" in main_text
+        assert "<gallery>" not in main_text
+        assert self._NO_MATCH_MARKER in system_prompt
+        assert "某人坐在电脑前" in system_prompt
+        assert "小明坐在电脑前" not in system_prompt
 
 
 class TestAdaptiveResolution:


### PR DESCRIPTION
## 问题与结果

库非空但本轮没有可用成员参考图时，原实现仍下发完整 identities 匹配说明，让模型对照并不存在的 gallery。两条进入路径是 `gallery_snapshot` 为空，以及某成员 body composite 无法解析、触发整段 gallery 放弃。纯人脸注册可以持久进入第一条路径：成员目录存在，但只有 face 样本，没有 body composite。

本 PR 让 identities 说明、任务行与成员匹配示例跟随实际 gallery 渲染结果。无参考图时使用只判 `unknown/no_person` 的精简说明，并禁止从家庭档案或名册给待识别 track 安名；待识别 track 列表仍保留。

实例 B 的人名另行判断：有候选时，只有实际名册含有效姓名或 gallery 渲染成功才使用带名版，否则示范使用“某人”。例如：纯 face 注册、无已确认人物的窗口，现在同时得到“已识别人物：无”、精简 identities 说明和泛称实例 B。

## 实现

- `_prepare_gallery_entries()` 统一解析 body/face composite、执行整段放弃与人数上限；`build_fused_payload()` 在构造 SceneDescriptor 前运行一次，spec 选版与 user gallery 渲染共用结果。无图时去掉旧的“库为空”占位文本。
- `identity_match_disabled` 控制 identities spec、任务行及实例 A；`member_names_unavailable` 只控制实例 B，两者独立。无图时仍可使用名册中的既有确认姓名。
- `_roster_will_name_members()` 与 `_build_device_header()` 共用 `_iter_roster_targets()` 过滤：排除候选重审和 `suppress_as_prior`；再按既有 person_id 分类及有效 label 判断姓名，裸 UUID 不算姓名。无 bbox 的确认姓名仍可进入名册。
- **无候选兼容例外**：不运行 gallery pre-flight，实例 B 仍按库是否为空选版；库非空且名册无姓名时仍保留带名版。本 PR 未统一修改这些窗口或非 fused 路径的示例策略。
- 同步更新字段与示例注释，并澄清纯 face 注册当前不满足 gallery 对 body composite 的要求。

## 行为矩阵

| 本轮状态 | identities spec | 实例 B |
|---|---|---|
| 有候选，库空且名册无姓名 | 精简版 | 泛称 |
| 有候选，snapshot 空，名册无姓名 | 精简版 | 泛称 |
| 有候选，snapshot 空，名册有有效姓名 | 精简版 | 带名 |
| 有候选，gallery 整段放弃，名册无姓名 | 精简版 | 泛称 |
| 有候选，gallery 整段放弃，名册有有效姓名 | 精简版 | 带名 |
| 有候选，gallery 正常渲染 | 完整版 | 带名 |
| 无候选，库非空 | 不下发 identities | 带名（兼容） |
| 无候选，库空 | 不下发 identities | 泛称（兼容） |

相对本轮评审前的 `3bd17cd3`，此次补丁只改变矩阵中“snapshot 空 / gallery 放弃且名册无姓名”的两格示例选版。匹配说明、任务行、实例 A gate 和 gallery 渲染逻辑延续该版本。

## 验证

在 `c4edbb8ca5f6315b9d3c42bd26589a15740f4a4c` 对应代码上本地实跑：

```sh
python -m pytest miloco/tests/perception/engine/omni \
  miloco/tests/perception/engine/identity/test_library_v12.py \
  miloco/tests/perception/engine/identity/test_library_management.py -q
```

结果：**522 passed in 21.96s**。改动文件 `ruff check` 与 `git diff --check` 均通过。

覆盖空 snapshot / gallery 放弃的有姓名与无姓名配对、正常渲染、无候选兼容分支、重审候选、被抑制先验、缺失/空 label、pending/unknown、无 bbox 姓名、多 packet 名册，以及真实写入纯 face 样本并重新打开身份库后的 payload。新增 16 个测试用例结果，同时修正原先强制空 snapshot 使用带名版的预期。

本轮未重跑本机全量 backend 测试，CI 由 GitHub 检查提供。未进行真模型 A/B，结论限定为消除上述 prompt 矛盾，不声称已测得错认率改善。caption 姓名不会直接写回身份状态；精简 schema 是提示约束，本 PR 未新增解析层按本轮 gallery 限制成员名的校验。
