### PR TITLE
fix(openclaw): miloco 插件适配 openclaw 2026.8.x(会话 API 双版本 + 产物剔 devDeps + 安装 consent)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,6 @@ eval/sampled_*.json
 
 # opengrep / semgrep 本地扫描产物（含全量命中片段与绝对路径），只在本地看，不入库。
 .opengrep-out/
+
+# scripts/build.sh 打包期临时备份的 package.json（正常退出被 mv 掉，硬杀时残留）
+*.build-bak

--- a/knowledge/05-external-deps/sdk-openclaw.md
+++ b/knowledge/05-external-deps/sdk-openclaw.md
@@ -28,13 +28,16 @@ Miloco 的 OpenClaw 插件（`plugins/openclaw/src/index.ts`）注册五类扩�
 
 Skill 源码在 `plugins/skills/`（`miloco-` 前缀），每个 Skill 一个目录，包含 `SKILL.md`（frontmatter + 指令正文）。frontmatter 遵循 `agentskills.io/specification`，必须包含 `name`、`description`、`metadata`（`author`/`version`/`date`），可选 `openclaw.requires`（声明依赖的 bins 和 built-in tools）。
 
-`pnpm run build` 构建时通过 `scripts/sync-skills.mjs` 把 `plugins/skills/` 整体复制到插件构建产物中。修改 Skill 后须重新 `pnpm run build` + `openclaw plugins install .` 才生效。
+`pnpm run build` 构建时通过 `scripts/sync-skills.mjs` 把 `plugins/skills/` 整体复制到插件构建产物中。修改 Skill 后须重新 `pnpm run build` + `openclaw plugins install .` 才生效（`openclaw >= 2026.8` 需加 `--accept-capabilities`，见下节「版本兼容约束」）。
 
 ### 版本兼容约束
 
 - Miloco 插件依赖 `openclaw/plugin-sdk` 的 `before_prompt_build` Hook 接口
 - 插件级配置读写依赖 OpenClaw 运行时提供的配置 API
 - 插件安装需先安装 OpenClaw 框架（`openclaw`）
+- 宿主版本下限 `>=2026.5.2`，由插件清单的 `openclaw.compat.pluginApi` / `openclaw.install.minHostVersion` 在安装期硬拒；`openclaw >= 2026.8` 本地 `openclaw plugins install .` 需加 `--accept-capabilities`（capability consent），老版本无此旗标
+- 编译基线记在 `package.json#openclaw.build.openclawVersion`（当前 `2026.5.20`）：devDependency 是浮动的 `>=2026.5.2`，真实基线由 `pnpm-lock.yaml` 决定，升级 openclaw 后须同步此字段及 `tools/notify.ts` 里「按该版本 typings 编译」的 docstring（如无法静态 import `resolveDefaultAgentId` 那段论证）
+- 会话读取跨两代 runtime（`tools/notify.ts` 按能力探测选路）：`<=2026.7` 走 `resolveStorePath` + `loadSessionStore` 整文件读、投递信息在 entry 顶层 `lastTo`/`lastChannel`；`>=2026.8` 走 `listSessionEntries`（须显式传 agentId）、投递信息在 `entry.delivery.route`
 - 后端通过 `run_agent_turn`（`utils/agent_client.py`）调 OpenClaw 的 `/miloco/webhook`
 
 ### 与后端的通信契约

--- a/knowledge/06-dev-guide/dev-guide.md
+++ b/knowledge/06-dev-guide/dev-guide.md
@@ -39,6 +39,7 @@ cd cli && uv sync && uv tool install . --force --reinstall
 
 # OpenClaw 插件（TypeScript）
 cd plugins/openclaw && pnpm install && pnpm run build && openclaw plugins install .
+# openclaw >= 2026.8 需改为：openclaw plugins install --accept-capabilities .
 ```
 
 ---
@@ -195,6 +196,7 @@ cd plugins/openclaw
 pnpm run build                 # 构建（prebuild 钩子把 plugins/skills/ 复制进来）
 pnpm test                      # 运行测试
 openclaw plugins install .     # 安装到 OpenClaw（build 后需重装）
+# openclaw >= 2026.8 需改为：openclaw plugins install --accept-capabilities .
 
 # 家庭面板前端（web/）
 cd web
@@ -205,7 +207,7 @@ pnpm test                      # 单元测试（vitest）
 pnpm typecheck                 # 类型检查
 ```
 
-**Skill 修改**：`plugins/skills/` 是唯一源，修改 `SKILL.md` 后须重新 `pnpm run build` + `openclaw plugins install`。
+**Skill 修改**：`plugins/skills/` 是唯一源，修改 `SKILL.md` 后须重新 `pnpm run build` + `openclaw plugins install`（`openclaw >= 2026.8` 需加 `--accept-capabilities`）。
 
 **家庭面板修改**：修改 `web/src/` 后 `pnpm build` 产出到 `web/dist/`，再手动复制到 `$MILOCO_HOME/static/`，或重跑 `install.sh` 自动同步。开发期用 `pnpm dev` + Vite proxy 直接对接 backend，无需额外部署步骤。
 
@@ -262,6 +264,7 @@ miloco-cli rule trigger <rule_id>
 cd plugins/openclaw
 pnpm run build
 openclaw plugins install .
+# openclaw >= 2026.8 需改为：openclaw plugins install --accept-capabilities .
 
 # 验证 Skill 已安装
 openclaw skills list | grep miloco
@@ -333,7 +336,7 @@ CLI 会读取 `$MILOCO_HOME/config.json` 中的 `server.url`（后端 HTTP Base 
 
 1. 在 `plugins/skills/` 下新建目录，命名为 `miloco-<name>`
 2. 创建 `SKILL.md`，填写 frontmatter 和指令正文
-3. 构建并安装：`cd plugins/openclaw && pnpm run build && openclaw plugins install .`
+3. 构建并安装：`cd plugins/openclaw && pnpm run build && openclaw plugins install .`（`openclaw >= 2026.8` 需加 `--accept-capabilities`）
 4. 验证：`openclaw skills list | grep miloco-<name>`
 5. 在 Agent 对话中触发，观察日志 `$MILOCO_HOME/log/openclaw-plugin.log`
 

--- a/plugins/openclaw/package.json
+++ b/plugins/openclaw/package.json
@@ -59,7 +59,14 @@
     "extensions": [
       "./dist/index.mjs"
     ],
+    "compat": {
+      "pluginApi": ">=2026.5.2"
+    },
+    "build": {
+      "openclawVersion": "2026.5.20"
+    },
     "install": {
+      "minHostVersion": ">=2026.5.2",
       "npmSpec": "miloco-openclaw-plugin",
       "localPath": "extensions/miloco-openclaw-plugin",
       "defaultChoice": "npm"

--- a/plugins/openclaw/src/tools/notify.ts
+++ b/plugins/openclaw/src/tools/notify.ts
@@ -10,6 +10,7 @@ import {
   setPluginConfig,
 } from "../config.js";
 import { getNotifyDedupWindowMs } from "../miloco/config.js";
+import { logger } from "../utils/logger.js";
 
 type NotifyTarget = {
   channel: string;
@@ -121,11 +122,13 @@ export function registerNotifyTool(api: OpenClawPluginApi) {
           error: "未指定 sessionKey 且当前上下文无 sessionKey",
         });
       }
-      const resolve = resolveSessionByKey(api, sessionKey);
+      const store = listSessionStore(api);
+      const resolve = resolveSessionByKey(store, sessionKey);
       if (!resolve) {
         return jsonResult({
           ok: false,
-          error: "当前 session 无有效的推送目标，无法绑定为通知渠道",
+          error:
+            "当前 session 无有效的推送目标，无法绑定为通知渠道（openclaw >= 2026.8 只扫默认 agent 名下的会话；若本对话属于其它 agent，请到默认 agent 的对话里绑定）",
         });
       }
 
@@ -137,7 +140,9 @@ export function registerNotifyTool(api: OpenClawPluginApi) {
         notifySessionKeys: nextKeys,
         notifySessionKey: "",
       });
