### PR TITLE
fix(omni): 模型下拉认全 Gemini 家族接入路径，列不出模型不再误报坏 Key

### DIFF
--- a/backend/miloco/src/miloco/perception/engine/omni/error_classifier.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/error_classifier.py
@@ -1,8 +1,13 @@
 """omni 调用异常/响应到统一错误码集合的映射。
 
 映射规则见 spec §2。CODES 与 web 前端 omniHealth.codes 一一对应(10 个 code),
-前端直接复用 i18n。「测试连接」结果表 OMNI_CODE_KEY 是本集合的裁剪变体:去掉
-probe 路径不会产生的 timeout(probe 把所有异常统一归 unreachable)、加上成功码 ok。
+前端直接复用 i18n。前端的 OMNI_CODE_KEY 是「测试连接」与「模型下拉」**两条路共用**的
+机器码 → i18n 表,为本集合的裁剪+增补变体:去掉 probe 路径不会产生的 timeout(probe 把
+所有异常统一归 unreachable)、加上成功码 ok、再加上只由 fetch_models 产出的
+list_unsupported —— 后者不参与熔断,故**不**属于本集合。
+
+新增任何面向前端的机器码,**不论走哪条路径**,都要同步登记进 OMNI_CODE_KEY 并补中英文案;
+漏登记时界面会回退到后端硬编码的中文 message、污染英文界面。
 """
 
 from __future__ import annotations

--- a/backend/miloco/src/miloco/perception/engine/omni/probe.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/probe.py
@@ -3,12 +3,15 @@
 统一被 web preflight (admin/router.py) 与运行时 circuit_breaker HALF_OPEN 复用。
 两阶段探测：GET /models 验鉴权+可达；再 max_tokens=1 chat 真校验模型。
 
-返回统一形状 {ok, code, status?, latency_ms?, message}。code 集合与 spec §2 一致。
+返回统一形状 {ok, code, status?, latency_ms?, message}。探测类 code 与 spec §2 的集合一致;
+``fetch_models`` 另有一个 ``list_unsupported``,不参与熔断、不属于该集合(见 error_classifier
+的 docstring),别因为在那边找不到就补进去。
 """
 
 from __future__ import annotations
 
 import time
+from collections.abc import Callable
 from typing import Any
 from urllib.parse import urlparse
 
@@ -16,6 +19,97 @@ import httpx
 
 _TIMEOUT = httpx.Timeout(15.0, connect=10.0)
 _ALLOWED_SCHEMES = ("http", "https")
+
+# Gemini 原生 generateContent 协议的两条官方接入路径:
+#   generativelanguage.googleapis.com   —— Gemini API
+#   {区域前缀-}aiplatform.googleapis.com —— Vertex AI
+# **两台主机下都是原生协议与 OpenAI 兼容协议并存**,主机名一样,只能靠 path 区分:
+#   Gemini API  原生 版本段如 /v1beta      兼容 /v1beta/openai
+#   Vertex      原生 路径含 /publishers/   兼容 路径含 /endpoints/openapi
+# 兼容那条走 ``Authorization: Bearer``;误判成原生会给它发 x-goog-api-key,被拒后报成
+# 「Key 无效」——正是本模块要消除的那类误报。
+# 两侧策略**故意不同**:
+#   Gemini API 侧用黑名单(只排除含 openai 段的路径)—— 原生的版本段会随 API 版本新增,白名单要跟着改;
+#   Vertex 侧用白名单(只放行含 publishers 段的路径)—— 该主机路径形态多,黑名单挡不住未知的非原生路径。
+_GEMINI_NATIVE_HOST = "generativelanguage.googleapis.com"
+_GEMINI_OPENAI_PATH_SEG = "openai"
+_VERTEX_HOSTS = frozenset({"aiplatform.googleapis.com"})
+_VERTEX_HOST_SUFFIX = "-aiplatform.googleapis.com"
+_VERTEX_NATIVE_PATH_SEG = "publishers"
+
+
+def _parse_model_ids(payload: Any, *, prefer_native: bool) -> list[str]:
+    """从模型列表响应里抽 model id,认识的几种形态都试。
+
+    认识三种形态:Gemini 原生 ``{models:[{name}]}``、Vertex 的 ``{publisherModels:[{name}]}``
+    (name 形如 ``publishers/google/models/xxx``)、OpenAI 兼容 ``{data:[{id}]}``。
+    前缀归一**按形态各配一条**:两种原生形态各剥各的前缀,兼容形态的 id 原样透传
+    (含 ``/`` 合法,如 ``accounts/<org>/models/<name>``,截断后 provider 认不出来)。
+    ``prefer_native`` 只决定**先试哪一种**,不再是唯一依据:绑死单一形态时,端点的形态一旦判错
+    (鉴权仍通过、只是响应形态与预期不符)就会解出空列表,却仍按 200 成功返回。
+
+    产出保证:恒为字符串列表且元素均非空——调用方据此可直接排序,不必再过滤。顶层非 dict、
+    列表位不是 list、条目不是 dict、标识是嵌套结构(dict/list)一律跳过而非抛出;标识为数字等
+    标量时转成字符串。
+    """
+    if not isinstance(payload, dict):
+        return []
+
+    def _pick(key: str, field: str, norm: Callable[[str], str]) -> list[str]:
+        items = payload.get(key)
+        if not isinstance(items, list):
+            return []
+        out: list[str] = []
+        for m in items:
+            if not isinstance(m, dict):
+                continue
+            raw = m.get(field)
+            # 只对标量归一:标识为数字时转字符串,免得调用方排序混排类型抛异常。dict / list
+            # 这类嵌套值 str() 之后是一串垃圾文本,会通过下面的非空过滤、被当成合法 model id
+            # 收进下拉,故与其他异常形态一样跳过。bool 是 int 的子类,一并排除。
+            if isinstance(raw, bool) or not isinstance(raw, (str, int, float)):
+                continue
+            # 归一规则**按形态配**,不能写死一条套到三种上:兼容形态的 id 里含 ``/models/``
+            # 是合法的(如 ``accounts/<org>/models/<name>``),截断后 provider 认不出来。
+            mid = norm(str(raw))
+            if mid:
+                out.append(mid)
+        return out
+
+    native = [
+        # Gemini 原生:name 形如 ``models/<id>``
+        ("models", "name", lambda v: v.removeprefix("models/")),
+        # Vertex:name 形如 ``publishers/<pub>/models/<id>``
+        ("publisherModels", "name", lambda v: v.rsplit("/models/", 1)[-1]),
+    ]
+    # OpenAI 兼容:id 原样透传——含 ``/`` 是合法的,不做任何剥离
+    compat = [("data", "id", lambda v: v)]
+    for key, field, norm in (native + compat if prefer_native else compat + native):
+        ids = _pick(key, field, norm)
+        if ids:
+            return ids
+    return []
+
+
+def _is_gemini_native_endpoint(base: str) -> bool:
+    """按**主机名 + 路径**判是否 Gemini 原生 generateContent 端点。
+
+    主机名取 ``urlparse().hostname`` 比对,不用 ``"…" in base_url`` 子串匹配——子串匹配会被
+    ``https://evil.com/generativelanguage.googleapis.com`` 之类绕过(CodeQL 报的 incomplete
+    URL substring sanitization)。两台主机都还要再过一道路径判断,用途见上方注释。
+    """
+    parsed = urlparse(base)
+    host = (parsed.hostname or "").lower()
+    # 按**路径段**比对而非子串:尾锚定会漏掉 ``…/openai/v1``(不少工具要求 base 以 /v1 结尾),
+    # 裸子串又会把 ``…/myopenai`` 之类误判。两侧同一写法,不再一边尾锚定一边包含。
+    # 与主机名一样做小写归一:URL 路径按 RFC 大小写敏感,但判定不该因大小写差异漏判——
+    # 漏判的后果是给兼容端点发原生鉴权头,正是本模块要消除的那类误报。
+    segments = parsed.path.lower().strip("/").split("/")
+    if host == _GEMINI_NATIVE_HOST:
+        return _GEMINI_OPENAI_PATH_SEG not in segments
+    if host in _VERTEX_HOSTS or host.endswith(_VERTEX_HOST_SUFFIX):
+        return _VERTEX_NATIVE_PATH_SEG in segments
+    return False
 
 
 def _normalize_base_url(base_url: str) -> tuple[str | None, str | None]:
@@ -48,7 +142,14 @@ async def probe_reachable(base_url: str) -> dict | None:
 
     - scheme 非法 / 网络错 → {code: unreachable, ...}
     - 2xx/3xx 或 401/403 → None(URL 没问题,问题在缺 key)
+    - Gemini 原生端点的 404 → None(见下方注释)
     - 其他 4xx/5xx → {code: http_error, ...}
+
+    **已知代价**:原生端点的 404 一律放行,而路径写错同样回 404,两者仅凭状态码分不开。
+    于是同族主机上的路径笔误(如版本段敲多一个字母)在**未填 Key 阶段**会被上层的「缺 key」
+    盖住,提示里一个字都不提地址。这是本函数契约的直接推论——它的既定职责就是让「缺 key」
+    优先于地址错暴露,收紧就得牺牲那个契约。影响只到填 Key 之前:填上 Key 后走拉模型列表
+    那条路,拿到的是并列「端点没有此方法」与「路径可能写错」两种可能的提示。
     """
     base, err = _normalize_base_url(base_url)
     if err is not None:
