### PR TITLE
feat(perception): Smart Crop 支持逐机位开关

### DIFF
--- a/backend/miloco/src/miloco/admin/router.py
+++ b/backend/miloco/src/miloco/admin/router.py
@@ -1492,6 +1492,9 @@ class PerceptionConfigBody(BaseModel):
     window_size: int | None = Field(default=None, ge=1, le=60)
     # Smart Crop 用户开关。与 video_short_edge 正交:裁不裁看这个,多清晰看 video_short_edge。
     # 写进 perception.engine.crop_enhance.user_enabled;发版级开关 enabled 不由 API 写。
+    # 注意本开关（连同 enabled）只是**必要非充分**条件：还要该机位自己的 per-camera 闸也开
+    # （KV CAMERA_CROP_DENY_LIST_KEY，deny-list/默认开，`scope camera crop-on/crop-off` 逐路配），
+    # 三闸相与才裁。生效态看 /api/miot/scope/cameras 的 crop_effective。
     smart_crop_enabled: bool | None = None
     min_suggestion_urgency: Literal["low", "medium", "high"] | None = Field(
         default=None,
@@ -1540,7 +1543,11 @@ def _perception_config_payload() -> dict:
         "window_size": s.perception.collect.window_size,
         # 双闸分开暴露:smart_crop_enabled = 用户态(开关位置,取 user_enabled)vs
         # smart_crop_available = 决定开关能不能点(取发版级开关 enabled)。
-        # available=false 时前端置灰 + 提示「服务端尚未开放」,避免"开关开着但后端不裁"。
+        # available=false 时前端置灰 + 提示「服务端尚未开放」,避免"开关开着但**发版级闸**
+        # 没开"。注意本接口这两个字段只覆盖三闸里的**全局两闸**:即便都为 true、开关也亮着,
+        # 某个机位仍可能被 per-camera 闸单独关掉而不裁(见 PerceptionConfigBody.
+        # smart_crop_enabled 上方注释)。逐机位的生效态本接口不透出,看
+        # /api/miot/scope/cameras 的 crop_effective。
         # 注意 available 不只反映发版级开关:整份 crop_enhance 校验不过(数值字段写成字符串 /
         # min>max)时运行时整份退默认,这里跟着报 false —— 此时那句提示归因是偏的,真因看
         # 日志 event=crop_enhance_config_bad 的 reason。

--- a/backend/miloco/src/miloco/config/settings.yaml
+++ b/backend/miloco/src/miloco/config/settings.yaml
@@ -93,9 +93,13 @@ perception:
       # 双闸:enabled = 发版级开关(本文件随包发布、不由 admin API 写,只能改文件;false 时
       #       整个能力关掉、前端开关随之置灰);
       #       user_enabled = 单机用户开关(UI「智能裁切增强」,admin API 写 config.json)。
-      #       两个都为 true 才裁。分两个 key 不是访问控制(本地部署拦不住),是配置层不同,
+      #       本文件这两个是**全局**闸,都为 true 只是必要条件 —— 还要该机位自己的
+      #       per-camera 闸也开(KV CAMERA_CROP_DENY_LIST_KEY,deny-list/默认开,
+      #       用 `miloco-cli scope camera crop-on/crop-off` 逐路配),三闸相与才裁。
+      #       分两个 key 不是访问控制(本地部署拦不住),是配置层不同,
       #       见 perception/engine/config.py::CropEnhanceConfig 的 docstring。
-      # 两闸默认放开:未改过 config.json / 未动 UI 开关的用户默认启用 Smart Crop。
+      # 两闸默认放开(per-camera 闸的默认也是开,空集=全开):未改过 config.json /
+      # 未动 UI 开关 / 未逐机位关过的用户默认启用 Smart Crop。
       # 关闭任一闸即回退全景路径(不再裁切),但**不等于**字节回到未接本特性前 —— 全景与 crop
       # 共用 _encode_video_mp4,其放大分支的重采样核已随本特性换成 LANCZOS4(源短边 < 用户档
       # 时命中,如 720p 子码流 + 768/1080 档),故关闸后全景 clip 字节仍与接特性前不同。

--- a/backend/miloco/src/miloco/database/kv_repo.py
+++ b/backend/miloco/src/miloco/database/kv_repo.py
@@ -235,6 +235,19 @@ class ScopeConfigKeys:
     # 改动下一窗即生效、不重启。用途：给模型补充该机位的环境描述 / 关注点 / 忽略项，
     # 消除固定误识（如门口机位把公共走廊电梯门误当自家入户门）。读取失败按「无自定义」处理。
     CAMERA_PROMPT_MAP_KEY = "CAMERA_PROMPT_MAP_KEY"
+    # 已**关闭** Smart Crop（智能裁切增强）的摄像头 did 列表（deny-list，默认开启）；
+    # 不在此集 = 该机位允许裁切。JSON array，空集 / NULL = 全部机位都开。
+    # 键口径同 CAMERA_PROMPT_MAP_KEY：按**合成 did**（``did:ch{n}``，多通道相机逐路），
+    # 因为"该不该裁"取决于该路镜头的视野（门口窄视野收益小、客厅广角收益大），逐路不同；
+    # 与按整台走的 CAMERA_BLACK_LIST_KEY / CAMERA_VOICE_ALLOW_LIST_KEY 不同口径。
+    # 与全局双闸（perception.engine.crop_enhance.enabled / user_enabled）**相与**：
+    # 全局关则本集无意义，全局开时才逐机位看本集。引擎每感知窗实时读取，改动下一窗即生效、
+    # 不重启（见 perception/engine/api.py 的 _crop_denied_dids）。
+    # 读取失败按**空集**处理（fail-open = 继续裁）：本项只影响视频编码构图、不涉隐私，
+    # 且"默认开启"的语义本就是"缺信息即为开"；反向 fail-closed 会让一次 KV 抖动静默关掉
+    # 全家 Smart Crop，是更难发现的失效态。与 CAMERA_VOICE_ALLOW_LIST_KEY 的 fail-closed
+    # 相反正是因为那项涉隐私。
+    CAMERA_CROP_DENY_LIST_KEY = "CAMERA_CROP_DENY_LIST_KEY"
 
 class OnboardingKeys:
     """主动 onboarding 邀请的一次性标记。

--- a/backend/miloco/src/miloco/miot/filter.py
+++ b/backend/miloco/src/miloco/miot/filter.py
@@ -9,6 +9,9 @@
 
 另有 ``CAMERA_PROMPT_MAP_KEY``（每摄像头自定义「感知须知」prompt，did→文本）——
 唯一的 map 语义 key（JSON object，非集合），供逐设备注入 omni 场景指导。
+
+``CAMERA_CROP_DENY_LIST_KEY``（已关闭 Smart Crop 的相机集合，deny-list / 默认开）同为
+JSON array，但键口径是**合成 did**（逐路，同 prompt），与按整台走的启停 / 拾音不同。
 """
 
 from __future__ import annotations
@@ -84,6 +87,20 @@ def voice_allowed_camera_dids(kv_repo: KVRepo) -> set[str]:
     改开关即时生效、不重启感知引擎。读 KV 失败时按空集处理（fail-closed）。
     """
     return set(_load_list(kv_repo, ScopeConfigKeys.CAMERA_VOICE_ALLOW_LIST_KEY))
+
+
+def crop_denied_camera_dids(kv_repo: KVRepo) -> set[str]:
+    """已**关闭** Smart Crop 的相机 did 集合（deny-list / 默认开）；空表示全部机位都开。
+
+    键是**合成 did**（``did:ch{n}``，多通道逐路），同 ``camera_prompts``——"该不该裁"取决于
+    该路镜头的视野，与按整台走的启停 / 拾音不同口径。
+
+    与全局双闸（``perception.engine.crop_enhance.enabled`` / ``user_enabled``）**相与**：
+    全局关则整个能力不可用、本集无意义；全局开时才逐机位看本集。引擎每感知窗实时读取，
+    改开关下一窗即生效、不重启感知引擎。读 KV 失败时按空集处理（fail-open = 继续裁：本项
+    只影响视频编码构图、不涉隐私，与 ``voice_allowed_camera_dids`` 的 fail-closed 相反）。
+    """
+    return set(_load_list(kv_repo, ScopeConfigKeys.CAMERA_CROP_DENY_LIST_KEY))
 
 
 def is_home_allowed(kv_repo: KVRepo, home_id: str | None) -> bool:
@@ -280,6 +297,19 @@ def set_cameras_voice_in_use(
     """批量切换相机拾音启用状态。去重后一次性写入 KV。拾音无投喂上限，不设 cap。"""
     return _toggle_members(
         kv_repo, ScopeConfigKeys.CAMERA_VOICE_ALLOW_LIST_KEY, dids, include=in_use
+    )
+
+
+def set_cameras_crop_in_use(
+    kv_repo: KVRepo, dids: list[str], in_use: bool
+) -> tuple[list[str], bool]:
+    """批量切换相机 Smart Crop 启用状态。``in_use=False`` 即加入**关闭集**（deny-list，
+    故 ``include=not in_use``，同 ``set_camera_in_use``）。``dids`` 为合成 did。
+
+    去重后一次性写入 KV。裁切无投喂上限，不设 cap。
+    """
+    return _toggle_members(
+        kv_repo, ScopeConfigKeys.CAMERA_CROP_DENY_LIST_KEY, dids, include=not in_use
     )
 
 

--- a/backend/miloco/src/miloco/miot/router.py
+++ b/backend/miloco/src/miloco/miot/router.py
@@ -25,6 +25,7 @@ from miloco.middleware import (
 from miloco.middleware.exceptions import HTTPException
 from miloco.miot.schema import (
     AuthorizeRequest,
+    CameraCropToggleRequest,
     CameraPromptRequest,
     CameraToggleRequest,
     CameraVoiceToggleRequest,
@@ -538,6 +539,22 @@ async def toggle_scope_camera_voice(
     # 与相机启用开关的 refresh/sync/restart 逻辑正交,分开更清晰。
     data = await manager.miot_service.toggle_camera_voice(
         [{"did": i.did, "voice_in_use": i.voice_in_use} for i in request.items]
+    )
+    return NormalResponse(code=0, message="ok", data=data)
+
+
+@router.put(
+    path="/scope/cameras/crop",
+    summary="Batch toggle per-camera Smart Crop (adaptive crop) state",
+    response_model=NormalResponse,
+)
+async def toggle_scope_camera_crop(
+    request: CameraCropToggleRequest, current_user: str = Depends(verify_token)
+):
+    # 单独端点：裁切开关无投喂上限/离线校验、不从属于感知开关、不重启感知引擎（引擎逐窗
+    # 实时读 KV）。按合成 did 逐路存取，与 prompt 同口径、与按整台走的启停/拾音不同。
+    data = await manager.miot_service.toggle_camera_crop(
+        [{"did": i.did, "crop_in_use": i.crop_in_use} for i in request.items]
     )
     return NormalResponse(code=0, message="ok", data=data)
 

--- a/backend/miloco/src/miloco/miot/schema.py
+++ b/backend/miloco/src/miloco/miot/schema.py
@@ -265,6 +265,32 @@ class CameraVoiceToggleRequest(BaseModel):
     items: list[CameraVoiceToggleItem] = Field(..., min_length=1)
 
 
+class CameraCropToggleItem(BaseModel):
+    """单个相机（通道）的 Smart Crop 开/关操作。"""
+
+    did: str = Field(
+        ...,
+        min_length=1,
+        description="相机 did：合成通道 did（cam:chN，逐路）或裸物理 did（多通道 = 全通道）",
+    )
+    crop_in_use: bool = Field(
+        ...,
+        description=(
+            "true = 该机位允许智能裁切增强（默认）；false = 该机位改走全景路径不裁切。"
+            "与全局双闸 crop_enhance.enabled / user_enabled 相与"
+        ),
+    )
+
+
+class CameraCropToggleRequest(BaseModel):
+    """批量切换相机 Smart Crop 状态。每项独立指定 did + crop_in_use。
+
+    与拾音不同，**不**要求相机感知已启用（裁切不涉隐私，允许预配置）。
+    """
+
+    items: list[CameraCropToggleItem] = Field(..., min_length=1)
+
+
 class CameraPromptItem(BaseModel):
     """单个相机的自定义「感知须知」prompt 设置。"""
 

--- a/backend/miloco/src/miloco/miot/service.py
+++ b/backend/miloco/src/miloco/miot/service.py
@@ -38,6 +38,7 @@ from miloco.miot.filter import (
     allowed_home_ids,
     camera_prompts,
     clear_camera_prompt,
+    crop_denied_camera_dids,
     denied_camera_dids,
     denied_channels_of,
     filter_by_home,
@@ -46,6 +47,7 @@ from miloco.miot.filter import (
     select_active_camera_dids,
     set_camera_prompt,
     set_cameras_channels_in_use,
+    set_cameras_crop_in_use,
     set_cameras_voice_in_use,
     set_homes_in_use,
     synthetic_camera_did,
@@ -366,6 +368,14 @@ class MiotService:
         self._kv_repo.delete(ScopeConfigKeys.CAMERA_BLACK_LIST_KEY)
         self._kv_repo.delete(ScopeConfigKeys.CAMERA_VOICE_ALLOW_LIST_KEY)
         self._kv_repo.delete(ScopeConfigKeys.CAMERA_PROMPT_MAP_KEY)
+        # 裁切关闭集同样按合成 did 逐路存、绑在当前账号的相机 did 上：换账号后旧 did 既读不到
+        # 也删不掉(读侧只遍历现账号相机)；同账号解绑重绑时 did 不变,不清就会让上一轮的关闭态
+        # 越过"回到出厂默认"这一步存活下来,而它对终端用户几乎不可见(网页前端未消费
+        # crop_in_use;唯一的运行时痕迹是那行回退日志,debug 级、默认 log_level=info 下
+        # grep 不到 —— 它本身是带 device_id 的,见 _maybe_encode_adaptive)。
+        # **本清单是手写的:每加一项 per-camera 配置都要往这里补一行**,
+        # 由 test_clear_account_scope_state_clears_all_scope_keys 钉住。
+        self._kv_repo.delete(ScopeConfigKeys.CAMERA_CROP_DENY_LIST_KEY)
         self._lru.clear()
 
     @property
@@ -1277,9 +1287,45 @@ class MiotService:
         也不算开。兼容字段 ``is_online`` = ``cloud_online and lan_reachable``（纯连通性）。
         ``voice_in_use`` 是**存储的拾音偏好**（在拾音白名单即 True，**默认 False**），与
         ``in_use`` 正交；「生效态」= ``in_use and voice_in_use`` 由前端派生，此处不合并。
+        ``crop_in_use`` 是**存储的 Smart Crop 偏好**（不在关闭集即 True，**默认 True**），
+        逐通道给（按合成 did，同 ``perception_prompt``）；``crop_effective`` 是**生效态**
+        （= ``in_use`` AND 全局双闸 ``crop_enhance.enabled`` / ``user_enabled``
+        AND ``crop_in_use``）——不在活跃集的相机根本没在投喂，不可能在裁。
+        这里合并而 ``voice_in_use`` 不合并，是因为拾音的生效态有前端在派生，而裁切没有
+        任何消费方——不在此合并就没有单一来源能回答"这台的三道闸有没有全开"。
+
+        本字段用 ``in_use``（是否被选中）而**不是** ``connected``（流是否真订阅上）：
+        选中但没订阅上时本字段仍为 True，而该路根本没进感知窗、裁切判定一次都没跑——那一层
+        要看同一行的 ``connected``（口径同说明书与 CLI help 里给的排查第一跳）。
+
+        注意本字段**只覆盖配置层**，**不含**逐窗内容判定：闸全开之后，裁切区域面积超/不足
+        上下限、区域退化、本窗无帧、候选框换算失败、编码或 JPEG 产物过短等都会回退全景，
+        而本字段仍为 True。上面这几项是举例、**不是全集**；全集只维护在一处——
+        omni/prompt_builder._maybe_encode_adaptive 的 docstring（含每项对应的 reason= 取值），
+        排查时以那份为准，别在此处复制它的子集。也就是说 ``crop_effective=True`` 不等于"这一窗真的裁了"；那一层只能
+        看日志 ``event=adaptive_crop_fallback`` 的 ``reason=``。
         """
         voice_allowed = voice_allowed_camera_dids(self._kv_repo)
         prompt_map = camera_prompts(self._kv_repo)
+        crop_denied = crop_denied_camera_dids(self._kv_repo)
+        # Smart Crop 全局双闸，用于派生 crop_effective。延迟导入（同 admin/router
+        # _perception_config_payload 的先例）——miot 层不在模块级依赖感知引擎。
+        # 读失败按**关闭**处理：crop_enhance_config_from_settings 内部对坏配置就是
+        # fail-closed 退默认（enabled=user_enabled=False，即不裁），这里跟它同向，
+        # 免得列表显示"在裁"而引擎实际没裁。
+        try:
+            from miloco.perception.engine.omni.crop_enhance import (
+                crop_enhance_config_from_settings,
+            )
+
+            _ce = crop_enhance_config_from_settings()
+            crop_global_on = bool(_ce.enabled) and bool(_ce.user_enabled)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "event=crop_global_gate_read_failed 列表按全局关闭派生 crop_effective",
+                exc_info=True,
+            )
+            crop_global_on = False
         connected = self._connected_camera_dids()
         cameras = filter_by_home(
             self._kv_repo, await self._miot_proxy.get_cameras() or {}
@@ -1336,6 +1382,31 @@ class MiotService:
                         # 每摄像头的自定义「感知须知」prompt（无则 ""）。
                         # 按合成 did 存取，双摄每路可有独立须知。
                         "perception_prompt": prompt_map.get(syn_did, ""),
+                        # 存储偏好：不在关闭集 = 该路允许 Smart Crop（**默认开**）。同样按
+                        # 合成 did 逐路存取。这是 per-camera 闸的**存储态**——只反映用户配了
+                        # 什么，不含全局闸、也不含该路是否真在投喂；生效态看下面
+                        # crop_effective（本字段保持纯存储语义，故关掉相机不改写它、
+                        # 重新启用后旧偏好自动回来，同 voice_in_use 的存储偏好口径）。
+                        "crop_in_use": syn_did not in crop_denied,
+                        # **生效态**：该路在感知**活跃集**里 AND 全局双闸 AND 本路存储偏好。
+                        # 三者缺一就没在裁。注意用的是 in_use（是否被选中），**不是**上面的
+                        # connected（流是否真订阅上）——选中但没订阅上时本字段仍为 True，那一
+                        # 层要看同一行的 connected（口径同 voice 的生效态，前端也只含 in_use）。
+                        # 与 voice_in_use 刻意不同——那项的生效态有前端在合
+                        # （HeroNow 渲染 `inUse && voiceInUse`，同样含 in_use），而 crop
+                        # 没有任何消费方，不在这里合就没有单一来源可回答"这台到底在不在裁"。
+                        # 本字段为 false 时,三种成因由 (in_use, crop_in_use) 反查区分：
+                        #   in_use=false                        → 这台压根不在感知范围里
+                        #   in_use=true, crop_in_use=false      → 这一路自己关了裁切
+                        #   in_use=true, crop_in_use=true       → 被全局双闸挡住
+                        # 另有一格**本字段为 true 却仍没在裁**,不由上面那对键区分:
+                        #   connected=false（in_use=true）       → 选中了但流没订阅上,该路没进
+                        #                                          感知窗、裁切判定一次都没跑
+                        "crop_effective": (
+                            syn_did in active
+                            and crop_global_on
+                            and syn_did not in crop_denied
+                        ),
                     }
                 )
         return out
