### PR TITLE
fix(hermes): 安装时按内容同步感知模型，不再跳过已存在的旧模型

### DIFF
--- a/backend/miloco/tests/test_hermes_model_sync.py
+++ b/backend/miloco/tests/test_hermes_model_sync.py
@@ -1,0 +1,244 @@
+# Copyright (C) 2025 Xiaomi Corporation
+# This software may be used and distributed according to the terms of the Xiaomi Miloco License Agreement.
+
+"""行为体检：install-hermes.sh step 4.7 必须「按内容同步」而不是「已存在就跳过」。
+
+从真脚本里抠出 4.7 的同步与收尾段跑，而不是在测试里复制一份实现——复制会造出第二份
+各自漂走的副本，正是本测试要防的那类问题。抠取的起止是代码行而非注释，改动那两行会
+让 ``_section`` 断言先红。
+
+不覆盖 ``MODEL_SRC`` 的解析（fork 源目录优先、包内 fallback）：抠取从解析之后开始，
+源目录由桩直接给。
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[3] / "plugins" / "hermes" / "install-hermes.sh"
+
+# 陪衬文件：只要不在必需清单里就行，用来验证「目录里有 .onnx」不足以放行。
+_NOT_REQUIRED = ("some-other-model.onnx", "some-tokenizer.json")
+
+# 与真脚本头部对齐：locale 钉死 UTF-8、解释器带 python 兜底。抠段来跑的前提是环境等价，
+# 差一项就会让失败红在环境上而不是被测行为上。
+_PRELUDE = textwrap.dedent(
+    """
+    set -euo pipefail
+    export LANG=C.UTF-8 LC_ALL=C.UTF-8
+    info() { echo "[i] $*"; }
+    warn() { echo "[w] $*"; }
+    err()  { echo "[e] $*" >&2; }
+    mark_done() { :; }
+    MILOCO_HOME="$1"
+    MODEL_SRC="$2"
+    PYTHON="$(command -v python3 || command -v python)"
+    """
+)
+
+
+def _section() -> str:
+    text = _SCRIPT.read_text(encoding="utf-8")
+    m = re.search(
+        r'^\[ -d "\$MILOCO_HOME/models" \].*?^mark_done 4\.7$', text, re.S | re.M
+    )
+    assert m, f"{_SCRIPT} 里找不到 step 4.7 的同步段（起止那两行变了？）"
+    return m.group(0)
+
+
+def _required_models() -> tuple[str, ...]:
+    """清单读被测段自己声明的那份——它与 MODELS 一致由 test_hermes_required_models 守。
+
+    在这里改用 MODELS 派生的话，「MODELS 多一个必需模型」会让本文件里所有
+    ``returncode == 0`` 的用例一起红，而要改的其实是 shell 那份手抄清单。
+    """
+    m = re.search(r'^REQUIRED_MODELS="([^"]*)"$', _section(), re.M)
+    assert m, "抠出的 4.7 段里找不到 REQUIRED_MODELS 赋值"
+    return tuple(m.group(1).split())
+
+
+_REQUIRED = _required_models()
+
+
+def _run(
+    tmp_path: Path,
+    src: dict[str, str] | None,
+    dest: dict[str, str],
+    config: dict | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """src=None 表示源目录不存在。返回跑完 4.7 段的结果。"""
+    home = tmp_path / "home"
+    (home / "models").mkdir(parents=True)
+    for rel, content in dest.items():
+        p = home / "models" / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+    if config is not None:
+        (home / "config.json").write_text(json.dumps(config), encoding="utf-8")
+
+    src_dir = tmp_path / "src"
+    if src is not None:
+        src_dir.mkdir()
+        for rel, content in src.items():
+            p = src_dir / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(content)
+
+    script = tmp_path / "seg.sh"
+    script.write_text(_PRELUDE + _section(), encoding="utf-8")
+    return subprocess.run(
+        ["bash", str(script), str(home), str(src_dir)],
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture
+def models_dir(tmp_path: Path) -> Path:
+    return tmp_path / "home" / "models"
+
+
+def test_content_differs_overwrites(tmp_path: Path, models_dir: Path) -> None:
+    """内容不同必须覆盖——判据换回「目标已存在就跳过」时这条红。"""
+    r = _run(tmp_path, {m: "NEW" for m in _REQUIRED}, {m: "OLD" for m in _REQUIRED})
+    assert r.returncode == 0, r.stderr
+    assert all((models_dir / m).read_text() == "NEW" for m in _REQUIRED)
+
+
+def test_content_same_not_rewritten(tmp_path: Path, models_dir: Path) -> None:
+    """内容一致不重写——比对换成无条件 cp 时这条红。"""
+    same = {m: "SAME" for m in _REQUIRED}
+    r = _run(tmp_path, same, same)
+    assert r.returncode == 0, r.stderr
+    assert "写入 0 个" in r.stdout
+
+
+def test_missing_required_model_exits_1(tmp_path: Path) -> None:
+    """缺必需模型必须以 1 退出并点名——收尾闸的循环被删掉时这条红。"""
+    present, absent = _REQUIRED[0], _REQUIRED[-1]
+    r = _run(tmp_path, {present: "NEW", **{m: "NEW" for m in _NOT_REQUIRED}}, {})
+    assert r.returncode == 1
+    assert absent in r.stderr
+
+
+def test_non_required_files_alone_are_not_enough(tmp_path: Path) -> None:
+    """目录里只有非必需的 .onnx 也要退出 1——判据换回「有任意 .onnx」时这条红。"""
+    r = _run(tmp_path, {m: "NEW" for m in _NOT_REQUIRED}, {})
+    assert r.returncode == 1
+    assert all(m in r.stderr for m in _REQUIRED)
+
+
+def test_zero_length_required_model_counts_as_missing(tmp_path: Path) -> None:
+    """长度为 0 的必需模型算缺失——``-s`` 换成 ``-f`` 时这条红。"""
+    empty = _REQUIRED[0]
+    dest = {m: "OK" for m in _REQUIRED}
+    dest[empty] = ""
+    r = _run(tmp_path, None, dest)
+    assert r.returncode == 1
+    assert empty in r.stderr
+
+
+def test_recurses_subdirs_and_hidden_files(tmp_path: Path, models_dir: Path) -> None:
+    """子目录与隐藏文件一并同步——``find`` 换回只扫顶层的 glob 时这条红。"""
+    r = _run(
+        tmp_path,
+        {**{m: "NEW" for m in _REQUIRED}, "sub/extra.bin": "X", ".hidden": "H"},
+        {},
+    )
+    assert r.returncode == 0, r.stderr
+    assert (models_dir / "sub" / "extra.bin").read_text() == "X"
+    assert (models_dir / ".hidden").read_text() == "H"
+
+
+def test_symlinked_source_is_followed(tmp_path: Path, models_dir: Path) -> None:
+    """源目录里的 symlink 要跟随——``find`` 少了 ``-L`` 时这条红。"""
+    real = tmp_path / "real"
+    real.mkdir()
+    src = tmp_path / "src"
+    src.mkdir()
+    for m in _REQUIRED:
+        (real / m).write_text("R")
+        (src / m).symlink_to(real / m)
+    home = tmp_path / "home"
+    (home / "models").mkdir(parents=True)
+    script = tmp_path / "seg.sh"
+    script.write_text(_PRELUDE + _section(), encoding="utf-8")
+    r = subprocess.run(
+        ["bash", str(script), str(home), str(src)], capture_output=True, text=True
+    )
+    assert r.returncode == 0, r.stderr
+    assert all((models_dir / m).read_text() == "R" for m in _REQUIRED)
+
+
+def test_stale_tmp_files_cleaned(tmp_path: Path, models_dir: Path) -> None:
+    """上次被打断留下的 ``*.tmp.<pid>`` 要清掉，真模型不动——清理那行被删时这条红。"""
+    r = _run(
+        tmp_path,
+        {m: "NEW" for m in _REQUIRED},
+        {f"{_REQUIRED[0]}.tmp.1234": "JUNK", "sub/x.onnx.tmp.99": "JUNK"},
+    )
+    assert r.returncode == 0, r.stderr
+    assert not (models_dir / f"{_REQUIRED[0]}.tmp.1234").exists()
+    assert not (models_dir / "sub" / "x.onnx.tmp.99").exists()
+    assert (models_dir / _REQUIRED[0]).read_text() == "NEW"
+
+
+def test_stale_tmp_cleaned_even_without_source(
+    tmp_path: Path, models_dir: Path
+) -> None:
+    """源目录找不到时也清残留——清理挪进同步分支里面时这条红。"""
+    r = _run(
+        tmp_path,
+        None,
+        {**{m: "OLD" for m in _REQUIRED}, f"{_REQUIRED[-1]}.tmp.77": "JUNK"},
+    )
+    assert r.returncode == 0, r.stderr
+    assert not (models_dir / f"{_REQUIRED[-1]}.tmp.77").exists()
+    assert (models_dir / _REQUIRED[-1]).read_text() == "OLD"
+
+
+def test_successful_sync_leaves_no_tmp(tmp_path: Path, models_dir: Path) -> None:
+    """正常同步完不留临时文件——``mv`` 那步被删时这条红。"""
+    r = _run(tmp_path, {m: "NEW" for m in _REQUIRED}, {})
+    assert r.returncode == 0, r.stderr
+    assert not list(models_dir.glob("*.tmp.*"))
+
+
+def test_models_elsewhere_warns_instead_of_exiting(tmp_path: Path) -> None:
+    """生效目录在别处时只警告不中止——那道分支被删时这条红（会变成 exit 1）。"""
+    r = _run(tmp_path, None, {}, config={"directories": {"models": "/data/models"}})
+    assert r.returncode == 0, r.stderr
+    assert "/data/models" in r.stdout
+
+
+def test_models_elsewhere_warned_even_when_default_dir_is_complete(
+    tmp_path: Path,
+) -> None:
+    """默认目录齐了也要提醒生效目录在别处——提醒挪回缺模型分支里面时这条红。"""
+    r = _run(
+        tmp_path,
+        {m: "NEW" for m in _REQUIRED},
+        {},
+        config={"directories": {"models": "/data/models"}},
+    )
+    assert r.returncode == 0, r.stderr
+    assert "/data/models" in r.stdout
+    assert "还缺" not in r.stdout
+
+
+@pytest.mark.parametrize("configured", ["models", "ABS_DEFAULT"])
+def test_configured_default_dir_still_hard_fails(
+    tmp_path: Path, configured: str
+) -> None:
+    """配的就是默认目录（相对或绝对写法）时照旧硬失败——判据只看字段非空时这条红。"""
+    if configured == "ABS_DEFAULT":
+        configured = str(tmp_path / "home" / "models")
+    r = _run(tmp_path, None, {}, config={"directories": {"models": configured}})
+    assert r.returncode == 1
+    assert all(m in r.stderr for m in _REQUIRED)

--- a/backend/miloco/tests/test_hermes_required_models.py
+++ b/backend/miloco/tests/test_hermes_required_models.py
@@ -1,0 +1,34 @@
+# Copyright (C) 2025 Xiaomi Corporation
+# This software may be used and distributed according to the terms of the Xiaomi Miloco License Agreement.
+
+"""仓库体检：install-hermes.sh 的必需模型清单必须与 resource_validator.MODELS 对齐。
+
+install-hermes.sh 的 step 4.7 装完模型后要判一次"引擎必需的模型齐没齐"，判据的出处是
+``resource_validator.MODELS`` 的非 optional 项。shell 侧不能依赖读到这个 Python 常量：
+跑脚本的解释器不保证是装了 miloco 的那个（``$PYTHON`` 取的是系统 python3，脚本里
+``import miloco`` 的地方全带 ``|| true``），而 release 通道走 ``--post-install`` 时
+tarball 里也没有源码树。只能复制一份文件名，由本测试负责让两份不各自漂走。
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from miloco.perception.engine.resource_validator import MODELS
+
+_SCRIPT = Path(__file__).resolve().parents[3] / "plugins" / "hermes" / "install-hermes.sh"
+
+
+def _required_models_in_script() -> list[str]:
+    m = re.search(
+        r'^REQUIRED_MODELS="([^"]*)"$', _SCRIPT.read_text(encoding="utf-8"), re.M
+    )
+    assert m, f"{_SCRIPT} 里找不到 REQUIRED_MODELS= 赋值"
+    return m.group(1).split()
+
+
+def test_required_models_match_resource_validator() -> None:
+    assert sorted(_required_models_in_script()) == sorted(
+        m.name for m in MODELS if not m.optional
+    )

