### PR TITLE
fix(rule): 停用再启用后把欠下的那次退出结掉

### DIFF
--- a/backend/miloco/src/miloco/rule/runner.py
+++ b/backend/miloco/src/miloco/rule/runner.py
@@ -170,6 +170,13 @@ _FIRE_PREAMBLE_WITH_RECORD = """**处理流程**：（按时间序 1→2→3 执
 辅助工具：派生量历史 / 跨窗口查询用 compute <task_id> [--window all|day|week|month] [--date YYYY-MM-DD]；所有 CLI 响应自带 derived 字段直接读，禁止心算。"""
 
 
+# 停用多久之内还认为"设备上那份设置仍是我们留下的那份", 超过就只清账、不动设备。
+# 判据本该是拿下发值与设备现值比对, 状态容器可信之后换回来的位置就是这里; 在那之前
+# 用失去观察的时长当替代指标 —— 间隔短则现状大概率没被人动过。
+# 故意不做成配置项: 要调就改这里发版, 依据是超时那条日志攒出来的时长分布。
+OWED_EXIT_RESEND_WINDOW_MS = 15 * 60 * 1000
+
+
 # 状态机判定为"该 fire"的结论。其余 (已在态内 / 被对侧条件拦住 / 不在会话中)
 # 都不 fire。
 _FIRING_OUTCOMES = frozenset(
@@ -286,6 +293,13 @@ class RuleRunner:
         # 是派生量、无人直接写 (§19.9)。放内存是因为 get_enabled_rules 每个判定
         # 周期都要走一遍, 不能查 DB。
         self._paused_tasks: set[str] = set()
+        # 对外下过进入动作、还没下过对应退出动作的 task。运行态是观测的投影, 而
+        # 进入动作在设备上留下的那份设置要等退出动作来改回去 —— 停用把运行态清成
+        # off 不会顺带把设备改回去, 所以这笔账要另记。
+        self._owed_exit: set[str] = set()
+        # 欠着账被停用的时刻 (ms)。不读 task.paused_at: 那一列在启用那一刻就被
+        # 写回 NULL, 等结算时去读只会读到空。
+        self._owed_exit_paused_at: dict[str, int] = {}
 
         # record 源。达标判断的全部逻辑在它里面, runner 只在 session 边界通知它。
         self._record_source = RecordSource(
@@ -560,6 +574,10 @@ class RuleRunner:
         """
         if paused:
             self._paused_tasks.add(task_id)
+            if task_id in self._owed_exit:
+                # 已经记着一个时刻就不覆盖: "停用 → 启用 → 没结算完又停用 → 再启用"
+                # 这条路上要按第一次欠账算, 否则失去观察的时长会算短。
+                self._owed_exit_paused_at.setdefault(task_id, now_ms())
             for rule in self._rules.values():
                 if rule.task_id == task_id:
                     self._reset_runtime_state(rule.id)
@@ -568,6 +586,102 @@ class RuleRunner:
 
     def is_task_paused(self, task_id: str) -> bool:
         return task_id in self._paused_tasks
+
+    # ---- 欠下的那次退出 ----
+
+    def owed_exit_paused_at(self, task_id: str) -> int | None:
+        """这个 task 是不是欠着一次退出被停用的; 是则返回停用时刻。"""
+        return self._owed_exit_paused_at.get(task_id)
+
+    def drop_owed_exit(self, task_id: str) -> None:
+        """账不欠了 —— 结清、放弃或 task 没了。"""
+        self._owed_exit.discard(task_id)
+        self._owed_exit_paused_at.pop(task_id, None)
+
+    def end_owed_exit_pause(self, task_id: str) -> None:
+        """这一轮结算收工, 但账还欠着 —— 等真正的退出动作来结。"""
+        self._owed_exit_paused_at.pop(task_id, None)
+
+    def _note_owed_exit(
+        self, task_id: str, slot: ActionSlot | None, *, dispatched: bool
+    ) -> None:
+        """记下这个 task 刚走过哪一侧的边界。
+
+        两侧的判据不对称, 是有意的:
+
+        - 清账不看有没有东西可下发, 也不看现在还有没有出路径。走过退出这一侧,
+          这一轮就结束了; 挂上和记账一样的闸, 就会出现"退出真的走完了、账还欠着",
+          之后一次停用启用就把运行态凭空补回 on。
+        - 记账要求确实下发过, 且这个 task 得有出路径。进入槽是空的等于设备上没留下
+          任何要复位的东西; 事件型 task 没有出路径, 运行态恒 ``off``, 谈不上在态。
+        """
+        if slot is ActionSlot.ON_EXIT:
+            self.drop_owed_exit(task_id)
+            return
+        if slot is not ActionSlot.ON_ENTER or not dispatched:
+            return
+        sm = self._state_machine
+        if sm is None or not sm.has_exit_path(task_id):
+            return
+        self._owed_exit.add(task_id)
+        # 新的一次进入让上一轮停用留下的结算作废。
+        self._owed_exit_paused_at.pop(task_id, None)
+
+    def _settle_owed_exit(self, rule: Rule) -> None:
+        """启用后第一次拿到确定的条件值时, 结算停用期间欠下的那次退出。
+
+        **只有 session 方向参与**: 它的条件为假就等于"该退出了"。exit 方向的条件为
+        假是"还没到该退出的时候", 拿它当退出依据极性正好反; enter + exit 形态的欠账
+        由启用时恢复运行态来结 (``TaskStateMachine.resume_session``)。
+
+        条件仍为真时不做任何特殊处理, 尤其不压掉随后那次 ``on_enter``。
+        """
+        paused_at = self._owed_exit_paused_at.get(rule.task_id)
+        if paused_at is None:
+            return
+        if rule.resolved_direction is not RuleDirection.SESSION:
+            return
+        if not self._all_sources_reported(rule):
+            return
+        if self._state[rule.id].last_rule_state:
+            self.end_owed_exit_pause(rule.task_id)
+            return
+
+        lost_sight_ms = now_ms() - paused_at
+        lost_sight_seconds = lost_sight_ms // 1000
+        self.drop_owed_exit(rule.task_id)
+        if lost_sight_ms >= OWED_EXIT_RESEND_WINDOW_MS:
+            logger.info(
+                "OWED_EXIT_EXPIRED: task=%s 失去观察 %d 秒, 超过 %d 秒的窗口, "
+                "不补发退出动作",
+                rule.task_id,
+                lost_sight_seconds,
+                OWED_EXIT_RESEND_WINDOW_MS // 1000,
+            )
+            return
+        if self.dispatch_task_action(
+            rule.task_id, ActionSlot.ON_EXIT.value, context="owed_exit_resend"
+        ):
+            logger.info(
+                "OWED_EXIT_RESENT: task=%s 失去观察 %d 秒, 补发退出动作",
+                rule.task_id,
+                lost_sight_seconds,
+            )
+
+    def _all_sources_reported(self, rule: Rule) -> bool:
+        """这条 rule 声明的感知源是不是每一个都已经报过至少一次。
+
+        比"``is_condition_satisfied`` 不返回 ``None``"严一档。那个只要有一个源报过
+        就给结论, 而 OR 聚合下先到的那个报假不代表整条为假 —— 据此补发退出, 等另一
+        个源随后报真又会进一次, 设备来回动一趟。
+        """
+        state = self._state.get(rule.id)
+        if state is None:
+            return False
+        declared = rule.condition.perceive_device_ids
+        if not declared:
+            return bool(state.sources)
+        return all(did in state.sources for did in declared)
 
     @property
     def state_machine(self) -> TaskStateMachine | None:
@@ -705,6 +819,10 @@ class RuleRunner:
             new_rule_state = any(s.last_bool for s in rule_state.sources.values())
             old_rule_state = rule_state.last_rule_state
             rule_state.last_rule_state = new_rule_state
+
+            # 必须排在下面那道早返之前: 停用期间条件层被清成假, 启用后喂假是
+            # old == new, 边沿永远不来 —— 而那正是欠账最该被结算的一帧。
+            self._settle_owed_exit(rule)
 
             if old_rule_state == new_rule_state:
                 return out(
@@ -1152,7 +1270,9 @@ class RuleRunner:
         "on_target": RuleEvent.TARGET_FIRED,
     }
 
-    def dispatch_task_action(self, task_id: str, slot_name: str) -> bool:
+    def dispatch_task_action(
+        self, task_id: str, slot_name: str, context: str | None = None
+    ) -> bool:
         """状态机自己发起的动作 —— 没有上游边沿, 由本函数补出一次 fire。
 
         用在 §19.5 重新配置时的强制 ``on_exit`` 与 §5 的手动注入。感知路径不走
@@ -1190,7 +1310,7 @@ class RuleRunner:
             rule,
             event,
             [],
-            f"task_state_machine_{slot_name}",
+            context or f"task_state_machine_{slot_name}",
             action_slot=ActionSlot(slot_name),
         )
         return True
@@ -1442,7 +1562,11 @@ class RuleRunner:
         action_slot: ActionSlot | None = None,
     ) -> RuleExecuteResult | None:
         """Pick the slot for (mode, event), execute, write log."""