@@ -1600,6 +1671,49 @@ class MiotService:
         for syn_dids in resolved:
             for syn in syn_dids:
                 clear_camera_prompt(self._kv_repo, syn)
+        all_cameras = await self.list_cameras_with_state()
+        affected = [cam for cam in all_cameras if cam["did"] in touched_physical]
+        return affected
+
+    async def toggle_camera_crop(self, items: list[dict]) -> list[dict]:
+        """批量切换相机 Smart Crop（智能裁切增强）状态。每项 {"did": str, "crop_in_use": bool}。
+
+        关闭 = 该机位改走全景路径（不裁切），视频分辨率档不变。裁不裁是**机位级**判断：
+        门口窄视野机位裁了收益小、客厅广角机位收益大，故逐路可配。
+
+        ``did`` 可为合成通道 did（``cam:chN``，双摄逐路）或裸物理 did（多通道 = 全通道设同一
+        值），口径与 ``set_camera_prompt`` 完全一致（复用 ``_resolve_prompt_target_dids``：
+        未知 did / 通道号格式非法 / 通道越界都在那里拒，后端是唯一执法点）。**全部校验通过
+        后才写**，不半写。
+
+        与全局双闸（``crop_enhance.enabled`` / ``user_enabled``）相与：全局关时本开关设了也
+        不生效（不报错——允许预配置，同 prompt）。**不**像拾音那样要求相机感知已启用：裁切
+        不涉隐私，给已关闭的机位预配置无害。
+
+        不 refresh / _sync / _restart —— 引擎每感知窗按合成 did 实时读 KV，下一窗即生效。
+        """
+        cameras = await self._miot_proxy.get_cameras() or {}
+        # 先整批解析 + 校验（任一项非法即抛，不写任何 KV），再统一写。
+        resolved = [
+            (self._resolve_prompt_target_dids(i["did"], cameras), bool(i["crop_in_use"]))
+            for i in items
+        ]
+        touched_physical = {physical_camera_did(i["did"]) for i in items}
+        # 同一 did 出现多次时按最后一项为准（同 toggle_camera 的"后到覆盖先到"）：先收敛成
+        # syn_did → in_use，再按值分两批写，避免同一 did 先加后删的中间写。
+        # 注意这条**不是**本层三个批量端点的共同语义：toggle_camera_voice 没有这一步
+        # （直接按取值分两个 list、固定先关后开），同一 did 取值冲突时恒倒向"开"。
+        # 那是既有行为，本 PR 不改；要动的话把这里这几行搬过去即可。
+        wanted: dict[str, bool] = {}
+        for syn_dids, in_use in resolved:
+            for syn in syn_dids:
+                wanted[syn] = in_use
+        enable_dids = [d for d, v in wanted.items() if v]
+        disable_dids = [d for d, v in wanted.items() if not v]
+        if disable_dids:
+            set_cameras_crop_in_use(self._kv_repo, disable_dids, False)
+        if enable_dids:
+            set_cameras_crop_in_use(self._kv_repo, enable_dids, True)
         all_cameras = await self.list_cameras_with_state()
         affected = [cam for cam in all_cameras if cam["did"] in touched_physical]
         return affected

--- a/backend/miloco/src/miloco/perception/engine/api.py
+++ b/backend/miloco/src/miloco/perception/engine/api.py
@@ -116,6 +116,24 @@ def _camera_prompt_map() -> dict[str, str]:
         return {}
 
 
+def _crop_denied_dids() -> set[str]:
+    """实时读已**关闭** Smart Crop 的机位集合（合成 did，deny-list / 默认开）。
+    与 ``_camera_prompt_map`` 同构（同一处 miloco.manager 延迟导入模式）。
+
+    读 KV（进程内缓存）失败时返回空集 —— 即全部机位照旧允许裁切（fail-open：本项只影响
+    视频编码构图、不涉隐私，且"默认开"的语义就是"缺信息即为开"；反向 fail-closed 会让一次
+    KV 抖动静默关掉全家 Smart Crop，更难发现）。与 voice 的 fail-closed 相反，同 prompt。
+    """
+    from miloco.manager import get_manager
+    from miloco.miot.filter import crop_denied_camera_dids
+
+    try:
+        return crop_denied_camera_dids(get_manager().kv_repo)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("crop deny list lookup failed, keeping crop enabled: %s", e)
+        return set()
+
+
 class PerceptionEngine(BasePerceptionEngine):
     """Real perception proxy backed by perception-engine batch pipeline.
 
@@ -983,6 +1001,10 @@ class PerceptionEngine(BasePerceptionEngine):
         # 每摄像头自定义「感知须知」prompt：整表读一次、循环内按 did 取（实时、改动下一窗
         # 即生效、不重启；读失败 fail-open 注入空）。逐窗一次 KV 读，避免 per-device 重复。
         prompt_map = _camera_prompt_map()
+        # per-camera Smart Crop 闸（deny-list，不在集内 = 开）。同样逐窗一次 KV 读、循环内按
+        # 合成 did 取，改开关下一窗即生效、不重启。与全局双闸在
+        # prompt_builder._maybe_encode_adaptive 里相与。
+        crop_denied = _crop_denied_dids()
         for room_name, snapshots in batch.by_room().items():
             for snapshot in snapshots:
                 did = snapshot.device.did
@@ -1013,6 +1035,7 @@ class PerceptionEngine(BasePerceptionEngine):
                     current_time=_fmt_clock(snapshot.start_timestamp),
                     room_name=room_name,
                     camera_prompt=camera_prompt,
+                    per_camera_crop_enabled=did not in crop_denied,
                 )
 
         # Prepend audio tail from previous window (overlap to reduce boundary truncation)

--- a/backend/miloco/src/miloco/perception/engine/config.py
+++ b/backend/miloco/src/miloco/perception/engine/config.py
@@ -40,7 +40,11 @@ class CropEnhanceConfig:
     crop_enhance.crop_enhance_config_from_settings() 每窗口热读 settings 字典
     (perception.engine.crop_enhance),同 video_short_edge 的模式,改配置免重启。
 
-    激活条件:enabled **且** user_enabled。分两个 key 不是访问控制(本地部署,用户对两个
+    激活条件:enabled **且** user_enabled **且** per-camera 闸。前两个是本配置里的全局闸;
+    第三个不在本配置里 —— 它按机位存在 KV(CAMERA_CROP_DENY_LIST_KEY,deny-list / 默认开),
+    经 OmniContext.per_camera_crop_enabled 透传进
+    omni/prompt_builder._maybe_encode_adaptive 与这两个相与(裁不裁取决于该路镜头的视野,
+    故可单独关掉某个机位)。全局两闸分两个 key 不是访问控制(本地部署,用户对两个
     配置文件都有全权、拦不住),而是配置层与用途不同:
       · enabled = 发版级开关(随包默认层 settings.yaml,不由 admin API 写)——团队随包关/开
         整个能力、或线上出问题时发一版止损;false 时前端开关随之置灰。

--- a/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
+++ b/backend/miloco/src/miloco/perception/engine/omni/prompt_builder.py
@@ -343,7 +343,11 @@ def build_fused_payload(
                 return False
         return True
 
-    adaptive = _maybe_encode_adaptive(packets, region_ok=_candidate_bbox_ok)
+    adaptive = _maybe_encode_adaptive(
+        packets,
+        region_ok=_candidate_bbox_ok,
+        per_camera_enabled=context.per_camera_crop_enabled,
+    )
     if adaptive is not None:
         video_b64, media_info = adaptive.video_b64, adaptive.media_info
         ref_image_jpeg = adaptive.ref_image_jpeg
@@ -1745,8 +1749,9 @@ def _encode_batch_crops(edge_packets: list[IdentityPacket]) -> list[dict[str, st
 def _effective_panorama_short_edge() -> int:
     """全景视频短边 = 用户设定值;非正值兜回 512 默认。
 
-    Smart Crop 与本值 **正交**(裁不裁看 crop_enhance 的双 key,不再看这里),所以用户选的
-    768/1080 在 crop 回退全景时依然生效。非正值兜底纯属防御:admin API 已拒 <64,但历史
+    Smart Crop 与本值 **正交**(裁不裁看三闸相与:crop_enhance 的 enabled / user_enabled
+    两个全局闸,加上该路自己的 per-camera 闸,见 _maybe_encode_adaptive;都不看这里),
+    所以用户选的 768/1080 在 crop 回退全景时依然生效。非正值兜底纯属防御:admin API 已拒 <64,但历史
     config.json 可能残留过 0(早期「自适应」哨兵),0 会让 _encode_video_mp4 算出 scale=0 崩掉。
     """
     se = _get_video_short_edge()
@@ -1781,15 +1786,50 @@ def _maybe_encode_adaptive(
     packets: list[IdentityPacket],
     *,
     region_ok: "Callable[[tuple[int, int, int, int], tuple[int, int]], bool] | None" = None,
+    per_camera_enabled: bool = True,
 ) -> "_AdaptiveResult | None":
     """Smart Crop 开启时算 crop 区域、编码 crop 视频 + 全景参考帧。
 