--- a/plugins/hermes/install-hermes.sh
+++ b/plugins/hermes/install-hermes.sh
@@ -286,7 +286,7 @@ fi
 # tarball 里没有的 scripts/sync-skills.py / skills/，必须整段跳）；
 # step 5 (config set) / 6 (.env) / 7 (backend 重启) / 8 (enable plugin) 主体幂等，
 # 会重跑一次以保证 config/enable/backend 状态收敛（step 7 会多一次 stop+sleep 3s+start）。
-# 重点补齐的是 1.6/1.75/1.9 env 持久化 + 4.7 ONNX 模型 + 8.5 disable 残留清理 +
+# 重点补齐的是 1.6/1.75/1.9 env 持久化 + 4.7 感知模型 + 8.5 disable 残留清理 +
 # 9 版本记录 + 10 cron reconcile + 收尾 banner。
 if [ "$POST_INSTALL_ONLY" -eq 1 ]; then
   info "post-install 模式: 跳过 step 3/4 前端部署；step 5-8 幂等重跑；补 env / cron / 收尾"
@@ -667,72 +667,93 @@ mkdir -p "$HERMES_HOME/memory"
 
 PLUGIN_STATE="$HERMES_PLUGINS_DIR/miloco-plugin/state.json"
 
-# --- 4.7 同步本地感知 ONNX 模型到 MILOCO_HOME/models/ ---
-# [PR合并后] 可简化：上游 --agent-finish 自动下载模型，不再需要从 fork 仓库 cp
-# 原因：fork 走"plugin in fork 仓库"路线，不能复用 upstream 下载逻辑
-# 对齐上游 install.sh --agent-finish 的"下载感知模型"步骤（见
-# upstream install-guide.md 第 131 行"下载感知模型"）。
-#
-# hermes fork 走的是"plugin in fork 仓库"路线，不能复用 upstream 下载逻辑，
-# 但 fork 仓库的 backend/miloco/src/miloco/perception/models/ 目录里其实打包了
-# 同一份模型 — 直接 cp 即可（避免再下 80MB+）。
-#
-# 跳过条件：MILOCO_HOME/models/det_4C.onnx 已存在（用户已装）。
-[ "$POST_INSTALL_ONLY" -eq 1 ] || step 4.7 "同步本地感知 ONNX 模型 → ${MILOCO_HOME}/models/"
+# --- 4.7 同步本地感知模型到 MILOCO_HOME/models/ ---
+# 对应上游 install.sh --agent-finish 里的"下载感知模型"步骤：fork 走"plugin in fork
+# 仓库"路线，复用不了上游那套下载，但 fork 仓库的
+# backend/miloco/src/miloco/perception/models/ 里带着模型，从那儿同步即可。
+[ "$POST_INSTALL_ONLY" -eq 1 ] || step 4.7 "同步本地感知模型 → ${MILOCO_HOME}/models/"
 