-      const channels = resolveConfiguredTargets(api, nextKeys).targets;
+      // 复用上面读的同一份快照：channel 与 channels/sessions 出自同一次枚举，
+      // 不会因两次读之间宿主侧的写入而不自洽（顺带省一次全表扫描）。
+      const channels = resolveConfiguredTargets(api, nextKeys, store).targets;
       return jsonResult({
         ok: true,
         changed,
@@ -259,43 +264,367 @@ function normalizeNotifySessionKeys(
   return deduped;
 }
 
-function loadSessionStore(api: OpenClawPluginApi) {
-  const cfg = getRuntimeConfig(api);
-  const sessionCfg = (cfg as Record<string, unknown>).session as
-    | { store?: string }
+type SessionStoreEntry = Record<string, unknown>;
+
+/**
+ * Minimal shape of the plugin runtime's agent session accessor, covering both
+ * plugin-runtime generations:
+ *
+ *  - openclaw <= 2026.7.x exposes `resolveStorePath` + `loadSessionStore` (reads the
+ *    whole session store file) and persists delivery at the entry top level as
+ *    `lastTo` / `lastChannel` / `lastAccountId` / `lastThreadId`.
+ *  - openclaw >= 2026.8 removed `loadSessionStore` from `runtime.agent.session` in
+ *    favor of the entry-based `listSessionEntries` / `getSessionEntry`, made
+ *    `resolveStorePath` throw `SessionStoreAgentIdRequiredError` when the store is
+ *    empty, and moved delivery under `entry.delivery.route` (ChannelRouteRef).
+ */
+type SessionAccessor = {
+  resolveStorePath?: (store?: string) => string;
+  loadSessionStore?: (storePath: string) => Record<string, SessionStoreEntry>;
+  listSessionEntries?: (params?: { agentId?: string }) => Array<{
+    sessionKey: string;
+    entry: SessionStoreEntry;
+  }>;
+};
+
+function isRecordValue(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === "object" && !Array.isArray(v);
+}
+
+// 宿主 normalizeAgentId（agent-id 模块）：小写、非法字符换 -、去首尾 -、截 64，
+// 规范化为空回 "main"——无 id 的名册项在宿主同样落成 "main"，不丢弃。
+function normalizeAgentIdValue(value: unknown): string {
+  return (
+    String(value ?? "")
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9_-]+/g, "-")
+      .replace(/^-+/, "")
+      .replace(/-+$/, "")
+      .slice(0, 64) || "main"
+  );
+}
+
+/**
+ * 镜像宿主 readAgentRosterProperty（8.2/9.1 同）：roster 双形态且 entries 优先——
+ * entries 键持 record → 用它（无视并存的 list：宿主此处直接短路返回，list 从不被
+ * consult，两形态并存且内容不同时以 entries 为准是宿主语义而非猜测）；键存在但值
+ * undefined → 宿主继续看 list；其余非 record 值连 list 兜底也吞掉（与宿主同）。
+ * list 分支丢非对象项。
+ */
+function listRosterAgents(
+  cfg: unknown,
+): Array<Record<string, unknown> & { id: string }> {
+  const agents = (
+    cfg as { agents?: { entries?: unknown; list?: unknown } }
+  ).agents;
+  if (!isRecordValue(agents)) return [];
+  if (Object.hasOwn(agents, "entries") && agents.entries !== undefined) {
+    if (!isRecordValue(agents.entries)) return [];
+    return Object.entries(agents.entries).flatMap(([id, entry]) =>
+      isRecordValue(entry) ? [{ ...entry, id: normalizeAgentIdValue(id) }] : [],
+    );
+  }
+  if (!Array.isArray(agents.list)) return [];
+  return agents.list.flatMap((entry) =>
+    isRecordValue(entry)
+      ? [{ ...entry, id: normalizeAgentIdValue(entry.id) }]
+      : [],
+  );
+}
+
+/**
+ * Default agent whose session store to scan. openclaw >= 2026.8 scopes the store
+ * per agent, so the entry read must name an agent. This mirrors the host's own
+ * ambient-owner resolution (agent-scope-config tryResolveAmbientOwnerAgentId;
+ * identical in 2026.8.2 and 2026.9.1):
+ *   1. `agents.defaults.systemAgent.agentId` — the materialized default; the host
+ *      strips the raw `default: true` roster markers from the in-memory config at
+ *      load (8.2 runtime-verified: disk keeps the marker, runtime.config.current()
+ *      exposes entries without it), so this is what actually survives there;
+ *   2. the sole `default: true` roster entry (unless `agents.ownership` is
+ *      "explicit"), else the sole agent;
+ *   3. the legacy implicit "main".
+ * Roster assembly (entries-first-over-list etc.) lives in listRosterAgents.
+ * Re-implemented here because the SDK export only exists in 2026.8+ while the
+ * plugin compiles against 2026.5.20 typings, and runtime.agent exposes no
+ * roster helper to call instead.
+ *
+ * Caller caveat: only this agent's sessions are read. `miloco_im_push` passes the
+ * picked sessionKey to subagent.run (which carries no agentId of its own), but
+ * `miloco_notify_bind` validates `ctx.sessionKey` against the same table — binding
+ * from a conversation owned by another agent fails. Widening the read scope is a
+ * separate delivery-scope decision.
+ */
+function resolveDefaultAgentIdFromConfig(cfg: unknown): string {
+  const agents = (
+    cfg as {
+      agents?: {
+        ownership?: unknown;
+        defaults?: { systemAgent?: { agentId?: unknown } };
+      };
+    }
+  ).agents;
+  // 优先读宿主物化的默认 agent：加载期宿主把 legacy default 标记从内存态 roster 剥掉
+  // （8.2 实测：磁盘 config 带 entries.home.default=true，runtime.config.current() 里
+  // 变成 home:{}），物化落点是 defaults.systemAgent.agentId——这正是宿主 ambient owner
+  // 解析（tryResolveAmbientOwnerAgentId）里 systemAgent 先于 legacy 标记的顺序。
+  const systemAgentId = agents?.defaults?.systemAgent?.agentId;
+  if (typeof systemAgentId === "string" && systemAgentId.trim()) {
+    return normalizeAgentIdValue(systemAgentId);
+  }
+  const roster = listRosterAgents(cfg);
+  if (roster.length === 0) return "main";
+  if (agents?.ownership !== "explicit") {
+    const marked = roster.filter((entry) => entry.default === true);
+    if (marked.length === 1) return marked[0].id;
+  }
+  if (roster.length === 1) return roster[0].id;
+  return "main";
+}
+
+// WARN 只报名册形状不报条目值：agent 条目可能携带 workspace/env 等不宜进日志的内容。
+function summarizeAgentsShape(agents: unknown): string {
+  if (!isRecordValue(agents)) {
+    return JSON.stringify(agents)?.slice(0, 60) ?? String(agents);
+  }
+  const entries = agents.entries;
+  const list = agents.list;
+  const defaults = agents.defaults;
+  return JSON.stringify({
+    ownership: agents.ownership,
+    systemAgent: isRecordValue(defaults) && isRecordValue(defaults.systemAgent)
+      ? defaults.systemAgent.agentId
+      : undefined,
+    entries: Object.hasOwn(agents, "entries")
+      ? isRecordValue(entries)
+        ? Object.keys(entries)
+        : typeof entries
+      : undefined,
+    list: Array.isArray(list)
+      ? list.map((entry) =>
+          isRecordValue(entry)
+            ? typeof entry.id === "string"
+              ? entry.id
+              : "<no-id>"
+            : "<non-object>",
+        )
+      : Object.hasOwn(agents, "list")
+        ? typeof list
+        : undefined,
+  }).slice(0, 300);
+}
+
+// 名册属性是否「带了值但一个 agent 都给不出来」：entries:null / "garbage" 这类畸形，
+// 以及 keys/元素全部非 record 的非空容器。合法空名册（entries:{} / list:[]）不算——
+// 隐式 main 照常工作，告警它们是每条通知的假警报。
+function hasUnusableRosterValue(cfg: unknown): boolean {
+  const agents = (cfg as { agents?: Record<string, unknown> }).agents;
+  if (!isRecordValue(agents)) return false;
+  if (Object.hasOwn(agents, "entries") && agents.entries !== undefined) {
+    const entries = agents.entries;
+    if (!isRecordValue(entries)) return true;
+    return (
+      Object.keys(entries).length > 0 &&
+      !Object.values(entries).some(isRecordValue)
+    );
+  }
+  if (Object.hasOwn(agents, "list") && agents.list !== undefined) {
+    const list = agents.list;
+    if (!Array.isArray(list)) return true;
+    return list.length > 0 && !list.some(isRecordValue);
+  }
+  return false;
+}
+
+function listSessionStore(api: OpenClawPluginApi): Record<string, SessionStoreEntry> {
+  // 可选访问：宿主连 agent/session 对象都摘掉时，裸取会抛 TypeError，把 no-channel
+  // 契约（结构化非 500）退化成 500——这里与「两代 API 都探测不到」同向降级。
+  const runtime = api.runtime as { agent?: { session?: unknown } } | undefined;
+  const session = runtime?.agent?.session as SessionAccessor | undefined;
+  if (!session || typeof session !== "object") {
+    logger.warn(
+      "notify: 宿主会话访问器（runtime.agent.session）不可用，按空表降级" +
+        "（通知与绑定将停在 no-channel）",
+    );
+    return {};
+  }
+
+  // openclaw >= 2026.8: entry-based read. Must pass an agent id (listSessionEntries
+  // without it throws "Cannot resolve SQLite session scope without an agent id").
+  // Only the default agent is scanned — delivery follows the sessionKey we pick,
+  // so a wider read scope without a matching delivery scope buys nothing.
+  if (typeof session.listSessionEntries === "function") {
+    const cfg = getRuntimeConfig(api);
+    const agentId = resolveDefaultAgentIdFromConfig(cfg);
+    let entries: Array<{ sessionKey: string; entry: SessionStoreEntry }> = [];
+    try {
+      entries = session.listSessionEntries({ agentId }) ?? [];
+    } catch (err) {
+      // 宿主一般不会走到这里：agentId 恒为非空串，「agent 不存在」宿主折成空数组而非
+      // 抛错（8.2/9.1 源码核实：resolveSqliteScope 只在 agentId 为假值时抛）。留这层
+      // 保护兜宿主行为变化 / 存储层 IO 异常。读不到会话等同「主人从没在 IM 里说过话」，
+      // 降级为空表——别把异常抛给 /miloco/webhook，那里靠 no-channel(非 500)告诉
+      // backend「未送达、不重试传输」。
+      logger.warn(
+        `listSessionEntries(agentId=${agentId}) failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      return {};
+    }
+    // 对账放在读之后：只有读回来确实是 0 条，才能断言「scope 猜偏」——名册里没有 main
+    // 但 main 库仍有历史会话的升级宿主上，读是成功的，读前告警会每条通知刷假警报。
+    // 局限（如实声明）：推导与名册同出 listRosterAgents，名册形态整段解析错时两边
+    // 一致、这类对账天然失效——插件拿不到宿主名册的第二个来源，只能靠读到的数据兜底。
+    // 名册属性带非空值却解析不出任何 agent（entries:null 等）是可定位的异常，单独告警；
+    // 合法空名册（entries:{} / list:[]）不算畸形——隐式 main 照常工作，告警反而是噪音。
+    const rosterIds = listRosterAgents(cfg).map((entry) => entry.id);
+    if (rosterIds.length === 0 && hasUnusableRosterValue(cfg)) {
+      logger.warn(
+        `notify: agents 的 entries/list 带非空值却解析不出任何 agent，名册按空表处理；` +
+          `插件读到的名册形状=${summarizeAgentsShape(
+            (cfg as { agents?: unknown }).agents,
+          )}`,
+      );
+    } else if (
+      rosterIds.length > 0 &&
+      !rosterIds.includes(agentId) &&
+      entries.length === 0
+    ) {
+      logger.warn(
+        `notify: 读了 agentId="${agentId}" 的会话库，0 条会话，而名册=[${rosterIds.join(", ")}]` +
+          "——默认 agent 推导疑似偏了，通知与绑定都会停在 no-channel；宿主会把 roster 的 " +
+          "default 标记物化进 agents.defaults.systemAgent.agentId，请核对该字段或名册标记。" +
+          `插件读到的名册形状=${summarizeAgentsShape(
+            (cfg as { agents?: unknown }).agents,
+          )}`,
+      );
+    }
+    const store: Record<string, SessionStoreEntry> = {};
+    for (const { sessionKey, entry } of entries) {
+      store[sessionKey] = entry;
+    }
+    return store;
+  }
+
+  // openclaw <= 2026.7.x: legacy whole-store file read.
+  if (
+    typeof session.resolveStorePath === "function" &&
+    typeof session.loadSessionStore === "function"
+  ) {
+    const cfg = getRuntimeConfig(api);
+    const sessionCfg = (cfg as Record<string, unknown>).session as
+      | { store?: string }
+      | undefined;
+    try {
+      return session.loadSessionStore(session.resolveStorePath(sessionCfg?.store));
+    } catch (err) {
+      // 会话文件损坏 / IO 异常同样降级空表——与 8.x 分支同一降级原则：异常穿透到
+      // /miloco/webhook 会被打成 HTTP 500，backend 按传输失败记账重试，而 no-channel
+      // （结构化非 500）才是「未送达、不重试传输」的正确信号。
+      logger.warn(
+        `legacy loadSessionStore failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      return {};
+    }
+  }
+
+  // 两条路径都探测不到：宿主把两代会话 API 都摘掉了（正是本插件适配过的那类宿主
+  // 变更）。降级空表本身对（守 no-channel 非 500 契约），但必须留痕——否则「宿主
+  // 变更导致读取失效」与「主人从没在 IM 说过话」在日志里完全同形，无从排查。
+  logger.warn(
+    "notify: 宿主既无 listSessionEntries 也无 resolveStorePath+loadSessionStore，" +
+      "会话读取能力不可用，按空表降级（通知与绑定将停在 no-channel）",
+  );
+  return {};
+}
+
+type LastDeliveryRoute = {
+  channel: string;
+  to: string | undefined;
+  accountId: string | undefined;
+  threadId: string | number | undefined;
+};
+
+type SessionDeliveryRouteShape = {
+  channel?: string;
+  accountId?: string;
+  target?: { to?: string };
+  thread?: { id?: string | number };
+};
+
+/**
+ * Read the persisted delivery route of one session entry, returning null when
+ * the entry has no usable outbound target. Understands both entry shapes:
+ *  - openclaw >= 2026.8 canonical `delivery.route` (delivery.kind === "external");
+ *  - legacy top-level `lastTo` / `lastChannel` fields (pre-2026.8 entries, and
+ *    unmigrated rows until `openclaw doctor --fix` rewrites them).
+ */
+function readLastDeliveryRoute(
+  entry: SessionStoreEntry | undefined,
+): LastDeliveryRoute | null {
+  if (!entry) return null;
+
+  const delivery = entry.delivery as
+    | { kind?: string; route?: SessionDeliveryRouteShape }
     | undefined;
-  const storePath = api.runtime.agent.session.resolveStorePath(sessionCfg?.store);
-  return api.runtime.agent.session.loadSessionStore(storePath) as Record<
-    string,
-    Record<string, unknown>
-  >;
+
+  // 有 delivery 且 kind 不是 external 时一律不投递:delivery 由宿主接管后,顶层
+  // lastTo/lastChannel 只是迁移残留,不可靠(kind=none/internal 明确不对外;未知的未来
+  // 枚举值同样不能确认可投,回退旧字段反而有错投风险)。仅两种情况回退老字段:
+  // ① kind 缺失/无 delivery 的未迁移行;② kind=external 但 route 里 channel/target.to
+  // 读不齐(惰性迁移写了一半,或宿主换了 route 形状)——此时控制流落到下方老字段分支。
+  if (delivery?.kind && delivery.kind !== "external") return null;
+
+  if (delivery?.kind === "external") {
+    const route = delivery.route;
+    const channel = route?.channel;
+    const to = route?.target?.to;
+    if (channel && to) {
+      return {
+        channel,
+        to,
+        accountId: route?.accountId,
+        threadId: route?.thread?.id,
+      };
+    }
+  }
+
+  const channel = entry.lastChannel as string | undefined;
+  const to = entry.lastTo as string | undefined;
+  if (channel && to) {
+    return {
+      channel,
+      to,
+      accountId: entry.lastAccountId as string | undefined,
+      threadId: entry.lastThreadId as string | number | undefined,
+    };
+  }
+  return null;
 }
 
 function resolveSessionByKey(
-  api: OpenClawPluginApi,
+  store: Record<string, SessionStoreEntry>,
   sessionKey: string,
 ): BoundSessionInfo | null {
-  const store = loadSessionStore(api);
-  const entry = store[sessionKey];
-  if (!entry?.lastTo || !entry?.lastChannel) return null;
-  return {
-    channel: entry.lastChannel as string,
-    to: entry.lastTo as string | undefined,
-    accountId: entry.lastAccountId as string | undefined,
-    threadId: entry.lastThreadId as string | number | undefined,
-    sessionKey,
-  };
+  const route = readLastDeliveryRoute(store[sessionKey]);
+  if (!route) return null;
+  return { ...route, sessionKey };
 }
 
 function resolveConfiguredTargets(
   api: OpenClawPluginApi,
   sessionKeys?: string[],
+  store: Record<string, SessionStoreEntry> = listSessionStore(api),
 ): { targets: NotifyTarget[]; invalidSessionKeys: string[] } {
   const keys = sessionKeys ?? normalizeNotifySessionKeys(getPluginConfig(api));
   const targets: NotifyTarget[] = [];
   const invalidSessionKeys: string[] = [];
   for (const key of keys) {
-    const target = resolveSessionByKey(api, key);
+    const target = resolveSessionByKey(store, key);
     if (target) {
       targets.push(target);
     } else {
@@ -308,8 +637,8 @@ function resolveConfiguredTargets(
 function selectMostRecentTarget(
   api: OpenClawPluginApi,
   preferredKeys?: string[],
+  store: Record<string, SessionStoreEntry> = listSessionStore(api),
 ): NotifyTarget | null {
-  const store = loadSessionStore(api);
   type TimedTarget = {
     channel: string;
     to: string | undefined;
@@ -318,38 +647,32 @@ function selectMostRecentTarget(
     sessionKey: string;
     lastInteractionAt: number;
   };
+  const toTimedTarget = (
+    sessionKey: string,
+    entry: SessionStoreEntry | undefined,
+  ): TimedTarget | null => {
+    const route = readLastDeliveryRoute(entry);
+    if (!route) return null;
+    return {
+      channel: route.channel,
+      to: route.to,
+      accountId: route.accountId,
+      threadId: route.threadId,
+      sessionKey,
+      // 排序键字段名已证实(2026-09-04 cat@mac openclaw 9.1 实测 100/100 会话顶层
+      // 都有必填 updatedAt,98/100 有可选 lastInteractionAt,未随投递迁入 delivery)。
+      lastInteractionAt: toTimestamp(
+        entry?.lastInteractionAt ?? entry?.updatedAt,
+      ),
+    };
+  };
   const candidates =
     preferredKeys && preferredKeys.length > 0
       ? preferredKeys
-          .map((key) => {
-            const entry = store[key];
-            if (!entry?.lastTo || !entry?.lastChannel) return null;
-            return {
-              channel: entry.lastChannel as string,
-              to: entry.lastTo as string | undefined,
-              accountId: entry.lastAccountId as string | undefined,
-              threadId: entry.lastThreadId as string | number | undefined,
-              sessionKey: key,
-              lastInteractionAt: toTimestamp(
-                entry.lastInteractionAt ?? entry.updatedAt,
-              ),
-            };
-          })
+          .map((key) => toTimedTarget(key, store[key]))
           .filter((v): v is TimedTarget => v !== null)
       : Object.entries(store)
-          .map(([key, entry]) => {
-            if (!entry?.lastTo || !entry?.lastChannel) return null;
-            return {
-              channel: entry.lastChannel as string,
-              to: entry.lastTo as string | undefined,
-              accountId: entry.lastAccountId as string | undefined,
-              threadId: entry.lastThreadId as string | number | undefined,
-              sessionKey: key,
-              lastInteractionAt: toTimestamp(
-                entry.lastInteractionAt ?? entry.updatedAt,
-              ),
-            };
-          })
+          .map(([key, entry]) => toTimedTarget(key, entry))
           .filter((v): v is TimedTarget => v !== null);
 
   let best: TimedTarget | null = null;
@@ -370,12 +693,15 @@ function selectMostRecentTarget(
 }
 
 export function resolveNotifyTarget(api: OpenClawPluginApi): ResolveResult {
-  const configured = resolveConfiguredTargets(api);
+  // 单次读表后透传,避免每个 bound key 各读一遍全表、且多次读间不是同一快照。
+  const store = listSessionStore(api);
+  const configured = resolveConfiguredTargets(api, undefined, store);
   if (configured.targets.length > 0) {
     return {
       target: selectMostRecentTarget(
         api,
         configured.targets.map((t) => t.sessionKey),
+        store,
       ),
       targets: configured.targets,
       needsBind: false,
@@ -384,7 +710,7 @@ export function resolveNotifyTarget(api: OpenClawPluginApi): ResolveResult {
   }
 
   const hasConfiguredKeys = normalizeNotifySessionKeys(getPluginConfig(api)).length > 0;
-  const fallback = selectMostRecentTarget(api);
+  const fallback = selectMostRecentTarget(api, undefined, store);
   const bindReason: BindReason = hasConfiguredKeys
     ? "configured_but_invalid"
     : "not_configured";

--- a/plugins/openclaw/tests/compile-baseline.test.ts
+++ b/plugins/openclaw/tests/compile-baseline.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+// build.openclawVersion 是 notify.ts 里宿主镜像实现的论证基线，而 devDependency 是
+// 浮动下限——这里把声明钉到实际安装的版本上：任何升级（改 lockfile / devDep）都会
+// 在此变红，逼着同步该字段与 notify.ts 的镜像论证，而不是靠知识库里的手动同步义务。
+describe("openclaw 编译基线", () => {
+  it("build.openclawVersion 与 node_modules 实际安装的 openclaw 版本一致", () => {
+    const pkg = JSON.parse(
+      readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+    ) as { openclaw?: { build?: { openclawVersion?: string } } };
+    const installed = JSON.parse(
+      readFileSync(
+        new URL("../node_modules/openclaw/package.json", import.meta.url),
+        "utf8",
+      ),
+    ) as { version?: string };
+    expect(
+      pkg.openclaw?.build?.openclawVersion,
+      "package.json#openclaw.build.openclawVersion 未随 openclaw 升级同步——" +
+        "notify.ts 的宿主镜像实现（默认 agent 解析等）论证基线已漂移，" +
+        "请按新版本核对镜像语义并同步该字段与 docstring",
+    ).toBe(installed.version);
+  });
+});

--- a/plugins/openclaw/tests/notify.test.ts
+++ b/plugins/openclaw/tests/notify.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const getRuntimeConfigMock = vi.fn();
 const getPluginConfigMock = vi.fn();
@@ -19,11 +19,17 @@ import {
   resolveNotifyTarget,
   toTimestamp,
 } from "../src/tools/notify.js";
+import { logger } from "../src/utils/logger.js";
 
 // 去重是模块级状态：每个用例前清空，且默认窗口 60s（个别用例可覆盖）。
 beforeEach(() => {
   __resetNotifyDedup();
   getNotifyDedupWindowMsMock.mockReturnValue(60_000);
+});
+
+// logger 是模块级单例：用例里 init 过 spy 的必须拆掉，避免泄漏进后续用例。
+afterEach(() => {
+  logger.init(undefined as any);
 });
 
 type SubagentMock = {
@@ -55,6 +61,25 @@ function makeSubagent(
     run: vi.fn(async () => ({ runId: "run-1" })),
     waitForRun: vi.fn(async () => waitResult),
   };
+}
+
+// openclaw >= 2026.8 的 runtime:agent.session 不再暴露 resolveStorePath/
+// loadSessionStore，投递信息收进 entry.delivery.route。这里只给 listSessionEntries，
+// 若实现还去碰已移除的旧方法会直接抛错 → 用例过 = 兼容路径生效。
+function makeApiV2(
+  entries: Array<{ sessionKey: string; entry: Record<string, unknown> }>,
+  subagent?: SubagentMock,
+) {
+  return {
+    runtime: {
+      agent: {
+        session: {
+          listSessionEntries: vi.fn(() => entries),
+        },
+      },
+      subagent,
+    },
+  } as any;
 }
 
 // ─── toTimestamp ─────────────────────────────────────────────────────────────
@@ -506,5 +531,504 @@ describe("notifyOwner dedup", () => {
     const second = await notifyOwner(api, "重复也发");
     expect(second.deduped).toBeUndefined();
     expect(subagent.run).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ─── openclaw >= 2026.8 runtime 兼容（listSessionEntries / delivery.route）────
+
+describe("2026.8 runtime session API 兼容", () => {
+  const routeEntry = {
+    sessionKey: "wechat:abc",
+    entry: {
+      delivery: {
+        kind: "external",
+        route: {
+          channel: "wechat",
+          accountId: "acc1",
+          target: { to: "user123" },
+          thread: { id: "t1" },
+        },
+      },
+    },
+  };
+
+  it("已配置 + delivery.route 有效 → needsBind: false，目标为新结构字段", () => {
+    const api = makeApiV2([routeEntry]);
+    getRuntimeConfigMock.mockReturnValue({ session: {} });
+    getPluginConfigMock.mockReturnValue({ notifySessionKeys: ["wechat:abc"] });
+
+    const result = resolveNotifyTarget(api);
+    expect(result.needsBind).toBe(false);
+    expect(result.target).toEqual({
+      channel: "wechat",
+      to: "user123",
+      accountId: "acc1",
+      threadId: "t1",
+      sessionKey: "wechat:abc",
+    });
+  });
+
+  it("delivery.kind = none/internal（无 route）→ 视为无推送目标", () => {
+    const api = makeApiV2([
+      { sessionKey: "wechat:abc", entry: { delivery: { kind: "none" } } },
+      { sessionKey: "mail:def", entry: { delivery: { kind: "internal" } } },
+    ]);
+    getRuntimeConfigMock.mockReturnValue({ session: {} });
+    getPluginConfigMock.mockReturnValue({ notifySessionKeys: ["wechat:abc", "mail:def"] });
+
+    const result = resolveNotifyTarget(api);
+    expect(result.needsBind).toBe(true);
+    expect(result.bindReason).toBe("configured_but_invalid");
+    expect(result.invalidSessionKeys).toEqual(["wechat:abc", "mail:def"]);
+  });
+
+  it("新 runtime 读到未迁移的 legacy 顶层 lastTo → 回退识别", () => {
+    const api = makeApiV2([
+      {
+        sessionKey: "telegram:xyz",
+        entry: { lastChannel: "telegram", lastTo: "tg_user", lastInteractionAt: 1000 },
+      },
+    ]);
+    getRuntimeConfigMock.mockReturnValue({ session: {} });
+    getPluginConfigMock.mockReturnValue({});
+
+    const result = resolveNotifyTarget(api);
+    expect(result.needsBind).toBe(true);
+    expect(result.bindReason).toBe("not_configured");
+    expect(result.target?.channel).toBe("telegram");
+    expect(result.target?.to).toBe("tg_user");
+  });
+
+  it("notifyOwner 走新 runtime 正常投递", async () => {
+    const subagent = makeSubagent({ status: "ok" });
+    const api = makeApiV2([routeEntry], subagent);
+    getRuntimeConfigMock.mockReturnValue({ session: {} });
+    getPluginConfigMock.mockReturnValue({ notifySessionKeys: ["wechat:abc"] });
+
+    const result = await notifyOwner(api, "正文");
+    expect(result.ok).toBe(true);
+    expect(result.channel).toBe("wechat");
+    expect(subagent.run).toHaveBeenCalledTimes(1);
+  });
+
+  it("新版路径按 config 默认 agent 传 agentId 给 listSessionEntries（默认 main）", () => {
+    const api = makeApiV2([]);
+    getRuntimeConfigMock.mockReturnValue({ session: {}, agents: { entries: { main: {} } } });
+    getPluginConfigMock.mockReturnValue({});
+
+    resolveNotifyTarget(api);
+    expect(api.runtime.agent.session.listSessionEntries).toHaveBeenCalledWith({
+      agentId: "main",
+    });
+  });
+
+  it("无 roster 配置（agents 缺失）→ 默认 main", () => {
+    const api = makeApiV2([]);
+    getRuntimeConfigMock.mockReturnValue({ session: {} });
+    getPluginConfigMock.mockReturnValue({});
+
+    resolveNotifyTarget(api);
+    expect(api.runtime.agent.session.listSessionEntries).toHaveBeenCalledWith({
+      agentId: "main",
+    });
+  });
+
+  it("entries 唯一 agent 非 main 时用该 id", () => {
+    const api = makeApiV2([]);
+    getRuntimeConfigMock.mockReturnValue({ session: {}, agents: { entries: { alice: {} } } });
+    getPluginConfigMock.mockReturnValue({});
+
+    resolveNotifyTarget(api);
+    expect(api.runtime.agent.session.listSessionEntries).toHaveBeenCalledWith({
+      agentId: "alice",
+    });
+  });
+
+  it("agents.list 唯一非 main agent → 用该 id（host 走 list 兜底）", () => {
+    const api = makeApiV2([]);
+    getRuntimeConfigMock.mockReturnValue({
+      session: {},
+      agents: { list: [{ id: "home" }] },
+    });
+    getPluginConfigMock.mockReturnValue({});
+
+    resolveNotifyTarget(api);
+    expect(api.runtime.agent.session.listSessionEntries).toHaveBeenCalledWith({
+      agentId: "home",
+    });
+  });
+
+  it("entries 与 list 并存时 entries 优先（host readAgentRosterProperty 语义）", () => {
+    const api = makeApiV2([]);
+    getRuntimeConfigMock.mockReturnValue({
+      session: {},
+      agents: { entries: { home: {} }, list: [{ id: "other" }] },
+    });
+    getPluginConfigMock.mockReturnValue({});
+
+    resolveNotifyTarget(api);
+    expect(api.runtime.agent.session.listSessionEntries).toHaveBeenCalledWith({
+      agentId: "home",
+    });
+  });
+
+  it("多 agent 中唯一 default:true 标记者胜出（非 main）", () => {
+    const api = makeApiV2([]);
+    getRuntimeConfigMock.mockReturnValue({
+      session: {},
+      agents: {
+        list: [{ id: "home", default: true }, { id: "guest" }],
+      },
+    });
+    getPluginConfigMock.mockReturnValue({});
+
+    resolveNotifyTarget(api);
+    expect(api.runtime.agent.session.listSessionEntries).toHaveBeenCalledWith({
+      agentId: "home",
+    });
+  });
+
+  it("多 agent 无 default 标记且不唯一 → 回退 main（host 该场景会抛，读侧降级）", () => {
+    const api = makeApiV2([]);
+    getRuntimeConfigMock.mockReturnValue({
+      session: {},
+      agents: { entries: { home: {}, guest: {} } },
+    });
+    getPluginConfigMock.mockReturnValue({});
+
+    resolveNotifyTarget(api);
+    expect(api.runtime.agent.session.listSessionEntries).toHaveBeenCalledWith({
+      agentId: "main",
+    });
+  });
+
+  it("agent id 规范化：大小写/非法字符/首尾连字符 → host normalizeAgentId", () => {
+    const api = makeApiV2([]);
+    getRuntimeConfigMock.mockReturnValue({
+      session: {},
+      agents: { list: [{ id: "Home Bot!" }] },
+    });
+    getPluginConfigMock.mockReturnValue({});
+
+    resolveNotifyTarget(api);
+    expect(api.runtime.agent.session.listSessionEntries).toHaveBeenCalledWith({
+      agentId: "home-bot",
+    });
+  });
+
+  it("8.2 runtime 真实形态：default 标记被宿主剥离、物化进 defaults.systemAgent → 读 systemAgent", () => {
+    const api = makeApiV2([]);
+    getRuntimeConfigMock.mockReturnValue({
+      session: {},
+      agents: {
+        defaults: { systemAgent: { agentId: "home" } },
+        entries: { home: {}, guest: {} },
+      },
+    });
+    getPluginConfigMock.mockReturnValue({});
+
+    resolveNotifyTarget(api);
+    expect(api.runtime.agent.session.listSessionEntries).toHaveBeenCalledWith({
+      agentId: "home",
+    });
+  });
+
+  it("entries 键存在但值 undefined → 宿主语义继续看 list（!== void 0 守卫）", () => {
+    const api = makeApiV2([]);
+    getRuntimeConfigMock.mockReturnValue({
+      session: {},
+      agents: { entries: undefined, list: [{ id: "home" }] },
+    });
+    getPluginConfigMock.mockReturnValue({});
+
+    resolveNotifyTarget(api);
+    expect(api.runtime.agent.session.listSessionEntries).toHaveBeenCalledWith({
+      agentId: "home",
+    });
+  });
+
+  it("名册多 agent 无 default 标记 → 推导 main 不在名册 → 打指名 WARN（宿主返回空表不抛错）", () => {
+    const warnSpy = vi.fn();
+    logger.init({ logger: { warn: warnSpy } } as any);
+    const api = makeApiV2([]);
+    getRuntimeConfigMock.mockReturnValue({
+      session: {},
+      agents: { entries: { home: {}, guest: {} } },
+    });
+    getPluginConfigMock.mockReturnValue({});
+
+    resolveNotifyTarget(api);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0][0])).toContain('agentId="main"');
+    expect(String(warnSpy.mock.calls[0][0])).toContain("home, guest");
+  });
+
+  it("合法空名册（entries:{}）不算畸形 → 不告警，隐式 main 照常工作", () => {
+    const warnSpy = vi.fn();
+    logger.init({ logger: { warn: warnSpy } } as any);
+    const api = makeApiV2([]);
+    getRuntimeConfigMock.mockReturnValue({
+      session: {},
+      agents: { entries: {} },
+    });
+    getPluginConfigMock.mockReturnValue({});
+
+    resolveNotifyTarget(api);
+    expect(api.runtime.agent.session.listSessionEntries).toHaveBeenCalledWith({
+      agentId: "main",
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("entries 与 list 并存且 list 带唯一 default 标记 → 仍按 entries 解析（宿主 readAgentRosterProperty 短路）", () => {
+    const api = makeApiV2([]);
+    getRuntimeConfigMock.mockReturnValue({
+      session: {},
+      agents: {
+        entries: { alpha: {} },
+        list: [{ id: "beta", default: true }],
+      },
+    });
+    getPluginConfigMock.mockReturnValue({});
+
+    resolveNotifyTarget(api);
+    expect(api.runtime.agent.session.listSessionEntries).toHaveBeenCalledWith({
+      agentId: "alpha",
+    });
+  });
+
+  it("id 规范化顺序与宿主一致：去首尾 - 早于截 64 → 65 字符 id 截出尾连字符", () => {
+    const api = makeApiV2([]);
+    getRuntimeConfigMock.mockReturnValue({
+      session: {},
+      agents: { list: [{ id: "a".repeat(63) + " b" }] },
+    });
+    getPluginConfigMock.mockReturnValue({});
+
+    resolveNotifyTarget(api);
+    expect(api.runtime.agent.session.listSessionEntries).toHaveBeenCalledWith({
+      agentId: "a".repeat(63) + "-",
+    });
+  });
+
+  it("宿主会话访问器缺失（runtime.agent.session 被摘）→ 空表降级 + WARN，不抛 500", () => {
+    const warnSpy = vi.fn();
+    logger.init({ logger: { warn: warnSpy } } as any);
+    const api = { runtime: { agent: {} } } as any;
+    getRuntimeConfigMock.mockReturnValue({ session: {} });
+    getPluginConfigMock.mockReturnValue({});
+
+    let result: ReturnType<typeof resolveNotifyTarget> | undefined;
+    expect(() => {
+      result = resolveNotifyTarget(api);
+    }).not.toThrow();
+    expect(result?.target).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0][0])).toContain("会话访问器");
+  });
+
+  it("两代会话 API 都探测不到 → 空表降级 + WARN（宿主再摘 API 的复发形态可排查）", () => {
+    const warnSpy = vi.fn();
+    logger.init({ logger: { warn: warnSpy } } as any);
+    const api = { runtime: { agent: { session: {} } } } as any;
+    getRuntimeConfigMock.mockReturnValue({ session: {} });
+    getPluginConfigMock.mockReturnValue({});
+
+    let result: ReturnType<typeof resolveNotifyTarget> | undefined;
+    expect(() => {
+      result = resolveNotifyTarget(api);
+    }).not.toThrow();
+    expect(result?.target).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0][0])).toContain("会话读取能力不可用");
+  });
+
+  it("kind=external 但 route 读不齐 → 回退顶层 lastTo/lastChannel（惰性迁移写一半）", () => {
+    const api = makeApiV2([
+      {
+        sessionKey: "wechat:abc",
+        entry: {
+          delivery: { kind: "external", route: { channel: "wechat" } },
+          lastChannel: "wechat",
+          lastTo: "user123",
+        },
+      },
+    ]);
+    getRuntimeConfigMock.mockReturnValue({ session: {} });
+    getPluginConfigMock.mockReturnValue({});
+
+    const result = resolveNotifyTarget(api);
+    expect(result.target?.channel).toBe("wechat");
+    expect(result.target?.to).toBe("user123");
+  });
+
+  it("kind=external 但 route 读不齐且无顶层老字段 → 无目标", () => {
+    const api = makeApiV2([
+      {
+        sessionKey: "wechat:abc",
+        entry: { delivery: { kind: "external" } },
+      },
+    ]);
+    getRuntimeConfigMock.mockReturnValue({ session: {} });
+    getPluginConfigMock.mockReturnValue({});
+
+    expect(resolveNotifyTarget(api).target).toBeNull();
+  });
+
+  it("老宿主 legacy 读失败（会话文件损坏）→ 空表降级 + WARN，不抛 500", () => {
+    const warnSpy = vi.fn();
+    logger.init({ logger: { warn: warnSpy } } as any);
+    const api = {
+      runtime: {
+        agent: {
+          session: {
+            resolveStorePath: vi.fn(() => "/tmp/sessions.json"),
+            loadSessionStore: vi.fn(() => {
+              throw new Error("Unexpected token } in JSON");
+            }),
+          },
+        },
+      },
+    } as any;
+    getRuntimeConfigMock.mockReturnValue({ session: {} });
+    getPluginConfigMock.mockReturnValue({});
+
+    let result: ReturnType<typeof resolveNotifyTarget> | undefined;
+    expect(() => {
+      result = resolveNotifyTarget(api);
+    }).not.toThrow();
+    expect(result?.target).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0][0])).toContain(
+      "legacy loadSessionStore failed",
+    );
+  });
+
+  it("listSessionEntries 抛错（agentId 在宿主上不存在）→ 降级为空表，不抛给调用方", () => {
+    const api = {
+      runtime: {
+        agent: {
+          session: {
+            listSessionEntries: vi.fn(() => {
+              throw new Error(
+                "Cannot resolve SQLite session scope without an agent id",
+              );
+            }),
+          },
+        },
+      },
+    } as any;
+    getRuntimeConfigMock.mockReturnValue({
+      session: {},
+      agents: { entries: { home: {}, guest: {} } },
+    });
+    getPluginConfigMock.mockReturnValue({});
+
+    expect(() => resolveNotifyTarget(api)).not.toThrow();
+    expect(resolveNotifyTarget(api).target).toBeNull();
+  });
+
+  it("对账不误报：agentId 不在名册但读到了会话（legacy main 库仍有数据的升级宿主）→ 无 WARN", () => {
+    const warnSpy = vi.fn();
+    logger.init({ logger: { warn: warnSpy } } as any);
+    const api = makeApiV2([
+      {
+        sessionKey: "wechat:abc",
+        entry: {
+          delivery: {
+            kind: "external",
+            route: {
+              channel: "wechat",
+              target: { to: "user123" },
+            },
+          },
+        },
+      },
+    ]);
+    getRuntimeConfigMock.mockReturnValue({
+      session: {},
+      agents: { ownership: "explicit", entries: { home: {}, guest: {} } },
+    });
+    getPluginConfigMock.mockReturnValue({});
+
+    resolveNotifyTarget(api);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("entries 属性存在但值为 null → 名册解析为空的异常路径单独告警", () => {
+    const warnSpy = vi.fn();
+    logger.init({ logger: { warn: warnSpy } } as any);
+    const api = makeApiV2([]);
+    getRuntimeConfigMock.mockReturnValue({
+      session: {},
+      agents: { entries: null },
+    });
+    getPluginConfigMock.mockReturnValue({});
+
+    resolveNotifyTarget(api);
+    expect(api.runtime.agent.session.listSessionEntries).toHaveBeenCalledWith({
+      agentId: "main",
+    });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0][0])).toContain("解析不出任何 agent");
+    expect(String(warnSpy.mock.calls[0][0])).toContain('"entries":"object"');
+  });
+
+  it("list 中无 id 的项与宿主同样落成 main 成员（不丢弃），多成员时推导 main 不告警", () => {
+    const warnSpy = vi.fn();
+    logger.init({ logger: { warn: warnSpy } } as any);
+    const api = makeApiV2([]);
+    getRuntimeConfigMock.mockReturnValue({
+      session: {},
+      agents: { list: [{ id: "home" }, {}] },
+    });
+    getPluginConfigMock.mockReturnValue({});
+
+    resolveNotifyTarget(api);
+    expect(api.runtime.agent.session.listSessionEntries).toHaveBeenCalledWith({
+      agentId: "main",
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("delivery.kind = none 但残留 legacy lastTo → 仍视为无推送目标", () => {
+    const api = makeApiV2([
+      {
+        sessionKey: "wechat:abc",
+        entry: {
+          delivery: { kind: "none" },
+          lastChannel: "wechat",
+          lastTo: "user123",
+        },
+      },
+    ]);
+    getRuntimeConfigMock.mockReturnValue({ session: {} });
+    getPluginConfigMock.mockReturnValue({ notifySessionKeys: ["wechat:abc"] });
+
+    const result = resolveNotifyTarget(api);
+    expect(result.needsBind).toBe(true);
+    expect(result.bindReason).toBe("configured_but_invalid");
+  });
+
+  it("多条 delivery.route 候选按最近活跃时间排序（不依赖枚举顺序）", () => {
+    const mk = (key: string, to: string, ts: number) => ({
+      sessionKey: key,
+      entry: {
+        delivery: {
+          kind: "external",
+          route: { channel: "wechat", target: { to } },
+        },
+        lastInteractionAt: ts,
+      },
+    });
+    const api = makeApiV2([
+      mk("wechat:new", "new_user", 2000),
+      mk("wechat:old", "old_user", 1000),
+    ]);
+    getRuntimeConfigMock.mockReturnValue({ session: {} });
+    getPluginConfigMock.mockReturnValue({});
+
+    const result = resolveNotifyTarget(api);
+    expect(result.target?.to).toBe("new_user");
   });
 });

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -107,10 +107,27 @@ resolve_version() {
     log "版本: pep440=$RESOLVED_PEP npm=$RESOLVED_NPM (raw=$RESOLVED_RAW)"
 }
 
-# 临时给 npm 包打版本号后还原 package.json，保证工作树不残留改动（CI 同样无害）。
+# 临时给 npm 包打版本号 / 剔 devDependencies 前备份 package.json，构建后还原。
+# 还原不能只靠 git checkout：部署机目录由 rsync 同步且排除了 .git/，那里 git 分支是
+# 空操作，残留「无 devDependencies + 版本号被改」会让下次 pnpm install --frozen-lockfile
+# 直接拒装（ERR_PNPM_OUTDATED_LOCKFILE）。所以先 cp 一份原文，还原时拷回。
+backup_pkg_json() {
+    local f="$1"
+    # 不覆盖已存在的备份：上次构建若被 SIGKILL / OOM 掐死(EXIT trap 跑不到)，树里会留下
+    # 「已剔 devDeps 的 package.json + 完好的 .build-bak」。此时直接 cp 会把好备份冲掉，
+    # 之后每次构建都撞 ERR_PNPM_OUTDATED_LOCKFILE 且部署机上无 git 可退。先还原再重备。
+    if [[ -f "$PROJECT_ROOT/$f.build-bak" ]]; then
+        log "WARN: 发现上次构建残留的 $f.build-bak（上次构建可能被硬杀），先还原再重新备份；若硬杀后有人工改动会被原文覆盖，需要保留请先手动合并两者差异"
+        restore_pkg_json "$f"
+    fi
+    cp "$PROJECT_ROOT/$f" "$PROJECT_ROOT/$f.build-bak"
+}
+
 restore_pkg_json() {
     local f="$1"
-    if git -C "$PROJECT_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    if [[ -f "$PROJECT_ROOT/$f.build-bak" ]]; then
+        mv -f "$PROJECT_ROOT/$f.build-bak" "$PROJECT_ROOT/$f"
+    elif git -C "$PROJECT_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
         git -C "$PROJECT_ROOT" checkout -- "$f" 2>/dev/null || true
     fi
 }
@@ -187,6 +204,10 @@ build_miloco_cli() {
 build_openclaw() {
     log "构建 openclaw 插件 ..."
 
+    # npm version / npm pkg delete 临时改脏 package.json；先备份原文，并用 EXIT trap
+    # 兜住 set -e 下子 shell pack 失败的退出路径，保证任何情况下都能还原。
+    backup_pkg_json plugins/openclaw/package.json
+    trap 'restore_pkg_json plugins/openclaw/package.json' EXIT
     (
         cd "$PROJECT_ROOT/plugins/openclaw"
         # 临时写版本号供 npm pack 命名 tgz，pack 后由外层 restore_pkg_json 还原
@@ -195,9 +216,16 @@ build_openclaw() {
         # 想删 node_modules 会因没 TTY 中止；CI=true 让 pnpm 自动跳过确认。
         CI=true pnpm install --frozen-lockfile
         pnpm build
+        # 发布产物不带 devDependencies：openclaw 安装插件依赖时会把 devDeps 当可装依赖，
+        # 其中 devDependencies.openclaw 会让 npm 解析整个框架包 → 10.9.x/12.x edgesOut 崩溃
+        # （2026-09-03 hcl-book podman 2026.5.2 / cat@mac 2026.6.11 实证）。devDeps 仅本地
+        # 构建/类型用，pack 后由 restore_pkg_json 从 .build-bak 拷回原文(git checkout 仅在
+        # 无备份时兜底)，连同临时写入的版本号一并还原。
+        npm pkg delete devDependencies >/dev/null
         npm pack --pack-destination "$DIST_DIR"
     )
     restore_pkg_json plugins/openclaw/package.json
+    trap - EXIT
 }
 
 build_hermes() {

--- a/scripts/i18n/en.json
+++ b/scripts/i18n/en.json
@@ -87,6 +87,7 @@
   "plugin.version_too_old": "openclaw version too old (%1), requires >= %2. Upgrade: npm install -g openclaw@latest",
   "plugin.openclaw_not_found": "openclaw command not found. Install: npm install -g openclaw@latest",
   "plugin.version_check_failed": "Could not detect openclaw version, skipping version check",
+  "plugin.capability_probe_timeout": "Timed out probing openclaw plugin install flags; installing the legacy way. On openclaw >= 2026.8 this may be blocked by the capability consent gate — if so, run manually: openclaw plugins install --force --accept-capabilities <tgz>",
   "plugin.skipped": "Plugin installation skipped",
   "plugin.plugin_ok": "Plugin installed",
   "plugin.plugin_fail": "Plugin installation failed",

--- a/scripts/i18n/zh.json
+++ b/scripts/i18n/zh.json
@@ -87,6 +87,7 @@
   "plugin.version_too_old": "openclaw 版本过低 (%1)，需要 >= %2，请先升级: npm install -g openclaw@latest",
   "plugin.openclaw_not_found": "未找到 openclaw 命令，请先安装: npm install -g openclaw@latest",
   "plugin.version_check_failed": "无法获取 openclaw 版本号，跳过版本检查",
+  "plugin.capability_probe_timeout": "探测 openclaw 插件安装参数超时，将按旧版方式安装；若宿主为 openclaw >= 2026.8 可能被 capability 授权拦下，届时请手动执行: openclaw plugins install --force --accept-capabilities <tgz>",
   "plugin.skipped": "已跳过插件安装",
   "plugin.plugin_ok": "插件安装完成",
   "plugin.plugin_fail": "插件安装失败",

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -1291,8 +1291,34 @@ class Installer:
             )
         pkg = str(tgz_files[0])
 
+        # openclaw >= 2026.8 引入 capability consent：带 capabilities 的插件安装需
+        # --accept-capabilities；老版本无此旗标，探测 install --help 决定是否追加。
+        # 判定只看输出文本（与 sync-to-remote.sh 同口径），退出码/超时不参与匹配；
+        # 超时时已捕获的部分输出也参与匹配——help 文本打印出该旗标即代表支持。
+        accept = []
+        timed_out = False
+        try:
+            probe = subprocess.run(
+                ["openclaw", "plugins", "install", "--help"],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            probe_out = f"{probe.stdout}\n{probe.stderr}"
+        except subprocess.TimeoutExpired as exc:
+            timed_out = True
+            out = exc.stdout.decode(errors="replace") if isinstance(exc.stdout, bytes) else (exc.stdout or "")
+            err = exc.stderr.decode(errors="replace") if isinstance(exc.stderr, bytes) else (exc.stderr or "")
+            probe_out = f"{out}\n{err}"
+        if "--accept-capabilities" in probe_out:
+            accept = ["--accept-capabilities"]
+        elif timed_out:
+            # 超时且没匹配到旗标：以空 accept 继续安装，8.x 上会被 consent 门拒——
+            # 提示实际原因免得误判成版本号问题。
+            self.ui.warn(self.ui.i18n.t("plugin.capability_probe_timeout"))
+
         self.ui.run_with_spinner(
-            ["openclaw", "plugins", "install", "--force", pkg],
+            ["openclaw", "plugins", "install", "--force", *accept, pkg],
             self.ui.i18n.t("plugin.installing"),
             text=True,
         )

--- a/scripts/sync-to-remote.sh
+++ b/scripts/sync-to-remote.sh
@@ -193,8 +193,35 @@ if [[ -n "$INSTALL_LIST" ]]; then
     if want openclaw; then
         TGZ=$(ls "$DIST"/miloco-openclaw-plugin-*.tgz 2>/dev/null | head -1)
         [[ -n "$TGZ" ]] || { echo "[remote] 缺 openclaw plugin tgz" >&2; exit 1; }
-        echo "[remote] openclaw plugins install --force $(basename "$TGZ")"
-        openclaw plugins install --force "$TGZ"
+        # openclaw >= 2026.8 引入 capability consent：带 capabilities 的插件安装需
+        # --accept-capabilities；老版本无此旗标，探测 install --help 决定是否追加。
+        # 探测必须有时间上限，否则宿主 CLI 启动挂住会卡死整条 ssh 部署。部署机是 mac，
+        # 基础系统无 GNU timeout(coreutils 装出来叫 gtimeout)，两个都没有时用 perl alarm
+        # 兜底——mac/linux 都自带 perl。
+        ACCEPT=""
+        PROBE=(openclaw plugins install --help)
+        if command -v timeout >/dev/null 2>&1; then
+            PROBE=(timeout 30 "${PROBE[@]}")
+        elif command -v gtimeout >/dev/null 2>&1; then
+            PROBE=(gtimeout 30 "${PROBE[@]}")
+        elif command -v perl >/dev/null 2>&1; then
+            PROBE=(perl -e 'alarm shift; exec @ARGV' 30 "${PROBE[@]}")
+        else
+            echo "[remote] WARN: 无 timeout/gtimeout/perl，capability 探测无超时保护" >&2
+        fi
+        # 只看输出文本判定，退出码不参与(与 install.py 语义对齐，避免 pipefail 把
+        # grep 提前退出导致的 EPIPE 非零码算成「没匹配」)；退出码仅用于识别超时并提示。
+        PROBE_OUT="$("${PROBE[@]}" 2>&1)" && PROBE_RC=0 || PROBE_RC=$?
+        if [[ "$PROBE_OUT" == *--accept-capabilities* ]]; then
+            ACCEPT="--accept-capabilities"
+        elif (( PROBE_RC == 124 || PROBE_RC == 142 )); then
+            # 124 = timeout(1) 超时；142 = perl alarm 触发的 SIGALRM
+            echo "[remote] WARN: 探测 openclaw 插件安装参数超时，将按旧版方式安装；" \
+                 "若宿主为 openclaw >= 2026.8 可能被 capability 授权拦下，届时请手动执行：" \
+                 "openclaw plugins install --force --accept-capabilities $TGZ" >&2
+        fi
+        echo "[remote] openclaw plugins install --force ${ACCEPT:+$ACCEPT }$(basename "$TGZ")"
+        openclaw plugins install --force $ACCEPT "$TGZ"
         echo "[remote] register-skill-tools.sh （把 SKILL.md tool 加进 tools.alsoAllow）"
         bash "$REMOTE_PATH/scripts/register-skill-tools.sh"
         echo "[remote] openclaw plugins registry --refresh （清 plugin tool registry stale cache）"


### PR DESCRIPTION
## 背景

openclaw 2026.8.1/8.2 对插件 runtime 做了 session-store→session-entry+route 重构,并在安装侧引入 capability-consent / trust 门,叠加发布产物里遗留的 devDependencies.openclaw,让 miloco-openclaw-plugin 在 2026.8+ 上出现三类故障:

1. **运行期 notify 读不到会话**:`api.runtime.agent.session.loadSessionStore` 从 runtime 移除、投递信息从 entry 顶层 `lastTo/lastChannel` 迁入 `delivery.route`,旧代码报 `loadSessionStore is not a function` / 绑定无目标;
2. **安装期 edgesOut 崩溃**:产物 package.json 携带 `devDependencies.openclaw`,openclaw 装插件依赖时把 devDeps 当可装依赖,npm 解析 openclaw 框架包即崩(`Cannot read properties of null (reading 'edgesOut')`,npm 10.9/12.x,2026.5.2/6.11/8.2 三机实证);
3. **8.x 安装需 capability consent**:装带 capabilities 的插件需 `--accept-capabilities`,install.sh 与部署脚本未带。

## 改动(两提交)

### `25e7f01d` fix(openclaw): notify 会话目标解析兼容 openclaw 2026.8 session API
- 按运行时能力选路:有 `listSessionEntries`(≥2026.8)走新条目式枚举,否则走原 `loadSessionStore` 整文件读(读失败同样降级空表 + WARN,会话文件损坏不穿透成 HTTP 500——两分支同一降级原则),共用 `listSessionStore` 返回 `{sessionKey→entry}` 给上层;
- 投递目标双结构读取(`readLastDeliveryRoute`):`delivery` 且 kind=external 且 route 齐整时用 `delivery.route`;delivery 存在但 kind 非 external 一律视为无目标(未知未来枚举值同样不能确认可投,回退旧字段有错投风险);仅 kind 缺失/无 delivery 的未迁移行、以及 external 但 route 读不出才回退顶层老字段;
- 新路径只扫默认 agent:`listSessionEntries` 必须传 agentId,投递侧 `subagent.run`(SubagentRunParams)无 agentId,投递作用域由传入的 sessionKey 决定。默认 agent 推导镜像宿主 ambient owner 解析(`tryResolveAmbientOwnerAgentId`,2026.8.2/2026.9.1 源码核对):① `agents.defaults.systemAgent.agentId`(**8.2 运行时实测:宿主加载期把 roster 的 `default:true` 标记从内存态剥掉**——磁盘 config 带 `entries.home.default=true`,`runtime.config.current()` 里变 `home:{}`——物化进 systemAgent,真机上唯一会命中的分支);② 唯一 `default:true` 标记(`ownership=explicit` 时跳过);③ 唯一 agent;④ 无 roster 落 `main`。名册双形态且 entries 优先于 list(`entries` 键持 record 即用、键存在但值 undefined 时继续看 list、其余非 record 值连 list 兜底也吞掉);id 过宿主 `normalizeAgentId`。8.2 才有的 SDK `resolveDefaultAgentId` 无法静态 import(插件按 2026.5.20 typings 编译),runtime.agent 也未暴露 roster 助手,故只能镜像实现;
- 对账 WARN 放在读之后:仅当「agentId 不在名册**且**读回 0 条」才告警 scope 猜偏(legacy main 库仍有会话的升级宿主上读是成功的,读前告警会每条通知刷假警报);名册属性带非空值却解析不出任何 agent(`entries:null` 等畸形)单独告警,合法空名册(`entries:{}`/`list:[]`)不算畸形不告警;诊断只报名册形状不报条目值;局限(推导与名册同源,名册整段解析错时对账失效)在注释如实声明。宿主对「agent 不存在」返回空数组而非抛错(两版源码核实),两代 API 都探测不到的兜底路径、以及 runtime.agent.session 访问器缺失(可选链访问,防 no-channel 契约退化成 500)都打 WARN;catch 留作行为变化/IO 异常兜底,降级空表不抛,保持 `/miloco/webhook` 的 no-channel 非 500 契约;
- `resolveNotifyTarget` 单次读表透传;`miloco_notify_bind` 的 channel 与 channels/sessions 复用同一份快照;bind 失败文案补「>=2026.8 只扫默认 agent」作用域说明;
- **vitest 29 条 + 1 条编译基线断言**:delivery.route 解析 / kind 守卫 / legacy 回退 / 多候选排序(8.x 条目顶层 updatedAt 必填,真机 100/100 证实)/ agentId 推导(无 roster、entries 唯一、list 兜底、entries 与 list 并存、default 标记、多 agent 回退、id 规范化、entries:undefined 走 list、8.2 runtime 真实形态、读不到会话不告警不误报、entries:null 异常告警、无 id 项落 main)/ 抛错降级 / legacy 读失败(会话文件损坏)降级 / 合法空名册不告警 / entries 优先于带标记的 list(宿主短路语义钉子) / 规范化截 64 顺序钉子。

### `cfb070f0` fix(openclaw): 依赖与安装适配——产物剔 devDeps，compat 版本门，安装/文档兼容 2026.8 consent
- `build.sh` 在 npm pack 前剔 devDependencies(edgesOut 崩溃唯一真凶),发布产物只带 ajv/json-schema-to-ts/typebox 三个 runtime 依赖;**peerDependencies.openclaw 相对 main 未改动**。打包前 cp 备份 package.json,还原优先从 `.build-bak` 拷回(不依赖 git checkout——部署机 rsync 目录无 `.git/`),备份前先认领残留并打 WARN,EXIT trap 兜住失败路径,`*.build-bak` 入 `.gitignore`;
- 安装期版本门:`openclaw.compat.pluginApi` / `install.minHostVersion` `>=2026.5.2`(4.29 实测拒装)+ `build.openclawVersion` `2026.5.20` 编译基线(由 `tests/compile-baseline.test.ts` 断言与 node_modules 实际安装版本一致——升级 openclaw 时该测试先红,逼着同步镜像论证;测试随本提交,保证每个 commit 自包含、bisect 不被污染);
- `install.py` / `sync-to-remote.sh` 探测 `install --help` 是否支持 `--accept-capabilities`,两侧同口径:旗标匹配只看输出文本、超时时已捕获的部分输出也参与匹配、仅「超时且未匹配」才告警。install.py `timeout=30` + 专用 i18n key;sync-to-remote.sh `timeout→gtimeout→perl alarm` 三级超时(mac 无 GNU timeout),退出码 124/142 仅用于识别超时;
- 同步 knowledge 文档:版本下限、双 runtime 会话读取事实、安装命令 2026.8 注记。

## 验证矩阵(2026-09-03~07)

| 版本 | 安装 | 通道解析(webhook `resolveTarget=owner-channel`) |
|---|---|---|
| 2026.4.29 | ❌ 版本门拒装(正确行为) | — |
| 2026.5.2 | ✅(宿主 dangerous-code 扫描需 `--dangerously-force-unsafe-install`;child_process 为插件既有设计,与旧产物行为一致) | — |
| 2026.6.11(oc611 真机) | ✅ install+gateway 加载 | ✅ legacy 整文件读解析到 feishu,投递 ok |
| 2026.8.2(podman ×3 场景) | ✅ `--force --accept-capabilities`,loaded | ✅ 无 roster→结构化 no-channel;default 标记→解析 home(标记物化验证,无误报 WARN);explicit 无标记→对账 WARN 带名册形状 |
| 2026.9.1(cat@mac 生产) | ✅ miloco-dev deploy,verify 版本一致/health 200 | ✅ 解析到 feishu external route,投递 ok;kind=none 的 cron 条目正确排除 |

released v2026.8.6 产物仍带 devDeps 全版本 edgesOut 崩——本 PR 的 devDeps 剔除是 8.2+ 能装上的必要条件。tsc `--noEmit` 干净(上轮类型红已修)。

## 待办
- 合入后删除已废弃的 `test/openclaw-tgz-strip-fix`。