-    返回 None = 回退全景(既有路径)。触发 None 的情形:双闸任一为 false(发版级开关 enabled /
-    单机用户开关 user_enabled)、无帧、无 crop 依据、面积超上限、``region_ok`` 否决、
-    crop/编码/JPEG 失败或产物过短。
+    返回 None = 回退全景(既有路径)。下表是 ``event=adaptive_crop_fallback`` 的**全部**
+    ``reason=`` 取值。排查按 ``grep adaptive_crop_fallback`` 后看 reason,但**注意日志级别**:
+    表里只有 ``per_camera_off`` 是 ``debug``,其余是 ``info`` / ``warning``,而默认
+    ``log_level=info``(root logger 与 console handler 两层都按它设)。所以默认配置下
+    grep **查不到** per_camera_off —— **0 命中不等于"这条路没走到"**,要确认逐机位关闭是否
+    生效得先把级别调到 debug。别据 0 命中判定开关没生效。
+
+    - ``per_camera_off``      —— per-camera 闸关。**本表唯一的 debug 级**(其余为 info /
+                                 warning),默认 log_level=info 下 grep 不到,见上方说明。
+                                 另注:发版级 enabled / 单机 user_enabled 两个全局闸为
+                                 false 时**静默**返回 None、不打任何日志
+    - ``no_frames``           —— 本窗无帧
+    - ``no_activity``         —— 无检测框且无显著运动块,算不出裁切依据(空房间 / 静止画面下
+                                 最常见的一条)
+    - ``area_too_large``      —— 区域面积超 crop_max_area_ratio
+    - ``area_too_small``      —— 区域面积不足 crop_min_area_ratio
+    - ``degenerate``          —— 区域退化成零宽高
+    - ``region_rejected``     —— 调用方的 ``region_ok`` 否决
+    - ``crop_empty``          —— 裁切结果为空
+    - ``video_too_short``     —— 编码产物过短
+    - ``jpeg_too_short``      —— 参考帧 JPEG 过短
+    - ``exception``           —— 兜底异常
+
+    上面 no_frames / no_activity / area_too_large / area_too_small / degenerate 五项由
+    compute_crop_region_detail 给出(no_frames 该函数也会返回,不只本函数自己打),其
+    docstring 是这五项的权威处。
+
+    ``region_ok`` 否决的**细节**另走 ``event=candidate_bbox_veto``(reason=multi_packet /
+    unmappable)——**刻意不同名**,否则按单一 event 统计回退率会翻倍(见 build_fused_payload
+    里 _candidate_bbox_ok 上方注释)。所以那两个 reason 用 grep adaptive_crop_fallback
+    **查不到**,别把它们当本 event 的取值。
+
+    **别在别处复制这份清单的子集** —— 要引用请指回本处,子集会让读者以为列全了。
     crop 视频与参考帧都跟随用户分辨率档,与「裁不裁」正交:crop 视频逐轴贴住同档全景画面
     (含放大),参考帧走 _resize_short_edge 只缩不放 —— 口径差异见上方「全链分辨率」⑥。
     all_frames 只读不改。
+
+    ``per_camera_enabled`` 是**机位级**闸,由调用方从 ``OmniContext.per_camera_crop_enabled``
+    透传(源头是 KV CAMERA_CROP_DENY_LIST_KEY,按合成 did 逐路存、逐窗热读、默认 True)。
+    裁不裁取决于该路镜头的视野,故与两个全局闸相与:门口窄视野机位可单独关掉,不牵动其它机位。
 
     ``region_ok(region, (w, h))`` 是调用方的区域准入校验,在**算出 region 之后、编码与
     ref.jpg/crop_meta 落盘之前**调用,返回 False 即回退全景。它必须在副作用之前:否则
@@ -1808,9 +1848,28 @@ def _maybe_encode_adaptive(
     # (调用方 build_fused_payload 没有 try,抛上去会被 omni.py 折成整相机 skipped)。
     try:
         cfg = crop_enhance_config_from_settings()
-        # 双闸:发版级开关 AND 单机用户开关。任一为 false → 回退全景路径(不裁切)。注意这不等于
-        # 字节回到接本特性前 —— 全景走的 _encode_video_mp4 放大分支已换重采样核,见该函数注释。
+        # 三闸相与:发版级开关 AND 单机用户开关(下面这个 if) AND per-camera 开关(再下一个 if,
+        # 单独判是为了打日志)。任一为 false → 回退全景路径(不裁切)。注意这不等于字节回到接本
+        # 特性前 —— 全景走的 _encode_video_mp4 放大分支已换重采样核,见该函数注释。
         if not (cfg.enabled and cfg.user_enabled):
+            return None
+        # per-camera 闸单独判是为了能打这一行,用来确认"逐机位关闭这条路真的走到了"。
+        # **降到 debug、与同函数其它 reason= 行不同级**,因为它是唯一由**用户配置**决定的回退:
+        # 其它 reason 取决于画面内容(无帧 / 区域太小 / 编码失败),不会长期恒真;而机位一旦关掉
+        # 就每窗必打 —— 4s 窗下约 2.2 万行/天/机位,default log_level=info 会被它灌满。
+        # **带上 did**:IdentityPacket 确实没有该字段、日志器也不注入 DeviceContext,但 pipeline
+        # 在调 omni 前已 set_device_context,本函数整个执行期都在该 ContextVar 作用域内 ——
+        # 同函数末尾的 push_crop_meta 正是靠它取 device_id。不带 did 的话,
+        # MAX_ENABLED_CAMERAS=4 路的日志交织在同一个文件里、行与行字节完全相同,这条日志自称
+        # 的用途("确认这条路真的走到了")就无法完成:分不清是哪台走到了这里。取不到时退 unknown。
+        if not per_camera_enabled:
+            from miloco.observability.context import get_device_context
+
+            _ctx = get_device_context()
+            logger.debug(
+                "event=adaptive_crop_fallback reason=per_camera_off device_id=%s",
+                _ctx.device_id if _ctx else "unknown",
+            )
             return None
         ep = next((p for p in packets if p.all_frames), None)  # 同 _encode_batch_video:首个有帧设备
         if ep is None:

--- a/backend/miloco/src/miloco/perception/engine/types.py
+++ b/backend/miloco/src/miloco/perception/engine/types.py
@@ -290,6 +290,15 @@ class OmniContext:
     # 该设备自定义「感知须知」prompt（用户/agent 配置，KV CAMERA_PROMPT_MAP_KEY 逐窗实时读取）。
     # 注入 omni system prompt 尾部（video / audio 路由均注入），给模型补充机位环境 / 关注 / 忽略指导。
     camera_prompt: str | None = None
+    # 该机位（合成 did，多通道逐路）的 Smart Crop per-camera 闸，KV CAMERA_CROP_DENY_LIST_KEY
+    # 逐窗实时读取（不在关闭集 = True，故**默认 True**）。与全局双闸
+    # perception.engine.crop_enhance.enabled / user_enabled **相与**才裁切，见
+    # omni/prompt_builder._maybe_encode_adaptive。False = 该机位改走全景路径（不裁切）。
+    # 名字带 per_camera_ 前缀是刻意的：admin API 的 PerceptionConfigBody 有个
+    # smart_crop_enabled，指的是**全局**用户闸（= crop_enhance.user_enabled，见
+    # admin/router.py），与本字段是相与关系的两个不同层级。两者都是 bool，同名的话跨层
+    # 搬字段时接错哪一个不会有任何类型信号。
+    per_camera_crop_enabled: bool = True
 
 
 

--- a/backend/miloco/tests/perception/engine/omni/test_prompt_builder.py
+++ b/backend/miloco/tests/perception/engine/omni/test_prompt_builder.py
@@ -1575,8 +1575,9 @@ def _adaptive_packet(
 class TestAdaptiveResolution:
     """Smart Crop(智能裁切增强)在 fused 路径的接线。
 
-    激活看 crop_enhance 双闸(enabled=发版级开关 AND user_enabled=单机用户开关),**与
-    video_short_edge 正交** —— 分辨率档只决定编码短边(全景 / crop / 参考帧),不再决定裁不裁。
+    激活看三闸相与:enabled=发版级开关 AND user_enabled=单机用户开关(两者都在 crop_enhance
+    配置里) AND OmniContext.per_camera_crop_enabled=per-camera 开关(按机位存 KV、逐窗热读)。
+    **与 video_short_edge 正交** —— 分辨率档只决定编码短边(全景 / crop / 参考帧),不决定裁不裁。
     """
 
     def _patches(self, *, short_edge: int = 512, enabled: bool = True, user_enabled: bool = True):
@@ -1593,11 +1594,11 @@ class TestAdaptiveResolution:
             ),
         )
 
-    def _content(self, packet=None, **kwargs):
+    def _content(self, packet=None, context=None, **kwargs):
         from miloco.perception.engine.omni.prompt_builder import build_fused_payload
 
         fused = build_fused_payload(
-            packets=[packet or _adaptive_packet()], context=OmniContext(),
+            packets=[packet or _adaptive_packet()], context=context or OmniContext(),
             gallery_snapshot={}, **kwargs,
         )
         return _multimodal_user_content(fused["messages"])
@@ -1785,6 +1786,93 @@ class TestAdaptiveResolution:
         with p1, p2:
             content = self._content(candidates=[])
         assert not self._has_ref(content)
+
+    def test_off_when_per_camera_switch_off(self):
+        """全局双闸都开,但该机位的 per-camera 闸关 → 回退全景(不裁)。"""
+        p1, p2 = self._patches()  # 两个全局闸都开
+        with p1, p2:
+            content = self._content(
+                context=OmniContext(per_camera_crop_enabled=False), candidates=[]
+            )
+        assert not self._has_ref(content)
+
+    def test_on_when_per_camera_switch_on(self):
+        """per-camera 闸显式为 True 时照旧裁切(与默认值同),证明第三道闸不是恒否。"""
+        p1, p2 = self._patches()
+        with p1, p2:
+            content = self._content(
+                context=OmniContext(per_camera_crop_enabled=True), candidates=[]
+            )
+        assert self._has_ref(content)
+
+    def test_per_camera_switch_defaults_on(self):
+        """OmniContext 不显式给该字段时默认开 —— 老调用点(未透传)零行为变化。"""
+        assert OmniContext().per_camera_crop_enabled is True
+        p1, p2 = self._patches()
+        with p1, p2:
+            content = self._content(candidates=[])
+        assert self._has_ref(content)
+
+    @pytest.mark.parametrize(
+        ("enabled", "user_enabled", "per_camera"),
+        [
+            (False, True, True),
+            (True, False, True),
+            (True, True, False),
+            (False, False, False),
+        ],
+    )
+    def test_any_gate_off_falls_back(self, enabled, user_enabled, per_camera):
+        """三闸是**相与**:任一为 false 就回退全景。"""
+        p1, p2 = self._patches(enabled=enabled, user_enabled=user_enabled)
+        with p1, p2:
+            content = self._content(
+                context=OmniContext(per_camera_crop_enabled=per_camera), candidates=[]
+            )
+        assert not self._has_ref(content)
+
+    def test_per_camera_off_log_carries_device_id(self, caplog):
+        """回退日志必须带 did：4 路交织在同一日志文件里，不带 did 的话行与行字节
+        完全相同，这条日志自称的用途（确认哪台走到了这里）就无法完成。"""
+        import logging
+
+        from miloco.observability.context import (
+            DeviceContext,
+            reset_device_context,
+            set_device_context,
+        )
+
+        p1, p2 = self._patches()
+        token = set_device_context(DeviceContext(
+            device_trace_id="t1", device_id="cam_x:ch1", room_name="客厅"
+        ))
+        try:
+            with p1, p2, caplog.at_level(
+                logging.DEBUG, logger="miloco.perception.engine.omni.prompt_builder"
+            ):
+                self._content(
+                    context=OmniContext(per_camera_crop_enabled=False), candidates=[]
+                )
+        finally:
+            reset_device_context(token)
+
+        hit = [r for r in caplog.records if "reason=per_camera_off" in r.getMessage()]
+        assert hit, "没打出 per_camera_off 回退日志"
+        assert "device_id=cam_x:ch1" in hit[0].getMessage()
+
+    def test_per_camera_off_log_falls_back_to_unknown_without_context(self, caplog):
+        """DeviceContext 未设置时退 unknown，不抛异常（该行在推理主路径上）。"""
+        import logging
+
+        p1, p2 = self._patches()
+        with p1, p2, caplog.at_level(
+            logging.DEBUG, logger="miloco.perception.engine.omni.prompt_builder"
+        ):
+            self._content(
+                context=OmniContext(per_camera_crop_enabled=False), candidates=[]
+            )
+        hit = [r for r in caplog.records if "reason=per_camera_off" in r.getMessage()]
+        assert hit and "device_id=unknown" in hit[0].getMessage()
 
     @pytest.mark.parametrize("short_edge", [360, 512, 768, 1080])
     def test_on_at_any_resolution(self, short_edge):

--- a/backend/miloco/tests/perception/engine/test_api_rule_filter.py
+++ b/backend/miloco/tests/perception/engine/test_api_rule_filter.py
@@ -274,3 +274,88 @@ async def test_device_rule_map_empty_rules_yields_empty_lists():
     ])
     result = await _run_perceive(batch, [])
     assert result.device_rule_map == {"cam_a": [], "cam_b": []}
