### PR TITLE
feat(miot): account-wide device online/offline state subscriptions

### DIFF
--- a/backend/miloco/src/miloco/miot/client.py
+++ b/backend/miloco/src/miloco/miot/client.py
@@ -10,7 +10,7 @@ import copy
 import json
 import logging
 import time
-from collections.abc import Callable, Coroutine
+from collections.abc import Awaitable, Callable, Coroutine
 
 from av.audio.frame import AudioFrame
 from av.video.frame import VideoFrame
@@ -30,6 +30,7 @@ from miot.types import (
     MIoTSceneChangedEvent,
     MIoTSetPropertyParam,
     MIoTUserInfo,
+    MipsConnectionError,
 )
 from pydantic_core import to_jsonable_python
 
@@ -51,6 +52,115 @@ from miloco.miot.schema import CameraImgSeq, normalize_sub_devices
 from miloco.miot.welcome_service import DeviceWelcomeService
 
 logger = logging.getLogger(__name__)
+
+
+# 三类对账(meta / device-state / scene)共享的总在飞订阅并发上限——压力落在
+# 同一条 broker 连接上,分闸会让上限变成 3×;SDK 重放侧 _REPLAY_CONCURRENCY
+# 与它限制的是同一件事,调值时两处一起改。
+_RECONCILE_CONCURRENCY = 16
+
+
+def _is_subscribable_did(did: str) -> bool:
+    """did 能否用于拼 MQTT topic:带 '/' 会打断 topic 路径与解码正则。"""
+    return "/" not in did
+
+
+async def _reconcile_subscriptions(
+    target_fn: Callable[[], set[str]],
+    subscribed: set[str],
+    sub: Callable[[str], Awaitable[None]],
+    unsub: Callable[[str], Awaitable[None]],
+    *,
+    lock: asyncio.Lock,
+    semaphore: asyncio.Semaphore,
+    generation: Callable[[], int],
+    label: str,
+    key_name: str = "did",
+) -> None:
+    """把某类订阅集合对账到 ``target_fn`` 算出的目标集。
+
+    订 ``target - subscribed``、退 ``subscribed - target``(并发上限
+    ``_RECONCILE_CONCURRENCY``);单键失败只记日志不中断。原地更新
+    ``subscribed``。
+
+    锁只保护意图集的读改写,不跨网络 I/O——整批 SUBACK 最坏要等
+    数十秒到分钟级,跨 I/O 持锁会把 unbind 抹记账和 mips 重建镜像挡在锁外:
+    - 差集在锁内计算并记下 ``generation``(纯内存,微秒级),锁随即释放;
+    - 网络 sub/unsub 在锁外并发执行,但三类对账共用一个 ``semaphore``
+      (``_RECONCILE_CONCURRENCY``),对同一条 broker 连接的总在飞 SUBSCRIBE
+      数封顶,不因三类并发而翻倍;
+    - 提交时回锁,仅当 ``generation`` 未变才把结果写回——期间若有 unbind 抹记账
+      或重建镜像改写过意图集,放弃本轮提交。这不丢一致性:被放弃轮的
+      ``to_add`` 仍在当前目标集里、``to_remove`` 仍在目标集补集里,改写方都
+      保证会触发下一轮对账,按新目标集重算后把网络侧与镜像拉回一致。
+
+    其余不变式:
+    - ``target_fn`` 在锁内求值,避免等锁期间快照过期把新绑设备当"该退订";
+    - 代次只由**作废他人在途提交**的改写方递增:unbind 抹记账、mips 重建后
+      按 SDK 真相重建镜像。本函数的提交**不**递增——三类对账并发跑,
+      任一类提交时递增会把另外两类在途的提交连带作废,一次刷新要多轮
+      才收敛;提交只做"代次没变才写回"的检查,不制造新代次;
+    - 生命周期边界的 _reset_subscription_mirrors 刻意不持锁,见该函数
+      docstring 的收敛论证;
+    - 意图集必须**原地**改集合对象(本函数在调用点捕获集合对象、之后才
+      等锁,换新对象会让排队对账写进孤儿集);
+    - 持锁期间不要调用任何 refresh_* 方法(否则可能成环)。
+    """
+    async with lock:
+        target = target_fn()
+        to_add = target - subscribed
+        to_remove = subscribed - target
+        if not to_add and not to_remove:
+            return
+        gen = generation()
+
+    async def _sub(key: str) -> str | None:
+        async with semaphore:
+            try:
+                await sub(key)
+                return key
+            except MipsConnectionError as e:
+                # broker 不可达是整批共性问题,不按 did 刷 error。
+                logger.debug("subscribe %s deferred %s=%s: %s", label, key_name, key, e)
+                return None
+            except Exception as e:
+                logger.error("subscribe %s failed %s=%s: %s", label, key_name, key, e)
+                return None
+
+    async def _unsub(key: str) -> str | None:
+        async with semaphore:
+            try:
+                await unsub(key)
+            except Exception as e:
+                logger.error("unsubscribe %s failed %s=%s: %s", label, key_name, key, e)
+            return key
+
+    added = await asyncio.gather(*(_sub(k) for k in to_add))
+    removed = await asyncio.gather(*(_unsub(k) for k in to_remove))
+
+    async with lock:
+        if generation() != gen:
+            # 意图集在飞行期间被 unbind 抹记账 / 重建镜像改写过,网络操作已按旧
+            # 差集执行;写回会覆盖新真相,放弃本轮,由下一轮对账收敛。
+            logger.info(
+                "%s subscriptions commit skipped (intent changed mid-flight)",
+                label,
+            )
+            return
+        subscribed |= {k for k in added if k}
+        subscribed -= {k for k in removed if k}
+        added_ok = [k for k in added if k]
+        removed_ok = [k for k in removed if k]
+        failed = len(to_add) - len(added_ok)
+        log = logger.warning if failed else logger.info
+        log(
+            "%s subscriptions synced: +%d -%d (total=%d, failed=%d)",
+            label,
+            len(added_ok),
+            len(removed_ok),
+            len(subscribed),
+            failed,
+        )
 
 
 def _resolve_camera_switch_iids(spec: dict) -> list[tuple[int, int]]:
@@ -102,6 +212,14 @@ class MiotProxy:
         self.init_miot_info_dict()
         self._camera_img_managers: dict[str, CameraVisionHandler] = {}
         self._token_refresh_task: asyncio.Task | None = None
+        # 后台顺带对账任务(见 _spawn_subscription_sync),deinit 时取消
+        self._background_syncs: set[asyncio.Task] = set()
+        # coalescing 状态:循环在飞期间的再次触发折叠成"补一轮"而不是新建任务。
+        # _sub_sync_running 在循环协程的 finally 里复位(与协程返回同步),不能用
+        # _background_syncs 非空代替——done_callback 是 call_soon 排队的,循环已
+        # 返回但 discard 未执行时,集合仍非空,会把新触发误折叠成没人读的 rerun。
+        self._sub_sync_rerun_requested = False
+        self._sub_sync_running = False
         # Serialize refresh_devices: multiple entries (MQTT reconnect,
         # bind-debounce, device refresh, lazy load) can fire concurrently
         # and would otherwise race on _device_info_dict / KV / diff log.
@@ -109,6 +227,17 @@ class MiotProxy:
         # 登录 / switch_home / unbind 可并发触发 refresh_cameras,加锁防
         # _camera_img_managers / SDK callback 状态竞争。
         self._refresh_cameras_lock = asyncio.Lock()
+        # 订阅意图集的读改写锁（对账 / unbind 抹记账 / 重建镜像共用）
+        self._sub_intent_lock = asyncio.Lock()
+        # 意图集代次:只有作废他人在途提交的改写方(unbind 抹记账 / mips 重建镜像)
+        # 在锁内递增;对账提交不递增、只校验代次,防止把飞行期间的改写覆盖掉
+        # (见 _reconcile_subscriptions)。
+        self._sub_intent_generation = 0
+        # 三类对账共用一个并发闸:同时刻对同一条 broker 连接的在飞 SUBSCRIBE
+        # 总数不超过 _RECONCILE_CONCURRENCY(每类自建会把上限放大成 3×)
+        self._sub_semaphore = asyncio.Semaphore(_RECONCILE_CONCURRENCY)
+        # 相机清单是否至少成功拉取过一次（区分"真没相机"与"还没加载"）
+        self._cameras_loaded = False
 
         # Save params for creating new MIoTClient instances
         self._uuid = uuid
@@ -174,19 +303,18 @@ class MiotProxy:
         # proxy intends to subscribe. Mirrors _subscribed_meta_dids but per home.
         self._subscribed_scene_home_ids: set[str] = set()
 
-        # Listener for device-level cloud online/offline state. Each event
-        # updates _camera_info_dict[did].online directly (in
-        # _on_camera_state_changed_event); this listener is the trailing
-        # reconciliation that re-fetches the authoritative cloud status once
-        # the burst settles.
+        # 上下线事件的 60s 对账防抖:事件批量落定后重拉相机状态。
+        # 非相机事件不重新武装——见 _on_device_state_changed_event。
         self._camera_state_listener = CameraStateEventListener(
             refresh_camera_online_status=self.refresh_camera_online_status
         )
         # Dids whose device/{did}/state/{online,offline} topics this proxy
         # intends to subscribe. Mirrors _subscribed_meta_dids but for cloud
         # online/offline state; drives the diff in