-# Release 装机场景 install.py step 7「准备感知模型」已经从 miloco-models-*.tar.gz
-# 解压 5 个 ONNX 到 $MILOCO_HOME/models/。本步只是 dev/fork 场景的兜底（从 git
-# checkout 或 miloco 包内 cp），已经有模型就跳过 fork/pkg 搜索，避免误报
-# 「找不到 ONNX 模型源目录」。
-if compgen -G "$MILOCO_HOME/models/*.onnx" >/dev/null 2>&1; then
-  onnx_count=$(ls "$MILOCO_HOME/models"/*.onnx 2>/dev/null | wc -l | tr -d ' ')
-  info "  $MILOCO_HOME/models/ 已有 $onnx_count 个 ONNX 模型（install.py step 7 已解压 release tarball），跳过 fork/pkg 兜底"
-  MODEL_SRC=""
-else
-  # 搜模型源目录：优先 fork 仓库（git checkout），其次 miloco Python 包内 models/
-  # 安装到 ~/.hermes/plugins/miloco/ 后 $HERE 不再指向 git checkout，
-  # 但 pip install -e 的 miloco 包内 models/ 仍可达，以此兜底。
-  MODEL_SRC="$HERE/../../backend/miloco/src/miloco/perception/models"
-  if [ ! -d "$MODEL_SRC" ]; then
-    MODEL_SRC=$("$PYTHON" -c "from pathlib import Path; import miloco; print(Path(miloco.__file__).parent / 'perception' / 'models')" 2>/dev/null || true)
-  fi
+# 先搜源目录再看已有模型：源在就以源为准，搜不到源而已有模型是 release 装机的正常
+# 形态（install.py 解压过），不该报「找不到源目录」。
+# 源优先 fork 仓库（git checkout），其次 miloco 包内：装到 ~/.hermes/plugins/miloco/ 后
+# $HERE 不再指向 git checkout，但 pip install -e 的包仍可达。
+MODEL_SRC="$HERE/../../backend/miloco/src/miloco/perception/models"
+if [ ! -d "$MODEL_SRC" ]; then
+  MODEL_SRC=$("$PYTHON" -c "from pathlib import Path; import miloco; print(Path(miloco.__file__).parent / 'perception' / 'models')" 2>/dev/null || true)
 fi
-if [ -n "$MODEL_SRC" ] && [ ! -d "$MODEL_SRC" ]; then
-  warn "找不到 ONNX 模型源目录（fork 仓库 & miloco 包内均无）"
-  warn "感知引擎可能跑不起来（perceive query 报 models_missing）"
-  warn "修法：重新从 git checkout 目录运行本脚本，或从 upstream release 下载到 $MILOCO_HOME/models/"
-elif [ -n "$MODEL_SRC" ]; then
-  mkdir -p "$MILOCO_HOME/models"
-  # 同步 .onnx + .json（bge tokenizer）；已存在的不覆盖（保留用户手动调整）
-  synced=0
-  skipped=0
-  for f in "$MODEL_SRC"/*.onnx "$MODEL_SRC"/*.json; do
-    [ -f "$f" ] || continue
-    bn="$(basename "$f")"
-    if [ -f "$MILOCO_HOME/models/$bn" ]; then
-      skipped=$((skipped + 1))
-    else
-      cp "$f" "$MILOCO_HOME/models/$bn"
-      synced=$((synced + 1))
-    fi
-  done
-  info "  同步 ONNX 模型：新增 $synced 个、跳过已存在 $skipped 个"
-  info "  模型目录：$MILOCO_HOME/models/"
 
-  # 在 config.json 写 models 字段（settings.models_dir 默认读这里）
-  if [ -f "$MILOCO_HOME/config.json" ]; then
-    "$PYTHON" - "$MILOCO_HOME" <<'PY' || true
-import json, sys
+# 上一次跑到一半被打断（Ctrl-C / 磁盘满）会留下 *.tmp.<pid>：名字带当次进程号，不会
+# 被下次的 mv 顶掉，每失败一次就在模型目录里积一份完整大小的垃圾。放在两条分支之前，
+# 源目录找不到时也清。
+[ -d "$MILOCO_HOME/models" ] && find "$MILOCO_HOME/models" -type f -name '*.tmp.[0-9]*' -delete 2>/dev/null || true
+
+if [ -n "$MODEL_SRC" ] && [ -d "$MODEL_SRC" ]; then
+  mkdir -p "$MILOCO_HOME/models"
+  # 递归同步源目录下的全部文件（含子目录与隐藏文件），既不挑后缀也不只扫顶层：上游
+  # 把整个 models 目录打进 tarball 再原样解压，挑后缀或只扫顶层会与那条路分裂，将来
+  # 源侧新增别的文件或子目录就会漏掉。
+  # cmp 对不存在的目标也返回非零，所以"目标缺失"和"内容不同"走同一条写分支。
+  # 先写临时文件再 mv：就地 cp 会先把目标截断再往里写，中途被打断会留下一个长度不对
+  # 的模型文件，之后 onnxruntime 加载它直接失败。
+  synced=0
+  same=0
+  while IFS= read -r f; do
+    rel="${f#"$MODEL_SRC"/}"
+    dest="$MILOCO_HOME/models/$rel"
+    if cmp -s "$f" "$dest"; then
+      same=$((same + 1))
+      continue
+    fi
+    mkdir -p "$(dirname "$dest")"
+    cp "$f" "$dest.tmp.$$"
+    mv -f "$dest.tmp.$$" "$dest"
+    synced=$((synced + 1))
+    info "    写入 ${rel}"
+  done < <(find -L "$MODEL_SRC" -type f)
+  info "  同步感知模型：写入 $synced 个、内容一致跳过 $same 个"
+  info "  模型目录：$MILOCO_HOME/models/"
+else
+  info "  没找到本地模型源目录，跳过同步（release 装机的模型由 install.py 解压）"
+fi
+
+# 收尾闸：判据是"引擎必需的模型逐个到位"，放在两条分支汇合后的必经处。"源路径在
+# 不在"和"目录里有没有任意 .onnx"答的都不是这个问题——源目录缺了 det_4C.onnx 时两
+# 者都放行，而装完感知引擎必然报 models_missing，继续装是交付空壳。
+# 清单的出处是 resource_validator.MODELS 的非 optional 项，两边一致由仓库体检测试守。
+# 安装期一律装到 $MILOCO_HOME/models（install.py 也写死这个目录），所以查的也是它；
+# 用户把 config.json::directories.models 指到别处时 4.7 管不到那个目录，不中止。
+MODELS_ELSEWHERE=$("$PYTHON" -c '
+import json, os, sys
 home = sys.argv[1]
-p = f"{home}/config.json"
 try:
-    cfg = json.load(open(p, encoding="utf-8"))
+    cfg = json.load(open(os.path.join(home, "config.json"), encoding="utf-8"))
 except Exception:
     cfg = {}
-cfg["models"] = f"{home}/models"
-json.dump(cfg, open(p, "w", encoding="utf-8"), indent=2, ensure_ascii=False)
-print(f"  config.json::models = {home}/models")
-PY
+configured = (cfg.get("directories") or {}).get("models") or ""
+d = configured if os.path.isabs(configured) else os.path.join(home, configured or "models")
+default = os.path.join(home, "models")
+print("" if os.path.realpath(d) == os.path.realpath(default) else d)
+' "$MILOCO_HOME" 2>/dev/null || true)
+
+REQUIRED_MODELS="det_4C.onnx human_body_reid_v2.onnx"
+missing_models=""
+for m in $REQUIRED_MODELS; do
+  [ -s "$MILOCO_HOME/models/$m" ] || missing_models="$missing_models $m"
+done
+# 生效目录不是默认目录时，4.7 装到的地方就不是引擎读的地方，不管默认目录里够不够都
+# 得先说一声。放进下面那道闸里面等于只在默认目录也缺模型时才提醒，而从 checkout 跑时
+# 上面的同步必然把默认目录填满，那条路走不到。
+if [ -n "$MODELS_ELSEWHERE" ]; then
+  warn "config.json::directories.models 指向 ${MODELS_ELSEWHERE}，4.7 只往 $MILOCO_HOME/models/ 装，请自行确认那边模型齐全"
+fi
+
+if [ -n "$missing_models" ]; then
+  if [ -n "$MODELS_ELSEWHERE" ]; then
+    warn "  另外 $MILOCO_HOME/models/ 还缺 ${missing_models# }（生效目录在别处，不中止）"
+  else
+    err "感知模型缺失：${missing_models# }（目标目录：$MILOCO_HOME/models/，源目录：${MODEL_SRC:-未找到}）"
+    echo "修法：从带模型的 git checkout 目录运行本脚本，或从 upstream release 下载模型到 $MILOCO_HOME/models/" >&2
+    exit 1
   fi
 fi
 mark_done 4.7

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -1359,7 +1359,7 @@ class Installer:
             scripts/ / skills/，只能整段跳，由 POST_INSTALL_SKIP guard 兜底
           - **幂等重跑**：step 5 (config set) / 6 (.env) / 7 (backend 重启) / 8 (enable)
             —— 都是幂等的，重跑一遍保证状态收敛（代价是 step 7 会多一次 stop+3s+start）
-          - **本模式真正补齐**：1.6/1.75/1.9 env 持久化、4.7 ONNX 模型、8.5 disable 残留
+          - **本模式真正补齐**：1.6/1.75/1.9 env 持久化、4.7 感知模型、8.5 disable 残留
             清理、9 版本记录、10 cron reconcile、收尾 banner「hermes gateway restart」提示
 
         install-hermes.sh 由 build.sh::build_hermes 打进 miloco-hermes-plugin tarball，


### PR DESCRIPTION
## 问题

`install-hermes.sh` step 4.7 的判据是「目标文件已存在就跳过」，外层还有一道更硬的闸：只要 `$MILOCO_HOME/models/` 下有任何 `.onnx`，就把源目录变量置空、整段放弃搜索。

结果源码树里换过模型之后重跑 `install-hermes.sh`，新模型一个字节都写不过去，而日志只报「跳过已存在」，看不出装的是旧模型。

4.7 是 hermes 侧的模型安装步骤（`install-hermes.sh` 不调 `install.py`）。官方装法 `curl install.sh | bash -s -- --agent-finish --agent-platform=hermes` 走 `install.py`，那条本来就是覆盖语义。

## 改动

只动 step 4.7 一段，另加一个仓库体检测试。

**同步**

- 逐文件判据从 `[ -f "$dest" ]` 换成 `cmp -s "$f" "$dest"`：内容一致才跳过，不同就写。目标不存在时 `cmp` 同样返回非零，于是「缺失」和「内容不同」共用一条写分支
- 外层分支倒序：先搜源目录，源在就以源为准；找不到源则跳过同步。不改这处，上一条走不到——已有模型时根本进不了比对
- 写入走「临时文件 + `mv`」：就地 `cp` 会先把目标截断再往里写，中途被打断会留下一个长度不对的模型文件，onnxruntime 加载它直接失败
- 进 4.7 先清掉上次被打断留下的 `*.tmp.<pid>`：名字带当次进程号，不会被下次的 `mv` 顶掉，每失败一次就在模型目录里积一份完整大小的垃圾。清理放在两条分支之前，源目录找不到时也清
- 范围从「挑 `*.onnx` / `*.json` 后缀」放开成 `find -L` 递归遍历源目录（含子目录与隐藏文件；`-L` 跟随 symlink，与原来 `[ -f ]` 同语义）
- 被写入的文件名逐个打进日志：本 PR 的起因是「日志看不出装的是旧模型」，反向那个坑（在旧 tag 的 checkout 里重跑、把新模型覆盖成旧的）同样得看得见

**收尾闸**

- 挪到两条分支汇合后的必经处
- 判据是「引擎必需的模型逐个到位」。「源路径在不在」和「目录里有没有任意 `.onnx`」答的都不是这个问题：源目录缺了 `det_4C.onnx`（rsync 中断、开发机删大文件省空间）时两者都放行，装机全绿、运行时才报 `models_missing`
- 必需清单的出处是 `resource_validator.MODELS` 的非 optional 项。shell 侧不能依赖读到这个 Python 常量：跑脚本的解释器不保证是装了 miloco 的那个（`$PYTHON` 取的是系统 python3，脚本里 `import miloco` 的地方全带 `|| true`），而 release 通道走 `--post-install` 时 tarball 里也没有源码树。只能复制一份文件名，新增 `backend/miloco/tests/test_hermes_required_models.py` 守两边一致
- 硬失败只针对 `$MILOCO_HOME/models`。用户把 `directories.models` 指到别处时 4.7 管不到那个目录，改成 warn 不中止：否则本来 warn 之后能装完 step 5-9 的流程会变成中止。判据是「解析后的生效目录是否就是 `$MILOCO_HOME/models`」，`"models"` 这种等价于默认值的相对写法照旧硬失败
- 这句提醒无条件打，不放在「默认目录也缺模型」的分支里面：从 checkout 跑时上面的同步必然把默认目录填满，放里面那条路走不到，而那恰恰是生效目录在别处时最需要提醒的场景

**删除**

- 往 `config.json` 写顶层 `models` 字段的那段：backend 读的是 `directories.models`，顶层键被 `Settings.model_config` 的 `extra="ignore"` 丢掉，从来没生效过，而 `models_dir` 的默认值本就是 `$MILOCO_HOME/models`。宣告写入成功的那行日志一并删掉
- 重写 4.7 上方的注释块（原文写「其实打包了同一份模型 — 直接 cp 即可」，正是本次替换掉的行为）

## 改后的分支路由

| 条件 | 走向 |
|---|---|
| 源目录存在 | 递归比对同步 |
| 源目录不存在 | info 跳过同步 |
| 以上任一之后，必需模型缺任一 | `err` + `exit 1` |
| 同上，但 `directories.models` 指向别处 | `warn`，继续 |

## 与 `install.py` 路径对账

| 维度 | 是否一致 |
|---|---|
| 装完 `models/` 等于源 | 一致 |
| 不删目标里多出来的旧文件 | 一致 |
| 同步范围 = 源目录递归全量 | 一致 |
| 复制失败硬失败 | 一致（脚本顶部 `set -e`） |
| 内容一致时是否重写 | 本侧不重写，解压会重写。结果无差，省掉每次安装的无效写入 |
| 拿不到模型硬失败的粒度 | **本侧更严**。`install.py` 判的是本次解压出的成员数（`if not count`），部分缺失时它放行；本侧逐个查必需模型 |

## 测试

`backend/miloco/tests/test_hermes_model_sync.py` —— 行为体检。从真脚本里用正则抠出 4.7 的同步段（起止是代码行而非注释，改动它会先让抠取断言红），注入桩后在临时目录里跑，锁住：按内容覆盖／内容一致不重写／缺必需模型退出 1／只有可选模型也不够／长度为 0 算缺失／递归子目录与隐藏文件／跟随 symlink／清理历史 `*.tmp.<pid>`（源目录找不到时也清）／正常同步完不留临时文件／生效目录在别处只警告／配的就是默认目录时照旧硬失败。

必需清单在行为体检里读的是**被测段自己声明的那份**（`REQUIRED_MODELS=`），不是从 `MODELS` 派生：派生的话「`MODELS` 多一个必需模型」会让本文件里所有 `returncode == 0` 的用例一起红，而要改的其实是 shell 那份手抄清单。

`backend/miloco/tests/test_hermes_required_models.py` —— 清单体检。shell 里的 `REQUIRED_MODELS` 与 `MODELS` 的非 optional 项比对，即上面那条一致性的唯一守卫。实测：把 `MODELS` 里一个 optional 改成必需，只有这一条红。

## 验证

- `bash -n` 通过
- 上面两个测试文件逐条做了变异测试。行为体检那边的变异包括：把 `cmp -s` 换回 `[ -f "$dest" ]`（本 PR 修的 bug 原样放回）／比对整个去掉／`find` 去掉 `-L`／同步范围退回只扫顶层／`-s` 换成 `-f`／收尾闸的校验循环删掉／清理改成只打印／清理加上「源目录在才清」的条件／生效目录的提醒挪回缺模型分支里面／生效目录判据换成「字段非空」／原子改名的 `mv` 删掉。每个变异红的都是对应那几条，牵连的都能解释（删掉 `mv` 让同步整个失效，所以内容类断言一起红）
- 手工场景（与上面的测试同一套，开发期用）：源在 + 已有旧模型（覆盖成源内容）／源在 + 内容一致（不写）／源在 + 含子目录与隐藏文件（一并递归同步）／源在但只有可选模型（报错退出）／源在但缺一个必需模型（报错并只点名缺的那个）／源在但目录是空的（报错退出）／源缺失 + 必需模型齐（跳过同步、退出 0）／源缺失 + 只有可选模型（报错退出）／必需模型存在但长度为 0（算缺失）／源目录里是 symlink（跟随链接同步内容）／缺必需模型 + `directories.models` 指向别处（只警告、退出 0）／缺必需模型 + `directories.models` 写成默认目录的相对或绝对形式（照旧报错退出）／生效目录在别处 + 默认目录模型齐（仍然提示、退出 0）／目标目录有历史 `*.tmp.<pid>` 残留（含子目录，进来先清掉且不误删真模型）／源目录找不到时也清残留
- 跑了 `cd backend && uv run pytest`、`cd backend && uv run ruff check . ../cli`、`plugins/hermes/tests/`，全过