+
+
+# ─── per-camera Smart Crop 闸注入（api.py 的 contexts 构造）──────────────────
+#
+# 覆盖 `per_camera_crop_enabled=did not in crop_denied` 这行的**反转方向**：写反了会让
+# 关掉的机位照旧裁、开着的机位不裁，而下游 _maybe_encode_adaptive 的单测看不出来
+# （它只管"给了 False 就回退"）。
+
+
+@pytest.mark.asyncio
+async def test_per_camera_crop_enabled_injected_per_device():
+    """deny-list 里的机位注入 False，不在集内的注入 True（默认开）。"""
+    cam_a = _make_snapshot("cam_a", "客厅")
+    cam_b = _make_snapshot("cam_b", "卧室")
+    batch = BatchedSnapshot(snapshots=[cam_a, cam_b])
+
+    engine = PerceptionEngine(PerceptionConfig())
+    captured: dict = {}
+
+    async def fake_run_batch_pipeline(batch_, contexts, *args, **kwargs):
+        captured["contexts"] = contexts
+        return BatchPipelineResult()
+
+    with patch(
+        "miloco.perception.engine.api._crop_denied_dids", return_value={"cam_a"}
+    ), patch(
+        "miloco.perception.engine.pipeline.run_batch_pipeline",
+        side_effect=fake_run_batch_pipeline,
+    ):
+        await engine.realtime_perceive(batch, rules=[])
+
+    assert captured["contexts"]["cam_a"].per_camera_crop_enabled is False
+    assert captured["contexts"]["cam_b"].per_camera_crop_enabled is True
+
+
+@pytest.mark.asyncio
+async def test_per_camera_crop_enabled_defaults_true_when_kv_empty():
+    """KV 无记录（空集）→ 全部机位默认开。"""
+    cam = _make_snapshot("cam_x", "厨房")
+    batch = BatchedSnapshot(snapshots=[cam])
+
+    engine = PerceptionEngine(PerceptionConfig())
+    captured: dict = {}
+
+    async def fake_run_batch_pipeline(batch_, contexts, *args, **kwargs):
+        captured["contexts"] = contexts
+        return BatchPipelineResult()
+
+    with patch(
+        "miloco.perception.engine.api._crop_denied_dids", return_value=set()
+    ), patch(
+        "miloco.perception.engine.pipeline.run_batch_pipeline",
+        side_effect=fake_run_batch_pipeline,
+    ):
+        await engine.realtime_perceive(batch, rules=[])
+
+    assert captured["contexts"]["cam_x"].per_camera_crop_enabled is True
+
+
+class _FakeManager:
+    """只提供 kv_repo 的桩：真 Manager 在单测环境下取 kv_repo 会抛 AttributeError，
+    不打桩的话下面两条都会因为"取 manager 就炸"而**恰好**通过——正向那条就白测了。"""
+
+    kv_repo = object()
+
+
+def test_crop_denied_dids_reads_through():
+    """正向：KV 有值时如实透出（钉住"真的读了"，防被改成恒空集还全绿）。"""
+    from miloco.perception.engine.api import _crop_denied_dids
+
+    with patch("miloco.manager.get_manager", return_value=_FakeManager()), patch(
+        "miloco.miot.filter.crop_denied_camera_dids", return_value={"cam_a", "cam_b:ch1"}
+    ):
+        assert _crop_denied_dids() == {"cam_a", "cam_b:ch1"}
+
+
+def test_crop_denied_dids_fails_open_on_kv_error():
+    """读 KV 抛错 → 返回空集（fail-open = 继续裁），不把异常传上去打断感知。"""
+    from miloco.perception.engine.api import _crop_denied_dids
+
+    with patch("miloco.manager.get_manager", return_value=_FakeManager()), patch(
+        "miloco.miot.filter.crop_denied_camera_dids",
+        side_effect=RuntimeError("kv down"),
+    ):
+        assert _crop_denied_dids() == set()

--- a/backend/miloco/tests/test_miot_filter_and_cameras.py
+++ b/backend/miloco/tests/test_miot_filter_and_cameras.py
@@ -108,6 +108,47 @@ def test_voice_allow_is_orthogonal_to_feed_deny():
     assert miot_filter.voice_allowed_camera_dids(kv) == {"c2"}
 
 
+def test_crop_denied_camera_dids_empty():
+    """空集 = 全部机位都允许裁切（默认开）。"""
+    kv = _FakeKV()
+    assert miot_filter.crop_denied_camera_dids(kv) == set()
+
+
+def test_crop_denied_camera_dids_with_values():
+    kv = _FakeKV(
+        {ScopeConfigKeys.CAMERA_CROP_DENY_LIST_KEY: json.dumps(["c1:ch0", "c2"])}
+    )
+    assert miot_filter.crop_denied_camera_dids(kv) == {"c1:ch0", "c2"}
+
+
+def test_set_cameras_crop_in_use_inverts_denylist():
+    """crop_in_use=False 才写进集合（deny-list 反转），True 是移出。"""
+    kv = _FakeKV()
+    assert miot_filter.set_cameras_crop_in_use(kv, ["c1"], False) == (["c1"], True)
+    assert miot_filter.set_cameras_crop_in_use(kv, ["c2:ch1"], False) == (
+        ["c1", "c2:ch1"],
+        True,
+    )
+    assert miot_filter.crop_denied_camera_dids(kv) == {"c1", "c2:ch1"}
+    # in_use=True 移出关闭集
+    assert miot_filter.set_cameras_crop_in_use(kv, ["c1"], True) == (["c2:ch1"], True)
+    # 本就不在集内再开 → 无写入
+    assert miot_filter.set_cameras_crop_in_use(kv, ["ghost"], True) == (
+        ["c2:ch1"],
+        False,
+    )
+
+
+def test_crop_deny_is_orthogonal_to_feed_deny_and_voice():
+    """裁切关闭集与感知黑名单 / 拾音白名单三者互不影响：改一个不动另两个。"""
+    kv = _FakeKV({ScopeConfigKeys.CAMERA_BLACK_LIST_KEY: json.dumps(["c1"])})
+    miot_filter.set_cameras_voice_in_use(kv, ["c2"], True)
+    miot_filter.set_cameras_crop_in_use(kv, ["c3"], False)
+    assert miot_filter.denied_camera_dids(kv) == {"c1"}
+    assert miot_filter.voice_allowed_camera_dids(kv) == {"c2"}
+    assert miot_filter.crop_denied_camera_dids(kv) == {"c3"}
+
+
 def test_is_home_allowed_no_filter():
     kv = _FakeKV()
     # 空启用集 → 什么都不允许
@@ -256,6 +297,9 @@ def _make_service(devices: dict | None = None, cameras: dict | None = None, kv: 
             ),
             get=kv.get,
             set=kv.set,
+            # delete 也要接：_clear_account_scope_state（账号切换清理）只用 delete，
+            # 不接的话那条路径在本 harness 下必抛 AttributeError、测不到。
+            delete=kv.delete,
         ),
         get_devices=AsyncMock(return_value=devices or {}),
         get_cameras=AsyncMock(return_value=cameras or {}),
@@ -1997,3 +2041,323 @@ async def test_set_camera_prompt_does_not_restart_or_refresh():
     svc._sync_camera_adapter.assert_not_awaited()
     svc._restart_perception_engine.assert_not_awaited()
 
+
+
+# ─── MiotService: Smart Crop 逐机位开关（crop_in_use，deny-list / 默认开）──────
+
+
+@pytest.mark.asyncio
+async def test_list_cameras_with_state_crop_field():
+    """crop_in_use 是存储偏好：不在关闭集即 True（**默认开**），与 in_use/voice/prompt 正交。"""
+    cameras = {"c1": _camera("c1"), "c2": _camera("c2")}
+    kv = _FakeKV({
+        ScopeConfigKeys.HOME_WHITE_LIST_KEY: json.dumps(["H1"]),
+        ScopeConfigKeys.CAMERA_CROP_DENY_LIST_KEY: json.dumps(["c1"]),
+    })
+    svc = _make_service(devices=dict(cameras), cameras=cameras, kv=kv)
+    out = await svc.list_cameras_with_state()
+    by_did = {c["did"]: c for c in out}
+    assert by_did["c1"]["crop_in_use"] is False
+    assert by_did["c2"]["crop_in_use"] is True  # 无记录 → 默认开
+
+
+@pytest.mark.asyncio
+async def test_list_cameras_with_state_crop_field_per_channel():
+    """双摄逐路：关掉 ch0 不影响 ch1（crop 按合成 did 存，与 perception_prompt 同口径）。"""
+    cam = _camera("dual", home_id="H1")
+    cam.channel_count = 2
+    kv = _FakeKV({
+        ScopeConfigKeys.HOME_WHITE_LIST_KEY: json.dumps(["H1"]),
+        ScopeConfigKeys.CAMERA_CROP_DENY_LIST_KEY: json.dumps(["dual:ch0"]),
+    })
+    svc = _make_service(devices={"dual": cam}, cameras={"dual": cam}, kv=kv)
+    out = await svc.list_cameras_with_state()
+    by_ch = {c["channel"]: c for c in out}
+    assert by_ch[0]["crop_in_use"] is False
+    assert by_ch[1]["crop_in_use"] is True
+
+
+@pytest.mark.asyncio
+async def test_toggle_camera_crop_writes_denylist():
+    kv = _FakeKV({ScopeConfigKeys.HOME_WHITE_LIST_KEY: json.dumps(["H1"])})
+    svc = _make_service(
+        devices={"c1": _camera("c1")}, cameras={"c1": _camera("c1")}, kv=kv
+    )
+    res = await svc.toggle_camera_crop([{"did": "c1", "crop_in_use": False}])
+    assert any(c["did"] == "c1" and c["crop_in_use"] is False for c in res)
+    assert json.loads(kv.get(ScopeConfigKeys.CAMERA_CROP_DENY_LIST_KEY)) == ["c1"]
+    # 再开回来 → 移出关闭集
+    res = await svc.toggle_camera_crop([{"did": "c1", "crop_in_use": True}])
+    assert any(c["did"] == "c1" and c["crop_in_use"] is True for c in res)
+    assert json.loads(kv.get(ScopeConfigKeys.CAMERA_CROP_DENY_LIST_KEY)) == []
+
+
+@pytest.mark.asyncio
+async def test_toggle_camera_crop_dual_camera_per_channel():
+    """双摄：合成 did 精确到某一路；裸物理 did 展成全部通道；越界通道被拒且不落库。"""
+    cam = _camera("dual", home_id="H1")
+    cam.channel_count = 2
+    kv = _FakeKV({ScopeConfigKeys.HOME_WHITE_LIST_KEY: json.dumps(["H1"])})
+    svc = _make_service(devices={"dual": cam}, cameras={"dual": cam}, kv=kv)
+
+    # 合成 did 只关 ch0
+    await svc.toggle_camera_crop([{"did": "dual:ch0", "crop_in_use": False}])
+    assert json.loads(kv.get(ScopeConfigKeys.CAMERA_CROP_DENY_LIST_KEY)) == ["dual:ch0"]
+
+    # 裸物理 did 关整台 → 展成两路
+    await svc.toggle_camera_crop([{"did": "dual", "crop_in_use": False}])
+    assert set(json.loads(kv.get(ScopeConfigKeys.CAMERA_CROP_DENY_LIST_KEY))) == {
+        "dual:ch0",
+        "dual:ch1",
+    }
+
+    # 越界通道拒绝、不落库
+    with pytest.raises(ValidationException):
+        await svc.toggle_camera_crop([{"did": "dual:ch9", "crop_in_use": True}])
+    assert set(json.loads(kv.get(ScopeConfigKeys.CAMERA_CROP_DENY_LIST_KEY))) == {
+        "dual:ch0",
+        "dual:ch1",
+    }
+
+
+@pytest.mark.asyncio
+async def test_toggle_camera_crop_rejects_unknown_before_write():
+    """任一 did 未知 → 整批拒绝，合法的那条也不落库。"""
+    kv = _FakeKV({ScopeConfigKeys.HOME_WHITE_LIST_KEY: json.dumps(["H1"])})
+    svc = _make_service(
+        devices={"c1": _camera("c1")}, cameras={"c1": _camera("c1")}, kv=kv
+    )
+    with pytest.raises(ValidationException):
+        await svc.toggle_camera_crop([
+            {"did": "c1", "crop_in_use": False},
+            {"did": "ghost", "crop_in_use": False},
+        ])
+    assert kv.get(ScopeConfigKeys.CAMERA_CROP_DENY_LIST_KEY) is None
+
+
+@pytest.mark.asyncio
+async def test_toggle_camera_crop_allowed_when_camera_disabled():
+    """与拾音不同：裁切不从属于感知开关，感知已关的机位也能预配置（同 prompt）。"""
+    kv = _FakeKV({
+        ScopeConfigKeys.HOME_WHITE_LIST_KEY: json.dumps(["H1"]),
+        ScopeConfigKeys.CAMERA_BLACK_LIST_KEY: json.dumps(["c1"]),  # c1 感知已关闭
+    })
+    svc = _make_service(
+        devices={"c1": _camera("c1")}, cameras={"c1": _camera("c1")}, kv=kv
+    )
+    await svc.toggle_camera_crop([{"did": "c1", "crop_in_use": False}])
+    assert json.loads(kv.get(ScopeConfigKeys.CAMERA_CROP_DENY_LIST_KEY)) == ["c1"]
+
+
+@pytest.mark.asyncio
+async def test_toggle_camera_crop_does_not_restart_or_refresh():
+    kv = _FakeKV({ScopeConfigKeys.HOME_WHITE_LIST_KEY: json.dumps(["H1"])})
+    svc = _make_service(
+        devices={"c1": _camera("c1")}, cameras={"c1": _camera("c1")}, kv=kv
+    )
+    svc._miot_proxy.refresh_cameras = AsyncMock()
+    svc._sync_camera_adapter = AsyncMock()  # type: ignore[assignment]
+    svc._restart_perception_engine = AsyncMock()  # type: ignore[assignment]
+    await svc.toggle_camera_crop([{"did": "c1", "crop_in_use": False}])
+    svc._miot_proxy.refresh_cameras.assert_not_awaited()
+    svc._sync_camera_adapter.assert_not_awaited()
+    svc._restart_perception_engine.assert_not_awaited()
+
+
+# ─── 账号切换清理：这份 key 清单是手写的，靠本用例钉住 ──────────────────────
+
+
+def test_clear_account_scope_state_clears_all_scope_keys():
+    """_clear_account_scope_state 必须清掉**全部** per-camera / 家庭范围配置。
+
+    这份清单是手写的枚举（每加一项 per-camera 配置都要补一行），而唯一提到该方法的
+    test_miot_onboarding_kick 把它整体替换成了桩、不断言清了哪些 key —— 漏一项不会变红。
+    本用例就是那道闸：断言五个 key 全部被 delete。
+
+    漏清的后果不对称地隐蔽：同账号解绑重绑时相机 did 不变，上一轮的偏好会越过"回到出厂
+    默认"存活；换账号时旧 did 变成读不到也删不掉的死键。
+    """
+    kv = _FakeKV({
+        ScopeConfigKeys.HOME_WHITE_LIST_KEY: json.dumps(["H1"]),
+        ScopeConfigKeys.CAMERA_BLACK_LIST_KEY: json.dumps(["c1"]),
+        ScopeConfigKeys.CAMERA_VOICE_ALLOW_LIST_KEY: json.dumps(["c1"]),
+        ScopeConfigKeys.CAMERA_PROMPT_MAP_KEY: json.dumps({"c1": "x"}),
+        ScopeConfigKeys.CAMERA_CROP_DENY_LIST_KEY: json.dumps(["c1:ch0"]),
+    })
+    svc = _make_service(devices={}, cameras={}, kv=kv)
+
+    svc._clear_account_scope_state()
+
+    for key in (
+        ScopeConfigKeys.HOME_WHITE_LIST_KEY,
+        ScopeConfigKeys.CAMERA_BLACK_LIST_KEY,
+        ScopeConfigKeys.CAMERA_VOICE_ALLOW_LIST_KEY,
+        ScopeConfigKeys.CAMERA_PROMPT_MAP_KEY,
+        ScopeConfigKeys.CAMERA_CROP_DENY_LIST_KEY,
+    ):
+        assert kv.get(key) is None, f"{key} 未被清理"
+
+
+def test_clear_account_scope_state_resets_crop_to_default_on():
+    """从读取侧确认语义：清理后该机位回到**默认开**，而不是留着上一账号的关闭态。"""
+    kv = _FakeKV({
+        ScopeConfigKeys.CAMERA_CROP_DENY_LIST_KEY: json.dumps(["c1:ch0"]),
+    })
+    svc = _make_service(devices={}, cameras={}, kv=kv)
+    assert miot_filter.crop_denied_camera_dids(kv) == {"c1:ch0"}
+
+    svc._clear_account_scope_state()
+
+    assert miot_filter.crop_denied_camera_dids(kv) == set()
+
+
+# ─── crop_effective：生效态 = 全局双闸 AND 逐机位存储偏好 ──────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("g_enabled", "g_user", "per_camera_on", "expect_effective"),
+    [
+        (True, True, True, True),     # 三闸全开 → 在裁
+        (True, True, False, False),   # 逐机位关
+        (True, False, True, False),   # 用户级全局关
+        (False, True, True, False),   # 发版级全局关
+        (False, False, False, False),
+    ],
+)
+async def test_crop_effective_is_global_and_per_camera(
+    g_enabled, g_user, per_camera_on, expect_effective
+):
+    """crop_effective 必须是三闸相与；crop_in_use 始终只反映存储偏好、不受全局影响。"""
+    from unittest.mock import patch
+
+    from miloco.perception.engine.config import CropEnhanceConfig
+
+    denied = [] if per_camera_on else ["c1"]
+    kv = _FakeKV({
+        ScopeConfigKeys.HOME_WHITE_LIST_KEY: json.dumps(["H1"]),
+        ScopeConfigKeys.CAMERA_CROP_DENY_LIST_KEY: json.dumps(denied),
+    })
+    svc = _make_service(
+        devices={"c1": _camera("c1")}, cameras={"c1": _camera("c1")}, kv=kv
+    )
+    with patch(
+        "miloco.perception.engine.omni.crop_enhance.crop_enhance_config_from_settings",
+        return_value=CropEnhanceConfig(enabled=g_enabled, user_enabled=g_user),
+    ):
+        out = await svc.list_cameras_with_state()
+
+    row = next(c for c in out if c["did"] == "c1")
+    assert row["crop_effective"] is expect_effective
+    # 存储偏好不随全局闸变化——这正是"全局关掉时 crop_in_use 仍是 true"的语义
+    assert row["crop_in_use"] is per_camera_on
+
+
+@pytest.mark.asyncio
+async def test_crop_effective_fails_closed_when_config_unreadable():
+    """全局闸读不出来时按**关闭**派生：与引擎侧 fail-closed 同向，
+    免得列表显示"在裁"而实际没裁（宁可少报，不可虚报）。"""
+    from unittest.mock import patch
+
+    kv = _FakeKV({ScopeConfigKeys.HOME_WHITE_LIST_KEY: json.dumps(["H1"])})
+    svc = _make_service(
+        devices={"c1": _camera("c1")}, cameras={"c1": _camera("c1")}, kv=kv
+    )
+    with patch(
+        "miloco.perception.engine.omni.crop_enhance.crop_enhance_config_from_settings",
+        side_effect=RuntimeError("settings 炸了"),
+    ):
+        out = await svc.list_cameras_with_state()
+
+    row = next(c for c in out if c["did"] == "c1")
+    assert row["crop_effective"] is False
+    assert row["crop_in_use"] is True   # 存储偏好仍如实透出
+
+
+@pytest.mark.asyncio
+async def test_crop_effective_distinguishes_global_off_from_per_camera_off():
+    """本字段存在的理由：靠 (crop_in_use, crop_effective) 两个值能区分两种"没在裁"。"""
+    from unittest.mock import patch
+
+    from miloco.perception.engine.config import CropEnhanceConfig
+
+    cams = {"c1": _camera("c1"), "c2": _camera("c2")}
+    kv = _FakeKV({
+        ScopeConfigKeys.HOME_WHITE_LIST_KEY: json.dumps(["H1"]),
+        ScopeConfigKeys.CAMERA_CROP_DENY_LIST_KEY: json.dumps(["c2"]),
+    })
+    svc = _make_service(devices=dict(cams), cameras=cams, kv=kv)
+    with patch(
+        "miloco.perception.engine.omni.crop_enhance.crop_enhance_config_from_settings",
+        return_value=CropEnhanceConfig(enabled=True, user_enabled=False),
+    ):
+        out = await svc.list_cameras_with_state()
+
+    by = {c["did"]: c for c in out}
+    # c1：逐机位开着，但被全局闸挡住 → (True, False)
+    assert (by["c1"]["crop_in_use"], by["c1"]["crop_effective"]) == (True, False)
+    # c2：逐机位自己关的 → (False, False)
+    assert (by["c2"]["crop_in_use"], by["c2"]["crop_effective"]) == (False, False)
+
+
+@pytest.mark.asyncio
+async def test_crop_effective_false_when_camera_not_in_scope():
+    """不在活跃集的相机根本没在投喂 → crop_effective 必须为 false，
+    即使全局双闸开着、逐机位偏好也是开。存储偏好 crop_in_use 仍如实透出 true。"""
+    from unittest.mock import patch
+
+    from miloco.perception.engine.config import CropEnhanceConfig
+
+    kv = _FakeKV({
+        ScopeConfigKeys.HOME_WHITE_LIST_KEY: json.dumps(["H1"]),
+        ScopeConfigKeys.CAMERA_BLACK_LIST_KEY: json.dumps(["c1"]),  # c1 感知已关闭
+    })
+    svc = _make_service(
+        devices={"c1": _camera("c1")}, cameras={"c1": _camera("c1")}, kv=kv
+    )
+    with patch(
+        "miloco.perception.engine.omni.crop_enhance.crop_enhance_config_from_settings",
+        return_value=CropEnhanceConfig(enabled=True, user_enabled=True),
+    ):
+        out = await svc.list_cameras_with_state()
+
+    row = next(c for c in out if c["did"] == "c1")
+    assert row["in_use"] is False
+    assert row["crop_in_use"] is True       # 存储偏好保留（关相机不改写它）
+    assert row["crop_effective"] is False   # 但没在投喂 → 没在裁
+
+
+@pytest.mark.asyncio
+async def test_crop_effective_distinguishes_three_kinds_of_not_cropping():
+    """(in_use, crop_in_use) 两个值要能把三种"没在裁"分开——这是把 crop_effective
+    称作"单一来源"的前提。"""
+    from unittest.mock import patch
+
+    from miloco.perception.engine.config import CropEnhanceConfig
+
+    cams = {"c1": _camera("c1"), "c2": _camera("c2"), "c3": _camera("c3")}
+    kv = _FakeKV({
+        ScopeConfigKeys.HOME_WHITE_LIST_KEY: json.dumps(["H1"]),
+        ScopeConfigKeys.CAMERA_BLACK_LIST_KEY: json.dumps(["c1"]),   # 不在感知范围
+        ScopeConfigKeys.CAMERA_CROP_DENY_LIST_KEY: json.dumps(["c2"]),  # 自己关了裁切
+    })
+    svc = _make_service(devices=dict(cams), cameras=cams, kv=kv)
+    with patch(
+        "miloco.perception.engine.omni.crop_enhance.crop_enhance_config_from_settings",
+        return_value=CropEnhanceConfig(enabled=True, user_enabled=True),
+    ):
+        out = await svc.list_cameras_with_state()
+    by = {c["did"]: c for c in out}
+
+    # c1：不在感知范围
+    assert (by["c1"]["in_use"], by["c1"]["crop_in_use"], by["c1"]["crop_effective"]) == (
+        False, True, False
+    )
+    # c2：在感知范围，但这一路自己关了裁切
+    assert (by["c2"]["in_use"], by["c2"]["crop_in_use"], by["c2"]["crop_effective"]) == (
+        True, False, False
+    )
+    # c3：三闸全通 → 真在裁
+    assert (by["c3"]["in_use"], by["c3"]["crop_in_use"], by["c3"]["crop_effective"]) == (
+        True, True, True
+    )