-        # _sync_camera_state_subscriptions.
-        self._subscribed_state_dids: set[str] = set()
+        # _sync_device_state_subscriptions. ACCOUNT-WIDE (every device,
+        # cameras included) so `device list` and `scope camera list` both
+        # reflect the push.
+        self._subscribed_device_state_dids: set[str] = set()
 
     def _build_bind_listener(self) -> BindEventListener:
         """Build a fresh BindEventListener.
@@ -240,6 +368,72 @@ class MiotProxy:
         )
         return instance
 
+    def _reset_subscription_mirrors(self) -> None:
+        """清空三个订阅意图镜像。
+
+        必须原地清空(见 _reconcile_subscriptions 的"原地改写"要求)。
+        不持锁——init/deinit 是生命周期边界,SDK 侧集合一并重置;此刻若有残留
+        对账把 did 写回这个(同一个)集合,下一轮对账会因 SDK 侧已空而算出退订、
+        自行收敛,不需要靠锁排除。
+        """
+        for mirror in (
+            self._subscribed_meta_dids,
+            self._subscribed_device_state_dids,
+            self._subscribed_scene_home_ids,
+        ):
+            mirror.clear()
+
+    def _spawn_subscription_sync(self) -> None:
+        """把顺带对账派成后台任务,移出响应路径。
+
+        锁已不跨网络 I/O(_reconcile_subscriptions 只拿微秒级临界区算差集/提交),
+        三类对账可以并发跑,互不阻塞(总在飞 SUBSCRIBE 由共享 semaphore 封顶);
+        与 refresh_devices 尾部口径一致,晚几秒完成没有语义影响。
+
+        coalescing:同一窗口内 refresh_devices / refresh_cameras /
+        refresh_camera_online_status 常各触发一次,若每次都新建任务,轮次会在同一
+        镜像快照上重叠、重复发包。这里只保留一个循环任务,在飞期间的再次触发只置
+        ``_sub_sync_rerun_requested``,由循环补一轮吸收——轮次串行后差集天然为空,
+        重复 SUBSCRIBE 从源头消失。
+        """
+
+        if self._sub_sync_running:
+            self._sub_sync_rerun_requested = True
+            return
+        self._sub_sync_running = True
+        self._sub_sync_rerun_requested = False
+        task = asyncio.create_task(self._subscription_sync_loop())
+        self._background_syncs.add(task)
+        task.add_done_callback(self._background_syncs.discard)
+
+    async def _subscription_sync_loop(self) -> None:
+        """对账循环:串行跑轮次,期间有新触发或代次被改写则补一轮再停。"""
+        labels = ("meta", "device-state", "scene")
+        try:
+            while True:
+                self._sub_sync_rerun_requested = False
+                gen_before = self._sub_intent_generation
+                results = await asyncio.gather(
+                    self._sync_meta_subscriptions(),
+                    self._sync_device_state_subscriptions(),
+                    self._sync_scene_subscriptions(),
+                    return_exceptions=True,
+                )
+                for label, r in zip(labels, results):
+                    if isinstance(r, BaseException):
+                        logger.error("%s subscription sync failed: %s", label, r)
+                # 运行期间有新的对账请求(可能算差集之后设备清单又变了),或代次被
+                # unbind/reset 改过(可能有提交被代次守卫放弃)——补一轮保证收敛,
+                # 不必等外部刷新(如 bind/unbind 的 5s 防抖)才恢复。
+                if (
+                    not self._sub_sync_rerun_requested
+                    and self._sub_intent_generation == gen_before
+                ):
+                    break
+        finally:
+            # 与协程返回同步,不留 add_done_callback 那种 call_soon 窗口。
+            self._sub_sync_running = False
+
     async def init(self):
         """Initialize MIoT proxy: create new client, init it, refresh info, start token refresh."""
         self._miot_client = self._create_miot_client()
@@ -259,13 +453,11 @@ class MiotProxy:
             refresh_scenes=self.refresh_scenes,
             welcome=self._welcome_service.welcome,
         )
-        self._subscribed_meta_dids = set()
         self._scene_listener = SceneEventListener(refresh_scenes=self.refresh_scenes)
-        self._subscribed_scene_home_ids = set()
         self._camera_state_listener = CameraStateEventListener(
             refresh_camera_online_status=self.refresh_camera_online_status
         )
-        self._subscribed_state_dids = set()
+        self._reset_subscription_mirrors()
         self._miot_client.register_user_bind_callback(self._on_user_bind_event)
         # Device meta change (rename/hr_change): refresh the list so the new
         # name/room/home propagates. Kept off the bind welcome path.
@@ -276,10 +468,14 @@ class MiotProxy:
         # directly (event-driven recovery for cameras that went stale across a
         # backend restart), plus a trailing reconciliation.
         self._miot_client.register_device_state_changed_callback(
-            self._on_camera_state_changed_event
+            self._on_device_state_changed_event
         )
         # Home scene change (rename/delete/edit): refresh the scene list.
         self._miot_client.register_scene_changed_callback(self._on_scene_changed_event)
+        # mips 实例重建后重建订阅意图镜像——见 _on_subscription_reset
+        self._miot_client.register_subscription_reset_callback(
+            self._on_subscription_reset
+        )
 
         await self._miot_client.init_async()
 
@@ -302,6 +498,15 @@ class MiotProxy:
         if self._token_refresh_task:
             self._token_refresh_task.cancel()
             self._token_refresh_task = None
+
+        # 1a. Cancel any in-flight background subscription syncs.
+        for task in list(self._background_syncs):
+            task.cancel()
+        self._background_syncs.clear()
+        self._sub_sync_rerun_requested = False
+        # 取消会经 finally 复位,但取消是异步投递的,显式复位防 deinit 之后、
+        # 取消生效之前又有刷新入口误以为循环在飞、把触发折叠掉。
+        self._sub_sync_running = False
 
         # 1b. Cancel any pending bind/rename-event debounce timers — otherwise
         # they might fire during teardown and try to call refresh_devices on a
@@ -340,9 +545,8 @@ class MiotProxy:
         self._device_info_dict = {}
         self._scene_info_dict = {}
         self._user_info = None
-        self._subscribed_meta_dids = set()
-        self._subscribed_state_dids = set()
-        self._subscribed_scene_home_ids = set()
+        self._reset_subscription_mirrors()
+        self._cameras_loaded = False
         # Welcome service survives deinit (rebuilt only in __init__), but its
         # dedup window state must reset alongside the other in-memory caches —
         # otherwise a re-bind of the same did within WELCOME_DEDUP_SEC after an
@@ -673,6 +877,8 @@ class MiotProxy:
                 cameras = copy.deepcopy(cameras)
                 # Publish before registering so callbacks resolve against the new dict.
                 self._camera_info_dict = cameras
+                # 相机列表已成功加载(放字典发布处,而非整段副作用全绿之后)
+                self._cameras_loaded = True
                 # 启动/新设备补读 awake：对当前家庭、awake 缓存里还没有的相机读一次并回填。
                 # 重启后 refresh_cameras 在感知首轮 sync 就会跑 → 镜头态从启动即热，不依赖
                 # 开面板/上下线推送；select_active 的镜头门随即可用。只补"缺失的"→ 启动读
@@ -750,9 +956,7 @@ class MiotProxy:
                         )
                         await self._camera_img_managers[camera_did].destroy()
                         del self._camera_img_managers[camera_did]
-                        logger.warning(
-                            "Camera native stream stopped: %s", camera_did
-                        )
+                        logger.warning("Camera native stream stopped: %s", camera_did)
                     except Exception as e:  # noqa: BLE001
                         logger.error(
                             "Failed to destroy camera manager %s, "
@@ -760,7 +964,8 @@ class MiotProxy:
                             camera_did,
                             e,
                         )
-                await self._sync_camera_state_subscriptions()
+                # 独立走 refresh_cameras 也顺带对账订阅,派后台任务不挡相机路径
+                self._spawn_subscription_sync()
                 return cameras
 
             except Exception as e:
@@ -768,9 +973,13 @@ class MiotProxy:
                 return None
 
     async def refresh_camera_online_status(self) -> dict[str, MIoTCameraInfo] | None:
-        """轻量刷新:重拉 SDK 相机列表、只更新 ``_camera_info_dict``(online / lan_online
+        """轻量刷新:重拉 SDK 相机列表、更新 ``_camera_info_dict``(online / lan_online
         等元数据),**不调 update_camera_info、不动解码注册 / 帧队列 / manager**——故
         完全不扰动 watch 视频流。
+
+        (别名副作用:``get_cameras_async`` 内部先 ``get_devices_async`` 重拉并原地合并
+        SDK 设备 buffer,而 ``_device_info_dict`` 与 SDK buffer 是同一对象,所以本方法
+        会**顺带**刷新 ``_device_info_dict`` 里全量设备的 online,不单是相机。)
 
         用途:``list_cameras_with_state`` 只读 ``_camera_info_dict`` 缓存,相机重新上线后
         该缓存不会自愈(云端 online 只有重拉 SDK 才更新),前端「此刻」页加载前调这个即可
@@ -783,6 +992,7 @@ class MiotProxy:
             try:
                 cameras = await self._miot_client.get_cameras_async()
                 self._camera_info_dict = copy.deepcopy(cameras)
+                self._cameras_loaded = True
             except Exception as e:
                 logger.error("Failed to refresh camera online status: %s", e)
                 return None
@@ -800,15 +1010,23 @@ class MiotProxy:
                 await self.read_cameras_awake(dids)
         except Exception as e:
             logger.warning("refresh awake cache failed: %s", e)
+        # 本方法经 get_cameras_async → get_devices_async 顺带增删了设备缓存(别名),
+        # 与 refresh_cameras 尾部同理补对账,同样派后台任务不挡响应路径。
+        self._spawn_subscription_sync()
         return self._camera_info_dict
 
     async def refresh_devices(self) -> dict[str, MIoTDeviceInfo] | None:
         async with self._refresh_devices_lock:
             try:
                 devices = await self._miot_client.get_devices_async()
+                # 故意不 deepcopy:返回的就是 SDK buffer 本体。refresh_cameras 尾部的
+                # 对账靠这个别名看到刚重拉的设备清单,改成拷贝会把新绑设备当"该退订"。
                 self._device_info_dict = devices
-                await self._sync_meta_subscriptions()
-                await self._sync_scene_subscriptions()
+                # 与 refresh_cameras / refresh_camera_online_status 同口径:对账派后台任务。
+                # 目标集合在进锁后才求值(见 _reconcile_subscriptions),晚几秒不影响正确性;
+                # 本方法挂在 /miot/home_info?refresh=true 与 /miot/refresh_miot_devices
+                # 两个 HTTP handler 上,不能被整批 SUBACK 拖住。
+                self._spawn_subscription_sync()
                 return devices
             except Exception as e:
                 logger.error("Failed to refresh devices: %s", e)
@@ -849,14 +1067,64 @@ class MiotProxy:
     # ---------------------------------------------------------------- mips
 
     async def _on_user_bind_event(self, msg: MIoTDeviceBindEvent) -> None:
-        """Forward bind/unbind push events to the dedicated listener.
+        """转发 bind/unbind 推送;bind 直接补订该 did,unbind 退订并抹记账。
 
-        The actual debounce + report logic lives in
-        ``miloco.miot.mips_listeners.BindEventListener`` — this method is a
-        thin shim so MiotProxy stays the user-bind callback target without
-        carrying the implementation.
+        bind = 设备回到账户,立即补订 state/meta(幂等:重绑时若 broker 订阅还
+        活着,SDK 的 ``did in set`` 短路直接返回、不重复发包),镜像记在订阅
+        成功之后——失败则不记录,防抖到点后的 refresh_devices 对账会照常把它
+        当 to_add 重试。unbind = 设备离开账户,锁内抹记账并递增代次(作废
+        可能把该 did 写回镜像的在途提交),锁外网络退订(best-effort)。
+        不再需要"bind 时先退订再重订":unbind 事件自己就会把订阅退掉。
         """
+
+        # 先转发:监听器武装 5s 尾沿防抖 / 欢迎播报,下面的记账与网络临界区
+        # (锁不跨网络 I/O)不会让推送处理链排队。
         await self._bind_listener.on_event(msg)
+        if not msg.did:
+            return
+
+        if msg.event == "bind":
+            # 镜像记在 SDK 确认订阅之后:失败时镜像不记录,5s 防抖后的对账会
+            # 重试;成功时 add(不递增代次——add 不会把已移除设备写回镜像,
+            # 递增反而会把并发三类对账的在途提交全部作废、白白补一轮)。
+            try:
+                await self._miot_client.sub_device_state_async(msg.did)
+            except Exception as e:
+                logger.error("sub device-state on bind failed did=%s: %s", msg.did, e)
+            else:
+                async with self._sub_intent_lock:
+                    self._subscribed_device_state_dids.add(msg.did)
+            try:
+                await self._miot_client.sub_device_meta_async(msg.did)
+            except Exception as e:
+                logger.error("sub device-meta on bind failed did=%s: %s", msg.did, e)
+            else:
+                async with self._sub_intent_lock:
+                    self._subscribed_meta_dids.add(msg.did)
+            return
+
+        if msg.event == "unbind":
+            # 抹记账在锁内(纯内存,与对账差集/提交互斥)、网络退订放锁外。
+            # 锁外安全的前提:SDK 退订从 discard 到发包无任何 await,对账插不
+            # 进来——若将来给退订加 UNSUBACK 等待,必须把这两次 unsub 挪回锁内。
+            # 代次递增让正在飞行中的对账提交自失效(见 _reconcile_subscriptions),
+            # 由防抖到点后的 refresh_devices 派出的下一轮对账按新设备清单收敛。
+            async with self._sub_intent_lock:
+                self._subscribed_device_state_dids.discard(msg.did)
+                self._subscribed_meta_dids.discard(msg.did)
+                self._sub_intent_generation += 1
+            try:
+                await self._miot_client.unsub_device_state_async(msg.did)
+            except Exception as e:
+                logger.error(
+                    "unsub device-state on unbind failed did=%s: %s", msg.did, e
+                )
+            try:
+                await self._miot_client.unsub_device_meta_async(msg.did)
+            except Exception as e:
+                logger.error(
+                    "unsub device-meta on unbind failed did=%s: %s", msg.did, e
+                )
 
     async def _on_device_meta_changed_event(self, msg: MIoTDeviceBindEvent) -> None:
         """Forward device-meta change push events to the meta listener.
@@ -872,15 +1140,12 @@ class MiotProxy:
         welcome = msg.event == "hr_change" and self._is_move_into_scope(msg)
         await self._meta_listener.on_event(msg, welcome=welcome)
 
-    async def _on_camera_state_changed_event(self, msg: MIoTDeviceStateEvent) -> None:
-        """Handle a device cloud online/offline state push.
+    async def _on_device_state_changed_event(self, msg: MIoTDeviceStateEvent) -> None:
+        """处理云端上下线推送:直接更新两份缓存的 `online`。
 
-        Updates the cached ``online`` field of the matching camera directly
-        from the event (online→True / offline→False), mirroring how
-        ``_on_lan_device_changed`` updates ``lan_online``. No cloud re-fetch
-        here — the authoritative reconciliation is deferred to the trailing
-        debounce (refresh_camera_online_status once the burst settles). Non-
-        camera devices are ignored (their state events carry no camera info).
+        末尾的相机对账防抖只在三种情况重新武装:命中相机、两份缓存都不认识、
+        相机清单从未成功加载(注意不是"缓存为空"——零相机账户加载成功是空字典,
+        按空判断会让每条灯事件永续重拉)。已知非相机设备不武装。
         """
         cam = self._camera_info_dict.get(msg.did)
         if cam is not None:
@@ -891,7 +1156,20 @@ class MiotProxy:
                 cam.online,
                 msg.event,
             )
-        await self._camera_state_listener.on_event(msg)
+        dev = self._device_info_dict.get(msg.did)
+        if dev is not None:
+            dev.online = msg.event == "online"
+            # 相机上面已打过 INFO;非相机设备按账户规模可能有上百台在反复翻转,
+            # 降到 DEBUG 免得刷掉运维日志。
+            if cam is None:
+                logger.debug(
+                    "device cloud state updated: did=%s online=%s (event=%s)",
+                    msg.did,
+                    dev.online,
+                    msg.event,
+                )
+        if cam is not None or dev is None or not self._cameras_loaded:
+            await self._camera_state_listener.on_event(msg)
 
     def _is_move_into_scope(self, msg: MIoTDeviceBindEvent) -> bool:
         """True if an hr_change moved a device into a managed home from an
@@ -918,10 +1196,10 @@ class MiotProxy:
     async def _sync_meta_subscriptions(self) -> None:
         """Reconcile per-device meta (rename/hr_change) subs to the device list.
 
-        Called at the tail of refresh_devices (under _refresh_devices_lock, so
-        the diff against _subscribed_meta_dids is race-free). New dids are
-        subscribed, removed dids unsubscribed; both run concurrently and
-        per-did failures only log — they never abort the refresh.
+        在 _spawn_subscription_sync 派出的后台任务里跑(经 refresh_devices /
+        refresh_cameras / refresh_camera_online_status 到达),不持任何刷新锁;
+        并发安全来自 _sub_intent_lock + 目标集锁内求值(见 _reconcile_subscriptions),
+        **别把 _sub_intent_lock 当多余的双重加锁删掉**。
 
         ACCOUNT-WIDE ON PURPOSE — do NOT scope-filter this by managed home.
         A device sitting in an out-of-scope home must already be subscribed so
@@ -931,100 +1209,66 @@ class MiotProxy:
         subscription. (Scene subs differ — they ARE scoped, since a scene has
         no move-into-scope analogue; see _sync_scene_subscriptions.)
 
-        Dids containing '/' (Huami/Zepp-bridged sub-devices, e.g.
-        ``huami.32098/12264203``) are skipped: the '/' breaks the topic path
-        AND the decoder regex, and the broker has no pub/sub ACL for them
-        anyway — every such subscribe is rejected with 0x87 Not authorized.
+        Dids containing '/' (Huami/Zepp-bridged sub-devices) are skipped:
+        the '/' breaks the topic path AND the decoder regex — see
+        _is_subscribable_did. (An older note here claimed 0x87 rejection; that
+        is UNVERIFIED, same origin as the disproven blt.* observation.)
         """
-        target = {did for did in self._device_info_dict if "/" not in did}
-        skipped = [did for did in self._device_info_dict if "/" in did]
+        skipped = [
+            did for did in self._device_info_dict if not _is_subscribable_did(did)
+        ]
         if skipped:
             logger.debug(
                 "device-meta: skipping %d did(s) with '/': %s", len(skipped), skipped
             )
-        to_add = target - self._subscribed_meta_dids
-        to_remove = self._subscribed_meta_dids - target
-        if not to_add and not to_remove:
-            return
-
-        async def _sub(did: str) -> str | None:
-            try:
-                await self._miot_client.sub_device_meta_async(did)
-                return did
-            except Exception as e:
-                logger.error("subscribe device-meta failed did=%s: %s", did, e)
-                return None
-
-        async def _unsub(did: str) -> str | None:
-            try:
-                await self._miot_client.unsub_device_meta_async(did)
-            except Exception as e:
-                logger.error("unsubscribe device-meta failed did=%s: %s", did, e)
-            return did
-
-        added = await asyncio.gather(*(_sub(d) for d in to_add))
-        removed = await asyncio.gather(*(_unsub(d) for d in to_remove))
-        self._subscribed_meta_dids |= {d for d in added if d}
-        self._subscribed_meta_dids -= {d for d in removed if d}
-        logger.info(
-            "device-meta subscriptions synced: +%d -%d (total=%d)",
-            len([d for d in added if d]),
-            len([d for d in removed if d]),
-            len(self._subscribed_meta_dids),
+        await _reconcile_subscriptions(
+            lambda: {
+                did for did in self._device_info_dict if _is_subscribable_did(did)
+            },
+            self._subscribed_meta_dids,
+            self._miot_client.sub_device_meta_async,
+            self._miot_client.unsub_device_meta_async,
+            lock=self._sub_intent_lock,
+            semaphore=self._sub_semaphore,
+            generation=lambda: self._sub_intent_generation,
+            label="device-meta",
         )
 
-    async def _sync_camera_state_subscriptions(self) -> None:
+    async def _sync_device_state_subscriptions(self) -> None:
         """Reconcile per-device cloud state (online/offline) subs to the
-        camera list.
+        device list.
 
-        Called at the tail of refresh_cameras (under _refresh_cameras_lock, so
-        the diff against _subscribed_state_dids is race-free). New dids are
-        subscribed, removed dids unsubscribed; both run concurrently and
-        per-did failures only log — they never abort the refresh. Mirrors
-        _sync_meta_subscriptions but scoped to cameras (we only care about
-        camera cloud online state).
+        在 _spawn_subscription_sync 派出的后台任务里跑——经 refresh_devices、
+        refresh_cameras 和 refresh_camera_online_status(60s 防抖的落点)到达,
+        不持任何刷新锁;并发安全见 _sync_meta_subscriptions。ACCOUNT-WIDE:
+        every device's online state surfaces in `device list` (cameras included).
 
         Dids containing '/' (Huami/Zepp-bridged sub-devices) are skipped:
-        the '/' breaks the topic path AND the decoder regex, and the broker
-        rejects them with 0x87 — same rationale as _sync_meta_subscriptions.
+        the '/' breaks the topic path AND the decoder regex. `blt.*` /
+        `proxy.*` gateway children are NOT excluded — their state subscribes
+        are SUBACK 0x00 (a live probe; the earlier 0x87 was a broken-instance
+        artifact), so subscribe them.
         """
-        target = {did for did in self._camera_info_dict if "/" not in did}
-        skipped = [did for did in self._camera_info_dict if "/" in did]
+        skipped = [
+            did for did in self._device_info_dict if not _is_subscribable_did(did)
+        ]
         if skipped:
             logger.debug(
-                "camera-state: skipping %d did(s) with '/': %s",
+                "device-online-state: skipping %d did(s) with '/': %s",
                 len(skipped),
                 skipped,
             )
-        to_add = target - self._subscribed_state_dids
-        to_remove = self._subscribed_state_dids - target
-        if not to_add and not to_remove:
-            return
-
-        async def _sub(did: str) -> str | None:
-            try:
-                await self._miot_client.sub_device_state_async(did)
-                return did
-            except Exception as e:
-                logger.error("subscribe device-state failed did=%s: %s", did, e)
-                return None
-
-        async def _unsub(did: str) -> str | None:
-            try:
-                await self._miot_client.unsub_device_state_async(did)
-            except Exception as e:
-                logger.error("unsubscribe device-state failed did=%s: %s", did, e)
-            return did
-
-        added = await asyncio.gather(*(_sub(d) for d in to_add))
-        removed = await asyncio.gather(*(_unsub(d) for d in to_remove))
-        self._subscribed_state_dids |= {d for d in added if d}
-        self._subscribed_state_dids -= {d for d in removed if d}
-        logger.info(
-            "camera-state subscriptions synced: +%d -%d (total=%d)",
-            len([d for d in added if d]),
-            len([d for d in removed if d]),
-            len(self._subscribed_state_dids),
+        await _reconcile_subscriptions(
+            lambda: {
+                did for did in self._device_info_dict if _is_subscribable_did(did)
+            },
+            self._subscribed_device_state_dids,
+            self._miot_client.sub_device_state_async,
+            self._miot_client.unsub_device_state_async,
+            lock=self._sub_intent_lock,
+            semaphore=self._sub_semaphore,
+            generation=lambda: self._sub_intent_generation,
+            label="device-online-state",
         )
 
     async def _on_scene_changed_event(self, msg: MIoTSceneChangedEvent) -> None:
@@ -1036,15 +1280,33 @@ class MiotProxy:
         """
         await self._scene_listener.on_event(msg)
 