-        slot = self._select_slot(rule, event, action_slot)
+        boundary_slot = action_slot or _slot_for(rule, event)
+        slot = self._select_slot(rule, event, boundary_slot)
+        # 记在这里而不是状态机的派发点: 感知边沿那条路进状态机时带 dispatch=False,
+        # 那一层在生产路径上一次都不派发, 挂上去等于整个机制静默失效。
+        self._note_owed_exit(rule.task_id, boundary_slot, dispatched=slot is not None)
         if slot is None:
             logger.debug(
                 "rule %s event %s: empty slot, skipping", rule.id, event.value

--- a/backend/miloco/src/miloco/rule/runner.py
+++ b/backend/miloco/src/miloco/rule/runner.py
@@ -244,6 +244,7 @@ class RuleRuntimeState:
     exit_debounce_at: float | None = None
     duration_window: "deque[int] | None" = None
     last_duration_round: int | None = None
+    owed_exit_false_since: int | None = None
     state_duration_fired: bool = False
     action_cooldown: dict[tuple[str, str], float] = field(default_factory=dict)
 
@@ -603,7 +604,7 @@ class RuleRunner:
         self._owed_exit_paused_at.pop(task_id, None)
 
     def _note_owed_exit(
-        self, task_id: str, slot: ActionSlot | None, *, dispatched: bool
+        self, task_id: str, slot: ActionSlot | None, *, has_action: bool
     ) -> None:
         """记下这个 task 刚走过哪一侧的边界。
 
@@ -612,13 +613,17 @@ class RuleRunner:
         - 清账不看有没有东西可下发, 也不看现在还有没有出路径。走过退出这一侧,
           这一轮就结束了; 挂上和记账一样的闸, 就会出现"退出真的走完了、账还欠着",
           之后一次停用启用就把运行态凭空补回 on。
-        - 记账要求确实下发过, 且这个 task 得有出路径。进入槽是空的等于设备上没留下
-          任何要复位的东西; 事件型 task 没有出路径, 运行态恒 ``off``, 谈不上在态。
+        - 记账要求槽里真有东西可下发, 且这个 task 得有出路径。进入槽是空的等于设备
+          上没留下任何要复位的东西; 事件型 task 没有出路径, 运行态恒 ``off``, 谈不上
+          在态。
+
+        不看下发成没成功: 与状态机"动作失败不反噬状态"同口径 —— 这笔账记的是我们下过
+        一次进入指令, 不是设备确认收到了。
         """
         if slot is ActionSlot.ON_EXIT:
             self.drop_owed_exit(task_id)
             return
-        if slot is not ActionSlot.ON_ENTER or not dispatched:
+        if slot is not ActionSlot.ON_ENTER or not has_action:
             return
         sm = self._state_machine
         if sm is None or not sm.has_exit_path(task_id):
@@ -641,32 +646,58 @@ class RuleRunner:
             return
         if rule.resolved_direction is not RuleDirection.SESSION:
             return
-        if not self._all_sources_reported(rule):
-            return
-        if self._state[rule.id].last_rule_state:
-            self.end_owed_exit_pause(rule.task_id)
-            return
 
+        state = self._state[rule.id]
         lost_sight_ms = now_ms() - paused_at
-        lost_sight_seconds = lost_sight_ms // 1000
-        self.drop_owed_exit(rule.task_id)
         if lost_sight_ms >= OWED_EXIT_RESEND_WINDOW_MS:
+            # 排在确定性之前: 超过窗口就不动设备了, 条件是真是假都不改变这个结论,
+            # 没什么可等的。排在后面的话, 声明的相机里有一台一直不上报, 这笔账会
+            # 永远悬着、连这条日志都留不下, 而窗口该取多长全靠它攒出来的分布。
+            self.drop_owed_exit(rule.task_id)
+            state.owed_exit_false_since = None
             logger.info(
                 "OWED_EXIT_EXPIRED: task=%s 失去观察 %d 秒, 超过 %d 秒的窗口, "
                 "不补发退出动作",
                 rule.task_id,
-                lost_sight_seconds,
+                lost_sight_ms // 1000,
                 OWED_EXIT_RESEND_WINDOW_MS // 1000,
             )
             return
+
+        if not self._all_sources_reported(rule):
+            return
+        if state.last_rule_state:
+            state.owed_exit_false_since = None
+            self.end_owed_exit_pause(rule.task_id)
+            return
+        if not self._absent_long_enough(rule, state):
+            return
+
+        self.drop_owed_exit(rule.task_id)
+        state.owed_exit_false_since = None
         if self.dispatch_task_action(
             rule.task_id, ActionSlot.ON_EXIT.value, context="owed_exit_resend"
         ):
             logger.info(
                 "OWED_EXIT_RESENT: task=%s 失去观察 %d 秒, 补发退出动作",
                 rule.task_id,
-                lost_sight_seconds,
+                lost_sight_ms // 1000,
             )
+
+    def _absent_long_enough(self, rule: Rule, state: RuleRuntimeState) -> bool:
+        """条件为假持续得够久了吗 —— 够久才拿它去动设备。
+
+        补发要的证据强度不能低于正常退出: 那条路上单帧为假不算数, 确认离开之后还要
+        再等 ``exit_debounce_seconds``。而停用把整条 rule 的状态弹掉了, 启用后每个源
+        的上一帧都是初值假, 那两道闸一道都不生效 —— 只能在这里自己看。
+
+        第一次确定为假只作起点、不下结论, 所以防抖再短也至少要两次观测。
+        """
+        now = now_ms()
+        if state.owed_exit_false_since is None:
+            state.owed_exit_false_since = now
+            return False
+        return now - state.owed_exit_false_since >= rule.exit_debounce_seconds * 1000
 
     def _all_sources_reported(self, rule: Rule) -> bool:
         """这条 rule 声明的感知源是不是每一个都已经报过至少一次。
@@ -1566,7 +1597,7 @@ class RuleRunner:
         slot = self._select_slot(rule, event, boundary_slot)
         # 记在这里而不是状态机的派发点: 感知边沿那条路进状态机时带 dispatch=False,
         # 那一层在生产路径上一次都不派发, 挂上去等于整个机制静默失效。
-        self._note_owed_exit(rule.task_id, boundary_slot, dispatched=slot is not None)
+        self._note_owed_exit(rule.task_id, boundary_slot, has_action=slot is not None)
         if slot is None:
             logger.debug(
                 "rule %s event %s: empty slot, skipping", rule.id, event.value

--- a/backend/miloco/src/miloco/rule/service.py
+++ b/backend/miloco/src/miloco/rule/service.py
@@ -323,6 +323,11 @@ def attach_task_state_machine(rule_runner: RuleRunner, rule_repo: RuleRepo) -> N
 
     task_repo = TaskRepo()
     tracker = DecisionTracker()
+
+    def forget_task_memory(task_id: str) -> None:
+        tracker.forget(task_id)
+        rule_runner.drop_owed_exit(task_id)
+
     state_machine = TaskStateMachine(
         is_condition_satisfied=rule_runner.is_condition_satisfied,
         # 只有状态机自己发起动作时才会走到这里 (重新配置时强制 on_exit、手动
@@ -334,7 +339,7 @@ def attach_task_state_machine(rule_runner: RuleRunner, rule_repo: RuleRepo) -> N
         track=lambda outcome, signal: tracker.record(
             signal.task_id, signal.rule_id, outcome.value, now_ms()
         ),
-        on_forget=tracker.forget,
+        on_forget=forget_task_memory,
     )
     rule_runner.attach_state_machine(state_machine)
     rule_runner.attach_tracker(tracker)
@@ -1296,12 +1301,41 @@ class RuleService:
                 sm.unregister_task(task_id)
             return
         sm.reconfigure(task_id, _live_topology(rules))
+        self._resume_owed_session(task_id)
         # 排 timer 只挂在「进入会话」那个边沿上, 而装配是分步的 —— 三样齐备的那
         # 一刻可能落在会话开始之后, 那时进入边沿早过去了, 这一天的达标就只能靠
         # 退出兜底或跨零点补发, 而这条通知的全部意义是到点提醒。已经在态内就补
         # 排一次: arm 自带撤旧, 等于按当前累计重排, 阈值改了也一并跟上。
         if sm.runtime_state(task_id) is TaskRuntimeState.ON:
             self._runner.record_source.arm(task_id)
+
+    def _resume_owed_session(self, task_id: str) -> None:
+        """停用清掉的在态, 启用时按欠账补回来 —— 只对 enter + exit 形态。
+
+        这类 task 的退出条件多是脉冲 (挥一下手), 停用后不会自动再成立: 运行态停在
+        ``off``, 住户再做退出动作会被状态机第一道闸判成"本来就没开着"、静默吃掉,
+        得先重新做一次进入动作才退得出去。而进入动作确实下过、退出动作没下过, 所以
+        ``off`` 是停用造成的失真, 补回 ``on`` 是修失真, 不是开例外通道。
+
+        判据是"欠着账被停用过"而不是"这次是不是 enable": 改一条 rule 也走
+        ``reconfigure_task``, 那时运行态没被清过, 不该动它。
+        """
+        runner = self._runner
+        sm = runner.state_machine
+        if sm is None or runner.is_task_paused(task_id):
+            return
+        if runner.owed_exit_paused_at(task_id) is None:
+            return
+        if not sm.resume_session(task_id):
+            return
+        runner.end_owed_exit_pause(task_id)
+        logger.info("OWED_EXIT_RESUMED: task=%s 启用后把在态补回来", task_id)
+        # 计时段要跟着回来: 恢复在态之后住户再做进入动作会判"已在态内"、不再 fire
+        # on_enter, 而段只能由那条路开 —— 不补这一下, 累计就永远不再走了。
+        try:
+            self._task_record_service.reopen_active_session(task_id)
+        except Exception:
+            logger.exception("task %s 恢复在态时重开计时段失败", task_id)
 
     def apply_task_status(self, task_id: str, active: bool) -> None:
         """task 启停 → 刷新派生的「有效启用」并走重新配置路径。

--- a/backend/miloco/src/miloco/rule/service.py
+++ b/backend/miloco/src/miloco/rule/service.py
@@ -993,7 +993,8 @@ class RuleService:
         """task 被删 —— 清掉所有 per-task 的内存态。
 
         rule 维度走 ``remove_rule_from_runner``, 它清不到按 task_id 存的那些:
-        状态机拓扑、运行态、判定跟踪、动作快照、停用标记、达标源的轮次计数。
+        状态机拓扑、运行态、判定跟踪、动作快照、停用标记、欠下的那次退出、达标源的
+        轮次计数。
         record timer 不在这里撤 —— 它按 rule_id 存, 逐条清 rule 时已经撤掉了。
 
         ``task_id`` 是用户自己起的名字, 删掉再用同名重建是正常操作 —— 不清的话新

--- a/backend/miloco/src/miloco/task/state_machine.py
+++ b/backend/miloco/src/miloco/task/state_machine.py
@@ -219,6 +219,15 @@ class TaskStateMachine:
     def runtime_state(self, task_id: str) -> TaskRuntimeState:
         return self._states.get(task_id, TaskRuntimeState.OFF)
 
+    def has_exit_path(self, task_id: str) -> bool:
+        """名下有没有能把 task 推回 ``off`` 的规则。
+
+        没有就是事件型: 运行态恒 ``off``, 每次进信号执行一次动作, 谈不上"在态",
+        也就没有"进入指令留在设备上等着退出指令来复位"这回事。
+        """
+        topology = self._topologies.get(task_id)
+        return topology is not None and topology.is_session_type
+
     # ── 拓扑维护 ──────────────────────────────────────────────────
 
     def register_task(self, task_id: str, directions: dict[str, RuleDirection]) -> None:
@@ -468,6 +477,26 @@ class TaskStateMachine:
             for stale in queue:
                 self._track(TransitionOutcome.SIGNAL_DROPPED, stale)
             queue.clear()
+
+    def resume_session(self, task_id: str) -> bool:
+        """把 ``suspend`` 清掉的在态补回来。恢复了返回 True。
+
+        **只对 enter + exit 形态**。session 形态的在态是持续条件的投影, 没有观测就
+        断言它成立等于说谎; enter + exit 没有持续条件可言, 在态与否由那一对进出动作
+        决定 —— 进入动作下过、退出动作没下过, 那它就还在态内, ``off`` 是停用造成的
+        失真。
+
+        调用方要自己确认这个 task 确实欠着一次退出, 本函数只判形态。
+        """
+        topology = self._topologies.get(task_id)
+        if topology is None:
+            return False
+        if topology.holding_rule_ids or not topology.is_session_type:
+            return False
+        if self.runtime_state(task_id) is TaskRuntimeState.ON:
+            return False
+        self._states[task_id] = TaskRuntimeState.ON
+        return True
 
     def _should_stay_on(self, topology: TaskTopology) -> bool:
         """配置变了、现实没变 —— 这个 task 还该留在 ``on`` 吗。

--- a/backend/miloco/src/miloco/task_record/service.py
+++ b/backend/miloco/src/miloco/task_record/service.py
@@ -927,6 +927,34 @@ class TaskRecordService:
                 conn.rollback()
                 raise
 
+    def reopen_active_session(self, task_id: str) -> str | None:
+        """重新开始观测这个 task —— 起一段新的计时，返回起点。
+
+        没有 duration record、或者段已经开着时返 None，不抛。
+
+        起点取当前时刻而不是停用时刻：停用期间没有观测，那段时间不该算进累计。
+        """
+        now = _now_iso()
+        with self.db.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("BEGIN")
+            try:
+                if _detect_kind(cursor, task_id) is not RecordKind.DURATION:
+                    conn.rollback()
+                    return None
+                row = DurationRepo.get_active(cursor, task_id)
+                if row is None or row["active_session_start_at"] is not None:
+                    conn.rollback()
+                    return None
+                DurationRepo.set_active_session_start(
+                    cursor, task_id=task_id, start_at=now, now=now
+                )
+                conn.commit()
+                return now
+            except Exception:
+                conn.rollback()
+                raise
+
     # ── compute（独立 op，含历史日期 / 跨窗口） ───────────────────────────
 
     def compute_derived(

--- a/backend/miloco/src/miloco/task_record/service.py
+++ b/backend/miloco/src/miloco/task_record/service.py
@@ -930,7 +930,7 @@ class TaskRecordService:
     def reopen_active_session(self, task_id: str) -> str | None:
         """重新开始观测这个 task —— 起一段新的计时，返回起点。
 
-        没有 duration record、或者段已经开着时返 None，不抛。
+        没有 duration record、段已经开着、今日已达标时返 None，不抛。
 
         起点取当前时刻而不是停用时刻：停用期间没有观测，那段时间不该算进累计。
         """
@@ -944,6 +944,12 @@ class TaskRecordService:
                     return None
                 row = DurationRepo.get_active(cursor, task_id)
                 if row is None or row["active_session_start_at"] is not None:
+                    conn.rollback()
+                    return None
+                if row["status"] == RecordStatus.COMPLETED.value:
+                    # 达标之后 agent 那条路就不再调 session-end 了，这里开的段没人
+                    # 收尾；非 recurring 的行又不跨日切段，派生累计会按「到现在」
+                    # 一直涨。
                     conn.rollback()
                     return None
                 DurationRepo.set_active_session_start(

--- a/backend/miloco/tests/test_owed_exit_on_suspend.py
+++ b/backend/miloco/tests/test_owed_exit_on_suspend.py
@@ -1,0 +1,500 @@
+# Copyright (C) 2025 Xiaomi Corporation
+# This software may be used and distributed according to the terms of the Xiaomi Miloco License Agreement.
+
+"""停用期间欠下的那次退出, 启用后怎么结。
+
+停用把运行态清成 off 而不派 on_exit —— 那是有意的 (停用是"不再观察", 不是"观察到
+条件不成立")。代价是设备上那份由进入动作留下的配置再没人复位: 启用后条件层从假重
+建, 退出边沿要的 True → False 跃变不会再来。
+
+两种形态的结法不同, 这里两半都测:
+
+- 互反 (单条 session): 启用后拿到第一次确定的条件值时按值结算, 为假就补发退出。
+- 非互反 (enter + exit): 退出条件多是脉冲, 启用后不会自动成立 —— 把在态补回来,
+  住户下一次主动退出才走得通。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+
+import pytest
+from miloco.database.rule_repo import RuleLogRepo, RuleRepo
+from miloco.database.task_repo import TaskRepo
+from miloco.rule import runner as runner_module
+from miloco.rule.runner import RuleRunner
+from miloco.rule.schema import Rule, RuleCondition, RuleDirection, RuleMode
+from miloco.rule.service import RuleService, attach_task_state_machine
+from miloco.task.state_machine import TaskRuntimeState
+
+
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    monkeypatch.setenv("MILOCO_DATABASE__PATH", str(tmp_path / "t.db"))
+    from miloco.config import reset_settings
+
+    reset_settings()
+    import miloco.database.connector as connector_module
+
+    monkeypatch.setattr(connector_module, "db_connector", None)
+    connector_module.init_database()
+    yield
+    reset_settings()
+
+
+@pytest.fixture
+def sent(monkeypatch):
+    """agent 回调的落点。断在这里而不是 ``_execute_dynamic`` 的入参上:
+
+    要验的"补发时 agent 收不到时间戳"是 ``_compose_prompt_text`` 拼出来的那段文本,
+    在入参上断言等于绕开了真正决定这件事的那一步。
+    """
+    captured = []
+
+    async def fake_send(self, callback):
+        captured.append(callback)
+        return True
+
+    monkeypatch.setattr(RuleRunner, "_send_dynamic_with_retry", fake_send)
+    return captured
+
+
+def _rule(name, task_id, direction, dids=("cam1",)):
+    return Rule(
+        name=name,
+        task_id=task_id,
+        mode=RuleMode.STATE if direction is RuleDirection.SESSION else RuleMode.EVENT,
+        direction=direction,
+        condition=RuleCondition(perceive_device_ids=list(dids), query="有人"),
+        exit_debounce_seconds=0,
+    )
+
+
+def _build(rules, task_ids=("t1",), actions=None):
+    actions = actions or {"on_enter_desc": "进入动作", "on_exit_desc": "退出动作"}
+    task_repo = TaskRepo()
+    for task_id in task_ids:
+        task_repo.create_task(task_id, "d")
+        task_repo.set_boundary_actions(task_id, **actions)
+    rule_repo = RuleRepo()
+    ids = [rule_repo.create(r) for r in rules]
+    runner = RuleRunner(
+        rules=rule_repo.get_all(enabled_only=False),
+        miot_proxy=None,
+        rule_log_repo=RuleLogRepo(),
+    )
+    attach_task_state_machine(runner, rule_repo)
+    service = RuleService(rule_repo, RuleLogRepo(), runner, None)
+    return service, runner, ids
+
+
+def _slot_texts(callbacks):
+    """每次回调派的是哪一侧的动作 —— 意图那段就是槽里存的文案。"""
+    return ["进入" if "进入动作" in c.prompt_text else "退出" for c in callbacks]
+
+
+def _extra_info(callback) -> dict:
+    """agent 解析的是提示语末尾那段 JSON。
+
+    不能改用"提示语里有没有出现过这个键名": task 带 record 时提示语会拼上一段处理
+    流程说明, 那段本身就把两个时间戳键名列在里面, 子串判断恒真。
+    """
+    return json.loads(callback.prompt_text.split("**额外信息**：\n")[-1])
+
+
+def _iso_ms(text: str) -> int:
+    return int(datetime.fromisoformat(text).timestamp() * 1000)
+
+
+def _init_duration_record(task_id="t1", started_minutes_ago=None):
+    from miloco.task_record.schema import RecordKind
+    from miloco.task_record.service import TaskRecordService
+    from miloco.utils.time_utils import ms_to_iso_local, now_ms
+
+    record = TaskRecordService()
+    record.init_record(task_id, RecordKind.DURATION, {})
+    started_at = None
+    if started_minutes_ago is not None:
+        started_at = ms_to_iso_local(now_ms() - started_minutes_ago * 60 * 1000)
+        record.session_start(task_id, at=started_at)
+    return record, started_at
+
+
+async def _enter(runner, rule_id, did="cam1"):
+    await runner.update_state(rule_id, did, True)
+    await runner.drain()
+
+
+async def _observe(runner, rule_id, did, value):
+    await runner.update_state(rule_id, did, value)
+    await runner.drain()
+
+
+async def _pause(service, runner, task_id="t1"):
+    service.apply_task_status(task_id, False)
+    await runner.drain()
+
+
+async def _resume(service, runner, task_id="t1"):
+    service.apply_task_status(task_id, True)
+    await runner.drain()
+
+
+async def _pause_then_resume(service, runner, task_id="t1"):
+    await _pause(service, runner, task_id)
+    await _resume(service, runner, task_id)
+
+
+# ── 互反形态: 单条 session 规则 ──────────────────────────────────────
+
+
+@pytest.fixture
+def reciprocal(env, sent):
+    service, runner, ids = _build([_rule("[t1] 观影", "t1", RuleDirection.SESSION)])
+    return service, runner, ids[0], sent
+
+
+@pytest.mark.asyncio
+async def test_resends_exit_when_resumed_inside_the_window(reciprocal):
+    """窗口内启用、人已经走了 → 退出动作补跑一次。"""
+    service, runner, rule_id, sent = reciprocal
+    await _enter(runner, rule_id)
+    assert _slot_texts(sent) == ["进入"]
+
+    await _pause(service, runner)
+    await _resume(service, runner)
+    # 补发要发生在拿到观测之后, 不是停用或启用那一刻
+    assert _slot_texts(sent) == ["进入"]
+
+    await _observe(runner, rule_id, "cam1", False)
+
+    assert _slot_texts(sent) == ["进入", "退出"]
+
+
+@pytest.mark.asyncio
+async def test_does_not_resend_after_the_window(reciprocal, monkeypatch):
+    """失去观察太久 → 一个动作都不派。
+
+    欠账记的是停用那一刻的意图, 隔太久现状多半已经被人动过, 补发是拿过期的意图
+    覆盖现状。
+    """
+    service, runner, rule_id, sent = reciprocal
+    await _enter(runner, rule_id)
+    monkeypatch.setattr(runner_module, "OWED_EXIT_RESEND_WINDOW_MS", 0)
+
+    await _pause_then_resume(service, runner)
+    await _observe(runner, rule_id, "cam1", False)
+
+    assert _slot_texts(sent) == ["进入"]
+
+
+@pytest.mark.asyncio
+async def test_expired_owed_exit_leaves_a_log(reciprocal, monkeypatch, caplog):
+    """超时不补发要留痕 —— 窗口该取多长, 依据就是这条日志攒出来的分布。"""
+    service, runner, rule_id, _sent = reciprocal
+    clock = [1_000_000_000]
+    monkeypatch.setattr(runner_module, "now_ms", lambda: clock[0])
+    await _enter(runner, rule_id)
+    await _pause(service, runner)
+    clock[0] += 3600 * 1000
+    await _resume(service, runner)
+
+    with caplog.at_level(logging.INFO, logger="miloco.rule.runner"):
+        await _observe(runner, rule_id, "cam1", False)
+
+    expired = [r for r in caplog.records if "OWED_EXIT_EXPIRED" in r.getMessage()]
+    assert len(expired) == 1
+    message = expired[0].getMessage()
+    assert "task=t1" in message
+    assert "失去观察 3600 秒" in message
+
+
+@pytest.mark.asyncio
+async def test_pausing_dispatches_nothing(reciprocal):
+    """停用那一刻不动设备。用户关掉自动化不该反过来被理解成"结束观影"。"""
+    service, runner, rule_id, sent = reciprocal
+    await _enter(runner, rule_id)
+
+    service.apply_task_status("t1", False)
+    await runner.drain()
+
+    assert _slot_texts(sent) == ["进入"]
+
+
+@pytest.mark.asyncio
+async def test_condition_still_true_takes_the_normal_enter_path(reciprocal):
+    """启用后人还在 → 照常走进入路径, 不压掉这次 on_enter。
+
+    压掉它会连带压掉计时段的开启: 段只能由 agent 收到 ``actual_started_at`` 之后
+    去开, 不 fire 就永远不重开, 结果是在态却不再累计。
+    """
+    service, runner, rule_id, sent = reciprocal
+    _init_duration_record()
+    await _enter(runner, rule_id)
+
+    await _pause_then_resume(service, runner)
+    await _observe(runner, rule_id, "cam1", True)
+
+    assert _slot_texts(sent) == ["进入", "进入"]
+    info = _extra_info(sent[-1])
+    assert info["record_kind"] == "duration"
+    assert "actual_started_at" in info
+
+
+@pytest.mark.asyncio
+async def test_resent_exit_carries_no_session_timestamp(reciprocal):
+    """补发只补设备动作, 记账不参与。
+
+    计时段在停用那一刻已经由 ``close_active_session`` 结清了。补发再带上
+    ``actual_exited_at``, agent 会照着调一次 session-end, 撞上"没有活跃段"报错。
+    """
+    service, runner, rule_id, sent = reciprocal
+    _init_duration_record()
+    await _enter(runner, rule_id)
+
+    await _pause(service, runner)
+    await _resume(service, runner)
+    assert _slot_texts(sent) == ["进入"]
+
+    await _observe(runner, rule_id, "cam1", False)
+
+    assert _slot_texts(sent) == ["进入", "退出"]
+    info = _extra_info(sent[-1])
+    # record 确实在, 否则这条判据验的是"agent 本来就没有记账操作可做"的形态
+    assert info["record_kind"] == "duration"
+    assert "actual_exited_at" not in info
+    assert "actual_started_at" not in info
+
+
+@pytest.mark.asyncio
+async def test_waits_until_every_source_has_reported(env, sent):
+    """两台相机的规则, 只回来一台不算数。
+
+    OR 聚合下先到的那台报假不代表整条为假 —— 据此补发退出, 等另一台随后报真又会
+    进一次, 设备来回动一趟, 而这正是要避免的那类误动作。
+    """
+    service, runner, ids = _build(
+        [_rule("[t1] 观影", "t1", RuleDirection.SESSION, dids=("cam1", "cam2"))]
+    )
+    rule_id = ids[0]
+    await _enter(runner, rule_id, "cam1")
+    await _observe(runner, rule_id, "cam2", True)
+    await _pause_then_resume(service, runner)
+
+    await _observe(runner, rule_id, "cam1", False)
+    assert _slot_texts(sent) == ["进入"]
+
+    await _observe(runner, rule_id, "cam2", False)
+    assert _slot_texts(sent) == ["进入", "退出"]
+
+
+@pytest.mark.asyncio
+async def test_second_pause_keeps_the_first_moment(reciprocal, monkeypatch):
+    """停用 → 启用 → 没结算完又停用 → 再启用: 按第一次欠账的时刻算。
+
+    覆盖成第二次的话失去观察的时长会算短, 早就该作废的欠账反而落回窗口内。
+    """
+    service, runner, rule_id, _sent = reciprocal
+    clock = [1_000_000]
+    monkeypatch.setattr(runner_module, "now_ms", lambda: clock[0])
+    await _enter(runner, rule_id)
+
+    service.apply_task_status("t1", False)
+    first = runner.owed_exit_paused_at("t1")
+    service.apply_task_status("t1", True)
+    clock[0] += 10 * 60 * 1000
+    service.apply_task_status("t1", False)
+    service.apply_task_status("t1", True)
+    await runner.drain()
+
+    assert first == 1_000_000
+    assert runner.owed_exit_paused_at("t1") == first
+
+
+@pytest.mark.asyncio
+async def test_enter_only_task_owes_nothing(env, sent):
+    """只有 enter 规则的 task 不记欠账 —— 它没有出路径, 运行态恒 off。
+
+    每次进信号执行一次动作就完事, 不存在一份留在设备上等着被复位的配置。
+    """
+    service, runner, ids = _build([_rule("[t1] 打招呼", "t1", RuleDirection.ENTER)])
+    await _enter(runner, ids[0])
+    assert _slot_texts(sent) == ["进入"]
+
+    service.apply_task_status("t1", False)
+    await runner.drain()
+
+    assert runner.owed_exit_paused_at("t1") is None
+
+
+# ── 非互反形态: enter + exit 两条规则 ────────────────────────────────
+
+
+@pytest.fixture
+def nonreciprocal(env, sent):
+    service, runner, ids = _build(
+        [
+            _rule("[t1] 比手势开灯", "t1", RuleDirection.ENTER, dids=("cam1",)),
+            _rule("[t1] 挥手关灯", "t1", RuleDirection.EXIT, dids=("cam2",)),
+        ]
+    )
+    return service, runner, ids[0], ids[1], sent
+
+
+@pytest.mark.asyncio
+async def test_exit_gesture_still_works_after_resume(nonreciprocal):
+    """停用再启用之后, 住户做退出动作 → 退出动作真的派发。
+
+    不把在态补回来的话, 退出信号会撞上状态机第一道闸判成"本来就没开着", 而那个
+    结论不派动作也不报错 —— 住户只会觉得手势失灵。
+    """
+    service, runner, enter_id, exit_id, sent = nonreciprocal
+    await _enter(runner, enter_id, "cam1")
+    assert _slot_texts(sent) == ["进入"]
+
+    await _pause(service, runner)
+    await _resume(service, runner)
+    # 退出动作要由住户那一下带出来, 不是停用或启用顺手派的
+    assert _slot_texts(sent) == ["进入"]
+
+    await _observe(runner, exit_id, "cam2", True)
+
+    assert _slot_texts(sent) == ["进入", "退出"]
+
+
+@pytest.mark.asyncio
+async def test_resume_reopens_the_duration_session(env, sent):
+    """恢复在态要连带把计时段重开。
+
+    补回在态之后住户再比一次手势会判"已在态内"、不再 fire on_enter, 而段只能由那
+    条路开 —— 不补这一下, "重新触发进入就恢复累计"这条自愈路径就被堵死了。
+    """
+    from miloco.utils.time_utils import now_ms
+
+    service, runner, ids = _build(
+        [
+            _rule("[t1] 比手势开灯", "t1", RuleDirection.ENTER, dids=("cam1",)),
+            _rule("[t1] 挥手关灯", "t1", RuleDirection.EXIT, dids=("cam2",)),
+        ]
+    )
+    # 起点放在过去: 与当前时刻同秒的段会被收尾那一步当成倒挂区间跳过, 段留着不收,
+    # 这条用例的前提就没建起来。
+    record, started_at = _init_duration_record(started_minutes_ago=5)
+
+    def active_start():
+        return record.get_active_record("t1")["derived"]["active_session_start_at"]
+
+    await _enter(runner, ids[0], "cam1")
+    await _pause(service, runner)
+    assert active_start() is None
+
+    before_ms = now_ms()
+    await _resume(service, runner)
+
+    reopened = active_start()
+    assert reopened is not None
+    # 起点是重新开始观测的那一刻。接上停用前那一段的起点, 会把没人看着的那段时间
+    # 一起算进累计。
+    assert _iso_ms(reopened) > _iso_ms(started_at)
+    assert _iso_ms(reopened) >= before_ms - 1000
+
+
+@pytest.mark.asyncio
+async def test_resume_is_not_subject_to_the_time_window(nonreciprocal, monkeypatch):
+    """时间闸只管互反那一半。
+
+    补回在态不新开任何口子: 之后的行为全走正常路径, 误识别的退出动作风险与正常在
+    态时完全一样。绕开这条去给它单独立一个窗口, 挡掉的是住户真实的退出意图。
+    """
+    service, runner, enter_id, exit_id, sent = nonreciprocal
+    await _enter(runner, enter_id, "cam1")
+    monkeypatch.setattr(runner_module, "OWED_EXIT_RESEND_WINDOW_MS", 0)
+
+    await _pause(service, runner)
+    await _resume(service, runner)
+    assert _slot_texts(sent) == ["进入"]
+
+    await _observe(runner, exit_id, "cam2", True)
+
+    assert _slot_texts(sent) == ["进入", "退出"]
+
+
+@pytest.mark.asyncio
+async def test_resume_needs_an_owed_exit(nonreciprocal):
+    """停用时本来就在 off 态 → 启用后仍是 off。
+
+    没有下过进入动作就没有欠账, 一律补成 on 会让从没开始过的 task 显示进行中, 并
+    且把随后一次误识别的退出动作放行出去。
+    """
+    service, runner, _enter_id, _exit_id, _sent = nonreciprocal
+
+    await _pause_then_resume(service, runner)
+
+    assert runner.state_machine.runtime_state("t1") is TaskRuntimeState.OFF
+
+
+@pytest.mark.asyncio
+async def test_real_exit_clears_the_debt_with_an_empty_exit_slot(env, sent):
+    """住户真的退出过, 账就不欠了 —— 哪怕退出槽没配动作。
+
+    退出槽为空只是没东西可下发, 不改变"这一轮结束了"。账留着的话, 之后一次停用启用
+    会把运行态凭空补回 on: 详情页恒显示进行中、达标被武装、计时段又开一段没人收。
+    """
+    service, runner, ids = _build(
+        [
+            _rule("[t1] 比手势开灯", "t1", RuleDirection.ENTER, dids=("cam1",)),
+            _rule("[t1] 挥手关灯", "t1", RuleDirection.EXIT, dids=("cam2",)),
+        ],
+        actions={"on_enter_desc": "进入动作"},
+    )
+    await _enter(runner, ids[0], "cam1")
+    await _observe(runner, ids[1], "cam2", True)
+    assert runner.state_machine.runtime_state("t1") is TaskRuntimeState.OFF
+    assert _slot_texts(sent) == ["进入"]
+
+    await _pause_then_resume(service, runner)
+
+    assert runner.state_machine.runtime_state("t1") is TaskRuntimeState.OFF
+
+
+@pytest.mark.asyncio
+async def test_forced_exit_on_losing_the_exit_path_clears_the_debt(env, sent):
+    """删掉出路径时强发的那次退出, 同样把账结掉。
+
+    那一刻拓扑已经换成新的、没有出路径了, 清账要是也看"有没有出路径"就会漏掉这一次:
+    出路径加回来之后一次停用启用, 运行态又凭空回到 on。
+    """
+    service, runner, ids = _build(
+        [
+            _rule("[t1] 比手势开灯", "t1", RuleDirection.ENTER, dids=("cam1",)),
+            _rule("[t1] 挥手关灯", "t1", RuleDirection.EXIT, dids=("cam2",)),
+        ]
+    )
+    await _enter(runner, ids[0], "cam1")
+
+    await service.delete_rule(ids[1])
+    await runner.drain()
+    assert _slot_texts(sent) == ["进入", "退出"]
+
+    repo = RuleRepo()
+    back = repo.create(_rule("[t1] 挥手关灯", "t1", RuleDirection.EXIT, dids=("cam2",)))
+    runner.add_rule(repo.get_by_id(back))
+    service.reconfigure_task("t1")
+    await _pause_then_resume(service, runner)
+
+    assert runner.state_machine.runtime_state("t1") is TaskRuntimeState.OFF
+
+
+@pytest.mark.asyncio
+async def test_entering_again_after_resume_is_idempotent(nonreciprocal):
+    """补回在态之后再触发进入 → 判"已在态内", 不重复派进入动作。"""
+    service, runner, enter_id, _exit_id, sent = nonreciprocal
+    await _enter(runner, enter_id, "cam1")
+    await _pause_then_resume(service, runner)
+
+    await _observe(runner, enter_id, "cam1", True)
+
+    assert _slot_texts(sent) == ["进入"]
+    assert runner.state_machine.runtime_state("t1") is TaskRuntimeState.ON

--- a/backend/miloco/tests/test_owed_exit_on_suspend.py
+++ b/backend/miloco/tests/test_owed_exit_on_suspend.py
@@ -61,14 +61,22 @@ def sent(monkeypatch):
     return captured
 
 
-def _rule(name, task_id, direction, dids=("cam1",)):
+@pytest.fixture
+def clock(monkeypatch):
+    """可控时钟。补发要熬过这条规则自己的退出防抖（默认一分钟），真等不现实。"""
+    now = [1_000_000_000]
+    monkeypatch.setattr(runner_module, "now_ms", lambda: now[0])
+    return now
+
+
+def _rule(name, task_id, direction, dids=("cam1",), exit_debounce_seconds=0):
     return Rule(
         name=name,
         task_id=task_id,
         mode=RuleMode.STATE if direction is RuleDirection.SESSION else RuleMode.EVENT,
         direction=direction,
         condition=RuleCondition(perceive_device_ids=list(dids), query="有人"),
-        exit_debounce_seconds=0,
+        exit_debounce_seconds=exit_debounce_seconds,
     )
 
 
@@ -108,13 +116,13 @@ def _iso_ms(text: str) -> int:
     return int(datetime.fromisoformat(text).timestamp() * 1000)
 
 
-def _init_duration_record(task_id="t1", started_minutes_ago=None):
+def _init_duration_record(task_id="t1", started_minutes_ago=None, content=None):
     from miloco.task_record.schema import RecordKind
     from miloco.task_record.service import TaskRecordService
     from miloco.utils.time_utils import ms_to_iso_local, now_ms
 
     record = TaskRecordService()
-    record.init_record(task_id, RecordKind.DURATION, {})
+    record.init_record(task_id, RecordKind.DURATION, content or {})
     started_at = None
     if started_minutes_ago is not None:
         started_at = ms_to_iso_local(now_ms() - started_minutes_ago * 60 * 1000)
@@ -151,15 +159,15 @@ async def _pause_then_resume(service, runner, task_id="t1"):
 
 
 @pytest.fixture
-def reciprocal(env, sent):
+def reciprocal(env, sent, clock):
     service, runner, ids = _build([_rule("[t1] 观影", "t1", RuleDirection.SESSION)])
-    return service, runner, ids[0], sent
+    return service, runner, ids[0], sent, clock
 
 
 @pytest.mark.asyncio
 async def test_resends_exit_when_resumed_inside_the_window(reciprocal):
     """窗口内启用、人已经走了 → 退出动作补跑一次。"""
-    service, runner, rule_id, sent = reciprocal
+    service, runner, rule_id, sent, clock = reciprocal
     await _enter(runner, rule_id)
     assert _slot_texts(sent) == ["进入"]
 
@@ -168,6 +176,8 @@ async def test_resends_exit_when_resumed_inside_the_window(reciprocal):
     # 补发要发生在拿到观测之后, 不是停用或启用那一刻
     assert _slot_texts(sent) == ["进入"]
 
+    await _observe(runner, rule_id, "cam1", False)
+    clock[0] += 61 * 1000
     await _observe(runner, rule_id, "cam1", False)
 
     assert _slot_texts(sent) == ["进入", "退出"]
@@ -180,22 +190,23 @@ async def test_does_not_resend_after_the_window(reciprocal, monkeypatch):
     欠账记的是停用那一刻的意图, 隔太久现状多半已经被人动过, 补发是拿过期的意图
     覆盖现状。
     """
-    service, runner, rule_id, sent = reciprocal
+    service, runner, rule_id, sent, clock = reciprocal
     await _enter(runner, rule_id)
     monkeypatch.setattr(runner_module, "OWED_EXIT_RESEND_WINDOW_MS", 0)
 
     await _pause_then_resume(service, runner)
+    # 喂够让证据成立的观测, 这样拦住补发的只可能是窗口这一条
+    await _observe(runner, rule_id, "cam1", False)
+    clock[0] += 61 * 1000
     await _observe(runner, rule_id, "cam1", False)
 
     assert _slot_texts(sent) == ["进入"]
 
 
 @pytest.mark.asyncio
-async def test_expired_owed_exit_leaves_a_log(reciprocal, monkeypatch, caplog):
+async def test_expired_owed_exit_leaves_a_log(reciprocal, caplog):
     """超时不补发要留痕 —— 窗口该取多长, 依据就是这条日志攒出来的分布。"""
-    service, runner, rule_id, _sent = reciprocal
-    clock = [1_000_000_000]
-    monkeypatch.setattr(runner_module, "now_ms", lambda: clock[0])
+    service, runner, rule_id, _sent, clock = reciprocal
     await _enter(runner, rule_id)
     await _pause(service, runner)
     clock[0] += 3600 * 1000
@@ -212,9 +223,61 @@ async def test_expired_owed_exit_leaves_a_log(reciprocal, monkeypatch, caplog):
 
 
 @pytest.mark.asyncio
+async def test_resend_needs_the_same_evidence_as_a_normal_exit(reciprocal):
+    """补发依据的"条件为假", 证据强度不能低于正常退出那条路。
+
+    正常退出要连续两帧为假才确认, 确认之后还要熬过这条规则的退出防抖。而停用把整条
+    规则的状态弹掉了, 启用后每个源的上一帧都是初值假 —— 那两道闸一道都不生效。住户
+    还在看电影、启用后第一帧恰好漏识, 就会当场把窗帘拉开。
+    """
+    service, runner, rule_id, sent, clock = reciprocal
+    debounce_ms = RuleRepo().get_by_id(rule_id).exit_debounce_seconds * 1000
+    await _enter(runner, rule_id)
+    await _pause(service, runner)
+    await _resume(service, runner)
+
+    await _observe(runner, rule_id, "cam1", False)
+    assert _slot_texts(sent) == ["进入"]
+
+    clock[0] += debounce_ms - 1000
+    await _observe(runner, rule_id, "cam1", False)
+    assert _slot_texts(sent) == ["进入"]
+
+    clock[0] += 2000
+    await _observe(runner, rule_id, "cam1", False)
+    assert _slot_texts(sent) == ["进入", "退出"]
+
+
+@pytest.mark.asyncio
+async def test_expires_without_waiting_for_a_source_that_never_reports(
+    env, sent, clock, caplog
+):
+    """声明的相机里有一台一直不上报 → 超过窗口就把账结掉, 别无声挂着。
+
+    超过窗口就不动设备了, 条件是真是假都不改变这个结论。等下去的话这笔账会永远悬着,
+    连超时那条日志都留不下 —— 而窗口该取多长全靠它攒出来的时长分布。
+    """
+    service, runner, ids = _build(
+        [_rule("[t1] 观影", "t1", RuleDirection.SESSION, dids=("cam1", "cam2"))]
+    )
+    rule_id = ids[0]
+    await _enter(runner, rule_id, "cam1")
+    await _pause(service, runner)
+    clock[0] += 3600 * 1000
+    await _resume(service, runner)
+
+    with caplog.at_level(logging.INFO, logger="miloco.rule.runner"):
+        await _observe(runner, rule_id, "cam1", False)
+
+    assert _slot_texts(sent) == ["进入"]
+    assert runner.owed_exit_paused_at("t1") is None
+    assert [r for r in caplog.records if "OWED_EXIT_EXPIRED" in r.getMessage()]
+
+
+@pytest.mark.asyncio
 async def test_pausing_dispatches_nothing(reciprocal):
     """停用那一刻不动设备。用户关掉自动化不该反过来被理解成"结束观影"。"""
-    service, runner, rule_id, sent = reciprocal
+    service, runner, rule_id, sent, clock = reciprocal
     await _enter(runner, rule_id)
 
     service.apply_task_status("t1", False)
@@ -230,7 +293,7 @@ async def test_condition_still_true_takes_the_normal_enter_path(reciprocal):
     压掉它会连带压掉计时段的开启: 段只能由 agent 收到 ``actual_started_at`` 之后
     去开, 不 fire 就永远不重开, 结果是在态却不再累计。
     """
-    service, runner, rule_id, sent = reciprocal
+    service, runner, rule_id, sent, clock = reciprocal
     _init_duration_record()
     await _enter(runner, rule_id)
 
@@ -250,7 +313,7 @@ async def test_resent_exit_carries_no_session_timestamp(reciprocal):
     计时段在停用那一刻已经由 ``close_active_session`` 结清了。补发再带上
     ``actual_exited_at``, agent 会照着调一次 session-end, 撞上"没有活跃段"报错。
     """
-    service, runner, rule_id, sent = reciprocal
+    service, runner, rule_id, sent, clock = reciprocal
     _init_duration_record()
     await _enter(runner, rule_id)
 
@@ -258,6 +321,8 @@ async def test_resent_exit_carries_no_session_timestamp(reciprocal):
     await _resume(service, runner)
     assert _slot_texts(sent) == ["进入"]
 
+    await _observe(runner, rule_id, "cam1", False)
+    clock[0] += 61 * 1000
     await _observe(runner, rule_id, "cam1", False)
 
     assert _slot_texts(sent) == ["进入", "退出"]
@@ -269,7 +334,7 @@ async def test_resent_exit_carries_no_session_timestamp(reciprocal):
 
 
 @pytest.mark.asyncio
-async def test_waits_until_every_source_has_reported(env, sent):
+async def test_waits_until_every_source_has_reported(env, sent, clock):
     """两台相机的规则, 只回来一台不算数。
 
     OR 聚合下先到的那台报假不代表整条为假 —— 据此补发退出, 等另一台随后报真又会
@@ -284,21 +349,24 @@ async def test_waits_until_every_source_has_reported(env, sent):
     await _pause_then_resume(service, runner)
 
     await _observe(runner, rule_id, "cam1", False)
+    clock[0] += 61 * 1000
+    await _observe(runner, rule_id, "cam1", False)
     assert _slot_texts(sent) == ["进入"]
 
+    await _observe(runner, rule_id, "cam2", False)
+    clock[0] += 61 * 1000
     await _observe(runner, rule_id, "cam2", False)
     assert _slot_texts(sent) == ["进入", "退出"]
 
 
 @pytest.mark.asyncio
-async def test_second_pause_keeps_the_first_moment(reciprocal, monkeypatch):
+async def test_second_pause_keeps_the_first_moment(reciprocal):
     """停用 → 启用 → 没结算完又停用 → 再启用: 按第一次欠账的时刻算。
 
     覆盖成第二次的话失去观察的时长会算短, 早就该作废的欠账反而落回窗口内。
     """
-    service, runner, rule_id, _sent = reciprocal
-    clock = [1_000_000]
-    monkeypatch.setattr(runner_module, "now_ms", lambda: clock[0])
+    service, runner, rule_id, _sent, clock = reciprocal
+    start = clock[0]
     await _enter(runner, rule_id)
 
     service.apply_task_status("t1", False)
@@ -309,7 +377,7 @@ async def test_second_pause_keeps_the_first_moment(reciprocal, monkeypatch):
     service.apply_task_status("t1", True)
     await runner.drain()
 
-    assert first == 1_000_000
+    assert first == start
     assert runner.owed_exit_paused_at("t1") == first
 
 
@@ -399,6 +467,34 @@ async def test_resume_reopens_the_duration_session(env, sent):
     # 一起算进累计。
     assert _iso_ms(reopened) > _iso_ms(started_at)
     assert _iso_ms(reopened) >= before_ms - 1000
+
+
+@pytest.mark.asyncio
+async def test_resume_does_not_reopen_a_completed_session(env, sent):
+    """今日已达标的 task, 恢复在态时不再开计时段。
+
+    达标之后 agent 那条路就不再调 session-end 了（意图里的处理流程第一步拦掉）, 这里
+    开的段没人收尾; 非 recurring 的行又不跨日切段, 派生累计会按「到现在」一直涨 ——
+    住户第二天打开看到的今日时长是几百分钟。
+    """
+    service, runner, ids = _build(
+        [
+            _rule("[t1] 比手势开灯", "t1", RuleDirection.ENTER, dids=("cam1",)),
+            _rule("[t1] 挥手关灯", "t1", RuleDirection.EXIT, dids=("cam2",)),
+        ]
+    )
+    record, _ = _init_duration_record(
+        started_minutes_ago=2, content={"target_minutes": 1}
+    )
+
+    await _enter(runner, ids[0], "cam1")
+    await _pause(service, runner)
+    assert record.get_active_record("t1")["record"]["status"] == "completed"
+
+    await _resume(service, runner)
+
+    assert runner.state_machine.runtime_state("t1") is TaskRuntimeState.ON
+    assert record.get_active_record("t1")["derived"]["active_session_start_at"] is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 问题

住户在实验室实测：比耶手势触发观影模式（拉窗帘 / 调灯 / 开投影）成功进入 on 态，随后停用再启用该 task，此后画面里早已没人比耶，`on_exit` 一条都没跑，窗帘停在拉上的位置。

停用把运行态清成 `off` 而**不派 `on_exit`** 是有意的设计——停用是「不再观察」，不是「观察到条件不再成立」，用户关掉自动化不该反过来动设备。它同时把条件层的边沿基线一并清掉，所以启用后喂假命中「与上次结果相同」的早返，退出边沿要的 true → false 跃变不会再来。

根上是把两件事当成了一件：运行态是观测的投影，而设备上那份设置是由进入 / 退出这对动作驱动的——运行态被清零，设备不会跟着回去。

## 改动

给「进入动作下过、退出动作还没下过」这件事自己的账，记在内存里，不塞进运行态：进入动作派出去时记上，退出动作派出去时清掉。两种形态结账的方式不同。

**互反（单条 session 规则）**：启用后运行态照旧从 `off` 起，等第一次拿到确定的条件值再结算——为假就补发退出动作，条件仍为真就走正常进入路径。「确定」要求该规则声明的感知源都已报过至少一次：OR 聚合下先到的那个报假不代表整条为假，据此补发，等另一个源随后报真又会进一次，设备来回动一趟。失去观察超过窗口则只清账、不动设备，并留一条日志——欠账记的是停用那一刻的意图，隔太久现状多半已经被人动过。

补发只补设备动作，不注入 session 时间戳：计时段在停用那一刻已经收过，再让 agent 调一次 `session-end` 会撞「没有活跃段」。

**非互反（enter + exit）**：退出条件多是脉冲（挥一下手），启用后不会自动成立，等不来。这类 task 在停用启用之后本来就该在态——进入动作下过、退出动作没下过、住户没做任何表示要退出的动作，`off` 是停用造成的失真。所以启用时把在态补回来，住户下一次主动退出才走得通；连带重开计时段，否则补回在态之后再触发进入会判「已在态内」、不再 fire `on_enter`，而计时段只能由那条路开。这一半不受时间闸管：补回在态不新开任何口子，之后全走正常路径。

记账与清账的判据不对称：记账要求槽里真有动作、且这个 task 有出路径（进入槽是空的等于设备上没留下要复位的东西，事件型 task 谈不上在态）；清账两样都不要求——退出这一侧只要走过，这一轮就结束了。

窗口长度是代码常量，不进配置项：要调就改常量发版，依据是超时那条日志攒出来的时长分布。全程只用内存，不加列、不做迁移，也不读状态容器。

不改 task 的「运行态只存内存、重启后从 off 起」这条：运行态仍然只由本次进程的观测置位，欠账另存。重启入口是同一个缺陷的另一半，它缺一个进程级的存活时刻，不在本 PR。

## 验证

新增 `test_owed_exit_on_suspend.py`，互反与非互反两组，覆盖窗口内补发 / 超时只清账 / 超时日志里的时长 / 停用那一刻零派发 / 条件仍为真走正常进入 / 补发不带 session 时间戳 / 只有 enter 规则的 task 不记账 / 感知源没凑齐时不结算 / 反复停用启用按第一次的时刻算，以及非互反的退出手势生效 / 计时段起点 / 不受时间闸管 / 没欠账就不恢复 / 恢复后再进入幂等 / 退出槽为空时照样清账 / 删掉出路径强发的那次退出照样清账。

每条判据都做了变异测试：改坏对应那行，确认恰好只有对应那几条变红，牵连到的逐条能解释；还原后基线仍绿。

跑过：`backend` 全量 pytest 全过，`ruff check . ../cli` 全过。