@@ -63,6 +164,10 @@ async def probe_reachable(base_url: str) -> dict | None:
         }
     if r.status_code < 400 or r.status_code in (401, 403):
         return None
+    # Gemini 原生端点未必都有 models.list,404 只说明这条路径没有该方法,不代表
+    # Base URL 写错;判 http_error 会让可用配置在「缺 key」之前先被报成地址错。
+    if r.status_code == 404 and _is_gemini_native_endpoint(base):
+        return None
     return {"code": "http_error", "message": f"服务返回异常（HTTP {r.status_code}）"}
 
 
@@ -70,19 +175,38 @@ async def fetch_models(base_url: str, api_key: str) -> dict[str, Any]:
     """拉取 provider 模型列表(GET /models)。
 
     模型下拉在「选定 model 之前」拉取,没有 model 可路由 adapter,故按 base_url 判 provider:
-    Gemini 原生根(generativelanguage)用 ``x-goog-api-key`` 鉴权、响应形态 ``{models:[{name}]}``
-    (需剥 "models/" 前缀);其余按 OpenAI 兼容 ``{data:[{id}]}`` + ``Bearer`` 解析。
-    (经代理转发的 Gemini 不含该域名时,仍走 OpenAI 兼容分支——用户可手填 model 名兜底。)
+    Gemini 原生端点(见 ``_is_gemini_native_endpoint``)用 ``x-goog-api-key`` 鉴权;其余用
+    ``Bearer``。响应形态不绑死判定结果——``_parse_model_ids`` 认识的几种形态都会试,判定只
+    决定先试哪一种。
+    (经代理转发的 Gemini 不含这些域名时,仍走 OpenAI 兼容分支——用户可手填 model 名兜底。)
+
+    ``{models:[{name}]}`` 这个响应形态只在 Gemini API 那条路上验证过;生产在用的那条
+    Vertex base_url 实测 GET /models 回 404,故走下方 ``list_unsupported`` 分支。
+
+    状态码阶梯(本函数只在 api_key 非空时被调用,空 key 由 admin 侧转 ``probe_reachable``):
+
+    ======  =================  ====================================================
+    状态码  归类               依据
+    ======  =================  ====================================================
+    200     解析模型列表       各种响应形态都试,见 ``_parse_model_ids``
+    404     list_unsupported   **仅原生端点**;其余一律 http_error——判据是端点级而非主机级,
+                               故同主机下的兼容路径也走 http_error
+    401/403 bad_key            坏 key / 受限 key 的典型返回,归「列不出来」会藏掉真问题
+    其余    http_error         **含 400/429/5xx/3xx/非 200 的 2xx —— 见下方已知限制**
+    ======  =================  ====================================================
+
+    **400 不单独分类**:它既可能是 key 写错(``API_KEY_INVALID``),也可能与凭据无关
+    (如出口 IP 地区不受支持的 ``FAILED_PRECONDITION``)。只凭数字码归进 Key 那一档,会把
+    后者指到 API Key 字段、让用户反复重签一把有效凭据;要区分须读响应体的 ``error.status``。
+
+    **已知限制**(改动前后一致,未收口):「其余」那一档统一走 http_error,前端据此挂到
+    Base URL 字段——对 400/429/5xx/3xx 而言这个归因是错的。另外本函数按 base_url 判协议,
+    而 ``provider.get_adapter`` 按 model 名判,两套判据对同一份配置可能得出不同结论。
     """
     base, err = _normalize_base_url(base_url)
     if err is not None:
         return {"ok": False, "code": "unreachable", "models": [], "message": err}