+    async def _on_subscription_reset(
+        self, meta_dids: set, state_dids: set, scene_home_ids: set
+    ) -> None:
+        """mips 实例重建后,把本层意图镜像重建为 SDK 重放后的集合(原地改写,见
+        _reconcile_subscriptions 的原地要求)。代次递增使飞行中对账的提交自失效,
+        由重建后必然触发的下一轮对账重订。由 SDK 在三个重放块之后调用。"""
+        async with self._sub_intent_lock:
+            for mirror, truth in (
+                (self._subscribed_meta_dids, meta_dids),
+                (self._subscribed_device_state_dids, state_dids),
+                (self._subscribed_scene_home_ids, scene_home_ids),
+            ):
+                mirror.clear()
+                mirror.update(truth)
+            self._sub_intent_generation += 1
+            logger.info("subscription intent rebuilt from SDK post-replay state")
+
     def _collect_home_ids(self) -> set[str]:
         """Union of home_ids across cached devices / cameras / scenes.
 
-        Reads each cache as of its last refresh, and is only called from
-        refresh_devices — so the device cache is always current while the
-        camera / scene caches reflect their previous refresh. A home appearing
-        ONLY in a not-yet-refreshed camera/scene cache is thus picked up one
-        device refresh late; in practice every home has devices, so the union
-        covers them immediately, without an extra homes HTTP call.
+        Reads each cache as of its last refresh. Called from the background
+        reconcile loop, which is spawned by refresh_devices, refresh_cameras
+        AND refresh_camera_online_status — so which cache is current depends
+        on the entry point; the others reflect their previous refresh. A home
+        appearing ONLY in a not-yet-refreshed cache is thus picked up one
+        refresh late; in practice every home has devices, so the union covers
+        them immediately, without an extra homes HTTP call.
 
         Returns the FULL set (no scope filter); the managed-home scoping is the
         caller's job — _sync_scene_subscriptions applies the whitelist.
@@ -1064,10 +1326,9 @@ class MiotProxy:
     async def _sync_scene_subscriptions(self) -> None:
         """Reconcile per-home scene subs to the current home set.
 