--- a/cli/src/miloco_cli/commands/scope.py
+++ b/cli/src/miloco_cli/commands/scope.py
@@ -9,6 +9,7 @@ _HOMES_PATH = "/api/miot/scope/homes"
 _CAMERAS_PATH = "/api/miot/scope/cameras"
 _CAMERAS_VOICE_PATH = "/api/miot/scope/cameras/voice"
 _CAMERAS_PROMPT_PATH = "/api/miot/scope/cameras/prompt"
+_CAMERAS_CROP_PATH = "/api/miot/scope/cameras/crop"
 
 
 def _compose_channel_dids(resp: dict) -> dict:
@@ -78,7 +79,17 @@ def scope_camera_list(pretty):
     lan_reachable(局域网可达)/awake(镜头开关:true=开/false=关/null=未知)，connected=视频流已连接。
     多通道相机(双摄)每路一行，did 显示为合成 did did:chN(单摄保持裸 did)——该 did 可直接复制给
     enable/disable 精确到某一路；mic-on/off 是相机级(拾音只在球机/ch0，:chN 会被归一到整台，
-    不精确到路)。"""
+    不精确到路)；crop-on/off 与 prompt-set 一样**精确到路**(裁不裁取决于该路镜头的视野)。
+    crop_in_use=该路的智能裁切**存储偏好**(默认 true)；crop_effective=**三道闸是否全开**
+    (= in_use AND 全局双闸 AND crop_in_use)。crop_effective=false 时按三种情形反查：in_use=false
+    是这台不在感知范围里；crop_in_use=false 是这一路自己关的；两者都 true 则是被全局闸挡住、
+    逐机位全白设。注意 crop_effective=true 只说明闸开着,**不含**
+    "流是否真订阅上"(看同一行 connected；connected=false 时这一路没进感知窗、裁切判定一次都
+    没跑),也**不保证每窗都在裁**——本窗无检测框且无显著运动块
+    (reason=no_activity,空房间最常见、属正常)、裁切区域面积超/不足上下限、区域退化、本窗无帧、
+    编码或 JPEG 产物过短等**内容层**回退只在后端日志 event=adaptive_crop_fallback 的 reason=
+    里可见(完整 11 项见 _maybe_encode_adaptive 的 docstring;注意 per_camera_off 是 debug 级、
+    默认级别下 grep 不到)。"""
     print_result(_compose_channel_dids(api_get(_CAMERAS_PATH)), pretty)
 
 
@@ -127,6 +138,41 @@ def scope_camera_mic_off(dids, pretty):
     result = api_put(
         _CAMERAS_VOICE_PATH,
         {"items": [{"did": d, "voice_in_use": False} for d in dids]},
+    )
+    print_result(result, pretty)
+
+
+# ── Smart Crop（智能裁切增强）逐机位开关：默认开，关掉即该路改走全景 ──
+#
+# 裁不裁是**机位级**判断：门口窄视野机位裁了收益小，客厅广角机位收益大，故逐路可配
+# （did 精确到 :chN，同 prompt-set；裸多通道 did = 该台全部通道）。与全局双闸
+# perception.engine.crop_enhance.enabled / user_enabled **相与** —— 全局关时这里设了也不
+# 生效（不报错，允许预配置）。与启用/拾音开关正交、不重启引擎，下一感知窗即生效。
+# 查状态分两层看 scope camera list：crop_in_use = 这里设成了什么（**存储偏好**，全局闸
+# 关着时它照样是 true）；crop_effective = 三道闸是否全开（= in_use AND 全局双闸 AND
+# crop_in_use）。问「这一路到底在不在裁」只能看后者，crop_in_use 答不了。
+
+
+@scope_camera.command("crop-on")
+@click.argument("dids", nargs=-1, required=True)
+@click.option("--pretty", is_flag=True)
+def scope_camera_crop_on(dids, pretty):
+    """开启指定机位的智能裁切增强（回到默认；DIDS 可用 did:chN 精确到某一路）。"""
+    result = api_put(
+        _CAMERAS_CROP_PATH,
+        {"items": [{"did": d, "crop_in_use": True} for d in dids]},
+    )
+    print_result(result, pretty)
+
+
+@scope_camera.command("crop-off")
+@click.argument("dids", nargs=-1, required=True)
+@click.option("--pretty", is_flag=True)
+def scope_camera_crop_off(dids, pretty):
+    """关闭指定机位的智能裁切增强（该路改走全景、不裁切；分辨率档不变）。"""
+    result = api_put(
+        _CAMERAS_CROP_PATH,
+        {"items": [{"did": d, "crop_in_use": False} for d in dids]},
     )
     print_result(result, pretty)
 

--- a/cli/src/miloco_cli/config.py
+++ b/cli/src/miloco_cli/config.py
@@ -106,7 +106,9 @@ _SCHEMA_PATHS: dict[str, tuple[type, Any, str]] = {
         "",
         "仅 Gemini：每帧视觉 token 预算档位（\"\"/\"low\"=省，\"high\"=小目标更清但 4× token），下一周期生效",
     ),
-    # Smart Crop 双闸相与，两者都 true 才裁切；默认值同下方注释的对齐约定（yaml 里都是 true）。
+    # 本表这两个是 Smart Crop 的**全局**闸，相与后仍只是必要条件——还要该机位自己的
+    # per-camera 闸也开（`miloco-cli scope camera crop-on/crop-off` 逐路配，默认开），
+    # 三闸相与才裁切。默认值同下方注释的对齐约定（yaml 里都是 true）。
     # 写「重启生效」而非「热读」：闸位在**后端进程内**确实是每窗口热读的，但 get_settings() 有
     # 进程级 lru_cache，只有 admin PUT 那条路会跟着调 reset_settings() 清缓存。CLI 是另一个进程、
     # 只落盘，清不掉运行中后端的缓存 —— `--no-restart` 时改了等于没改（正是「以为已经关掉了、