-    # 解析出主机名精确匹配,不用子串判断(``"…" in base_url`` 会被
-    # ``https://evil.com/generativelanguage.googleapis.com`` 之类绕过——CodeQL 报的
-    # incomplete URL substring sanitization)。
-    is_gemini = (
-        (urlparse(base).hostname or "").lower() == "generativelanguage.googleapis.com"
-    )
+    is_gemini = _is_gemini_native_endpoint(base)
     headers = (
         {"x-goog-api-key": api_key}
         if is_gemini
@@ -99,18 +223,22 @@ async def fetch_models(base_url: str, api_key: str) -> dict[str, Any]:
             "message": f"无法连接 Base URL（{type(e).__name__}）",
         }
     if r.status_code == 200:
+        # 解析与排序一起放进 try:响应体不是 JSON 时 r.json() 会抛,逃出去会让本接口 500。
+        # 排序本身靠 _parse_model_ids「恒产非空字符串」的产出保证不抛,一并纳入只是防后续改动。
         try:
-            if is_gemini:
-                ids = [
-                    (m.get("name") or "").removeprefix("models/")
-                    for m in (r.json().get("models") or [])
-                    if m.get("name")
-                ]
-            else:
-                ids = [m.get("id") for m in (r.json().get("data") or []) if m.get("id")]
+            models = sorted(_parse_model_ids(r.json(), prefer_native=is_gemini))
         except Exception:  # noqa: BLE001