-        Called at the tail of refresh_devices (under _refresh_devices_lock, so
-        the diff against _subscribed_scene_home_ids is race-free). New homes
-        are subscribed, removed homes unsubscribed; both run concurrently and
-        per-home failures only log — they never abort the refresh.
+        在 _spawn_subscription_sync 派出的后台任务里跑,不持刷新锁;与
+        _subscribed_scene_home_ids 的差集由 _sub_intent_lock 串行化、目标集锁内
+        求值(见 _reconcile_subscriptions)。
 
         Scoped to managed homes only: a scene in an out-of-scope home is
         irrelevant and has no move-into-scope analogue (unlike device-meta,
@@ -1075,38 +1336,18 @@ class MiotProxy:
         A home leaving scope therefore drops out of ``target`` and gets
         unsubscribed on the next sync.
         """
-        target = {
-            h for h in self._collect_home_ids() if is_home_allowed(self._kv_repo, h)
-        }
-        to_add = target - self._subscribed_scene_home_ids
-        to_remove = self._subscribed_scene_home_ids - target
-        if not to_add and not to_remove:
-            return
-
-        async def _sub(home_id: str) -> str | None:
-            try:
-                await self._miot_client.sub_home_scene_async(home_id)
-                return home_id
-            except Exception as e:
-                logger.error("subscribe home-scene failed home=%s: %s", home_id, e)
-                return None
-
-        async def _unsub(home_id: str) -> str | None:
-            try:
-                await self._miot_client.unsub_home_scene_async(home_id)
-            except Exception as e:
-                logger.error("unsubscribe home-scene failed home=%s: %s", home_id, e)
-            return home_id
-
-        added = await asyncio.gather(*(_sub(h) for h in to_add))
-        removed = await asyncio.gather(*(_unsub(h) for h in to_remove))
-        self._subscribed_scene_home_ids |= {h for h in added if h}
-        self._subscribed_scene_home_ids -= {h for h in removed if h}
-        logger.info(
-            "home-scene subscriptions synced: +%d -%d (total=%d)",
-            len([h for h in added if h]),
-            len([h for h in removed if h]),
-            len(self._subscribed_scene_home_ids),
+        await _reconcile_subscriptions(
+            lambda: {
+                h for h in self._collect_home_ids() if is_home_allowed(self._kv_repo, h)
+            },
+            self._subscribed_scene_home_ids,
+            self._miot_client.sub_home_scene_async,
+            self._miot_client.unsub_home_scene_async,
+            lock=self._sub_intent_lock,
+            semaphore=self._sub_semaphore,
+            generation=lambda: self._sub_intent_generation,
+            label="home-scene",
+            key_name="home",
         )
 
     def get_mips_status(self) -> dict:
@@ -1349,7 +1590,9 @@ class MiotProxy:
             # 它**不是**用来顶替错序映射的，错序请走上面的 per-model 配置路径。
             ch_iids: dict[int, list[tuple[int, int]]] = {}
             if channel_count > 1 and len(switch_iids) >= channel_count:
-                per_lens = sorted(switch_iids)[-channel_count:]  # 最高 cc 个、已按 siid 升序
+                per_lens = sorted(switch_iids)[
+                    -channel_count:
+                ]  # 最高 cc 个、已按 siid 升序
                 for ch in range(channel_count):
                     ch_iids[ch] = [per_lens[ch]]
             else:

--- a/backend/miloco/src/miloco/miot/mips_listeners.py
+++ b/backend/miloco/src/miloco/miot/mips_listeners.py
@@ -1,16 +1,18 @@
 # Copyright (C) 2025 Xiaomi Corporation
 # This software may be used and distributed according to the terms of the Xiaomi Miloco License Agreement.
 
-"""MIPS push-event listeners (bind / device-meta / scene).
+"""MIPS push-event listeners (bind / device-meta / scene / camera-state).
 
-All three share one shape: a trailing-edge debounce that, once it settles,
+All four share one shape: a trailing-edge debounce that, once it settles,
 refreshes the authoritative cloud state and acts on it. They differ only in:
 
-  * the debounce KEY — bind debounces per-did (independent timers); meta and
-    scene use a single global timer (any event refreshes the whole list);
+  * the debounce KEY — bind debounces per-did (independent timers); meta,
+    scene and camera-state use a single global timer (any event refreshes the
+    whole list);
   * the settled ACTION — bind decides bind-vs-unbind and delegates the
     greeting; meta refreshes devices+cameras+scenes (and greets move-ins);
-    scene refreshes the scene list.
+    scene refreshes the scene list; camera-state re-fetches the camera online
+    status.
 
 The shared debounce skeleton lives in ``_TrailingDebounce``; each listener is
 a thin subclass. The welcome ACTION itself lives in
@@ -52,7 +54,8 @@ SCENE_DEBOUNCE_SEC: float = 5.0
 # via _schedule).
 CAMERA_STATE_DEBOUNCE_SEC: float = 60.0
 
-# Single key used by the global (non-per-did) debouncers (meta / scene).
+# Single key used by the global (non-per-did) debouncers (meta / scene /
+# camera-state).
 _GLOBAL_KEY = "_global"
 
 
@@ -357,15 +360,10 @@ class SceneEventListener(_TrailingDebounce):
 
 
 class CameraStateEventListener(_TrailingDebounce):
-    """Global debounce for `device/{did}/state/{online,offline}`.
+    """`device/{did}/state/*` 事件的全局防抖,批量落定后重拉相机状态。
 
-    Each state event already updated the cached `online` field directly (in
-    MiotProxy._on_camera_state_changed_event) — this listener is the trailing
-    reconciliation: once the burst settles it re-fetches the authoritative
-    cloud camera status once, so a missed or stale event can't strand a
-    camera. refresh_camera_online_status is lightweight (metadata only, no
-    stream disturbance). Any state event (any did) re-arms the single global
-    timer.
+    Camera 事件总能重新武装;非相机事件也会到达(proxy 只拦能确定非相机的),
+    别假定 msg.did 一定是相机。
     """
 
     def __init__(

--- a/backend/miloco/tests/test_camera_state_subscriptions.py
+++ b/backend/miloco/tests/test_camera_state_subscriptions.py
@@ -5,15 +5,20 @@
 
 Behavior under test:
 
-* _sync_camera_state_subscriptions reconciles the per-camera cloud state
-  (online/offline) subscription set to the camera list: new dids subscribed,
-  removed dids unsubscribed, tracked set updated.
+* _sync_device_state_subscriptions reconciles the ACCOUNT-WIDE cloud state
+  subscription set to the device list (cameras + non-camera devices): new
+  dids subscribed, removed dids unsubscribed, tracked set updated.
 * A no-op sync issues no sub/unsub calls.
 * A subscribe failure does not record the did as subscribed (so a later
   refresh retries it).
-* _on_camera_state_changed_event updates _camera_info_dict[did].online
-  directly from the event (online→True / offline→False) and forwards to the
-  trailing-reconciliation listener. Non-camera devices are ignored.
+* _on_device_state_changed_event updates _camera_info_dict[did].online and
+  _device_info_dict[did].online directly from the event (online→True /
+  offline→False). The trailing camera reconciliation debounce is re-armed
+  for camera hits, for dids unknown to both caches, and while the camera
+  list has never loaded successfully (self-heal, tracked by _cameras_loaded
+  — NOT "the cache is empty": a zero-camera account loads successfully into
+  an empty dict); known non-camera devices whose camera list HAS loaded do
+  not re-arm it.
 
 A bare MiotProxy is built via __new__ with only the attributes these methods
 touch, so no MIoTClient / camera / OAuth stack is required.
@@ -21,18 +26,27 @@ touch, so no MIoTClient / camera / OAuth stack is required.
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
-from miloco.miot.client import MiotProxy
+from miloco.miot.client import _RECONCILE_CONCURRENCY, MiotProxy
 from miot.types import MIoTDeviceStateEvent
 
 
 def _bare_proxy() -> MiotProxy:
     proxy = MiotProxy.__new__(MiotProxy)
-    proxy._subscribed_state_dids = set()
+    proxy._subscribed_device_state_dids = set()
     proxy._camera_info_dict = {}
+    proxy._device_info_dict = {}
+    proxy._sub_intent_lock = asyncio.Lock()
+    proxy._sub_intent_generation = 0
+    proxy._sub_semaphore = asyncio.Semaphore(_RECONCILE_CONCURRENCY)
+    proxy._cameras_loaded = False
+    proxy._background_syncs = set()
+    proxy._sub_sync_rerun_requested = False
+    proxy._sub_sync_running = False
     proxy._miot_client = AsyncMock()
     proxy._camera_state_listener = SimpleNamespace(on_event=AsyncMock())
     return proxy
@@ -42,74 +56,93 @@ def _cam(did: str, online: bool = False) -> SimpleNamespace:
     return SimpleNamespace(did=did, online=online)
 
 
+def _dev(did: str, online: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(did=did, online=online)
+
+
 def _state_evt(did: str, event: str = "online") -> MIoTDeviceStateEvent:
     return MIoTDeviceStateEvent(
         did=did, event=event, raw={"device_id": did, "event": event}
     )
 
 
-# ----------------------------------------------------- _sync_camera_state_subscriptions
+# ----------------------------------------- _sync_device_state_subscriptions
 
 
 @pytest.mark.asyncio
-async def test_sync_subscribes_new_and_unsubscribes_removed():
+async def test_sync_device_state_subscribes_new_and_unsubscribes_removed():
     proxy = _bare_proxy()
-    # Already subscribed to A and B; camera list now has B and C.
-    proxy._subscribed_state_dids = {"A", "B"}
-    proxy._camera_info_dict = {"B": _cam("B"), "C": _cam("C")}
+    # Already subscribed to A and B; device list now has B and C.
+    proxy._subscribed_device_state_dids = {"A", "B"}
+    proxy._device_info_dict = {"B": _dev("B"), "C": _dev("C")}
 
-    await proxy._sync_camera_state_subscriptions()
+    await proxy._sync_device_state_subscriptions()
 
     proxy._miot_client.sub_device_state_async.assert_awaited_once_with("C")
     proxy._miot_client.unsub_device_state_async.assert_awaited_once_with("A")
-    assert proxy._subscribed_state_dids == {"B", "C"}
+    assert proxy._subscribed_device_state_dids == {"B", "C"}
 
 
 @pytest.mark.asyncio
-async def test_sync_skips_dids_containing_slash():
-    """Bridged sub-device dids with '/' are never subscribed — the '/' breaks
-    the topic and the broker rejects them (same rationale as meta subs)."""
+async def test_sync_device_state_subscribes_all_devices_not_just_cameras():
+    """The account-wide state sync covers every device, cameras + gateway
+    children (blt.*/proxy.*) included; only '/' bridged dids are skipped.
+    Gateway children are NOT excluded — a live probe showed their state
+    subscribes return SUBACK 0x00 (the earlier 0x87 was a broken-instance
+    artifact)."""
     proxy = _bare_proxy()
-    proxy._camera_info_dict = {
-        "938000855": _cam("938000855"),
-        "huami.32098/12264203": _cam("huami.32098/12264203"),
+    proxy._device_info_dict = {
+        "lamp-1": _dev("lamp-1"),
+        "cam-1": _dev("cam-1"),
+        "huami.32098/12264203": _dev("huami.32098/12264203"),
+        "blt.3.1pku383ht8o00": _dev("blt.3.1pku383ht8o00"),
+        "proxy.foo.1": _dev("proxy.foo.1"),
     }
 
-    await proxy._sync_camera_state_subscriptions()
+    await proxy._sync_device_state_subscriptions()
 
-    proxy._miot_client.sub_device_state_async.assert_awaited_once_with("938000855")
-    assert proxy._subscribed_state_dids == {"938000855"}
+    assert proxy._miot_client.sub_device_state_async.await_count == 4
+    proxy._miot_client.sub_device_state_async.assert_any_await("lamp-1")
+    proxy._miot_client.sub_device_state_async.assert_any_await("cam-1")
+    proxy._miot_client.sub_device_state_async.assert_any_await("blt.3.1pku383ht8o00")
+    proxy._miot_client.sub_device_state_async.assert_any_await("proxy.foo.1")
+    assert proxy._subscribed_device_state_dids == {
+        "lamp-1",
+        "cam-1",
+        "blt.3.1pku383ht8o00",
+        "proxy.foo.1",
+    }
 
 
 @pytest.mark.asyncio
-async def test_sync_noop_when_already_in_sync():
+async def test_sync_device_state_noop_when_already_in_sync():
+    """When the subscribed set already matches the device list, the sync is a
+    no-op — no subscribe/unsubscribe calls at all (locks the shared
+    _reconcile_subscriptions early-return)."""
     proxy = _bare_proxy()
-    proxy._subscribed_state_dids = {"A", "B"}
-    proxy._camera_info_dict = {"A": _cam("A"), "B": _cam("B")}
+    proxy._subscribed_device_state_dids = {"A", "B"}
+    proxy._device_info_dict = {"A": _dev("A"), "B": _dev("B")}
 
-    await proxy._sync_camera_state_subscriptions()
+    await proxy._sync_device_state_subscriptions()
 
     proxy._miot_client.sub_device_state_async.assert_not_awaited()
     proxy._miot_client.unsub_device_state_async.assert_not_awaited()
-    assert proxy._subscribed_state_dids == {"A", "B"}
 
 
 @pytest.mark.asyncio
-async def test_sync_subscribe_failure_keeps_did_untracked():
+async def test_sync_device_state_subscribe_failure_keeps_did_untracked():
     proxy = _bare_proxy()
-    proxy._camera_info_dict = {"C": _cam("C")}
+    proxy._device_info_dict = {"lamp-1": _dev("lamp-1")}
     proxy._miot_client.sub_device_state_async = AsyncMock(
         side_effect=RuntimeError("ACL rejected")
     )
 
-    # Must not raise — failure only logs.
-    await proxy._sync_camera_state_subscriptions()
+    await proxy._sync_device_state_subscriptions()
 
-    # Failed subscribe must not be recorded as subscribed.
-    assert proxy._subscribed_state_dids == set()
+    assert proxy._subscribed_device_state_dids == set()
 
 
-# ----------------------------------------- _on_camera_state_changed_event
+# ----------------------------------------- _on_device_state_changed_event
 
 
 @pytest.mark.asyncio
@@ -117,7 +150,7 @@ async def test_online_event_sets_camera_online_true():
     proxy = _bare_proxy()
     proxy._camera_info_dict = {"cam-1": _cam("cam-1", online=False)}
 
-    await proxy._on_camera_state_changed_event(_state_evt("cam-1", "online"))
+    await proxy._on_device_state_changed_event(_state_evt("cam-1", "online"))
 
     assert proxy._camera_info_dict["cam-1"].online is True
     proxy._camera_state_listener.on_event.assert_awaited_once()
@@ -128,23 +161,240 @@ async def test_offline_event_sets_camera_online_false():
     proxy = _bare_proxy()
     proxy._camera_info_dict = {"cam-1": _cam("cam-1", online=True)}
 
-    await proxy._on_camera_state_changed_event(_state_evt("cam-1", "offline"))
+    await proxy._on_device_state_changed_event(_state_evt("cam-1", "offline"))
 
     assert proxy._camera_info_dict["cam-1"].online is False
     proxy._camera_state_listener.on_event.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_state_event_for_unknown_did_is_ignored():
-    """A state event for a device that is not a camera (or not yet cached)
-    must not raise and must still forward to the reconciliation listener —
-    the burst itself may warrant a reconciliation even if this did is a no-op
-    for the camera cache."""
+async def test_state_event_for_unknown_did_rearms_reconciliation():
+    """A state event for a did in neither cache must not raise or touch either
+    cache, but DOES re-arm the camera reconciliation debounce — it may be a
+    camera the camera cache hasn't picked up yet (stale/empty restart case),
+    and the debounce is the self-heal that rebuilds the cache."""
     proxy = _bare_proxy()
     proxy._camera_info_dict = {"cam-1": _cam("cam-1", online=False)}
 
-    await proxy._on_camera_state_changed_event(_state_evt("non-camera", "online"))
+    await proxy._on_device_state_changed_event(_state_evt("unknown-did", "online"))
 
     # cam-1 untouched.
     assert proxy._camera_info_dict["cam-1"].online is False
     proxy._camera_state_listener.on_event.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_offline_event_sets_device_online_false():
+    """A known non-camera device's offline event updates _device_info_dict so
+    `device list` reflects it immediately, and does NOT re-arm the camera
+    reconciliation debounce (camera list loaded non-empty, lamp not in it)."""
+    proxy = _bare_proxy()
+    proxy._cameras_loaded = True
+    proxy._camera_info_dict = {"cam-1": _cam("cam-1")}
+    proxy._device_info_dict = {"lamp-1": _dev("lamp-1", online=True)}
+
+    await proxy._on_device_state_changed_event(_state_evt("lamp-1", "offline"))
+
+    assert proxy._device_info_dict["lamp-1"].online is False
+    proxy._camera_state_listener.on_event.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_state_event_rearms_until_camera_list_loaded():
+    """While the camera list has never loaded successfully (refresh_cameras
+    failed at startup), even a known device's state event must re-arm the
+    reconciliation — otherwise the only self-heal path for the camera list
+    never runs. Once loaded (even to an empty dict for a camera-less
+    account), the re-arming stops for known non-cameras."""
+    proxy = _bare_proxy()
+    proxy._device_info_dict = {"lamp-1": _dev("lamp-1", online=True)}
+
+    await proxy._on_device_state_changed_event(_state_evt("lamp-1", "offline"))
+
+    assert proxy._device_info_dict["lamp-1"].online is False
+    proxy._camera_state_listener.on_event.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_camera_event_also_updates_device_cache():
+    """A camera lives in BOTH caches; the device cache must follow the event
+    too, or `device list` would keep showing a stale online for it."""
+    proxy = _bare_proxy()
+    proxy._camera_info_dict = {"cam-1": _cam("cam-1", online=True)}
+    proxy._device_info_dict = {"cam-1": _dev("cam-1", online=True)}
+
+    await proxy._on_device_state_changed_event(_state_evt("cam-1", "offline"))
+
+    assert proxy._camera_info_dict["cam-1"].online is False
+    assert proxy._device_info_dict["cam-1"].online is False
+
+
+# ------------------------------------------- refresh_devices wiring
+
+
+@pytest.mark.asyncio
+async def test_refresh_devices_invokes_device_state_sync():
+    """refresh_devices must wire in the account-wide state subscription — not
+    just leave _sync_device_state_subscriptions as an uncalled helper."""
+    proxy = _bare_proxy()
+    proxy._refresh_devices_lock = asyncio.Lock()
+    proxy._miot_client.get_devices_async = AsyncMock(
+        return_value={"lamp-1": _dev("lamp-1")}
+    )
+    # Stub the sibling syncs so the wiring under test is isolated.
+    proxy._sync_meta_subscriptions = AsyncMock()
+    proxy._sync_scene_subscriptions = AsyncMock()
+
+    await proxy.refresh_devices()
+    await asyncio.gather(*list(proxy._background_syncs))
+
+    proxy._miot_client.sub_device_state_async.assert_awaited_once_with("lamp-1")
+
+
+@pytest.mark.asyncio
+async def test_refresh_cameras_also_syncs_device_state(monkeypatch):
+    """Standalone refresh_cameras (not refresh_devices) must also reconcile
+    state subscriptions — otherwise /refresh_miot_cameras & friends leave a
+    newly-bound camera late-subscribed / a removed camera leaked."""
+    proxy = _bare_proxy()
+    proxy._refresh_cameras_lock = asyncio.Lock()
+    proxy._camera_img_managers = {}
+    proxy._camera_awake_cache = {}
+    proxy._kv_repo = SimpleNamespace()
+    proxy._miot_client.get_cameras_async = AsyncMock(return_value={})
+    # The real _sync_device_state_subscriptions reads _device_info_dict; set it
+    # so the assertion below proves refresh_cameras actually invoked the sync.
+    proxy._device_info_dict = {"cam-1": _dev("cam-1")}
+    # refresh_cameras spawns the sync as a BACKGROUND task; stub the sibling
+    # syncs and await the spawned task below.
+    proxy._sync_meta_subscriptions = AsyncMock()
+    proxy._sync_scene_subscriptions = AsyncMock()
+    # Skip the streaming-set selection (KV / home / blacklist heavy).
+    monkeypatch.setattr(
+        "miloco.miot.client.select_active_camera_dids", lambda *a, **k: []
+    )
+
+    await proxy.refresh_cameras()
+    await asyncio.gather(*list(proxy._background_syncs))
+
+    proxy._miot_client.sub_device_state_async.assert_awaited_once_with("cam-1")
+
+
+@pytest.mark.asyncio
+async def test_refresh_camera_online_status_spawns_subscription_sync():
+    """refresh_camera_online_status must also reconcile state subscriptions —
+    it's the self-heal path that picks up a reconcile dropped in the sync-loop
+    teardown window; without it a freshly-bound device's online/offline pushes
+    stay silent until the next device/camera list load."""
+    proxy = _bare_proxy()
+    proxy._refresh_cameras_lock = asyncio.Lock()
+    proxy._camera_awake_cache = {}
+    # 相机不带 home_id → is_home_allowed 短路为 False,read_cameras_awake 不会
+    # 被调,测试聚焦在尾部派对账这一句。
+    proxy._kv_repo = SimpleNamespace(get=lambda key, default=None: None)
+    proxy._device_info_dict = {"cam-1": _dev("cam-1")}
+    proxy._miot_client.get_cameras_async = AsyncMock(
+        return_value={"cam-1": _cam("cam-1")}
+    )
+    proxy._sync_meta_subscriptions = AsyncMock()
+    proxy._sync_scene_subscriptions = AsyncMock()
+
+    await proxy.refresh_camera_online_status()
+    await asyncio.gather(*list(proxy._background_syncs))
+
+    proxy._miot_client.sub_device_state_async.assert_awaited_once_with("cam-1")
+
+
+@pytest.mark.asyncio
+async def test_refresh_cameras_state_sync_sees_sdk_device_buffer(monkeypatch):
+    """refresh_cameras' trailing state sync must see devices merged in-place
+    into the SDK buffer by get_cameras_async — i.e. _device_info_dict must be
+    the SAME object as the buffer, not a frozen snapshot. If someone changed
+    `self._device_info_dict = devices` to a deepcopy, a device bound between
+    refresh_devices and refresh_cameras would be treated as "should unsub"."""
+    proxy = _bare_proxy()
+    proxy._refresh_devices_lock = asyncio.Lock()
+    proxy._refresh_cameras_lock = asyncio.Lock()
+    proxy._camera_img_managers = {}
+    proxy._camera_awake_cache = {}
+    proxy._kv_repo = SimpleNamespace()
+    buffer: dict = {}
+    proxy._miot_client.get_devices_async = AsyncMock(return_value=buffer)
+    proxy._sync_meta_subscriptions = AsyncMock()
+    proxy._sync_scene_subscriptions = AsyncMock()
+
+    async def _get_cameras():
+        # Mimic the SDK: get_cameras_async internally runs get_devices_async,
+        # which merges newly-bound devices into the SAME buffer object.
+        buffer["lamp-2"] = _dev("lamp-2")
+        return {}
+
+    proxy._miot_client.get_cameras_async = AsyncMock(side_effect=_get_cameras)
+    monkeypatch.setattr(
+        "miloco.miot.client.select_active_camera_dids", lambda *a, **k: []
+    )
+
+    await proxy.refresh_devices()  # binds _device_info_dict to the buffer
+    await proxy.refresh_cameras()  # this sync must see lamp-2
+    await asyncio.gather(*list(proxy._background_syncs))
+
+    proxy._miot_client.sub_device_state_async.assert_any_await("lamp-2")
+
+
+@pytest.mark.asyncio
+async def test_spawn_subscription_sync_coalesces_overlapping_spawns():
+    """同一窗口内多次 _spawn_subscription_sync 只产生一个对账任务:后续触发折叠成
+    rerun 标志,由循环补一轮吸收,而不是各建一个任务(轮次重叠会重复发包)。"""
+    proxy = _bare_proxy()
+    proxy._sync_meta_subscriptions = AsyncMock()
+    proxy._sync_scene_subscriptions = AsyncMock()
+
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _controlled_state_sync() -> None:
+        started.set()
+        await release.wait()
+
+    proxy._sync_device_state_subscriptions = _controlled_state_sync
+
+    proxy._spawn_subscription_sync()
+    await started.wait()  # 第 1 轮已起飞(差集已算完),state 停在等 release
+    proxy._spawn_subscription_sync()  # 轮次飞行期间的触发 → 只置 rerun 标志
+
+    # 只建了一个任务(第二次触发没有新建)。
+    assert len(proxy._background_syncs) == 1
+
+    release.set()
+    await asyncio.gather(*list(proxy._background_syncs))
+
+    # rerun 标志让循环补跑了一轮:meta/scene 各执行两次。
+    assert proxy._sync_meta_subscriptions.await_count == 2
+    assert proxy._sync_scene_subscriptions.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_spawn_subscription_sync_after_loop_returns_reruns():
+    """循环协程已经 return、但 done_callback(discard)还排在就绪队列里没执行时
+    再次触发,必须起新一轮——不能因为 _background_syncs 还残留旧任务就把触发
+    折叠成没人读的 rerun 标志(这次对账会被静默丢掉)。"""
+    proxy = _bare_proxy()
+    proxy._sync_meta_subscriptions = AsyncMock()
+    proxy._sync_device_state_subscriptions = AsyncMock()
+    proxy._sync_scene_subscriptions = AsyncMock()
+
+    proxy._spawn_subscription_sync()
+    task = next(iter(proxy._background_syncs))
+
+    # 泵到循环任务完成:sleep(0) 的续体排在 discard 之前,所以回到这里时
+    # task.done() 已为 True 而 discard 还没执行——正是 add_done_callback 的
+    # call_soon 窗口。
+    while not task.done():
+        await asyncio.sleep(0)
+
+    proxy._spawn_subscription_sync()
+    await asyncio.gather(*list(proxy._background_syncs))
+
+    assert proxy._sync_meta_subscriptions.await_count == 2
+    assert proxy._sync_device_state_subscriptions.await_count == 2
+    assert proxy._sync_scene_subscriptions.await_count == 2

--- a/backend/miloco/tests/test_meta_subscriptions.py
+++ b/backend/miloco/tests/test_meta_subscriptions.py
@@ -18,6 +18,7 @@ touch, so no MIoTClient / camera / OAuth stack is required.
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -29,10 +30,14 @@ from miloco.miot.client import MiotProxy
 def _bare_proxy() -> MiotProxy:
     proxy = MiotProxy.__new__(MiotProxy)
     proxy._subscribed_meta_dids = set()
+    proxy._subscribed_device_state_dids = set()
     proxy._subscribed_scene_home_ids = set()
     proxy._device_info_dict = {}
     proxy._camera_info_dict = {}
     proxy._scene_info_dict = {}
+    proxy._sub_intent_lock = asyncio.Lock()
+    proxy._sub_intent_generation = 0
+    proxy._sub_semaphore = asyncio.Semaphore(client_module._RECONCILE_CONCURRENCY)
     proxy._miot_client = AsyncMock()
     proxy._kv_repo = object()  # only passed through to is_home_allowed
     return proxy
@@ -151,9 +156,7 @@ async def test_sync_scene_skips_out_of_scope_homes(monkeypatch):
     unsubscribed. Unlike device-meta (account-wide for move-into-scope),
     scene subs follow the managed-home whitelist."""
     allowed = {"H_OK"}
-    monkeypatch.setattr(
-        client_module, "is_home_allowed", lambda _kv, h: h in allowed
-    )
+    monkeypatch.setattr(client_module, "is_home_allowed", lambda _kv, h: h in allowed)
     proxy = _bare_proxy()
     # H_OLD was managed and subscribed; now only H_OK is in scope. Devices
     # span a managed (H_OK) and an out-of-scope (H_DENY) home.
@@ -169,3 +172,58 @@ async def test_sync_scene_skips_out_of_scope_homes(monkeypatch):
     proxy._miot_client.sub_home_scene_async.assert_not_awaited()
     proxy._miot_client.unsub_home_scene_async.assert_awaited_once_with("H_OLD")
     assert proxy._subscribed_scene_home_ids == {"H_OK"}
+
+
+@pytest.mark.asyncio
+async def test_reconcile_commit_skipped_when_intent_changed_mid_flight():
+    """A bind-style invalidation bumping the generation while a reconcile's
+    network round is in flight must not be clobbered by the stale commit: the
+    mirror stays as the invalidation left it, and the next round re-subscribes.
+    """
+    proxy = _bare_proxy()
+    proxy._device_info_dict = {"did-1": SimpleNamespace(did="did-1")}
+
+    started = asyncio.Event()
+    release = asyncio.Event()
+    real_sub = proxy._miot_client.sub_device_meta_async
+
+    async def _controlled_sub(did: str) -> None:
+        started.set()
+        await release.wait()
+        await real_sub(did)
+
+    proxy._miot_client.sub_device_meta_async = _controlled_sub
+
+    task = asyncio.create_task(proxy._sync_meta_subscriptions())
+    await started.wait()
+    # 模拟 unbind 抹记账:镜像移除 did-1 + 代次 +1(与 _on_user_bind_event 同型)。
+    async with proxy._sub_intent_lock:
+        proxy._subscribed_meta_dids.discard("did-1")
+        proxy._sub_intent_generation += 1
+    release.set()
+    await task
+
+    # 提交被放弃:镜像保持作废后的状态,不会把 did-1 写回。
+    assert proxy._subscribed_meta_dids == set()
+    real_sub.assert_awaited_once_with("did-1")
+
+
+@pytest.mark.asyncio
+async def test_three_syncs_share_one_sub_semaphore(monkeypatch):
+    """meta / device-state / scene 三类对账必须共用一个并发闸——否则三类并发
+    时,同一条 broker 连接上的总在飞 SUBSCRIBE 上限会变成 3×16。"""
+    captured: dict[str, asyncio.Semaphore] = {}
+
+    async def _fake_reconcile(target_fn, subscribed, sub, unsub, **kwargs):
+        captured[kwargs["label"]] = kwargs["semaphore"]
+
+    monkeypatch.setattr(client_module, "_reconcile_subscriptions", _fake_reconcile)
+    proxy = _bare_proxy()
+
+    await proxy._sync_meta_subscriptions()
+    await proxy._sync_device_state_subscriptions()
+    await proxy._sync_scene_subscriptions()
+
+    assert set(captured) == {"device-meta", "device-online-state", "home-scene"}
+    assert len({id(s) for s in captured.values()}) == 1
+    assert captured["device-meta"] is proxy._sub_semaphore

--- a/backend/miloco/tests/test_miot_proxy_lifecycle.py
+++ b/backend/miloco/tests/test_miot_proxy_lifecycle.py
@@ -77,9 +77,16 @@ def _make_client_stub():
     c.deinit_async = AsyncMock()
     c.register_user_bind_callback = MagicMock()
     c.register_mips_connect_callback = MagicMock()
+    c.register_subscription_reset_callback = MagicMock()
     c.get_devices_async = AsyncMock(return_value={})
     c.get_cameras_async = AsyncMock(return_value={})
     c.get_manual_scenes_async = AsyncMock(return_value={})
+    # bind path subscribes the device's per-device topics (state + meta),
+    # unbind path unsubscribes them; the stub must be awaitable for both.
+    c.sub_device_state_async = AsyncMock()
+    c.sub_device_meta_async = AsyncMock()
+    c.unsub_device_state_async = AsyncMock()
+    c.unsub_device_meta_async = AsyncMock()
     return c
 
 
@@ -94,7 +101,8 @@ def proxy_env(monkeypatch):
     monkeypatch.setattr(bl_module, "BIND_DEBOUNCE_SEC", 0.05)
     # The greeting goes through DeviceWelcomeService → dispatch_event.
     monkeypatch.setattr(
-        ws_module, "dispatch_event",
+        ws_module,
+        "dispatch_event",
         AsyncMock(return_value=True),
     )
 
@@ -168,6 +176,163 @@ async def test_init_after_deinit_rebuilds_bind_listener(proxy_env):
     # dispatch_event("bind", [msg_text], builder) — items list is arg[1].
     sent = ws_module.dispatch_event.await_args.args[1][0]
     assert did in sent and "新台灯" in sent
+
+    await p.deinit()
+
+
+@pytest.mark.asyncio
+async def test_bind_event_subscribes_device(proxy_env):
+    """A bind push means the device is back in the account: the handler must
+    subscribe state+meta immediately (recorded into the intent mirrors on SDK
+    success) so the trailing refresh_devices reconcile no-ops instead of
+    re-issuing — and a rebind whose broker subscription survived is an
+    idempotent no-op at the SDK."""
+    p, client = proxy_env
+
+    await p.init()
+    # 原地填充、不换集合对象,保住"记账集合只能原地改"的回归检测。
+    state_set = p._subscribed_device_state_dids
+    meta_set = p._subscribed_meta_dids
+    state_set.clear()
+    meta_set.clear()
+
+    await p._on_user_bind_event(
+        MIoTDeviceBindEvent(uid="u", event="bind", did="did-1", raw={"did": "did-1"})
+    )
+
+    assert p._subscribed_device_state_dids == {"did-1"}
+    assert p._subscribed_meta_dids == {"did-1"}
+    assert p._subscribed_device_state_dids is state_set
+    assert p._subscribed_meta_dids is meta_set
+    client.sub_device_state_async.assert_awaited_once_with("did-1")
+    client.sub_device_meta_async.assert_awaited_once_with("did-1")
+
+    await p.deinit()
+
+
+@pytest.mark.asyncio
+async def test_unbind_event_forgets_device_subscriptions(proxy_env):
+    """An unbind push means the device left the account: the handler must drop
+    the did from both intent mirrors (in-place) and unsubscribe (best-effort,
+    outside the lock) — the trailing refresh_devices reconcile then no-ops."""
+    p, client = proxy_env
+
+    await p.init()
+    # Simulate a device already subscribed, then unbound.
+    state_set = p._subscribed_device_state_dids
+    meta_set = p._subscribed_meta_dids
+    state_set.clear()
+    state_set.update({"did-1"})
+    meta_set.clear()
+    meta_set.update({"did-1"})
+
+    await p._on_user_bind_event(
+        MIoTDeviceBindEvent(uid="u", event="unbind", did="did-1", raw={"did": "did-1"})
+    )
+
+    assert p._subscribed_device_state_dids == set()
+    assert p._subscribed_meta_dids == set()
+    assert p._subscribed_device_state_dids is state_set
+    assert p._subscribed_meta_dids is meta_set
+    client.unsub_device_state_async.assert_awaited_once_with("did-1")
+    client.unsub_device_meta_async.assert_awaited_once_with("did-1")
+
+    await p.deinit()
+
+
+@pytest.mark.asyncio
+async def test_subscription_reset_rebuilds_intent_sets(proxy_env):
+    """When the SDK rebuilds its mips instance it calls the reset callback
+    AFTER replay with the post-replay tracked sets; the proxy must rebuild its
+    intent mirrors as faithful copies — so a replay-failed entity (dropped
+    from the SDK set) is retried next reconcile, and a departed entity that
+    replay re-subscribed stays removable."""
+    p, client = proxy_env
+    await p.init()
+    # init() registered the callback — capture it.
+    reset_cb = client.register_subscription_reset_callback.call_args.args[0]
+    assert reset_cb.__self__ is p
+    assert reset_cb.__func__.__name__ == "_on_subscription_reset"
+
+    # 原地填充、不换集合对象,保住"记账集合只能原地改"的回归检测。
+    meta_set = p._subscribed_meta_dids
+    state_set = p._subscribed_device_state_dids
+    scene_set = p._subscribed_scene_home_ids
+    meta_set.clear()
+    meta_set.update({"stale-1"})
+    state_set.clear()
+    state_set.update({"stale-1"})
+    scene_set.clear()
+    scene_set.update({"stale-home"})
+
+    await reset_cb({"did-1"}, {"did-1"}, {"home-9"})
+
+    assert p._subscribed_meta_dids == {"did-1"}
+    assert p._subscribed_device_state_dids == {"did-1"}
+    assert p._subscribed_scene_home_ids == {"home-9"}
+    # 原地改写不变式的真正断言:重建必须原地改,不能换新集合对象。
+    assert p._subscribed_meta_dids is meta_set
+    assert p._subscribed_device_state_dids is state_set
+    assert p._subscribed_scene_home_ids is scene_set
+
+    await p.deinit()
+
+
+@pytest.mark.asyncio
+async def test_bind_event_forwards_despite_sub_failure(proxy_env):
+    """A failed bind-triggered subscribe must only log — it must NOT abort
+    delivery to _bind_listener.on_event, or this bind's debounce/welcome
+    would never fire. The mirror stays untracked so the trailing
+    refresh_devices reconcile retries the subscribe."""
+    p, client = proxy_env
+    await p.init()
+    client.sub_device_state_async = AsyncMock(side_effect=RuntimeError("mqtt blip"))
+    client.sub_device_meta_async = AsyncMock(side_effect=RuntimeError("mqtt blip"))
+
+    await p._on_user_bind_event(
+        MIoTDeviceBindEvent(uid="u", event="bind", did="did-1", raw={"did": "did-1"})
+    )
+
+    # Both subs attempted despite raising; local bookkeeping NOT recorded
+    # (self-healing: next refresh_devices treats did-1 as to-be-subscribed).
+    client.sub_device_state_async.assert_awaited_once_with("did-1")
+    client.sub_device_meta_async.assert_awaited_once_with("did-1")
+    assert p._subscribed_device_state_dids == set()
+    assert p._subscribed_meta_dids == set()
+    # The bind debounce timer for did-1 was armed — proves on_event ran.
+    assert "did-1" in p._bind_listener._timers
+
+    await p.deinit()
+
+
+@pytest.mark.asyncio
+async def test_unbind_event_forwards_despite_unsub_failure(proxy_env):
+    """A failed unbind-triggered unsubscribe must only log — it must NOT abort
+    delivery to _bind_listener.on_event (which arms the trailing refresh /
+    final-state detection). Local bookkeeping is still cleared: the mirror
+    no longer claims the did, so nothing re-subscribes a departed device."""
+    p, client = proxy_env
+    await p.init()
+    state_set = p._subscribed_device_state_dids
+    meta_set = p._subscribed_meta_dids
+    state_set.clear()
+    state_set.update({"did-1"})
+    meta_set.clear()
+    meta_set.update({"did-1"})
+    client.unsub_device_state_async = AsyncMock(side_effect=RuntimeError("mqtt blip"))
+    client.unsub_device_meta_async = AsyncMock(side_effect=RuntimeError("mqtt blip"))
+
+    await p._on_user_bind_event(
+        MIoTDeviceBindEvent(uid="u", event="unbind", did="did-1", raw={"did": "did-1"})
+    )
+
+    # Both unsubs attempted despite raising; local bookkeeping still cleared.
+    client.unsub_device_state_async.assert_awaited_once_with("did-1")
+    client.unsub_device_meta_async.assert_awaited_once_with("did-1")
+    assert p._subscribed_device_state_dids == set()
+    assert p._subscribed_meta_dids == set()
+    # The bind debounce timer for did-1 was armed — proves on_event ran.
+    assert "did-1" in p._bind_listener._timers
 
     await p.deinit()
 

--- a/backend/miot/src/miot/client.py
+++ b/backend/miot/src/miot/client.py
@@ -8,7 +8,7 @@ MIoT Client.
 import asyncio
 import logging
 import time
-from typing import Any, Callable, Coroutine, Dict, List, Optional
+from typing import Any, Awaitable, Callable, Coroutine, Dict, List, Optional
 
 from miot.error import MIoTClientError
 from miot.spec import MIoTSpecParser
@@ -50,6 +50,42 @@ from .types import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+# 同轮刷新内重复骤降只累加一次,见 get_devices_async 的骤降守卫注释
+_DEVICE_REPLY_SHRINK_MIN_GAP_SEC = 30.0
+# 本轮返回设备数低于缓存这么多倍才视为"骤降"(单个 home 解析失败即触发)
+_DEVICE_REPLY_SHRINK_RATIO = 0.5
+# 重放并发上限。与上层对账的 _RECONCILE_CONCURRENCY 限制的是同一件事
+# (同时在飞的 SUBSCRIBE 条数,压力落在同一个 broker 连接上),调整时两处一起改。
+_REPLAY_CONCURRENCY = 16
+
+
+def _now() -> float:
+    """monotonic 时钟的模块级封装,便于测试只 patch 这一处而不冻结事件循环。"""
+    return time.monotonic()
+
+
+async def _replay_subscriptions(
+    keys: list[str],
+    subscribe: Callable[[str], Awaitable[None]],
+    label: str,
+) -> int:
+    """并发重放一批 tracked key(上限 _REPLAY_CONCURRENCY),best-effort,返回成功数。"""
+    sem = asyncio.Semaphore(_REPLAY_CONCURRENCY)
+
+    async def _one(key: str) -> bool:
+        async with sem:
+            try:
+                await subscribe(key)
+                return True
+            except Exception as e:
+                _LOGGER.warning(
+                    "mips_cloud re-subscribe %s FAILED %s: %s", label, key, e
+                )
+                return False
+
+    results = await asyncio.gather(*(_one(k) for k in keys))
+    return sum(results)
 
 
 class MIoTClient:
@@ -164,6 +200,8 @@ class MIoTClient:
         self._last_lan_ping_ts = 0
         self._callbacks_lan_device_status_changed = {}
         self._device_buffer = None
+        self._device_shrink_streak = 0
+        self._last_device_shrink_ts = 0.0
 
         # mips_cloud state
         self._mips_cloud = None
@@ -176,6 +214,9 @@ class MIoTClient:
         self._scene_sub_home_ids = set()
         self._callback_scene_changed = None
         self._callback_mips_connect: Optional[Callable[[], Any]] = None
+        self._callback_subscription_reset: Optional[
+            Callable[[set[str], set[str], set[str]], Any]
+        ] = None
 
         # Pre-declare sub-client slots so deinit_async can safely walk them
         # even if init_async aborted before creating the full set.
@@ -420,6 +461,8 @@ class MIoTClient:
             self._i18n = None  # type: ignore
             self._cameras_buffer = None
             self._device_buffer = None
+            self._device_shrink_streak = 0
+            self._last_device_shrink_ts = 0.0
             self._last_lan_ping_ts = 0
             self._callbacks_lan_device_status_changed = {}
             self._mips_cloud = None
@@ -432,6 +475,7 @@ class MIoTClient:
             self._scene_sub_home_ids = set()
             self._callback_scene_changed = None
             self._callback_mips_connect = None
+            self._callback_subscription_reset = None
             self._init_done = False
 
     async def gen_oauth_url_async(self, redirect_uri: Optional[str] = None) -> str:
@@ -554,7 +598,45 @@ class MIoTClient:
         devices: Dict[str, MIoTDeviceInfo] = await self._http_client.get_devices_async(
             home_infos=home_list, fetch_share_home=fetch_share_home
         )
-        if not self._device_buffer:
+        # 一次瞬时"骤降"(整份返空只是极端情形——单个 home 解析失败返回的是部分列表,
+        # cloud.py 对缺字段的 home 静默 continue)不该被当成"账户真的缩了":否则合并分支
+        # 把没返回的 did pop 光,对账会整批退订再重订,推送全断。连续两轮骤降才认缩;
+        # 同轮并发调用(refresh_devices + refresh_cameras)只算一次,窗口锚定本轮第一次。
+        buffered = len(self._device_buffer) if self._device_buffer else 0
+        shrank = buffered > 0 and len(devices) < buffered * _DEVICE_REPLY_SHRINK_RATIO
+        if not shrank:
+            self._device_shrink_streak = 0
+            self._last_device_shrink_ts = 0.0
+        else:
+            now = _now()
+            if now - self._last_device_shrink_ts >= _DEVICE_REPLY_SHRINK_MIN_GAP_SEC:
+                self._device_shrink_streak += 1
+                # 锚点只在开新一轮时推进,否则窗口被同 streak 内的返空续期、永不收敛
+                self._last_device_shrink_ts = now
+            if self._device_shrink_streak < 2:
+                _LOGGER.warning(
+                    "get_devices_async: cloud returned %d devices while %d are "
+                    "buffered; keeping the buffer this round (streak=%d)",
+                    len(devices),
+                    buffered,
+                    self._device_shrink_streak,
+                )
+                await self._merge_lan_status()
+                return self._device_buffer
+            # 认账:buffer 即将与云端对齐,计数器和锚点一并复位——否则紧跟着的
+            # 下一次瞬时骤降会因 streak 仍是 2 而直接穿透守卫。
+            _LOGGER.warning(
+                "get_devices_async: shrink confirmed over %d rounds, "
+                "accepting %d devices (was %d)",
+                self._device_shrink_streak,
+                len(devices),
+                buffered,
+            )
+            self._device_shrink_streak = 0
+            self._last_device_shrink_ts = 0.0
+        # 判 None 而非真值:合并会把未返回的 did pop 光,空 buffer 若被换成新对象,
+        # 上层 _device_info_dict 还指着旧对象、别名断开,对账会拿空字典算差集。
+        if self._device_buffer is None:
             self._device_buffer = devices
         else:
             # Merge cloud updates into existing buffer.
@@ -568,7 +650,15 @@ class MIoTClient:
             for did in list(devices.keys()):
                 self._device_buffer[did] = devices.pop(did)
 
-        # Merge LAN status for all buffered devices.
+        await self._merge_lan_status()
+        return self._device_buffer
+
+    async def _merge_lan_status(self) -> None:
+        """把 LAN 发现合并进 buffered 设备(lan_online / local_ip)。
+
+        正常路径与骤降守卫的提前返回共用——被守卫拦下的那轮,刚上电的相机仍应可被
+        require_lan 发现,lan_online 不能停在上一轮旧值。
+        """
         lan_devices = await self._lan_client.get_devices_async()
         for did in self._device_buffer:
             if did in lan_devices:
@@ -577,8 +667,6 @@ class MIoTClient:
             else:
                 self._device_buffer[did].lan_online = False
                 self._device_buffer[did].local_ip = None
-
-        return self._device_buffer
 
     async def get_manual_scenes_async(
         self,
@@ -772,6 +860,22 @@ class MIoTClient:
         """
         return self._mips_user_sub_error
 
+    async def _fire_subscription_reset(self) -> None:
+        """Hand the upper layer the current tracked sets so it can rebuild
+        its intent mirrors as a faithful copy of what mips actually has."""
+        if not self._callback_subscription_reset:
+            return
+        try:
+            ret = self._callback_subscription_reset(
+                self._meta_sub_dids,
+                self._state_sub_dids,
+                self._scene_sub_home_ids,
+            )
+            if asyncio.iscoroutine(ret):
+                await ret
+        except Exception as e:
+            _LOGGER.error("subscription reset callback failed: %s", e)
+
     async def _setup_mips_async(self) -> None:
         """Build (or rebuild) the mips_cloud client and attempt user-level subs.
 
@@ -818,6 +922,16 @@ class MIoTClient:
             )
             self._mips_cloud = None
             self._mips_user_sub_error = f"connect failed: {e}"
+            # 旧实例已在上面拆掉,broker 上一个订阅都不剩。若把三个 tracked 集合
+            # 原样留着,上层对账会算出 to_add = ∅、SDK 侧 `did in set` 短路也会
+            # 吞掉重试,推送要等到下一次 token 刷新重跑本方法才可能恢复(小时级)。
+            # 清空并通知上层重建镜像,下一轮 refresh_* 就能重新下发全量订阅
+            # ——此时 mips 仍不可用,sub_*_async 会抛 MipsConnectionError,
+            # 对账不记录、继续重试,直到连接恢复为止。
+            self._meta_sub_dids = set()
+            self._state_sub_dids = set()
+            self._scene_sub_home_ids = set()
+            await self._fire_subscription_reset()
             return
         self._mips_cloud = mips
         # Listen for unattended-subscribe failures (currently: subscribes
@@ -869,17 +983,9 @@ class MIoTClient:
         if self._meta_sub_dids:
             dids = sorted(self._meta_sub_dids)
             self._meta_sub_dids = set()
-            ok = 0
-            for did in dids:
-                try:
-                    await self.sub_device_meta_async(did)
-                    ok += 1
-                except Exception as e:
-                    _LOGGER.error(
-                        "mips_cloud re-subscribe device-meta FAILED did=%s: %s",
-                        did,
-                        e,
-                    )
+            ok = await _replay_subscriptions(
+                dids, self.sub_device_meta_async, "device-meta"
+            )
             _LOGGER.info(
                 "mips_cloud re-subscribed device-meta for %d/%d devices",
                 ok,
@@ -890,17 +996,9 @@ class MIoTClient:
         if self._scene_sub_home_ids:
             home_ids = sorted(self._scene_sub_home_ids)
             self._scene_sub_home_ids = set()
-            ok = 0
-            for home_id in home_ids:
-                try:
-                    await self.sub_home_scene_async(home_id)
-                    ok += 1
-                except Exception as e:
-                    _LOGGER.error(
-                        "mips_cloud re-subscribe home-scene FAILED home=%s: %s",
-                        home_id,
-                        e,
-                    )
+            ok = await _replay_subscriptions(
+                home_ids, self.sub_home_scene_async, "home-scene"
+            )
             _LOGGER.info(
                 "mips_cloud re-subscribed home-scene for %d/%d homes",
                 ok,
@@ -911,22 +1009,27 @@ class MIoTClient:
         if self._state_sub_dids:
             dids = sorted(self._state_sub_dids)
             self._state_sub_dids = set()
-            ok = 0
-            for did in dids:
-                try:
-                    await self.sub_device_state_async(did)
-                    ok += 1
-                except Exception as e:
-                    _LOGGER.error(
-                        "mips_cloud re-subscribe device-state FAILED did=%s: %s",
-                        did,
-                        e,
-                    )
+            ok = await _replay_subscriptions(
+                dids, self.sub_device_state_async, "device-state"
+            )
             _LOGGER.info(
                 "mips_cloud re-subscribed device-state for %d/%d devices",
                 ok,
                 len(dids),
             )
+
+        # mips 实例被重建 → 上层的订阅意图镜像必须重建为 SDK 重放后的真相:
+        # 若镜像里留着"重放失败的 did"(SDK 集合已无它),下次对账算不出重订;
+        # 若镜像丢了"重放重订上的已解绑 did",下次对账算不出退订。这里在三个
+        # 重放块**之后**把 post-replay 集合交给上层,让镜像成为它们的忠实副本。
+        await self._fire_subscription_reset()
+
+        # 新实例的首次 CONNACK 发生在 register_mips_state_handler 之前
+        # (_dispatch_state_handlers 当时读到的 handler 列表还是空的), _on_mips_connect
+        # 不会被触发。若上一轮连接失败已把 tracked 集合清空、这里重放为空,不主动踢一次
+        # 对账的话 SDK 记账与上层镜像会停在空集,推送要等下一次外部 refresh_* 才恢复
+        # (小时级)。显式补一次,与 paho 重连路径复用同一个入口。
+        self._on_mips_connect(True)
 
     def register_user_bind_callback(
         self, callback: Optional[Callable[[MIoTDeviceBindEvent], Any]]
@@ -967,26 +1070,18 @@ class MIoTClient:
             asyncio.ensure_future(ret)
 
     async def sub_device_meta_async(self, did: str) -> None:
-        """Subscribe one device's `device/{did}/g_op/{rename,hr_change}` meta
-        topics (idempotent).
+        """订阅一台设备的 g_op meta topic(幂等)。
 
-        `_meta_sub_dids` tracks dids confirmed subscribed at the broker, so it
-        stays an accurate mirror: _setup_mips_async replays it after a re-OAuth,
-        and the proxy-level diff in _sync_meta_subscriptions retries anything
-        not in it. A failed SUBACK therefore propagates WITHOUT recording the
-        did — leaving it untracked so the next refresh_devices sync retries it
-        (recording on failure would let the proxy diff short-circuit and the
-        did's meta events would be silently lost forever).
-
-        If mips is not connected yet, only the intent is recorded — the actual
-        subscribe happens at the next setup.
+        失败传播、不记入 `_meta_sub_dids`,让上层 diff 下次重试;mips 不可用时
+        抛 MipsConnectionError(记意图当成功会让上层以为已订阅、重连重放也补不上)。
         """
         if did in self._meta_sub_dids:
             return
         mips = self._mips_cloud
         if mips is None or not mips.is_connected:
-            self._meta_sub_dids.add(did)
-            return
+            raise MipsConnectionError(
+                f"mips_cloud unavailable; device-meta subscribe not issued did={did}"
+            )
         await mips.sub_device_meta_changed_async(did, self._on_device_meta_changed_msg)
         self._meta_sub_dids.add(did)
 
@@ -1020,20 +1115,14 @@ class MIoTClient:
             asyncio.ensure_future(ret)
 
     async def sub_device_state_async(self, did: str) -> None:
-        """Subscribe one device's `device/{did}/state/{online,offline}` cloud
-        state topics (idempotent).
-
-        Same ownership/replay contract as sub_device_meta_async: failed
-        SUBACK propagates WITHOUT recording the did (so the proxy diff
-        retries it); if mips is not connected yet only the intent is
-        recorded and the actual subscribe happens at the next setup.
-        """
+        """订阅一台设备的 state topic(幂等);契约同 sub_device_meta_async。"""
         if did in self._state_sub_dids:
             return
         mips = self._mips_cloud
         if mips is None or not mips.is_connected:
-            self._state_sub_dids.add(did)
-            return
+            raise MipsConnectionError(
+                f"mips_cloud unavailable; device-state subscribe not issued did={did}"
+            )
         await mips.sub_device_state_async(did, self._on_device_state_msg)
         self._state_sub_dids.add(did)
 
@@ -1065,21 +1154,15 @@ class MIoTClient:
             asyncio.ensure_future(ret)
 
     async def sub_home_scene_async(self, home_id: str) -> None:
-        """Subscribe one home's `home/{home_id}/scene/{rename,delete,edit}`
-        topics (idempotent).
-
-        `_scene_sub_home_ids` tracks homes confirmed subscribed at the broker;
-        same ownership model as sub_device_meta_async. A failed SUBACK
-        propagates WITHOUT recording the home, so the next sync retries it
-        instead of the proxy diff short-circuiting on a stale record. If mips is
-        not connected yet, only the intent is recorded.
-        """
+        """订阅一个家庭的 scene topic(幂等);契约同 sub_device_meta_async。"""
         if home_id in self._scene_sub_home_ids:
             return
         mips = self._mips_cloud
         if mips is None or not mips.is_connected:
-            self._scene_sub_home_ids.add(home_id)
-            return
+            raise MipsConnectionError(
+                f"mips_cloud unavailable; home-scene subscribe not issued "
+                f"home={home_id}"
+            )
         await mips.sub_home_scene_changed_async(home_id, self._on_scene_changed_msg)
         self._scene_sub_home_ids.add(home_id)
 
@@ -1101,6 +1184,12 @@ class MIoTClient:
         window, so an unconditional refresh is the safe default.
         """
         self._callback_mips_connect = callback
+
+    def register_subscription_reset_callback(
+        self, callback: Optional[Callable[[set[str], set[str], set[str]], Any]]
+    ) -> None:
+        """mips 重放后回调上层,把三个重放后的 tracked 集合交回(meta/state/scene)。"""
+        self._callback_subscription_reset = callback
 
     def _on_mips_connect(self, connected: bool) -> None:
         if not connected:

--- a/backend/miot/src/miot/mips_cloud.py
+++ b/backend/miot/src/miot/mips_cloud.py
@@ -80,10 +80,10 @@ _PERMANENT_SUBACK_FAILURES = frozenset(
 # Account-level g_op bind/unbind: `user/{uid}/g_op/{bind,unbind}`.
 _TOPIC_USER_OP = re.compile(r"^user/([^/]+)/g_op/(bind|unbind)$")
 
-# Device-level g_op meta changes: `device/{did}/g_op/{rename,hr_change}`
-# (name change / home+room reassignment). did = group(1), op = group(2).
-# Subscribed as EXACT leaf topics (one per op) — the broker ACL rejects the
-# `device/{did}/g_op/#` wildcard with 0x87 Not authorized. The Literal in
+# Device-level g_op meta changes: `device/{did}/g_op/{rename,hr_change}`.
+# Subscribed as EXACT leaf topics. NOTE: the old "broker ACL rejects the
+# `g_op/#` wildcard" claim is UNVERIFIED — its state-topic twin was a
+# misdiagnosis (see _TOPIC_DEVICE_STATE). The Literal in
 # MIoTDeviceBindEvent.event must stay in sync with these ops.
 _DEVICE_META_OPS = ("rename", "hr_change")
 _TOPIC_DEVICE_META = re.compile(
@@ -91,19 +91,21 @@ _TOPIC_DEVICE_META = re.compile(
 )
 
 # Home-level scene changes: `home/{home_id}/scene/{rename,delete,edit}`.
-# home_id = group(1), op = group(2). Also subscribed as EXACT leaf topics
-# (the `home/{home_id}/scene/#` wildcard is likewise ACL-rejected). The
-# Literal in MIoTSceneChangedEvent.event must stay in sync with these ops.
+# Subscribed as EXACT leaf topics. The old "`scene/#` wildcard is
+# ACL-rejected" claim is likewise UNVERIFIED (see _TOPIC_DEVICE_STATE).
+# The Literal in MIoTSceneChangedEvent.event must stay in sync with these ops.
 _HOME_SCENE_OPS = ("rename", "delete", "edit")
 _TOPIC_HOME_SCENE = re.compile(
     r"^home/([^/]+)/scene/(" + "|".join(_HOME_SCENE_OPS) + r")$"
 )
 
 # Device-level cloud online/offline state: `device/{did}/state/{online,
-# offline}`. did = group(1), event = group(2). Subscribed as EXACT leaf
-# topics (one per op) — the broker ACL rejects the `device/{did}/state/#`
-# wildcard with 0x87 Not authorized, same as the g_op/# case above. The
-# Literal in MIoTDeviceStateEvent.event must stay in sync with these ops.
+# offline}`. Subscribed as ONE wildcard per did (`device/{did}/state/#`,
+# probe-verified SUBACK 0x00 — an earlier "ACL rejects the wildcard" note
+# was a misdiagnosis). Messages still arrive on exact leaves. The Literal
+# in MIoTDeviceStateEvent.event must stay in sync with these ops — the `#`
+# sub means a new cloud-side leaf reaches the decoder, so adding an op here
+# without widening that Literal raises at validation.
 _DEVICE_STATE_OPS = ("online", "offline")
 _TOPIC_DEVICE_STATE = re.compile(
     r"^device/([^/]+)/state/(" + "|".join(_DEVICE_STATE_OPS) + r")$"
@@ -449,12 +451,10 @@ class MIoTMipsCloud:
     async def sub_device_meta_changed_async(
         self, did: str, handler: BindHandler
     ) -> None:
-        """Subscribe a device's meta topics: `device/{did}/g_op/{rename,
-        hr_change}`.
+        """订阅一台设备的 g_op meta topic(每个 op 一条精确叶子)。
 
-        One SUBSCRIBE per exact op leaf — the broker ACL rejects the
-        `device/{did}/g_op/#` wildcard. Ops share one decoder. SUBACK
-        rejection on any op raises MipsSubscribeRejectedError.
+        NOTE: "broker ACL 拒 `g_op/#` 通配"是未验证断言——state 侧同款已被证伪
+        (见 _TOPIC_DEVICE_STATE),收敛成一条通配前需先真机探针。
         """
         decoder = self._make_device_meta_decoder()
         for op in _DEVICE_META_OPS:
@@ -467,13 +467,8 @@ class MIoTMipsCloud:
     async def sub_home_scene_changed_async(
         self, home_id: str, handler: SceneChangedHandler
     ) -> None:
-        """Subscribe a home's scene topics: `home/{home_id}/scene/{rename,
-        delete,edit}`.
-
-        One SUBSCRIBE per exact op leaf — the broker ACL rejects the
-        `home/{home_id}/scene/#` wildcard. Ops share one decoder. SUBACK
-        rejection on any op raises MipsSubscribeRejectedError.
-        """
+        """订阅一个家庭的 scene topic(每个 op 一条精确叶子);`scene/#` 通配断言同
+        meta 侧一样未验证(见 sub_device_meta_changed_async)。"""
         decoder = self._make_scene_decoder()
         for op in _HOME_SCENE_OPS:
             await self._subscribe_async(f"home/{home_id}/scene/{op}", handler, decoder)
@@ -485,21 +480,12 @@ class MIoTMipsCloud:
     async def sub_device_state_async(
         self, did: str, handler: DeviceStateHandler
     ) -> None:
-        """Subscribe a device's state topics: `device/{did}/state/{online,
-        offline}`.
-
-        One SUBSCRIBE per exact op leaf — the broker ACL rejects the
-        `device/{did}/state/#` wildcard (same as the g_op/# case). Ops share
-        one decoder. SUBACK rejection on any op raises
-        MipsSubscribeRejectedError.
-        """
+        """订阅一台设备的 state topic,一条通配 filter `device/{did}/state/#`。"""
         decoder = self._make_device_state_decoder()
-        for op in _DEVICE_STATE_OPS:
-            await self._subscribe_async(f"device/{did}/state/{op}", handler, decoder)
+        await self._subscribe_async(f"device/{did}/state/#", handler, decoder)
 
     async def unsub_device_state_async(self, did: str) -> None:
-        for op in _DEVICE_STATE_OPS:
-            await self._unsubscribe_async(f"device/{did}/state/{op}")
+        await self._unsubscribe_async(f"device/{did}/state/#")
 
     # ------------------------------------------------------- subscribe core
 
@@ -554,6 +540,18 @@ class MIoTMipsCloud:
                 with self._pending_lock:
                     self._pending_subscribes.pop(mid, None)
                 raise MipsSubscribeTimeoutError(topic) from None
+
+            # 等 SUBACK 期间若有并发退订(如上层 bind 作废路径)把本 topic 从
+            # _subs 弹出并已发出 UNSUBSCRIBE:这次授权已过期,必须抛错让调用方
+            # 不记账——否则 SDK 记"已订阅"、broker 无订阅,`did in set` 短路
+            # 会吞掉之后所有重试,该 topic 的推送静默丢失直到 mips 实例重建。
+            # 合法的 sub→unsub→sub 交错不受影响:新订阅已重新占位,topic 仍在
+            # _subs,旧 SUBACK 正常返回(SDK 记账幂等)。
+            with self._subs_lock:
+                if topic not in self._subs:
+                    raise MipsConnectionError(
+                        f"subscribe({topic}) superseded by concurrent unsubscribe"
+                    )
 
             for code in reason_codes:
                 if code not in _SUBACK_SUCCESS_CODES:
@@ -851,10 +849,11 @@ class MIoTMipsCloud:
         [str, bytes], Optional[MIoTDeviceStateEvent]
     ]:
         # Device-level cloud online/offline: did + event come from the topic;
-        # the payload is undocumented and kept verbatim in `raw`. Only the
-        # exact op leaves are subscribed (no `#` wildcard), so a non-matching
-        # topic should never arrive — the `if not m` guard is purely
-        # defensive.
+        # the payload is undocumented and kept verbatim in `raw`. We subscribe
+        # the `device/{did}/state/#` WILDCARD, so any other leaf the cloud may
+        # publish under state/ also lands here — the `if not m` guard is
+        # LOAD-BEARING (the whitelist that keeps unknown leaves out), not
+        # merely defensive. Do not remove it.
         def decode(topic: str, payload: bytes) -> Optional[MIoTDeviceStateEvent]:
             m = _TOPIC_DEVICE_STATE.match(topic)
             if not m:

--- a/backend/miot/tests/test_client_meta_sub.py
+++ b/backend/miot/tests/test_client_meta_sub.py
@@ -11,7 +11,8 @@ subscribed at the broker, NOT mere intent-to-subscribe:
   record it — otherwise the idempotency guard would short-circuit the
   proxy-level retry in _sync_meta_subscriptions and the entity's events would
   be silently lost forever.
-* While mips is disconnected only the intent is recorded (replayed at setup).
+* While mips is disconnected the call raises MipsConnectionError and records
+  nothing — the proxy-level diff must be able to retry it on the next sync.
 * Already-tracked entities are a no-op (idempotent).
 
 A bare MIoTClient is built via __new__ with only the attributes these methods
@@ -25,6 +26,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 from miot.client import MIoTClient
+from miot.types import MipsConnectionError
 
 from miot import client as client_mod
 
@@ -87,14 +89,18 @@ async def test_sub_device_meta_failure_leaves_untracked_and_raises():
 
 
 @pytest.mark.asyncio
-async def test_sub_device_meta_disconnected_records_intent_only():
+async def test_sub_device_meta_disconnected_raises():
+    """mips unavailable → must RAISE, not record intent and return success:
+    recording would let the proxy mark the did subscribed while mips._subs
+    has no such topic (reconnect replay couldn't re-issue it)."""
     mips = _FakeMips(connected=False)
     client = _bare_client(mips)
 
-    await client.sub_device_meta_async("dev-1")
+    with pytest.raises(MipsConnectionError):
+        await client.sub_device_meta_async("dev-1")
 
     mips.sub_device_meta_changed_async.assert_not_awaited()
-    assert client._meta_sub_dids == {"dev-1"}
+    assert client._meta_sub_dids == set()
 
 
 @pytest.mark.asyncio
@@ -134,14 +140,15 @@ async def test_sub_home_scene_failure_leaves_untracked_and_raises():
 
 
 @pytest.mark.asyncio
-async def test_sub_home_scene_disconnected_records_intent_only():
+async def test_sub_home_scene_disconnected_raises():
     mips = _FakeMips(connected=False)
     client = _bare_client(mips)
 
-    await client.sub_home_scene_async("home-1")
+    with pytest.raises(MipsConnectionError):
+        await client.sub_home_scene_async("home-1")
 
     mips.sub_home_scene_changed_async.assert_not_awaited()
-    assert client._scene_sub_home_ids == {"home-1"}
+    assert client._scene_sub_home_ids == set()
 
 
 # --------------------------------------------------- _setup_mips_async replay
@@ -203,6 +210,8 @@ def _setup_client(
     client._callback_device_meta_changed = None
     client._callback_scene_changed = None
     client._callback_device_state_changed = None
+    client._callback_subscription_reset = None
+    client._callback_mips_connect = None
     return client
 
 
@@ -250,7 +259,8 @@ async def test_setup_replay_partial_failure_keeps_failed_untracked(monkeypatch):
 #
 # `_state_sub_dids` mirrors what is actually subscribed at the broker, same
 # contract as _meta_sub_dids: success records, failure does not, disconnected
-# records intent only, idempotent for already-tracked dids.
+# raises MipsConnectionError and records nothing, idempotent for
+# already-tracked dids.
 
 
 @pytest.mark.asyncio
@@ -280,14 +290,15 @@ async def test_sub_device_state_failure_leaves_untracked_and_raises():
 
 
 @pytest.mark.asyncio
-async def test_sub_device_state_disconnected_records_intent_only():
+async def test_sub_device_state_disconnected_raises():
     mips = _FakeMips(connected=False)
     client = _bare_client(mips)
 
-    await client.sub_device_state_async("dev-1")
+    with pytest.raises(MipsConnectionError):
+        await client.sub_device_state_async("dev-1")
 
     mips.sub_device_state_async.assert_not_awaited()
-    assert client._state_sub_dids == {"dev-1"}
+    assert client._state_sub_dids == set()
 
 
 @pytest.mark.asyncio
@@ -299,6 +310,27 @@ async def test_sub_device_state_idempotent():
     await client.sub_device_state_async("dev-1")
 
     mips.sub_device_state_async.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_sub_device_state_superseded_not_tracked_and_retry_reissues():
+    """mips 层发现订阅被并发退订(SUBACK 后 topic 已被 unsub 弹掉)抛
+    MipsConnectionError 时,SDK 必须不记 `_state_sub_dids`;紧接的第二次订阅
+    要真正再次下发,而不是被 `did in set` 短路吞掉。"""
+    mips = _FakeMips(connected=True)
+    client = _bare_client(mips)
+    mips.sub_device_state_async = AsyncMock(
+        side_effect=[MipsConnectionError("superseded by unsubscribe"), None]
+    )
+
+    with pytest.raises(MipsConnectionError):
+        await client.sub_device_state_async("dev-1")
+    assert client._state_sub_dids == set()
+
+    # 下一轮对账重试:必须真正发出新的 SUBSCRIBE 并记账。
+    await client.sub_device_state_async("dev-1")
+    assert client._state_sub_dids == {"dev-1"}
+    assert mips.sub_device_state_async.await_count == 2
 
 
 # ------------------------------------------- _setup_mips_async state replay
@@ -346,6 +378,65 @@ async def test_setup_replay_state_partial_failure_keeps_failed_untracked(
     }
     # dev-bad failed → not re-recorded; dev-ok succeeded and is tracked.
     assert client._state_sub_dids == {"dev-ok"}
+
+
+@pytest.mark.asyncio
+async def test_setup_mips_fires_subscription_reset_with_post_replay_sets(monkeypatch):
+    """The upper-layer mirror invalidation callback must fire AFTER replay,
+    passing the post-replay tracked sets — so the mirror can be a faithful
+    copy (replay-failed entities dropped, departed re-subscribed ones kept)."""
+    fake = _SetupFakeMips()
+    client = _setup_client(
+        monkeypatch, fake, meta_dids={"dev-a", "dev-bad"}, scene_home_ids=set()
+    )
+    fake._fail_meta_dids = frozenset({"dev-bad"})
+    received: list = []
+
+    async def _reset(*args) -> None:
+        received.append(tuple(map(set, args)))
+
+    client._callback_subscription_reset = _reset
+
+    await client._setup_mips_async()
+
+    # Callback fired exactly once, after replay, with the post-replay sets:
+    # dev-bad's replay failed → dropped from the meta set; dev-a succeeded.
+    assert len(received) == 1
+    meta_dids, state_dids, scene_home_ids = received[0]
+    assert meta_dids == {"dev-a"}
+    assert state_dids == set()
+    assert scene_home_ids == set()
+
+
+@pytest.mark.asyncio
+async def test_setup_mips_connect_failure_clears_tracked_and_fires_reset(monkeypatch):
+    """If the rebuilt mips instance fails to connect, the broker has ZERO
+    subscriptions (old instance torn down, new never came up) — the tracked
+    sets and upper mirror must be emptied so the next reconcile re-issues
+    everything instead of no-op'ing forever (a silent hours-long push gap)."""
+    fake = _SetupFakeMips()
+    client = _setup_client(
+        monkeypatch,
+        fake,
+        meta_dids={"dev-a"},
+        scene_home_ids=set(),
+        state_dids={"dev-b"},
+    )
+    fake.init_async = AsyncMock(side_effect=MipsConnectionError("connect refused"))
+    received: list = []
+
+    async def _reset(*args):
+        received.append(tuple(map(set, args)))
+
+    client._callback_subscription_reset = _reset
+
+    await client._setup_mips_async()
+
+    assert client._meta_sub_dids == set()
+    assert client._state_sub_dids == set()
+    assert client._scene_sub_home_ids == set()
+    assert len(received) == 1
+    assert received[0] == (set(), set(), set())
 
 
 # ------------------------------------ mips_user_sub_error scoping (reconnect)
@@ -409,3 +500,80 @@ def test_home_scene_subscribe_results_do_not_touch_user_error():
     client._mips_user_sub_error = "stale user error"
     client._on_mips_subscribe_success("home/h1/scene/edit")
     assert client._mips_user_sub_error == "stale user error"
+
+
+# ------------------------------------------------- shrink guard (get_devices_async)
+#
+# get_devices_async keeps a streak of consecutive SHRUNK cloud replies (a
+# reply holding < _DEVICE_REPLY_SHRINK_RATIO of the buffered device count —
+# an empty reply is just the extreme case); two within
+# _DEVICE_REPLY_SHRINK_MIN_GAP_SEC count as ONE round (refresh_devices and
+# refresh_cameras hit it concurrently under different locks), and the buffer
+# is only dropped after TWO rounds so a transient partial reply doesn't
+# cause a full unsubscribe storm.
+
+
+def _dev_client(monkeypatch):
+    # 只 patch miot.client._now(生产代码取时间的唯一入口),不碰全局 time.monotonic,
+    # 以免顺带冻结 asyncio 事件循环的时钟(那样将来任何基于时间的等待都会永久挂住)。
+    client = MIoTClient.__new__(MIoTClient)
+    client._device_buffer = {"d1": SimpleNamespace(did="d1", lan_online=True)}
+    client._device_shrink_streak = 0
+    client._last_device_shrink_ts = 0.0
+    client._http_client = SimpleNamespace(get_devices_async=AsyncMock(return_value={}))
+    client._lan_client = SimpleNamespace(get_devices_async=AsyncMock(return_value={}))
+    clock = [1000.0]
+    monkeypatch.setattr(client_mod, "_now", lambda: clock[0])
+    return client, clock
+
+
+@pytest.mark.asyncio
+async def test_get_devices_shrink_same_round_counts_once(monkeypatch):
+    client, clock = _dev_client(monkeypatch)
+    # Two shrunk replies within the same round (identical monotonic time) — the
+    # second must NOT bump the streak: a single transient shrink in a
+    # refresh_devices+refresh_cameras gather must not trip the storm.
+    for _ in range(2):
+        res = await client.get_devices_async()
+        assert "d1" in res
+    assert client._device_shrink_streak == 1
+    assert client._device_buffer == {"d1": client._device_buffer["d1"]}
+
+
+@pytest.mark.asyncio
+async def test_get_devices_shrink_two_rounds_clears(monkeypatch):
+    client, clock = _dev_client(monkeypatch)
+    # First round: keep the buffer.
+    res = await client.get_devices_async()
+    assert "d1" in res
+    assert client._device_shrink_streak == 1
+    # >30s later (a genuine account clear, not one round): streak -> 2, buffer
+    # is dropped and the streak resets, so a following transient shrink re-arms.
+    clock[0] += 31.0
+    res = await client.get_devices_async()
+    assert "d1" not in res
+    assert client._device_shrink_streak == 0
+
+
+@pytest.mark.asyncio
+async def test_get_devices_partial_shrink_triggers_guard(monkeypatch):
+    """A single-home parse failure returns a PARTIAL list, not empty — the
+    guard must treat a >50% shrink the same as an empty reply (keep the
+    buffer), while a mild dip is normal."""
+    client, clock = _dev_client(monkeypatch)
+    client._device_buffer = {f"d{i}": SimpleNamespace(did=f"d{i}") for i in range(1, 4)}
+    # Cloud returns only 1 of 3 (< 0.5 ratio) → transient shrink, buffer kept.
+    client._http_client.get_devices_async = AsyncMock(
+        return_value={"d1": SimpleNamespace(did="d1")}
+    )
+    res = await client.get_devices_async()
+    assert set(res) == {"d1", "d2", "d3"}
+    assert client._device_shrink_streak == 1
+    # A mild dip (2 of 3, >= 0.5 ratio) is NOT a shrink — no guard.
+    client._device_shrink_streak = 0
+    client._http_client.get_devices_async = AsyncMock(
+        return_value={"d1": SimpleNamespace(did="d1"), "d2": SimpleNamespace(did="d2")}
+    )
+    res = await client.get_devices_async()
+    assert set(res) == {"d1", "d2"}  # merged normally
+    assert client._device_shrink_streak == 0

--- a/backend/miot/tests/test_mips_cloud.py
+++ b/backend/miot/tests/test_mips_cloud.py
@@ -30,6 +30,7 @@ from miot.types import (
     MIoTDeviceBindEvent,
     MIoTDeviceStateEvent,
     MIoTSceneChangedEvent,
+    MipsConnectionError,
     MipsSubscribeRejectedError,
     MipsSubscribeTimeoutError,
 )
@@ -746,10 +747,10 @@ async def test_subscribe_transient_rejection_keeps_topic_and_reconnect_retries()
 
 
 @pytest.mark.asyncio
-async def test_device_state_subscribes_exact_topics():
-    """sub_device_state_async subscribes the exact per-op leaf topics
-    (NOT a `state/#` wildcard — the broker ACL rejects the wildcard, same as
-    the g_op/# case)."""
+async def test_device_state_subscribes_wildcard():
+    """sub_device_state_async issues ONE wildcard subscription per did —
+    `device/{did}/state/#` (same filter as xiaomi-ha; probe-verified allowed
+    by the broker ACL). Exact leaves are NOT subscribed individually."""
     mips, _ = _make_mips()
     holder: dict[str, _FakeMqttClient] = {}
 
@@ -763,12 +764,11 @@ async def test_device_state_subscribes_exact_topics():
     try:
         await asyncio.gather(
             mips.sub_device_state_async("dev-1", handler=lambda _m: None),
-            _ack_subscribes(fake, 2),
+            _ack_subscribes(fake, 1),
         )
         topics = {t for t, _, _ in fake.subscribed}
-        assert "device/dev-1/state/online" in topics
-        assert "device/dev-1/state/offline" in topics
-        assert "device/dev-1/state/#" not in topics
+        assert "device/dev-1/state/#" in topics
+        assert len(topics) == 1
     finally:
         await mips.deinit_async()
 
@@ -776,8 +776,8 @@ async def test_device_state_subscribes_exact_topics():
 @pytest.mark.parametrize("op", ["online", "offline"])
 @pytest.mark.asyncio
 async def test_device_state_decoded_event_dispatched(op):
-    """device/{did}/state/{online,offline} → MIoTDeviceStateEvent with
-    event=op and did parsed from the topic; payload kept in `raw`."""
+    """Messages arrive on exact leaf topics despite the `#` subscription →
+    MIoTDeviceStateEvent with event=op and did parsed from the topic."""
     mips, _ = _make_mips()
     holder: dict[str, _FakeMqttClient] = {}
 
@@ -793,7 +793,7 @@ async def test_device_state_decoded_event_dispatched(op):
     try:
         await asyncio.gather(
             mips.sub_device_state_async("dev-42", handler=received.append),
-            _ack_subscribes(fake, 2),
+            _ack_subscribes(fake, 1),
         )
         fake.fire_message(
             f"device/dev-42/state/{op}",
@@ -809,8 +809,35 @@ async def test_device_state_decoded_event_dispatched(op):
 
 
 @pytest.mark.asyncio
-async def test_device_state_unsubscribes_exact_topics():
-    """unsub_device_state_async removes both online + offline leaf topics."""
+async def test_device_state_unknown_leaf_dropped():
+    """We subscribe `state/#`, so ANY other leaf the cloud publishes under
+    state/ reaches the decoder too — it must be silently dropped (the
+    load-bearing `if not m` guard), not raise or dispatch an illegal event."""
+    mips, _ = _make_mips()
+    holder: dict[str, _FakeMqttClient] = {}
+
+    def factory(client_id: str) -> _FakeMqttClient:
+        holder["c"] = _FakeMqttClient(client_id)
+        return holder["c"]  # type: ignore[return-value]
+
+    mips._client_factory = factory  # type: ignore[assignment]
+    fake = await _connect(mips, holder)
+    received: list = []
+    try:
+        await asyncio.gather(
+            mips.sub_device_state_async("dev-9", handler=received.append),
+            _ack_subscribes(fake, 1),
+        )
+        fake.fire_message("device/dev-9/state/whatever", b"{}")
+        await asyncio.sleep(0.01)
+        assert received == []
+    finally:
+        await mips.deinit_async()
+
+
+@pytest.mark.asyncio
+async def test_device_state_unsubscribes_wildcard():
+    """unsub_device_state_async removes the single wildcard topic."""
     mips, _ = _make_mips()
     holder: dict[str, _FakeMqttClient] = {}
 
@@ -824,20 +851,62 @@ async def test_device_state_unsubscribes_exact_topics():
     try:
         await asyncio.gather(
             mips.sub_device_state_async("dev-7", handler=lambda _m: None),
-            _ack_subscribes(fake, 2),
+            _ack_subscribes(fake, 1),
         )
         await mips.unsub_device_state_async("dev-7")
         unsubbed = set(fake.unsubscribed)
-        assert "device/dev-7/state/online" in unsubbed
-        assert "device/dev-7/state/offline" in unsubbed
+        assert "device/dev-7/state/#" in unsubbed
     finally:
         await mips.deinit_async()
 
 
 @pytest.mark.asyncio
-async def test_device_state_reconnect_resubscribes_both_topics():
-    """After disconnect/reconnect both online + offline leaf topics are
-    re-issued by the _subs replay."""
+async def test_subscribe_superseded_by_concurrent_unsubscribe_raises():
+    """SUBACK 等待期间同 topic 被并发退订(上层 bind 作废路径的 unsub 弹掉了
+    在飞订阅自己的 _subs 条目)时,订阅必须抛 MipsConnectionError——否则 SDK
+    在 await 之后记"已订阅"、broker 却已 UNSUB,`did in set` 短路会吞掉之后
+    所有重试,该 did 的推送静默丢失直到 mips 实例重建。"""
+    mips, _ = _make_mips()
+    holder: dict[str, _FakeMqttClient] = {}
+
+    def factory(client_id: str) -> _FakeMqttClient:
+        holder["c"] = _FakeMqttClient(client_id)
+        return holder["c"]  # type: ignore[return-value]
+
+    mips._client_factory = factory  # type: ignore[assignment]
+    fake = await _connect(mips, holder)
+
+    try:
+        subscribe_task = asyncio.create_task(
+            mips.sub_device_state_async("dev-x", handler=lambda _m: None)
+        )
+        # 等 SUBSCRIBE 发出、停在 SUBACK 等待上。
+        for _ in range(50):
+            if fake.subscribed:
+                break
+            await asyncio.sleep(0.005)
+        _, _, mid = fake.subscribed[-1]
+
+        # 并发退订:弹掉 _subs 条目、发出 UNSUBSCRIBE,但不补 SUBACK。
+        await mips.unsub_device_state_async("dev-x")
+
+        # SUBACK 到达后,订阅路径必须发现自己的授权已过期。
+        fake.fire_suback(mid, [2])
+        with pytest.raises(MipsConnectionError):
+            await subscribe_task
+
+        # _subs 里已无该 topic(不会进重连重放),且 UNSUBSCRIBE 已发出。
+        with mips._subs_lock:
+            assert "device/dev-x/state/#" not in mips._subs
+        assert "device/dev-x/state/#" in set(fake.unsubscribed)
+    finally:
+        await mips.deinit_async()
+
+
+@pytest.mark.asyncio
+async def test_device_state_reconnect_resubscribes_wildcard():
+    """After disconnect/reconnect the wildcard topic is re-issued by the
+    _subs replay."""
     mips, _ = _make_mips()
     holder: dict[str, _FakeMqttClient] = {}
 
@@ -851,18 +920,17 @@ async def test_device_state_reconnect_resubscribes_both_topics():
     try:
         await asyncio.gather(
             mips.sub_device_state_async("dev-rec", handler=lambda _m: None),
-            _ack_subscribes(fake, 2),
+            _ack_subscribes(fake, 1),
         )
         before = len(fake.subscribed)
         fake.fire_disconnect(reason_code=1)
         fake.fire_connect(reason_code=0)
         for _ in range(10):
             await asyncio.sleep(0)
-            if len(fake.subscribed) >= before + 2:
+            if len(fake.subscribed) >= before + 1:
                 break
         resub_topics = {t for t, _, _ in fake.subscribed[before:]}
-        assert "device/dev-rec/state/online" in resub_topics
-        assert "device/dev-rec/state/offline" in resub_topics
+        assert "device/dev-rec/state/#" in resub_topics
         for _, _, mid in fake.subscribed[before:]:
             fake.fire_suback(mid, [2])
         await asyncio.sleep(0.01)


### PR DESCRIPTION
## Summary
- 相机之外，账户级订阅全部设备的 `device/{did}/state/#` 云端上下线推送，
  `device list` 现在能实时反映上下线，不再只有 `scope camera list` 能看到。
- 事件处理同时更新 `_camera_info_dict` 和 `_device_info_dict` 两份缓存；相机对账防抖的
  重新武装条件为「相机命中 / 两份缓存都不认识 / 相机清单从未成功加载」，已知非相机设备
  不武装（零相机账户加载成功后不再被每条灯事件拖着重拉）。
- bind/unbind 事件改为「bind 直接补订、unbind 退订抹账」：`_on_user_bind_event` 收到
  `bind` 时直接订阅该 did 的 state/meta（SDK 幂等短路——重绑时若 broker 订阅还活着就不
  重复发包），镜像在订阅成功后才记账（失败不记，5s 防抖后的对账照常重试）；收到 `unbind`
  时锁内抹掉镜像记账并递增代次、锁外网络退订（best-effort）。不再有「bind 时先退订再
  重订」：unbind 事件自己就把订阅退掉，解绑重绑塌缩由这两拍天然覆盖。
- `_sub_intent_lock` 只保护意图集的**内存读改写**（diff 计算与提交，微秒级），**不跨网络
  I/O**：对账差集在锁内计算并记下意图代次，网络 sub/unsub 在锁外并发执行；提交时回锁，
  仅当代次未变才写回——unbind 抹记账、实例重建镜像都在锁内递增代次，飞行中对账的提交
  因此自失效，由下一轮对账收敛（被放弃轮的 to_add 仍 ⊆ 当前目标集，且改写方都保证触发
  新对账）。target 仍在锁内求值。第四处 `_reset_subscription_mirrors` 是 init/deinit 生命
  周期边界，刻意不持锁（SDK 侧集合一并重置，残留对账写回后下一轮会自行收敛）。
- 对账并发上限 16，**三类对账（meta / state / scene）共享一个并发闸**——压力落在同一条
  broker 连接上，分闸会让总在飞 SUBSCRIBE 上限变成 3×（与 SDK 重放侧 `_REPLAY_CONCURRENCY`
  限制的是同一件事，调值时一起改）；`refresh_devices` / `refresh_cameras` /
  `refresh_camera_online_status` 三条刷新入口的顺带对账**统一派后台任务**
  （`_spawn_subscription_sync`），不占任何 HTTP 响应路径。
- 对账任务 coalescing：同一窗口内多个刷新入口常各触发一次，若各建任务会让轮次在同一
  镜像快照上重叠、重复发包。`_spawn_subscription_sync` 只保留一个后台循环任务，在飞期间
  的再次触发折叠成 rerun 标志、由循环补一轮吸收；循环每轮结束还检查意图代次，unbind/reset
  中途改写代次（可能有提交被放弃）时立即补轮收敛，不等外部刷新。「循环在飞」用显式布尔
  `_sub_sync_running` 判定、在循环协程的 `finally` 里同步复位，而不是看后台任务集合是否
  非空——`add_done_callback` 是 `call_soon` 排队的，循环已返回而 discard 未执行时任务集合
  仍非空，会把窗口期的新触发折叠成没人读的 rerun 标志、静默丢掉一次对账。
- 后台循环三类对账用 `asyncio.gather(..., return_exceptions=True)` 收集异常、按类记日志：
  一类抛错不再让 gather 立即向上抛、连带把另外两类变成脱离追踪的孤儿任务（deinit 取消
  不到、可能把废弃 did 写回记账），也不会丢已经置上的 rerun 标志；循环只被 deinit 取消。
- 修正 `_reconcile_subscriptions` / `_collect_home_ids` 的 docstring：代次只由「作废他人在途
  提交」的改写方递增（unbind 抹记账 / mips 重建镜像；对账提交不递增，否则并发跑的三类会
  互相作废）；`_collect_home_ids` 的「哪个缓存最新」取决于触发它的刷新入口（三条入口都会
  派后台对账）。
- `miot` SDK：`sub/unsub_device_state_async` 从「每 did 两个精确 leaf」改为「每 did 一个
  `device/{did}/state/#` 通配 filter」。主分支注释里「broker ACL 会用 0x87 拒掉该通配符」
  的断言经探针实测（SUBACK 0x00）证实为误判，已在注释中更正。`g_op/#` 与 `scene/#` 的
  同类断言**行为上保持原样**（仍是每个 op 一条精确叶子），但注释已从肯定语气改写为
  「UNVERIFIED，需真机探针复核」。
- SDK 在 mips 未连接时不再「记意图当成功」返回：`sub_device_meta/state/scene_async` 改为
  抛 `MipsConnectionError`，让上层对账把 did 留在未订阅集合、下次 refresh 重试。

- 修复「订阅等 SUBACK 期间被同 topic 并发退订」竞态：`_subscribe_async` 在
  SUBACK 到达后、向上返回前复查 `_subs`——条目已被并发退订（bind 作废路径的
  unsub 会弹掉在飞订阅自己的条目）就抛 `MipsConnectionError`，SDK 不记"已订阅"。
  否则 SDK 记账、broker 却已 UNSUB，`did in set` 短路会吞掉后续所有重试，该设备
  推送静默丢失直到 mips 实例重建（重连重放只走 `_subs`、token 轮换不重建，两条
  自愈路径都断）。回归测试：mips 层卡 SUBACK 先 unsub 再补 SUBACK，断言抛
  MipsConnectionError 且 `_subs` 无该 topic；SDK 层断言 `_state_sub_dids` 不记账、
  第二次订阅真正重新下发。
- mips 实例重建（re-OAuth / token 刷新）**重放后**，新增 `register_subscription_reset_callback`
  把重放后的 SDK 订阅集合交回上层，上层把订阅意图镜像**重建为它的忠实副本**。两个方向
  都要堵：重放中失败的 entity 已从 SDK 集合掉出，镜像若仍留着它，下次对账差集算不出
  重订（该设备推送永久失效）；反过来，一个已解绑但尚未被上一轮对账退掉的 did 会被重放
  重新订回 broker，镜像若被清空则差集算不出退订（broker 订阅永久泄漏）。重放并发上限 16；
  重建完成后主动踢一次对账（连接失败恢复后也能立即重新订阅）。
- SDK `get_devices_async` 加「连续两轮骤降（本轮设备数 < 缓存的 50%）才认缩」守卫：
  单个 home 解析失败返回的**部分**列表（整份返空只是其极端情形）不再把整份设备
  buffer pop 光，避免全账户 state + meta 整批退订再整批重订（推送盲窗 + SUBSCRIBE
  风暴）。同一轮并发调用只算一次（窗口锚定本轮第一次骤降）；认账后计数器复位；
  守卫提前返回那条路径同样合并 LAN 发现（`_merge_lan_status`）。mips 连接失败分支同样
  清空 SDK 记账并触发重置回调。
- 网关子设备（blt.*/proxy.*）**不排除**：真机探针实测它们的 state 订阅（精确叶子与
  通配符）均 SUBACK 0x00——早先「0x87 被拒」的观察来自故障实例窗口、非 did 类型所致。
- 删除冗余的相机专属订阅 `_sync_camera_state_subscriptions` / `_subscribed_state_dids`
  （相机是设备子集）；抽出公共 `_reconcile_subscriptions`，三个订阅同步方法折叠到它上面。

## Test plan
- [x] `uv run pytest` proxy 相关 5 文件（test_meta_subscriptions / test_camera_state_subscriptions /
      test_miot_proxy_lifecycle / test_miot_filter_and_cameras / test_mips_listeners）— 158 passed
- [x] `uv run pytest` miot 侧 `test_mips_cloud.py` + `test_client_meta_sub.py` — 49 passed
- [x] 真机验证（cat@mac，通配订阅版本）：账户级订阅建立成功
      （`device-online-state subscriptions synced`）、`state/#` SUBACK 0x00、
      blt.* 精确叶子与通配符均 SUBACK 0x00、bind 事件触发重订、
      状态推送正常反映到 `device list` / `scope camera list`