@@ -127,8 +129,10 @@ _SCHEMA_PATHS: dict[str, tuple[type, Any, str]] = {
     "perception.engine.crop_enhance.user_enabled": (
         bool,
         True,
-        "Smart Crop 单机用户开关（同 UI「智能裁切增强」）；与 enabled 相与，重启生效"
-        "（在 UI 拨这个开关走 admin API，则热更、下个感知窗口生效）",
+        "Smart Crop 单机用户开关（同 UI「智能裁切增强」）；与发版级 enabled、以及各机位"
+        "自己的逐机位闸（用 miloco-cli scope camera crop-on/crop-off 逐路配，默认开）"
+        "三闸相与才裁切，重启生效（在 UI 拨这个开关走 admin API，则热更、下个感知窗口"
+        "生效）。某一路到底裁没裁，看 scope camera list 的 crop_effective",
     ),
     "perception.collect.window_size": (
         int,

--- a/cli/tests/test_commands.py
+++ b/cli/tests/test_commands.py
@@ -2067,6 +2067,49 @@ def test_scope_camera_disable(runner):
     )
 
 
+# ─── scope camera crop-on / crop-off（Smart Crop 逐机位开关，走 crop 端点）────
+
+
+def test_scope_camera_crop_off(runner):
+    """crop-off → PUT crop 端点 crop_in_use=false。"""
+    with patch("miloco_cli.commands.scope.api_put") as mock_put:
+        mock_put.return_value = _SUCCESS
+        result = runner.invoke(cli, ["scope", "camera", "crop-off", "c1"])
+    assert result.exit_code == 0
+    mock_put.assert_called_once_with(
+        "/api/miot/scope/cameras/crop",
+        {"items": [{"did": "c1", "crop_in_use": False}]},
+    )
+
+
+def test_scope_camera_crop_on_batch(runner):
+    """批量 did 语义与 mic-on/off 同款；合成 did 直接透传给 backend 解析。"""
+    with patch("miloco_cli.commands.scope.api_put") as mock_put:
+        mock_put.return_value = _SUCCESS
+        result = runner.invoke(
+            cli, ["scope", "camera", "crop-on", "c1", "dual:ch0", "dual:ch1"]
+        )
+    assert result.exit_code == 0
+    mock_put.assert_called_once_with(
+        "/api/miot/scope/cameras/crop",
+        {
+            "items": [
+                {"did": "c1", "crop_in_use": True},
+                {"did": "dual:ch0", "crop_in_use": True},
+                {"did": "dual:ch1", "crop_in_use": True},
+            ]
+        },
+    )
+
+
+def test_scope_camera_crop_requires_did(runner):
+    """不给 did 直接报用法错（nargs=-1 + required=True）。"""
+    with patch("miloco_cli.commands.scope.api_put") as mock_put:
+        result = runner.invoke(cli, ["scope", "camera", "crop-off"])
+    assert result.exit_code != 0
+    mock_put.assert_not_called()
+
+
 # ─── scope camera mic-on / mic-off（拾音开关，走 voice 端点）──────────────────
 
 

--- a/plugins/skills/miloco-miot-scope/SKILL.md
+++ b/plugins/skills/miloco-miot-scope/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: miloco-miot-scope
-description: 感知范围控制 — 管理 miloco 感知哪些家庭、哪些摄像头，每台摄像头的声音（是否参与感知），以及每台摄像头的「感知须知」（专属 prompt，补机位环境 / 关注 / 忽略以提升感知准确性）。用户说「只用/不用某家庭」「让 miloco 感知/别感知 某家庭或摄像头」「屏蔽某摄像头/把某摄像头从感知里去掉」「把某摄像头声音关了/打开」「XX 老误报（声音类）」「哪些家庭在用」时激活；也在用户吐槽**画面/视觉类固定误识**时激活——「门口摄像头老把电梯门当成我家门」「XX 老把 Y 认成 Z」「这台摄像头总把走廊的人当成家里人」「能不能告诉它忽略窗外的马路」等，用「感知须知」给该机位补指导。注意区分：开关摄像头设备本身（开机/关机/电源/录制）走 miloco-devices；感知引擎自身的开关/参数走 miloco-perception。
+description: 感知范围控制 — 管理 miloco 感知哪些家庭、哪些摄像头，每台摄像头的声音（是否参与感知），每台摄像头的「感知须知」（专属 prompt，补机位环境 / 关注 / 忽略以提升感知准确性），以及每台摄像头的「智能裁切增强」（Smart Crop，送模型的画面构图：裁主体 vs 送整幅）。用户说「只用/不用某家庭」「让 miloco 感知/别感知 某家庭或摄像头」「屏蔽某摄像头/把某摄像头从感知里去掉」「把某摄像头声音关了/打开」「XX 老误报（声音类）」「哪些家庭在用」时激活；也在用户吐槽**画面/视觉类固定误识**时激活——「门口摄像头老把电梯门当成我家门」「XX 老把 Y 认成 Z」「这台摄像头总把走廊的人当成家里人」「能不能告诉它忽略窗外的马路」等，用「感知须知」给该机位补指导；还在用户提**画面构图**类诉求时激活——「这台别裁了 / 只看整个画面 / 别老对着一块地方」「这台小目标看不清 / 远处的东西看不清」「智能裁切给这台关了 / 打开」等，用「智能裁切增强」（Smart Crop：裁主体 vs 送整幅）逐机位调。注意区分：开关摄像头设备本身（开机/关机/电源/录制）走 miloco-devices；感知引擎自身的开关/参数（分辨率档 / 全局裁切闸 / 感知窗口大小等）**没有 skill 覆盖**，miloco-perception 只有 perceive devices / logs / query / clear 四条命令（前三条是查询，clear 是清空感知流缓冲，都不是配置/开关），别往那儿转——正确入口（网页「设置」或 miloco-cli config set）与全局闸和逐机位闸的关系，见本 skill 正文。
 metadata:
   author: miloco
-  version: "2.3"
-  date: "2026-07-14"
+  version: "2.4"
+  date: "2026-08-28"
   openclaw:
     requires:
       bins: ["miloco-cli"]
@@ -20,14 +20,25 @@ metadata:
 - 声音开关的定位是「**每摄像头的信噪比开关**」——安静房间（书房 / 卧室）开、嘈杂位（对着电视 / 街边窗口）保持关；用户抱怨某摄像头声音类**误报**是典型触发词（多半是嘈杂位被开了声音，建议关）。
 - **摄像头感知须知（每台专属 prompt）**：给某台摄像头补一段自定义指导——机位环境描述、要**关注**的东西、要**忽略**的东西。逐感知窗注入该相机的视觉感知，指导模型消解**固定误识**。`scope camera prompt-set <did> "<文本>"` 设置、`prompt-clear <did>` 清除。默认无。与视频 / 声音开关**正交**：不从属感知开关，相机关着也能预配，只在被感知时生效；改动下一窗即生效、不重启。上限 500 字。典型用途：门口机位能看到公共走廊的电梯门，模型误把电梯门开合当自家入户门 → 用须知说明「画面右侧是公共走廊电梯门，与本户无关，只有正中木色入户门才是本户」。
 
+- **摄像头智能裁切增强（Smart Crop，逐机位）**：**默认开启**。开启时 miloco 会在该机位画面里裁出主体区域再送模型，等效提高主体分辨率、小目标看得更清；关掉即该路改送整幅画面（分辨率档不变）。`scope camera crop-off <did>` 关、`crop-on <did>` 开回默认。逐路可配（`did:chN`，同 prompt-set），因为裁不裁取决于该路镜头的视野。与视频 / 声音 / 须知开关**正交**，不从属感知开关（相机关着也能预配），改动下一窗即生效、不重启。另有一对**全局**开关（`crop_enhance.enabled` / `user_enabled`）与之**相与**：全局关时逐机位设了也不生效。这对开关**不在本 skill、也不在 miloco-miot-admin**（后者只覆盖 `status` / `home-info` / `cost`）——`user_enabled` 在**网页「设置」里的「智能裁切增强」开关**（拨 UI 走 admin API、热更、下一窗生效）。`enabled` 是发版级开关，**admin API 不写它**，随包 `settings.yaml` 发布。
+
+  用 CLI 改这两个都要注意两件事：① `config set` 写的是本机 config.json，**`enabled` 也在 CLI 白名单里**——哪台机器执行过 `config set perception.engine.crop_enhance.enabled`，之后就固定读 config.json，后续发版改 yaml 对这台机器不再生效；② `config set` **默认会顺手重启后端**（因为后端 `get_settings()` 有进程级缓存，CLI 只落盘清不掉），显式传 `--no-restart` 时改动对运行中的后端等于没生效——正是「以为已经关掉了、实际还在裁」那种失效态。用户反馈「逐机位关了没效果 / 开了没效果」时，先用 `scope camera list` 定位**配置层**。`crop_effective=false` 时按这三种情形反查：`in_use=false` = 这一路没进感知采集，**先别急着 `scope camera enable`**——`in_use` 是一串条件的合取（不在黑名单 **且** 家庭已启用 **且** `online and lan_online` **且** 该路镜头未关 **且** 没被 `MAX_ENABLED_CAMERAS=4` 按合成 did 升序截掉），`enable` 只动"不在黑名单"这一项。先看同一行的 `is_online`（云端在线 且 局域网可达）/ `connected`（流已订阅）/ `awake`（该路镜头开关：`true` 开 / `false` 关（隐私遮挡）/ `null` 该机型无此属性或读取失败）：离线、不在同一局域网、镜头被物理关闭、或已超出 4 台名额时，这台本来就不在黑名单里，`enable` 会因"集合无变化"直接短路、连 KV 都不写，接口照样返回成功但 `in_use` 不会变——此时该报的是真实原因，不是重试 `enable`；`in_use=true` 且 `crop_in_use=false` = 这一路自己关了裁切；`in_use=true` 且 `crop_in_use=true` = 被全局闸挡住（逐机位怎么设都是白设），引导用户去网页「设置」开全局开关，**不要**转给 miloco-miot-admin。
+
+  **若 `crop_effective=true` 而用户仍反馈「小目标看不清 / 开了没效果」，先看同一行的 `connected`。** `crop_effective` 只合了「被选中 + 全局双闸 + 本路偏好」，**不含**「流是否真订阅上」：`connected=false` 时这一路根本没进感知窗、裁切判定一次都没被调用，`grep adaptive_crop_fallback` 会是 0 命中——该报的是拉流未建立，别当成内容层回退。`connected=true` 才轮到下面这一层。
+
+  **`connected` 也正常、仍反馈没效果，那就不是配置问题，别停在这里。** 该字段只表示三道闸全开，**不表示每一窗真的裁了**：闸开之后还有**逐窗的内容层判定**会回退全景——裁切区域（窗口内**主体检测框**与**帧差分运动块**两者的并集，再做扩展与最小面积放大）本窗**无检测框且无显著运动块**（`reason=no_activity`，空房间 / 静止画面下最常见的一条，属正常回退、无需处置）、区域面积超上限 `crop_max_area_ratio=0.49` 或不足下限 `crop_min_area_ratio=0.10`、区域退化、本窗无帧、编码或 JPEG 产物过短等。**这里只是举例，完整清单（11 项及各自的 `reason=` 取值）在 `omni/prompt_builder._maybe_encode_adaptive` 的 docstring**，以那份为准，别把本段当全集。**广角机位尤其容易撞上上限**：一个人在 4 秒窗里横穿客厅，并集就可能越过半个画面；**即使画面里只有一个人不动**，电视亮着 / 窗帘飘动 / 摄像头轻微位移产生的运动块也会把并集撑开——所以别用"画面里就一个人、并集不可能超过 0.49"来排除这条。这一层 `scope camera list` 完全看不出来，只能看后端日志：`miloco-cli service logs -n 200 | grep adaptive_crop_fallback`（全仓只有 `service logs` 能读后端应用日志——**不是** `perceive logs`，那个查的是结构化感知事件流；也**不在** miloco-miot-admin 名下）。原因看 `reason=`；`reason=area_too_large` 那行还会带出 `union=` 框，是唯一能看出"谁把并集撑开了"的线索。
+
 所有子命令未知 did/id 均被拒绝（防 typo）。先 `list` 确认合法再操作。
 
 ## 何时激活 vs 走别的 skill
 
 - 「感知 X 摄像头」「让 miloco 接入 X 家庭」「只用 / 不用某个目标」「哪些家庭在用」= 控制 miloco 的**感知范围** → 本 skill
-- 「关闭感知」「打开感知」「感知开关」「调感知参数」= 控制**感知引擎自身** → miloco-perception
+- 「关闭感知」「打开感知」「感知开关」= 先问清指的是哪一层，**没有"感知引擎总开关"这种命令**：想让某台相机不被感知 → 本 skill 的 `scope camera disable/enable`；想停掉整个后端 → `miloco-cli service stop/start`。miloco-perception **不能**做这两件事，它只有 `perceive devices` / `logs` / `query` / `clear` 四条命令（均不能开关感知引擎），别往那儿转
+- 「调感知参数」（分辨率档 / 全局裁切闸 / 感知窗口大小等）= **没有 skill 覆盖**：miloco-perception 只有 `perceive devices` / `perceive logs` / `perceive query` / `perceive clear` 四条命令（前三条查询，`clear` 清空感知流缓冲），**没有任何配置/参数命令**。直接引导用户去网页「设置」，或给出 `miloco-cli config set perception.<配置路径> <值>`（注意它默认会重启后端，见本文档裁切段落的说明）
 - 切设备属性 / 调动作 → miloco-devices
-- 刷新缓存 / 看日志 → miloco-miot-admin
+- 刷新设备 / 摄像头列表缓存 → miloco-devices（`miloco-cli device refresh`）。miloco-miot-admin 的 `home-info` 只是读一遍打计数，**不刷新**
+- 「清一下感知缓存 / 感知好像卡住了」→ miloco-perception 的 `miloco-cli perceive clear`（POST，清空所有感知设备的流缓冲区）。**不是**配置项，别引到网页「设置」或 `config set`
+- 看后端日志（含 `event=adaptive_crop_fallback` 这类感知内部事件）= **没有 skill 覆盖**：直接给 `miloco-cli service logs -n 200`（持续跟踪加 `-f`），全仓只有这一条能读后端应用日志。miloco-miot-admin **不能**做这件事（只有 `status` / `home-info` / `cost`）；`perceive logs` 查的是结构化感知事件流、grep 不到 `adaptive_crop_fallback`，也别往那儿转
 
 ### ⚠️ 摄像头：开关「设备」≠ 关闭「感知」
 
@@ -43,6 +54,7 @@ metadata:
 - 用户想改变 **miloco 看不看它**（视频感知范围）→ `scope camera enable/disable`。
 - 用户想改变 **miloco 听不听它**（声音，是否参与感知）→ `scope camera mic-on/mic-off`。
 - 用户想让 miloco **看得更准**（某机位画面/视觉类固定误识，要补环境说明 / 关注 / 忽略）→ `scope camera prompt-set`。
+- 用户想改变某机位**送模型的画面构图**（「这台别裁了 / 只看整个画面」「这台小目标看不清」）→ `scope camera crop-off/crop-on`。注意这**不是**改分辨率档（`video_short_edge`，管多清晰；裁不裁与多清晰正交）——分辨率档和上面那对全局裁切闸在同一处：网页「设置」或 `miloco-cli config set perception.engine.input.video_short_edge <值>`。它**不在** miloco-miot-admin（只有 status / home-info / cost）；上面那条「调感知参数」的路由也覆盖不到它（miloco-perception 只有 `perceive devices` / `logs` / `query` / `clear` 四条命令，**没有任何配置命令**——不是缺分辨率档这一条，是整个配置面都不在那儿），所以别转给任何 skill，直接按上面这一处引导用户。也不是改看不看它。
 - 拿不准时按字面：「感知 / 接入 / 别看 / 别分析」→ 视频范围；「声音 / 别听 / 声音误报」→ 声音开关；「误认 / 认成 / 当成 / 老把 X 当 Y / 忽略画面里的 Z」这类**画面识别错误**→ 感知须知。
 
 ### 声音类误报 vs 画面类误识（别混）
@@ -58,13 +70,15 @@ miloco-cli scope home   list | switch <id>
 miloco-cli scope camera list | enable <did>... | disable <did>...
 miloco-cli scope camera mic-on <did>... | mic-off <did>...
 miloco-cli scope camera prompt-set <did> "<文本>" | prompt-clear <did>...
+miloco-cli scope camera crop-on <did>... | crop-off <did>...
 ```
 
 - **家庭 `switch <id>`**：切换到该家庭（唯一启用），其余自动停用。只接受 1 个 id。
 - **摄像头 `enable/disable <did>...`**：视频感知批量启用/停用，可同时操作多个 did。
 - **摄像头 `mic-on/mic-off <did>...`**：声音批量开/关，同款批量 did 语义。`mic-off` = 该相机声音完全不被处理；仅感知已启用(in_use=true)的相机可设，感知已关闭时整批被拒。改动即时生效、无需重启。
 - **摄像头 `prompt-set <did> "<文本>"`**：给该机位设自定义「感知须知」（**文本务必加引号**）。`prompt-clear <did>...` 清除（可批量）。上限 500 字，超限被后端拒。与启用/声音开关正交，不从属感知，改动下一窗即生效、不重启。
-- `list` 输出每项含 `in_use`（是否启用）；camera 额外带 `is_online`（设备在线）、`connected`（流已订阅）、`voice_in_use`（声音开关）和 `perception_prompt`（该机位自定义感知须知）。`in_use`/`is_online`/`connected` 三者都 true = 正常采集，任一 false 即某层未就位。`voice_in_use=false` = 该相机声音完全不被处理（不转写、不上云、听不到指令），视频照常感知。
+- **摄像头 `crop-on/crop-off <did>...`**：智能裁切增强批量开/关，同款批量 did 语义，**精确到路**（`did:chN`；裸多通道 did = 该台全部通道）。`crop-off` = 该路改送整幅画面。不校验 in_use（关着的相机也可预配）。与全局双闸相与，全局关时不生效但**不报错**。改动下一窗即生效、不重启。
+- `list` 输出每项含 `in_use`（是否启用）；camera 额外带 `room_name`（房间名——相机 `name` 常是「小米智能摄像机 2 代」这类泛称，按房间定位机位靠它）、`is_online`（设备在线，= `cloud_online` AND `lan_reachable`，这两个分量也一并透出）、`connected`（流已订阅）、`awake`（该路镜头开关，`null`=机型无此属性或读取失败）、`voice_in_use`（声音开关）、`crop_in_use`（该路智能裁切**存储偏好**，默认 true）、`crop_effective`（智能裁切**生效态** = `in_use` AND 全局双闸 AND `crop_in_use`）和 `perception_prompt`（该机位自定义感知须知）。`in_use`/`is_online`/`connected` 三者都 true = 正常采集，任一 false 即某层未就位。`voice_in_use=false` = 该相机声音完全不被处理（不转写、不上云、听不到指令），视频照常感知。
 
 ## "只用 X" 模式
 
@@ -81,6 +95,7 @@ miloco-cli scope camera prompt-set <did> "<文本>" | prompt-clear <did>...
 | **摄像头 disable** | **拒绝**未知 did |
 | **摄像头 mic-on/mic-off** | **拒绝**未知 did；**拒绝**感知已关闭(in_use=false)的相机（声音从属于视频感知，先 `enable` 再设声音） |
 | **摄像头 prompt-set/prompt-clear** | **拒绝**未知 did；**拒绝**超 500 字。不校验 in_use（关着的相机也可预配须知） |
+| **摄像头 crop-on/crop-off** | **拒绝**未知 did；**拒绝**越界通道号（`:chN` 超出该台通道数）。不校验 in_use，也不校验全局双闸（全局关时可设但不生效） |
 
 未知 id / 从属违规由 backend 拒绝并返回错误，CLI 透传错误信息。若不确定 id 合法性，先 `scope home list` / `scope camera list` 看一眼。
 
@@ -104,6 +119,13 @@ miloco-cli scope camera prompt-set <did> "<文本>" | prompt-clear <did>...
 
 ## 示例
 
+> **响应形状（下面各例共用）**：所有返回**相机列表**的命令（`list` / `enable` / `disable` /
+> `mic-*` / `crop-*` / `prompt-*`）返回的行是同一个形状，即下面 `scope camera list` 那一份。
+> 差别只有一处：**只有 `list`** 会过 CLI 展示层变换（多通道相机的 `did` 拼成 `did:chN`，并去掉
+> `channel` / `channel_count`）；其余命令直接打印后端响应，`did` 是**裸物理 did** 且带
+> `channel` / `channel_count`。为省篇幅，`list` 以外的示例只列出与该次操作相关的键，
+> 其余用 `…` 略过——**不是**这些命令的响应真的更短。
+
 ```
 # 查看接入状态（list 返回 {code, message, data} 信封）
 $ miloco-cli scope home list
@@ -113,7 +135,25 @@ $ miloco-cli scope home list
 
 $ miloco-cli scope camera list
   → {"code":0,"message":"ok","data":[
-       {"did":"1154253569","name":"小米智能摄像机C700","is_online":true,"in_use":true,"connected":true}]}
+       {"did":"1154253569","name":"小米智能摄像机C700","room_name":"客厅",
+        "cloud_online":true,"lan_reachable":true,"is_online":true,"voice_in_use":true,
+        "awake":true,"in_use":true,"connected":true,"perception_prompt":"",
+        "crop_in_use":true,"crop_effective":true},
+       {"did":"1154253570:ch0","name":"小米智能摄像机C700","room_name":"次卧",
+        "cloud_online":true,"lan_reachable":true,"is_online":true,"voice_in_use":false,
+        "awake":true,"in_use":true,"connected":true,"perception_prompt":"",
+        "crop_in_use":true,"crop_effective":true},
+       {"did":"1154253570:ch1","name":"小米智能摄像机C700","room_name":"次卧",
+        "cloud_online":true,"lan_reachable":true,"is_online":true,"voice_in_use":false,
+        "awake":true,"in_use":true,"connected":true,"perception_prompt":"",
+        "crop_in_use":true,"crop_effective":true},
+       {"did":"1154253571","name":"小米智能摄像机C700","room_name":"门口",
+        "cloud_online":true,"lan_reachable":true,"is_online":true,"voice_in_use":false,
+        "awake":true,"in_use":true,"connected":true,"perception_prompt":"",
+        "crop_in_use":true,"crop_effective":true}]}
+#  ↑ 双摄（1154253570）在 list 里是**两行**、did 已拼成 `did:chN`（`channel` /
+#    `channel_count` 已并入 did，list 输出里没有这两个键）；单摄保持裸 did。
+#    这里的 did 可**直接复制**给 crop-off / prompt-set 精确到某一路。
 
 # 切换到 xiaomi 家庭（其余自动停用，返回全量家庭列表）
 $ miloco-cli scope home switch 611001866489