-            ids = []
-        return {"ok": True, "models": sorted(i for i in ids if i)}
+            models = []
+        return {"ok": True, "models": models}
+    if r.status_code == 404 and is_gemini:
+        # 无法仅凭 404 区分「该端点没有 models.list」与「Base URL 路径写错」,故文案并列
+        # 两种可能,不把不确定说成确定。
+        return {
+            "ok": False,
+            "code": "list_unsupported",
+            "models": [],
+            "message": "该 Base URL 未返回模型列表，请手动填写模型名（并确认 Base URL 路径无误）",
+        }
     if r.status_code in (401, 403):
         return {
             "ok": False,

--- a/backend/miloco/tests/perception/engine/omni/test_probe.py
+++ b/backend/miloco/tests/perception/engine/omni/test_probe.py
@@ -22,7 +22,9 @@ def _fake_async_client(
     exc: Exception | None = None,
     get_resp: _FakeResp | None = None,
     post_resp: _FakeResp | None = None,
+    seen: dict | None = None,
 ):
+    """``seen`` 传入则记录 GET 实际用的 url / headers，供鉴权头断言。"""
     g = get_resp if get_resp is not None else resp
     p = post_resp if post_resp is not None else resp
 
@@ -37,6 +39,9 @@ def _fake_async_client(
             return False
 
         async def get(self, *a, **k):
+            if seen is not None:
+                seen["url"] = a[0] if a else k.get("url")
+                seen["headers"] = k.get("headers") or {}
             if exc:
                 raise exc
             return g
@@ -429,3 +434,259 @@ async def test_probe_chat_stream_429_preserves_retry_after(monkeypatch):
     assert r["code"] == "rate_limited"
     # 关键:Retry-After 被解析出来传给上层 _grow_backoff_locked
     assert r["retry_after_seconds"] == 45.0
+
+
+# ─── Gemini 家族主机名判定（Gemini API / Vertex 两条接入路径）──────────────────
+
+
+def test_is_gemini_native_endpoint_covers_both_access_paths():
+    f = probe._is_gemini_native_endpoint
+    assert f("https://generativelanguage.googleapis.com/v1beta")
+    # Vertex 原生：express 形态与项目级形态，都经 /publishers/
+    assert f("https://aiplatform.googleapis.com/v1/publishers/google")
+    assert f(
+        "https://us-central1-aiplatform.googleapis.com"
+        "/v1/projects/p/locations/us-central1/publishers/google"
+    )
+    # 按主机名判而非 URL 子串：把域名塞进路径不算命中
+    assert not f("https://evil.com/aiplatform.googleapis.com")
+    assert not f("https://evil.com/generativelanguage.googleapis.com")
+    assert not f("https://api.xiaomimimo.com/v1")
+
+
+def test_parse_model_ids_tries_all_shapes():
+    """认识的几种形态都试：prefer_native 只决定先试哪一种，不是唯一依据。
+
+    绑死单一形态时，端点形态一旦判错（经代理转发、或没验证过的路径）就解出空列表
+    并被报成成功，下拉恒空且用户拿不到提示。
+    """
+    f = probe._parse_model_ids
+    native = {"models": [{"name": "models/gemini-3.6-flash"}]}
+    compat = {"data": [{"id": "m1"}]}
+    # 判对时按各自形态解
+    assert f(native, prefer_native=True) == ["gemini-3.6-flash"]
+    assert f(compat, prefer_native=False) == ["m1"]
+    # 判错时回退到另一种形态，而不是解出空列表
+    assert f(compat, prefer_native=True) == ["m1"]
+    assert f(native, prefer_native=False) == ["gemini-3.6-flash"]
+    # Vertex 的 publisherModels 形态（name 带 publishers/…/models/ 前缀）也认
+    assert f(
+        {"publisherModels": [{"name": "publishers/google/models/gemini-3.6-flash"}]},
+        prefer_native=True,
+    ) == ["gemini-3.6-flash"]
+    # 兼容形态的 id 原样透传：含 /models/ 是合法的（如 accounts/<org>/models/<name>），
+    # 套用原生形态的剥前缀规则会把它截断成 provider 认不出的名字
+    assert f(
+        {"data": [{"id": "accounts/fireworks/models/llama-v3-70b"}]}, prefer_native=False
+    ) == ["accounts/fireworks/models/llama-v3-70b"]
+    # 三种都不认 / 非 dict → 空
+    assert f({"someOtherShape": [{"name": "x"}]}, prefer_native=True) == []
+    assert f(["not", "a", "dict"], prefer_native=True) == []
+    # 条目不是 dict、列表位不是 list 都只跳过，不抛
+    assert f({"models": ["bad", {"name": "models/ok"}]}, prefer_native=True) == ["ok"]
+    assert f({"models": "notalist", "data": [{"id": "m1"}]}, prefer_native=True) == ["m1"]
+    # 产出不含空串：剥完前缀为空的条目要被丢掉，且不能因此短路掉另一种形态的回退
+    assert f({"models": [{"name": "models/"}]}, prefer_native=True) == []
+    assert f(
+        {"models": [{"name": "models/"}], "data": [{"id": "real"}]}, prefer_native=True
+    ) == ["real"]
+    # 标识是数字等标量时归一而非抛（旧实现会让调用方的 sorted 混排类型报 TypeError）
+    assert f({"data": [{"id": "a"}, {"id": 1}]}, prefer_native=False) == ["a", "1"]
+    # 但嵌套结构不是合法标识：跳过，而不是 str() 成一串垃圾文本混进下拉
+    assert f({"data": [{"id": {"name": "x"}}, {"id": "ok"}]}, prefer_native=False) == ["ok"]
+    assert f({"data": [{"id": ["a"]}]}, prefer_native=False) == []
+    assert f({"models": [{"name": {"k": "v"}}], "data": [{"id": "fallback"}]},
+             prefer_native=True) == ["fallback"]
+
+
+async def test_fetch_models_mixed_id_types_do_not_500(monkeypatch):
+    """条目 id 类型混杂时不能让异常逃出本接口。"""
+    monkeypatch.setattr(
+        probe.httpx,
+        "AsyncClient",
+        _fake_async_client(_FakeResp(200, {"data": [{"id": "b"}, {"id": 1}]})),
+    )
+    r = await probe.fetch_models("https://aiplatform.googleapis.com/v1/publishers/google", "k")
+    assert r["ok"] is True and r["models"] == ["1", "b"]
+
+
+async def test_fetch_models_recovers_when_shape_mismatches(monkeypatch):
+    """原生端点回了兼容形态时仍解得出模型，而不是静默返回空列表。"""
+    monkeypatch.setattr(
+        probe.httpx,
+        "AsyncClient",
+        _fake_async_client(_FakeResp(200, {"data": [{"id": "gemini-3.6-flash"}]})),
+    )
+    r = await probe.fetch_models(
+        "https://aiplatform.googleapis.com/v1/publishers/google", "k"
+    )
+    assert r == {"ok": True, "models": ["gemini-3.6-flash"]}
+
+
+def test_gemini_api_openai_compat_path_stays_on_openai_branch():
+    """Gemini API 主机下的 OpenAI 兼容 base_url 必须留在 Bearer 分支。
+
+    官方兼容 base_url 是 https://generativelanguage.googleapis.com/v1beta/openai/，
+    走 Authorization: Bearer + {data:[{id}]}。判成原生有两种落点、都坏：发 x-goog-api-key
+    被拒 → 401 误报 bad_key；或被收下 → 按 {models:[{name}]} 解析 → 空列表且 ok=true。
+    """
+    f = probe._is_gemini_native_endpoint
+    assert not f("https://generativelanguage.googleapis.com/v1beta/openai")
+    assert not f("https://generativelanguage.googleapis.com/v1beta/openai/")
+    # 不少工具要求 base 以 /v1 结尾——尾锚定判定会漏掉这一形态
+    assert not f("https://generativelanguage.googleapis.com/v1beta/openai/v1")
+    assert f("https://generativelanguage.googleapis.com/v1beta")
+    # 按路径段比对，不误伤名字里恰好含 openai 的段
+    assert f("https://generativelanguage.googleapis.com/v1beta/myopenai")
+    # 路径段与主机名一样做大小写归一：URL 路径大小写敏感，但判定不该因此漏判
+    assert not f("https://generativelanguage.googleapis.com/v1beta/OpenAI")
+    assert not f("https://generativelanguage.googleapis.com/v1beta/OPENAI/v1")
+
+
+async def test_fetch_models_gemini_openai_compat_uses_bearer(monkeypatch):
+    """兼容路径走到发请求这一层也要是 Bearer，且按 {data:[{id}]} 解析出模型。"""
+    seen: dict = {}
+    monkeypatch.setattr(
+        probe.httpx,
+        "AsyncClient",
+        _fake_async_client(_FakeResp(200, {"data": [{"id": "gemini-3.6-flash"}]}), seen=seen),
+    )
+    r = await probe.fetch_models(
+        "https://generativelanguage.googleapis.com/v1beta/openai", "k"
+    )
+    assert r == {"ok": True, "models": ["gemini-3.6-flash"]}
+    assert "Authorization" in seen["headers"]
+    assert "x-goog-api-key" not in seen["headers"]
+
+
+def test_vertex_openai_compat_path_stays_on_openai_branch():
+    """Vertex 同主机下的 OpenAI 兼容路径必须留在 Bearer 分支。
+
+    该端点鉴权走 ``Authorization: Bearer``；只按主机名判会给它发 x-goog-api-key
+    → 401 → 误报 bad_key，正是本模块要消除的那类误报。
+    """
+    assert not probe._is_gemini_native_endpoint(
+        "https://us-central1-aiplatform.googleapis.com"
+        "/v1beta1/projects/p/locations/us-central1/endpoints/openapi"
+    )
+
+
+def test_vertex_non_native_path_not_treated_as_native():
+    """Vertex 主机上**任何**不经 publishers 段的路径都不按原生处理。
+
+    这条锁的是「白名单」而非「黑名单」语义：**若改成**只排除已知的 OpenAI 兼容路径，
+    该主机上其余非原生路径就会被误判成原生、发错鉴权头——本用例即为拦住那种改法。
+    """
+    assert not probe._is_gemini_native_endpoint(
+        "https://us-central1-aiplatform.googleapis.com/v1beta1/projects/p/locations/l/datasets"
+    )
+    assert not probe._is_gemini_native_endpoint(
+        "https://aiplatform.googleapis.com/v1"
+    )
+
+
+async def test_fetch_models_vertex_openai_compat_uses_bearer(monkeypatch):
+    """走到发请求这一层也要是 Bearer —— 判定改错时这条会连带变红。"""
+    seen: dict = {}
+    monkeypatch.setattr(
+        probe.httpx, "AsyncClient", _fake_async_client(_FakeResp(200, {"data": [{"id": "m1"}]}), seen=seen)
+    )
+    r = await probe.fetch_models(
+        "https://us-central1-aiplatform.googleapis.com"
+        "/v1beta1/projects/p/locations/us-central1/endpoints/openapi",
+        "k",
+    )
+    assert r == {"ok": True, "models": ["m1"]}
+    assert "Authorization" in seen["headers"]
+    assert "x-goog-api-key" not in seen["headers"]
+
+
+async def test_fetch_models_vertex_uses_goog_key_header(monkeypatch):
+    """Vertex 主机按 Gemini 家族处理：走 x-goog-api-key，不发 Bearer。"""
+    seen: dict = {}
+    monkeypatch.setattr(
+        probe.httpx,
+        "AsyncClient",
+        _fake_async_client(
+            _FakeResp(200, {"models": [{"name": "models/gemini-3.6-flash"}]}), seen=seen
+        ),
+    )
+    r = await probe.fetch_models("https://aiplatform.googleapis.com/v1/publishers/google", "k")
+    assert r == {"ok": True, "models": ["gemini-3.6-flash"]}
+    assert "x-goog-api-key" in seen["headers"]
+    assert "Authorization" not in seen["headers"]
+
+
+async def test_fetch_models_gemini_404_is_list_unsupported(monkeypatch):
+    """该端点没有 models.list（Vertex 实测回 404）→ 提示手填模型名，不报地址错。"""
+    monkeypatch.setattr(probe.httpx, "AsyncClient", _fake_async_client(_FakeResp(404)))
+    r = await probe.fetch_models("https://aiplatform.googleapis.com/v1/publishers/google", "k")
+    assert r["ok"] is False and r["code"] == "list_unsupported" and r["models"] == []
+
+
+async def test_fetch_models_404_gate_is_endpoint_level_not_host_level(monkeypatch):
+    """404 归「列不出来」的判据是**端点**级，不是主机级。
+
+    同主机下的 OpenAI 兼容路径本身就有 /models 接口，那里的 404 更可能是路径写错，
+    应落 http_error；把判据放宽到「同族主机」会让它被误报成「该端点没有列模型接口」。
+    """
+    monkeypatch.setattr(probe.httpx, "AsyncClient", _fake_async_client(_FakeResp(404)))
+    native = await probe.fetch_models(
+        "https://generativelanguage.googleapis.com/v1beta", "k"
+    )
+    assert native["code"] == "list_unsupported"
+
+    monkeypatch.setattr(probe.httpx, "AsyncClient", _fake_async_client(_FakeResp(404)))
+    compat = await probe.fetch_models(
+        "https://generativelanguage.googleapis.com/v1beta/openai", "k"
+    )
+    assert compat["code"] == "http_error", "同主机的兼容路径 404 不该归 list_unsupported"
+
+
+async def test_fetch_models_gemini_401_403_still_bad_key(monkeypatch):
+    """坏 key / 被限制的 key 正是回 401/403 —— 不能被「列不出来」吞掉。"""
+    for status in (401, 403):
+        monkeypatch.setattr(
+            probe.httpx, "AsyncClient", _fake_async_client(_FakeResp(status))
+        )
+        r = await probe.fetch_models("https://generativelanguage.googleapis.com/v1beta", "k")
+        assert r["code"] == "bad_key", f"HTTP {status} 应仍判 bad_key"
+
+
+async def test_fetch_models_non_gemini_unchanged(monkeypatch):
+    """非 Gemini 主机行为不变：401 → bad_key，404 → http_error。"""
+    monkeypatch.setattr(probe.httpx, "AsyncClient", _fake_async_client(_FakeResp(401)))
+    assert (await probe.fetch_models("https://api.example.com/v1", "k"))["code"] == "bad_key"
+    monkeypatch.setattr(probe.httpx, "AsyncClient", _fake_async_client(_FakeResp(404)))
+    assert (await probe.fetch_models("https://api.example.com/v1", "k"))["code"] == "http_error"
+
+
+async def test_probe_reachable_404_gate_is_endpoint_level_not_host_level(monkeypatch):
+    """预检侧的 404 判据同样是**端点**级，与拉模型列表那侧对称。
+
+    同主机下的 OpenAI 兼容路径 404 仍应报出来；放宽到「同族主机」会让它被当作
+    「该端点没有列模型接口」而放行，把地址错盖成「缺 key」。
+    """
+    monkeypatch.setattr(probe.httpx, "AsyncClient", _fake_async_client(_FakeResp(404)))
+    assert (
+        await probe.probe_reachable("https://generativelanguage.googleapis.com/v1beta")
+        is None
+    )
+    monkeypatch.setattr(probe.httpx, "AsyncClient", _fake_async_client(_FakeResp(404)))
+    compat = await probe.probe_reachable(
+        "https://generativelanguage.googleapis.com/v1beta/openai"
+    )
+    assert compat is not None and compat["code"] == "http_error"
+
+
+async def test_probe_reachable_gemini_404_not_reported_as_url_error(monkeypatch):
+    """Vertex 没有 models.list，404 不该在「缺 key」之前先被报成地址错。"""
+    monkeypatch.setattr(probe.httpx, "AsyncClient", _fake_async_client(_FakeResp(404)))
+    assert (
+        await probe.probe_reachable("https://aiplatform.googleapis.com/v1/publishers/google")
+        is None
+    )
+    # 非 Gemini 主机的 404 仍然要报出来
+    monkeypatch.setattr(probe.httpx, "AsyncClient", _fake_async_client(_FakeResp(404)))
+    r = await probe.probe_reachable("https://api.example.com/v1")
+    assert r is not None and r["code"] == "http_error"

--- a/web/src/components/UsageOmniConfig.tsx
+++ b/web/src/components/UsageOmniConfig.tsx
@@ -32,10 +32,12 @@ const INPUT_CLS =
   "focus:border-brand-primary focus:outline-none text-text-primary num";
 
 // omni 测试 / 模型列表的后端机器码 → i18n key;命中走前端本地化,
-// 未命中(如 http_error,含动态 HTTP 细节)回退后端 message。
-// 与 error_classifier.CODES 保持一致(10 个 code):测试路径撞 429 会返 rate_limited、
-// 200+非 JSON body 会返 bad_response,retry 被中断会返 cancelled。缺 code = 回退
-// 后端硬编码中文 message、污染英文界面。
+// 未命中回退后端 message。
+// 除 ok 与 list_unsupported 外,其余键取自 error_classifier.CODES(不含 timeout ——
+// probe 把所有异常统一归 unreachable,不产出该码):测试路径撞 429 会返 rate_limited、
+// 200+非 JSON body 会返 bad_response,retry 被中断会返 cancelled。
+// list_unsupported 是拉模型列表专有码,不参与熔断,故不在 CODES 里。
+// 缺 code = 回退后端硬编码中文 message、污染英文界面。
 const OMNI_CODE_KEY: Record<string, string> = {
   ok: "usage.testOk",
   bad_key: "usage.testBadKey",
@@ -47,7 +49,13 @@ const OMNI_CODE_KEY: Record<string, string> = {
   rate_limited: "usage.testRateLimited",
   bad_response: "usage.testBadResponse",
   cancelled: "usage.testCancelled",
+  list_unsupported: "usage.modelsListUnsupported",
 };
+
+// 拉不到模型列表 ≠ 配置有问题,故这类码走中性灰字提示、不打红 ✗:同一件事(这个地址列不出
+// 模型)在 ok:true+空列表 那条路上本来就是灰字,两条路不该一灰一红。文案已并列「端点没有这个
+// 方法」与「路径可能写错」两种可能,由用户自查,不必用错误色替他下判断。
+const MODELS_INFO_CODES = new Set(["list_unsupported"]);
 
 // 测试结果三档语义:连接正常(✓ 绿,chat 调通)/ 鉴权过但探测被拒(⚠ 黄,rejected_authed)/ 失败(✗ 红)。
 const TEST_WARN_CODES = new Set(["rejected_authed"]);
@@ -279,8 +287,9 @@ export function UsageOmniConfig() {
         setModels([]);
         const k = res.code ? OMNI_CODE_KEY[res.code] : undefined;
         setModelsMsg(k ? t(k) : res.message || t("usage.modelsFetchFailed"));
-        setModelsErr(true);
-        setModelsErrCode(res.code ?? null);
+        const isInfo = !!res.code && MODELS_INFO_CODES.has(res.code);
+        setModelsErr(!isInfo);
+        setModelsErrCode(isInfo ? null : (res.code ?? null));
       }
     } catch (e) {
       setModels([]);

--- a/web/src/i18n/locales/en/usage.json
+++ b/web/src/i18n/locales/en/usage.json
@@ -92,6 +92,7 @@
     "testNotFound": "Model or URL not found",
     "testRejectedAuthed": "Connected, but the request was rejected (model name or API key may be wrong)",
     "testUnreachable": "Couldn't reach the Base URL",
+    "modelsListUnsupported": "This Base URL returned no model list — enter the model name manually (and double-check the Base URL path)",
     "testNoKey": "No API key configured",
     "testHttpError": "Server returned an error — check the Base URL",
     "testRateLimited": "Rate-limited by the provider, please retry later",

--- a/web/src/i18n/locales/zh/usage.json
+++ b/web/src/i18n/locales/zh/usage.json
@@ -92,6 +92,7 @@
     "testNotFound": "模型或地址不存在",
     "testRejectedAuthed": "已连接，但请求被拒绝（模型名或 API Key 可能有误）",
     "testUnreachable": "无法连接 Base URL",
+    "modelsListUnsupported": "该 Base URL 未返回模型列表,请手动填写模型名(并确认 Base URL 路径无误)",
     "testNoKey": "未配置 API Key",
     "testHttpError": "服务返回异常,请检查 Base URL 是否正确",
     "testRateLimited": "被 provider 限流,请稍后再试",

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -457,7 +457,7 @@ export interface OmniProfileRef {
 /** 拉取模型列表结果。 */
 export interface OmniModelsResult {
   ok: boolean;
-  /** 失败时的机器码(no_key/unreachable/bad_key/http_error);缺省回退 message。 */
+  /** 失败时的机器码(no_key/unreachable/bad_key/http_error/list_unsupported);缺省回退 message。 */
   code?: string;
   models: string[];
   message?: string;


### PR DESCRIPTION
## 概述

修一个设置页的误报：配置 Gemini 时，「测试连接」显示成功、模型下拉却红字说「API Key 无效」或「Base URL 有问题」——同一套可用配置给出两个互相矛盾的信号。

根因是「按 base_url 猜 provider」这个判定只认了 Gemini 其中一条官方接入路径的主机名。本 PR 把判定改成「主机名 + 路径」两级，并把「这个端点没有列模型这个方法」与「Key 真的有问题」区分开。

术语：**模型下拉的拉取**和**无 key 时的可达性预检**这两条路径，都在用户选定模型**之前**执行，此时没有模型名可以路由到对应的 provider adapter，只能退而按 base_url 判断 provider——这是本 PR 涉及的全部范围。

需要说清的一道跨层裂缝：感知主链路与「测试连接」按钮按**模型名**路由 adapter，与这里按 base_url 的判定是两套判据，对同一份配置可能得出不同结论。「模型名含 gemini、base_url 却是该家族 OpenAI 兼容接入路径」这种组合，改动后能在模型下拉里列出模型，但选协议那层仍按原生协议发请求、拿不到结果。该组合本就跑不通感知主链路——兼容端点不收视频输入，而主链路是视频感知（见 provider 模块 docstring）——本 PR 没有改变这一点，只是让它在模型下拉这一层看起来可用。代码里已在对应 docstring 记下这道裂缝。

## 1. 判定改成「主机名 + 路径」两级（修复发错鉴权头）· fix

**问题**：判定只精确匹配了其中一条接入路径的主机名，另一条接入路径（含其区域端点）落进 OpenAI 兼容分支，发 `Bearer` 而非该家族要求的鉴权头，且按错误的响应形态解析。

更关键的是：**两台主机下都是原生协议与 OpenAI 兼容协议并存**，主机名一样，只能靠路径区分。只按主机名判会把兼容那条也当成原生，有两种落点、都坏——发 API key 头被拒则 401、误报「Key 无效」（正是本 PR 存在的理由）；被收下则拿原生形态去解兼容层的响应，解出空列表却仍报成功，用户看到一个空下拉、连可行动的提示都没有。

**解决方案**：
- **判定改成两级**：先按主机名识别两条官方接入路径（含区域端点形态），命中后**再过一道路径判断**，把同主机下的 OpenAI 兼容接入路径分出去。
- **两侧策略故意不同，理由写进注释**：Gemini API 侧用黑名单只排除兼容路径段——原生的版本段会随 API 版本新增，白名单要跟着改；Vertex 侧用白名单只放行原生路径段——该主机路径形态多，黑名单挡不住未知的非原生路径。
- **保留原有的绕过防护**：主机名仍取解析后的 hostname 比对，不用 URL 子串匹配——子串匹配会被「把域名塞进路径」的构造绕过（原代码为此收敛过一次 CodeQL 告警，本次未放松）。

## 2. 区分「列不出来」与「Key 有问题」（避免藏住真实 Key 故障）· fix

**问题**：该家族并非每条接入路径都提供列模型的方法，缺这个方法时返回的状态码被当成「地址错」或「Key 错」报给用户。

**解决方案**：
- **新增一个机器码，只用于 404**：文案是「该 Base URL 未返回模型列表，请手动填写模型名（并确认 Base URL 路径无误）」——仅凭该状态码无法区分「端点没有这个方法」与「路径写错」，故并列两种可能，不把不确定说成确定。
- **401/403 维持原判**：坏 Key、被限制的 Key 正是回这两个码，一并归入「列不出来」会把真实的 Key 故障藏掉。这条有专门的用例守着。

## 3. 可达性预检不再抢报地址错 · fix

**问题**：没填 Key 时的预检打的是同一个列模型接口，缺该方法时的 404 被判成「Base URL 有问题」，抢在「缺 key」这个真实原因之前报错。

**解决方案**：**同类端点的 404 视为可达**，让「缺 key」正常暴露；其他端点的 404 行为不变。

## 4. 前端接住新机器码 · fix

**问题**：后端新增机器码若前端没有对应文案，会掉回后端硬编码的中文串，污染英文界面（该文件既有注释已写明这个坑）。

**解决方案**：
- **补齐中英文案**并接入机器码映射；提示就近显示在模型输入框旁，与「手动填写模型名」这个动作对应。
- **这类码按中性提示渲染，不打红 ✗**：拉不到模型列表 ≠ 配置有问题。此前前端只按成功与否二分，把它和鉴权失败、服务端错误一样打成红 ✗，于是一套可用配置会在同一个表单里同时出现红 ✗ 与「测试连接」的绿 ✓——正是本 PR 概述第一句要消除的矛盾信号。同一件事在「成功但列表为空」那条路上本来就走灰字，两条路不该一灰一红。
- **修正失真注释**：凡自陈「新码与熔断错误码集合一一对应」的注释都改成按集合关系描述——新码只在拉模型列表这条路上产生、不参与熔断，不属于那个集合。**包括真正 `return` 这个码的那个文件**，那处额外写明「别因为在那个集合里找不到就把它补进去」：补进去等于让它变成熔断码，与其余各处的定性相反，还会连带要求健康状态的中英文案各补一条本该只出现在模型下拉的提示。

## 5. 模型列表解析不再绑死单一响应形态 · fix

**问题**：解析形态原先由端点判定单独决定，判错就解出空列表、却仍按成功返回，模型下拉恒空且不给任何可行动提示。

**解决方案**：
- **认识的几种形态都试，谁解出算谁**：端点判定只决定先试哪一种，不再是唯一依据。覆盖 Gemini 原生、Vertex 的列模型形态、以及 OpenAI 兼容三种；前缀归一**按形态各配一条**——两种原生形态各剥各的前缀，兼容形态的标识原样透传（含 `/` 是合法的，截断后 provider 认不出来）。
- **解析器给出产出保证**：产出恒为**可直接排序的非空字符串列表**——异常形态一律跳过而非抛出；数字等标量标识归一为字符串而非丢弃，嵌套结构不进结果。调用方据此可直接排序，不必再过滤。这条保证的两半各有必要：不归一，则形态回退让该路径第一次读到另一种形态的字段、标识类型混杂时排序会抛异常逃出接口变成服务端错误；不排除嵌套结构，则它字符串化后是一串非空垃圾文本、会通过空值过滤被当成合法模型名收进下拉，用户选中后存进配置。具体判据以代码与用例为准。

## 测试与兼容性

**怎么验**：用例覆盖端点判定表（两条接入路径的原生形态、区域端点、两台主机各自的 OpenAI 兼容路径、Vertex 主机上其余非原生路径、把域名塞进路径的绕过尝试、一个非 Gemini 主机）、鉴权头选择（原生与兼容各自断言实际发出的 header）、404 与 401/403 的分流、可达性预检两侧行为，以及模型列表解析的几种形态互为回退、兼容形态标识的原样透传、标量标识的归一与嵌套结构的排除，和各类异常与边界形态。

**变异测试**：以下回退实现均能让对应用例变红（包括但不限于）——去掉 Gemini API 侧的路径判断、去掉 Vertex 侧的路径判断、把 Vertex 侧的白名单换成只排除已知兼容路径的黑名单、删掉 404 分支、删掉预检分支、把 404 放宽成 401/403/404（即第 2 节要避免的那个设计缺陷）、解析退回单一形态、去掉空串过滤、去掉标识类型归一。确认护栏不是空断言。

**兼容性**：非 Gemini 主机的所有分支行为逐条不变（401 仍 `bad_key`、404 仍 `http_error`），有用例锁定。新增的机器码是纯增量，旧 code 集合未改。

**回滚**：`git revert` 即可，无数据/配置迁移。

**风险提醒**：本次只改「选定模型之前」的两条探测路径，不触碰推理与鉴权主链路。

**生产路径上真正起作用的是哪一半**：生产在用的 Vertex base_url，`GET /models` 无论 Key 有效与否一律回 404（该路径没有列模型接口，请求根本到不了鉴权层）。所以把红 ✗ 变成中性提示的是 **404 分类 + 前端中性渲染**这两步；鉴权头的切换、模型列表的双形态解析与标识归一在这条路上执行不到，属正确性/前瞻性修复。别据此以为鉴权头是生产症状的成因。

**状态码归类的边界**：明确归类的只有少数几档，其余统一落兜底并被前端归到 Base URL 字段——对限流、上游故障、未跟随的重定向而言这个归因是错的。其中 400 **刻意不分类**：它既可能是 Key 写错，也可能与凭据无关（如出口 IP 地区不受支持），只凭数字码归进 Key 那一档会把后者指到 API Key 字段、让用户反复重签一把有效凭据。完整的状态码阶梯与逐档理由写在 `fetch_models` 的 docstring 里，**以代码为准**——描述里不再复述一份，免得两处粒度漂移。以上行为在本次改动前后一致。

**同一状态码在两条探测路径上定性不同**：同样是 `GET /models` 的 404，「测试连接」那条路把它当作「说明不了什么，以 chat 探测的结论为准」，而模型下拉这条路把它当作「该端点没有列模型接口 / 路径可能写错」。不实现该接口的兼容网关会同时拿到「测试连接」的绿 ✓ 与 Base URL 框下的红 ✗。这是两个函数各自既有的定性，本 PR 未改变、也未统一——收口要动「测试连接」那条路，超出本 PR 范围。

**已知未覆盖**：两类原生形态仍会落进兼容分支——① **主机名对不上的**：多区域端点（形如 `aiplatform.{us|eu}.rep.googleapis.com`，注意与已覆盖的**区域**端点 `{区域}-aiplatform.googleapis.com` 不是一回事，后者由主机名后缀匹配覆盖、有用例锁定）、Private Service Connect 分配的自定义 DNS、以及经用户自建代理转发的形态；② **主机名命中但路径不含原生路径段的**：tuned endpoint（`…/endpoints/{id}`）等。落进兼容分支的后果是拿不到模型下拉、用户手填模型名即可继续，属安全侧失败。这些在改动前同样如此，不属本次引入的回退。