@@ -131,33 +171,59 @@ $ miloco-cli scope home switch 611001054724
 $ miloco-cli scope camera list        # 看 did
 $ miloco-cli scope camera disable 1154253569
   → {"code":0,"message":"ok","data":[
-       {"did":"1154253569","name":"小米智能摄像机C700","is_online":true,"in_use":false,"connected":false}]}
+       {"did":"1154253569","name":"小米智能摄像机C700","channel":0,"in_use":false,"connected":false,…}]}
 
 # 恢复被停用的摄像头
 $ miloco-cli scope camera enable 1154253569
   → {"code":0,"message":"ok","data":[
-       {"did":"1154253569","name":"小米智能摄像机C700","is_online":true,"in_use":true,"connected":true}]}
+       {"did":"1154253569","name":"小米智能摄像机C700","channel":0,"in_use":true,"connected":true,…}]}
 
 # 「客厅电视老误报，把客厅摄像头声音关了」——关声音（视频照常感知）
 $ miloco-cli scope camera list        # 按 room/name 找到客厅摄像头 did
 $ miloco-cli scope camera mic-off 1154253569
   → {"code":0,"message":"ok","data":[
-       {"did":"1154253569","name":"小米智能摄像机C700","is_online":true,"in_use":true,"voice_in_use":false,"connected":true}]}
+       {"did":"1154253569","name":"小米智能摄像机C700","channel":0,"voice_in_use":false,…}]}
 
 # 「次卧很安静，把声音打开」——开声音
 $ miloco-cli scope camera mic-on 1154253570
   → {"code":0,"message":"ok","data":[
-       {"did":"1154253570","name":"小米智能摄像机C700","is_online":true,"in_use":true,"voice_in_use":true,"connected":true}]}
+       {"did":"1154253570","name":"小米智能摄像机C700","channel":0,"voice_in_use":true,…},
+       {"did":"1154253570","name":"小米智能摄像机C700","channel":1,"voice_in_use":true,…}]}
+#  拾音按**整台**存，双摄两路的 voice_in_use 一起变（与逐路的 crop / prompt 刻意不同）。
+
+# 「次卧这台别裁了 / 只看整个画面」——画面**构图**类诉求，逐机位关裁切
+#  注意与下面的「误识」场景分界：认错东西（把 A 当 B）→ 写感知须知；
+#  构图粗细（裁主体 vs 送整幅）→ crop-off/crop-on。别互相套用。
+$ miloco-cli scope camera crop-off 1154253570:ch0    # 双摄，只关 ch0 这一路（精确到 :chN）
+  → {"code":0,"message":"ok","data":[
+       {"did":"1154253570","name":"小米智能摄像机C700","channel":0,"crop_in_use":false,"crop_effective":false,…},
+       {"did":"1154253570","name":"小米智能摄像机C700","channel":1,"crop_in_use":true,"crop_effective":true,…}]}
+#  返回按**物理 did** 过滤：双摄两路都会回来（不只被点名的 ch0），只有 ch0 那行的值变了——
+#  看到另一行仍是 true 是**正常的**，别当成没生效去重试。
+#  关掉后：crop_in_use=false（存储偏好），crop_effective 随之 false
+
+$ miloco-cli scope camera crop-on  1154253570        # 裸 did = 该台全部通道，开回默认
+  → {"code":0,"message":"ok","data":[
+       {"did":"1154253570","name":"小米智能摄像机C700","channel":0,"crop_in_use":true,"crop_effective":true,…},
+       {"did":"1154253570","name":"小米智能摄像机C700","channel":1,"crop_in_use":true,"crop_effective":true,…}]}
+#  开回来后：crop_in_use=true；crop_effective 还要全局双闸也开才会是 true
+
+# 「这台裁切开了、小目标还是看不清」——按 list 的四个字段反查
+$ miloco-cli scope camera list
+#   crop_effective=false 时：in_use=false → 不在感知范围（先看 is_online/connected/awake，
+#     别急着 enable）；crop_in_use=false → 这一路自己关的；两者都 true → 被全局闸挡住。
+#   crop_effective=true 仍反馈没效果 → 先看 connected（false = 流没订阅上，裁切判定一次都没跑），
+#     再看后端日志：miloco-cli service logs -n 200 | grep adaptive_crop_fallback
 
 # 「门口摄像头老把电梯门开了当成我家门开了」——画面类误识，写感知须知（不是关摄像头）
 $ miloco-cli scope camera list        # 按 room/name 找到门口那台 did
 # （先复述须知给用户确认："画面右侧公共走廊里的电梯门，与本户无关……"，确认后再写）
 $ miloco-cli scope camera prompt-set 1154253571 "本摄像头装在入户门内，画面右侧公共走廊里可见电梯门。电梯门开合与本户无关，不要据此判断有人回家/开门；只有画面正中的木色入户门开合才是本户事件。"
   → {"code":0,"message":"ok","data":[
-       {"did":"1154253571","name":"小米智能摄像机C700","is_online":true,"in_use":true,"voice_in_use":false,"perception_prompt":"本摄像头装在入户门内……","connected":true}]}
+       {"did":"1154253571","name":"小米智能摄像机C700","channel":0,"perception_prompt":"本摄像头装在入户门内……",…}]}
 
 # 清除某台的感知须知（回到无自定义）
 $ miloco-cli scope camera prompt-clear 1154253571
   → {"code":0,"message":"ok","data":[
-       {"did":"1154253571","name":"小米智能摄像机C700","is_online":true,"in_use":true,"perception_prompt":"","connected":true}]}
+       {"did":"1154253571","name":"小米智能摄像机C700","channel":0,"perception_prompt":"",…}]}
 ```

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -760,7 +760,11 @@ export interface PerceptionConfig {
   smart_crop_enabled?: boolean;
   /** 发版级开关(backend crop_enhance.enabled)的只读投影,**PUT 不可写**。
    *  false = 当前这一版没打开该能力,用户开关即便为 true 也不裁 → 前端置灰 + 提示,
-   *  避免"开关开着但后端不裁"的静默失效。老后端不返此字段 → undefined,同样置灰。 */
+   *  避免"开关开着但**发版级闸**没开"的静默失效。老后端不返此字段 → undefined,同样置灰。
+   *  注意本字段与 smart_crop_enabled 只覆盖三闸里的**全局两闸**:两者都 true、开关既亮
+   *  又可点时,某个机位仍可能被 per-camera 闸(逐路 deny-list,`miloco-cli scope camera
+   *  crop-on/crop-off` 配)单独关掉而不裁。逐机位生效态本接口不透出,在
+   *  /api/miot/scope/cameras 每行的 crop_effective。 */
   smart_crop_available?: boolean;
   // 老 backend(<0.10.x)不返此字段,前端在读取处 ?? DEFAULTS.min_suggestion_urgency 回退。
   // 声明成可选是为了把这层运行时兼容语义显式化,别让未来维护者把 ?? 当成死代码删。

--- a/web/src/components/SettingsDrawer.tsx
+++ b/web/src/components/SettingsDrawer.tsx
@@ -103,8 +103,23 @@ export function SettingsDrawer({ open, onClose }: Props) {
   }, [open, t]);
 
   // 发版级开关没放开时开关不可用（同 schedulerAvailable 的降级套路）：拨动不写盘，
-  // 故置灰 + 换 hint，避免呈现「看着能动、实则后端不裁」的控件。
+  // 故置灰 + 换 hint，避免呈现「看着能动、实则**发版级闸**没开」的控件。
   // 老后端不返 smart_crop_available → undefined → 同样置灰。
+  // 注意本抽屉只覆盖三闸里的**全局两闸**：开关既亮又可点、拨到 ON 之后，某个机位仍可能
+  // 被 per-camera 闸（逐路 deny-list，`miloco-cli scope camera crop-on/crop-off` 配）
+  // 单独关掉而不裁。逐机位生效态本抽屉不透出，在 /api/miot/scope/cameras 每行的
+  // crop_effective。UI 暂无逐机位控件，故 hint 文案（i18n smartCropHint）刻意不提它。
+  // 已知该文案本身与三闸口径不一致：它把「开启」讲成充分条件，且把回退成因说成只有
+  // 「识别不到活动区域」一种——实际 _maybe_encode_adaptive 的 docstring 列了 11 项
+  // reason，其中只有 per_camera_off 由**开关**决定，其余 10 项都不由任何开关决定：
+  // 或由逐窗画面内容触发（无检测框且无显著运动块、区域退化、本窗无帧、产物过短），
+  // 或是兜底异常。注意「面积超上限 / 不足下限」虽由画面内容触发，判据本身
+  // （crop_max_area_ratio=0.49 / crop_min_area_ratio=0.10）仍是可热改的配置项——
+  // 广角机位反馈「开了没效果」而日志全是 reason=area_too_large 时，抬这个阈值就是
+  // 处置办法，别因为它不是「开关」就排除掉配置这条路。
+  // 本 PR 不改文案：改产品措辞是产品
+  // 决定，且此刻在小字里指向 CLI 会让用户去找一个界面上不存在的开关。待前端补上
+  // 逐机位控件时，与该控件一并订正这行文案。
   const smartCropAvailable = config?.smart_crop_available === true;
   const perceptionDirty =
     config != null &&


### PR DESCRIPTION
> 本 PR 是 #525 的重开版本，改动内容相同。#525 的分支历史里累积了 15 个 commit（其中 10 个是逐轮订正文档与注释）、三次 force-push 与二十轮 review 线程，正文中按 commit 组织的小节每追加一次提交就失效一次。这里以单个 commit 重新提交，正文只描述最终状态，不再随后续改动变假。#525 将关闭并指回本 PR。

## 背景

裁不裁本质是**机位级**判断——窄视野机位（如门口）裁切收益小，广角机位（如客厅）收益大。此前只有 `crop_enhance.enabled` / `user_enabled` 两个全局闸，想关掉单个机位只能整机关掉。

## 改动

加第三道 per-camera 闸，生效条件变为三闸相与：

```
enabled AND user_enabled AND per_camera_crop
```

三侧默认均为 `true`，不配置时行为与改动前完全一致。

**存储沿用 `camera_prompt` 那套、不是拾音那套**：KV `CAMERA_CROP_DENY_LIST_KEY`，deny-list 语义（空集 = 全开，天然满足"默认 true"、存量用户零迁移），键按**合成 did** 逐路——同一台双摄的两路视野不同、该不该裁也不同。引擎每感知窗热读，改开关下一窗生效、不重启。

两处容错方向**刻意相反**，判据是"哪个方向的错更难被发现"：

| 位置 | 读不到时 | 理由 |
| --- | --- | --- |
| 引擎读 deny-list | 空集（fail-open，继续裁） | 只影响视频构图、不涉隐私；反向会让一次 KV 抖动静默关掉全家裁切，无人察觉。与拾音白名单的 fail-closed 相反，正因为那项涉隐私 |
| 列表派生 `crop_effective` 读全局闸 | 按关闭算（fail-closed） | 与 `crop_enhance_config_from_settings` 自身行为同向；宁可少报，也不在实际没裁时告诉用户在裁 |

配置面：

- `PUT /api/miot/scope/cameras/crop` —— 单独端点，不从属感知开关（相机关着也能预配置，同 prompt）
- `miloco-cli scope camera crop-on/crop-off <did>...` —— 精确到 `:chN`，裸多通道 did 展成全通道；did 校验复用 `_resolve_prompt_target_dids`，全部通过才写、不半写
- `scope camera list` 多透两个字段：`crop_in_use`（**存储偏好**）与 `crop_effective`（**三道闸是否全开** = `in_use` AND 全局双闸 AND `crop_in_use`）

拆成两个字段是必要的：全局闸关着时用户仍可逐机位预配置，此时偏好为 true 而生效态为 false，一个字段表达不了；且 `crop_in_use` 全仓零消费方，不在此合并就没有单一来源能回答"这台的闸有没有全开"。

`crop_effective` 只覆盖**配置层**——闸全开之后还有逐窗**内容层**判定会回退全景（无检测框且无显著运动块、区域面积超/不足上下限、区域退化、无帧、编码或 JPEG 产物过短等）。这里只是举例，完整 11 项及各自 `reason=` 取值以 `_maybe_encode_adaptive` 的 docstring 为准。那一层只能看日志 `event=adaptive_crop_fallback`，注意 `per_camera_off` 是 **debug** 级、默认 `log_level=info` 下 grep 不到——**0 命中不等于这条路没走到**。

前端**无逻辑改动、无文案改动**：web 侧相机字段是普通 TS interface + 显式字段映射、无 strict 校验，多一个 JSON 字段被忽略。web 目录下只订正了两段已失真的注释（`api/index.ts` 的 JSDoc 与 `SettingsDrawer.tsx` 的置灰说明，见下节），没有代码行。

## 「三闸相与」口径的副本清单

加第三道闸会让"两闸就够"这句旧口径在全仓多处同时失真，而这些副本分散在后端注释、前端注释和用户可见文案里。这次按 grep 枚举了提到 smart crop 的**全部非测试文件（18 个）**逐处核对，不再点修：

- `settings.yaml` / `cli/config.py` / `admin/router.py` 的 `PerceptionConfigBody` —— 说明两个全局闸只是必要非充分条件
- `admin/router.py` 返回值上方那段 —— 原文写「`available=false` 时置灰，避免『开关开着但后端不裁』」。加第三道闸后这句不再成立：两个全局闸都真、开关既亮又可点时，某个机位仍可能被单独关掉。已把承诺收窄回它真正管的那一闸，并指明逐机位生效态在 `crop_effective`
- `web/src/api/index.ts` 的 `smart_crop_available` 注释 —— 上面那句话的**第三份副本**，同改
- `cli/src/miloco_cli/config.py` 里 `user_enabled` 的配置项说明 —— 这条不是注释，而是 `describe()` 返回、`miloco-cli config list-paths` 原样打给用户的那个字段，此前只写「与 enabled 相与」。同一处上方新加的注释虽然讲清了三闸，但**注释不会被 `list-paths` 打出来**：运维照这行说明只核两个全局闸、看到都是 true 就会判「配置没问题」，正好漏掉逐机位闸——恰是本 PR 想消灭的那种失效态

- `web/src/components/SettingsDrawer.tsx` 的置灰注释 —— 上面那句「避免开关开着但后端不裁」的**第三份副本**，而且它就在置灰行为的实现处。同样收窄回发版级闸，并写明本抽屉只覆盖全局两闸、逐机位生效态不在这里透出
- `prompt_builder.py` 的 `_effective_panorama_short_edge` docstring —— 写着「裁不裁看 `crop_enhance` 的双 key」。这句想表达的正交关系本身仍成立，失真的是括号里那句顺带交代：第三道闸不在 `crop_enhance` 里。而这个文件正是第三道闸的执行处，同一文件里说法不一致比在别处更容易误导

**枚举方法修过两次，两次都是被漏网项倒逼的。** 按文件枚举一直没问题（18 个），漏的是**按关键词筛行**这一步：第一遍用「两闸 / 双闸 / 两个开关」，漏掉 `cli/config.py` 那条写作「与 enabled 相与」的；改用「相与」复扫后，又漏掉写作「后端不裁」和「双 key」的两条——**两遍判据是同一个盲区**。最终改用并集判据（`相与|两闸|双闸|两个开关|双 key|两个 key|不裁|才裁|就裁|会裁|置灰`）扫全仓，**全部命中逐条过**（不写具体行数：这个判据会命中本 PR 自己新增的注释，行数随每轮改动自增，是个必然过期的数字），与 smart crop 相关且确实失真的就是上面列的这些。教训是：口径句的措辞不可穷举，靠关键词筛必然漏——要么逐条读完整个文件集，要么给这类句子加一个可 grep 的统一锚点。

**唯一一处本 PR 不改、已知仍是旧口径的副本**：`web/src/i18n/locales/{zh,en}/settings.json` 的 `smartCropHint` —— 开关下方那行说明（服务端已开放时显示它，未开放时显示 `smartCropUnavailable`）。它同样把开关讲成充分条件、把回退原因说成只有「识别不到活动区域」这一种内容层成因。不在本 PR 改的理由：那是终端用户可见的**产品文案**，改措辞是产品决定；且 UI 上并没有逐机位开关（只有 CLI），在这行小字里指向 CLI 命令会让用户去设置页找一个不存在的控件。留待后续与「前端补逐机位开关」一并处理——`crop_in_use` / `crop_effective` 已从相机列表透出，届时不需要再改后端。**这笔债已同时记在实现处**（`SettingsDrawer.tsx` 渲染该 hint 的那段注释里写明了文案与三闸口径不一致、以及为什么本 PR 不改），而不是只记在本描述里——描述不会随代码被读到。

## agent 侧文档

`miloco-miot-scope` 的 SKILL.md 是这组命令的 agent 说明书，其 frontmatter `description` 是**加载闸**（正文写得再准、skill 没被加载就等于不存在），故 description 与正文同步更新，并给出两跳排查链：先看 `crop_effective` 定位配置层，再看 `connected` 与后端日志定位内容层。

示例段重写过。`scope camera list` 是该文档里**唯一**会过 CLI 展示层变换的命令（`_compose_channel_dids` 无条件 pop 掉 `channel` / `channel_count`，多通道 did 拼成 `did:chN`），而此前的样例带着 `channel`、且全文档没有一行合成 did —— agent 照着学会去读一个真实输出里不存在的键定位某一路，正好丢掉本 PR 的能力。现在：

- `list` 样例给全字段集（含 SOP 第 1 步要用的 `room_name`），并含一台双摄的两行 `did:ch0` / `did:ch1`
- 其余命令的样例统一到「同一形状 + 省略号」的约定，段首写明它们**不过**展示层变换、`did` 是裸物理 did —— 避免再出现「同一端点 `mic-off` 返回 10 个键、`mic-on` 返回 5 个键」这种形状不一致被 agent 当成真实差异
- crop 两条示例改为在双摄上演示，明确返回按**物理 did** 过滤、两路都会回来（只有被点名那路的值变了），免得 agent 把另一行的 `true` 判成"没生效"去重试
- `list` 样例的初始状态与后续每条命令的状态变化对齐，不再出现"关一个本来就关着的"

## 已知边界

- 相机通道数变化时行为分两类，分界线是 `channel_count` 有没有**跨过 1**。根因是键形态在这条线上整体切换：`synthetic_camera_did` 在 `cc > 1` 时产出 `did:chN`、否则产出裸 `did`，而读侧精确匹配、**没有**裸 did 回退（启停黑名单的 `is_camera_channel_denied` 有这条回退，故不受影响）。读写两侧都用 `channel_count or 1` 兜底，所以"云端一时没下发通道数"也会落进单路那一侧。
  - **不跨 1**（如 2 → 3 或 3 → 2）：键形态不变，旧通道关闭态保持；新增通道默认开，减少的通道留下读不到也删不掉的死键，无功能影响。
  - **跨 1**（1 → N 或 N → 1）：存的键形态与读的对不上，该台 `crop_in_use` 整体翻回 `true`、**重新开始裁**，旧键全部变成死键。用户看到的现象是"整台又开始裁了"。
  - 两类处置相同：重跑一次 `crop-off <裸 did>`，按当时的 `channel_count` 展开成正确键形态。
  - 这是与逐机位「感知须知」共享的既有取舍，本 PR 不改这条口径。换账号导致的旧 did 残留已由账号切换清理覆盖。
- web 上的全局「智能裁切增强」开关仍只反映 `user_enabled`，per-camera 关掉几台后 UI 仍显示"已开启"。`crop_in_use` / `crop_effective` 已从相机列表透出，将来做前端不需要再改后端。

## 测试与验证

新增 **31 个测试函数 / 38 条用例**（两条走 `parametrize`，×4 与 ×5）。计数用两种独立方法交叉核对：`git show origin/main:<file>` 与工作树各取 `def test_*` 的**函数名集合相减**得 31；再用 `pytest --collect-only` 数这 31 个函数展开后的节点数得 38。不数 diff 行数——那会把插入锚点处的既有测试算成新增。

覆盖：deny-list 反转、逐通道回显、越界通道拒绝且不落库、不触发 restart/refresh、账号切换清理整份清单、三闸相与的四种组合、`crop_effective` 的全局×逐机位组合与 fail-closed、api 侧注入方向与 fail-open、回退日志带 did 与 ContextVar 缺失时退 `unknown`、CLI 命令打对端点。

**10 处关键行做过变异检查**（逐个改错后重跑，对应用例均变红；括号内为变红条数）：

| 变异 | 变红 |
| --- | --- |
| deny-list 写侧反转 `include=not in_use` → `include=in_use` | 5 |
| 读侧 `crop_in_use` 反转 | 12 |
| 引擎注入方向反转 | 2 |
| per-camera 闸恒不生效 | 4 |
| 调用点不接 context | 1 |
| `crop_effective` 漏与全局闸相与 | 4 |
| `crop_effective` 的 fail-closed 改成 fail-open | 1 |
| 全局双闸 `and` 写成 `or` | 3 |
| 回退日志去掉 `device_id` | 2 |
| 账号切换漏清 deny-list 键 | 2 |

本地全量回归：backend **3390 通过 / 5 失败**，cli **589 全通过**。5 项失败分别在 `node_monitor`（3，Linux `/proc` 专有路径在 macOS 上不走）、identity 的加载耗时断言（1）与 settings 的默认值断言（1，被本机环境变量覆盖），均在本 PR 未触及的模块内。前端因本地未安装依赖，`tsc` / `vitest` 未在本地执行，由 CI 的 `Quality (ts-shard)` / `Analyze (javascript-typescript)` 覆盖（均已通过）；web 侧改动只有两段注释，无代码行与文案改动。
