### PR TITLE
fix(perception): 感知日志不再打印 timing

### DIFF
--- a/backend/miloco/src/miloco/perception/client.py
+++ b/backend/miloco/src/miloco/perception/client.py
@@ -122,6 +122,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# timing 供 observability traces 使用,对外副本(日志 / meaningful_events payload)不带。
+_EXCLUDE_TIMING = {"timing"}
+
 # 模块级强引用持有 _persist_meaningful_event 后台任务,防 asyncio 只持弱引用导致
 # 任务运行中被 GC 回收(CPython 文档明确警告).done_callback 在任务结束时自动 discard.
 _PERSIST_BG_TASKS: set[asyncio.Task] = set()
@@ -651,7 +654,7 @@ class PerceptionEngineProxy:
             if not result.skipped:
                 logger.info(
                     "✅ realtime_perceive: %s | skipped_task_ids=%s",
-                    result.model_dump_json(ensure_ascii=False),
+                    result.model_dump_json(ensure_ascii=False, exclude=_EXCLUDE_TIMING),
                     skipped_task_ids,
                 )
 
@@ -1109,9 +1112,7 @@ async def _persist_meaningful_event(
         dao = mgr.meaningful_events_dao
         event_id = str(uuid.uuid4())
         timestamp_ms = int(time.time() * 1000)
-        # timing 已被 observability traces 消费,DB 里这份是冗余副本
-        payload_dict = result.model_dump()
-        payload_dict.pop("timing", None)
+        payload_dict = result.model_dump(exclude=_EXCLUDE_TIMING)
         payload_json = json.dumps(payload_dict, ensure_ascii=False)
 
         # 反查 rule_names:让 DB.text 与 webhook 文本里 rule 段渲染为

--- a/backend/miloco/src/miloco/perception/engine/config.py
+++ b/backend/miloco/src/miloco/perception/engine/config.py
@@ -94,7 +94,7 @@ class GateConfig:
     speech_vad_enabled: bool = True
     # threshold=0.4 + min_chunks=3：在 82 幻觉 + 149 真实语音 clip 上实测 FP 4% / FN 5%
     # 的拐点(对话 peak 概率中位 0.998、键鼠噪声 0.10,分得很开)。残留 FP 由下游
-    # needs_response 佐证兜底。speech_prob 已落 trace,后续可据线上分布再调。
+    # needs_response 佐证兜底。speech_prob 进 traces.timing_detail,可据线上分布再调。
     speech_vad_threshold: float = 0.4  # 单帧人声概率阈(silero)
     speech_vad_min_speech_chunks: int = 3  # 需 >= 此数的 512 样本帧过阈才判有人声(抗单次咔哒尖峰)
     # visual 滞回时长(秒)。visual 最近通过过、距今 <= 此值时,本窗 visual

--- a/backend/miloco/src/miloco/perception/engine/pipeline.py
+++ b/backend/miloco/src/miloco/perception/engine/pipeline.py
@@ -555,13 +555,14 @@ async def run_batch_pipeline(
         room_timing[f"gate_video_{did}_pass"] = int(gate_timing.video_pass)
         room_timing[f"gate_audio_{did}_pass"] = int(gate_timing.audio_pass)
         room_timing[f"gate_hold_{did}_pass"] = int(gate_timing.hold_opened_window)
-        # gate 真实评估的打分 → traces_device.gate_video_score / gate_audio_energy
-        # 经 _merge_results 保留顶层"_"前缀,在 processor._publish_trace 复用。
+        # "_" 前缀留给 traces_device 有专属列的打分:_merge_results 不加 "{room}/" 前缀,
+        # 由 processor._publish_trace 逐 key 显式读。带前缀又没人读的 key 会被
+        # timing_detail 的前缀过滤丢掉,写进去等于扔掉。
         # on-demand bypass / 系统异常 fallback 路径不走这里,score 字段保持 NULL。
         room_timing[f"_gate_video_score_{did}"] = gate_timing.video_score
         room_timing[f"_gate_audio_energy_{did}"] = gate_timing.audio_energy
-        room_timing[f"_gate_speech_prob_{did}"] = gate_timing.speech_prob
-        # intra/cross 拆分 → 经 _merge_results 加 "{room}/" 前缀进 timing_detail JSON。
+        # 其余打分经 _merge_results 加 "{room}/" 前缀进 timing_detail JSON。
+        room_timing[f"gate_speech_prob_{did}"] = gate_timing.speech_prob
         room_timing[f"gate_video_intra_score_{did}"] = gate_timing.video_intra_score
         room_timing[f"gate_video_cross_score_{did}"] = gate_timing.video_cross_score
 

--- a/backend/miloco/tests/perception/engine/test_pipeline.py
+++ b/backend/miloco/tests/perception/engine/test_pipeline.py
@@ -2041,3 +2041,31 @@ async def test_gate_passed_equals_packet_built():
                 f"[{name}] gate_passed={gate_passed} 但建包={built}"
                 " —— 整体过滤率曲线会静默偏移"
             )
+
+
+@pytest.mark.asyncio
+async def test_gate_speech_prob_reaches_timing_detail():
+    """speech_prob 不带 "_" 前缀,经 _merge_results 加 "{room}/" 前缀进 timing_detail。
+
+    带 "_" 前缀的 key 要在 processor._publish_trace 有对应读取行才有出口,
+    speech_prob 没有专属列也没有那一行,带前缀就会被静默丢弃。
+    """
+    config = PerceptionConfig()
+    config.omni.api_key = "test-key"
+    gray = _solid(100, 100, 100)
+    silent = np.zeros(16000, dtype=np.int16)
+
+    with patch(
+        "miloco.perception.engine.omni.omni.call_omni",
+        new_callable=AsyncMock,
+        return_value=MOCK_OMNI_RESPONSE,
+    ):
+        result = await run_batch_pipeline(
+            BatchedSnapshot(snapshots=[_make_snapshot("living", "cam-1", [gray] * 6, silent)]),
+            {}, config,
+        )
+
+    merged = PerceptionEngine()._merge_results(result)
+
+    assert merged.timing is not None
+    assert "living/gate_speech_prob_cam-1" in merged.timing

--- a/backend/miloco/tests/test_perception_client.py
+++ b/backend/miloco/tests/test_perception_client.py
@@ -846,3 +846,31 @@ async def test_window_duration_survives_engine_dropping_snapshots(proxy):
 
     assert result is not None
     assert result.timing["_window_duration_ms"] == 4000.0
+
+
+async def test_realtime_log_excludes_timing(proxy, caplog):
+    """realtime_perceive 日志那份 JSON 不带 timing:per-device key 按相机数展开,
+    正式消费方是 observability traces,日志里只是副本。"""
+    import logging
+
+    from miloco.perception.types import CaptionEntry
+
+    async def engine_realtime(*args, **kwargs):
+        return RealtimePerceptionResult(
+            skipped=False,
+            caption=[CaptionEntry(description="厨房区域空无一人", room_name="厨房")],
+            timing={"厨房/gate_video_1184458598_ms": 7.46},
+        )
+
+    proxy.perception_engine.realtime_perceive = engine_realtime
+
+    with caplog.at_level(logging.INFO, logger="miloco.perception.client"):
+        await proxy._realtime_perceive_impl(
+            _stub_snapshot(), [], 0, 0.0, asyncio.get_running_loop(), [],
+        )
+
+    logged = [r.getMessage() for r in caplog.records if "realtime_perceive:" in r.getMessage()]
+    assert len(logged) == 1
+    assert "gate_video_1184458598_ms" not in logged[0]
+    assert '"timing"' not in logged[0]
+    assert "厨房区域空无一人" in logged[0]

--- a/backend/miloco/tests/test_persist_meaningful_event.py
+++ b/backend/miloco/tests/test_persist_meaningful_event.py
@@ -790,3 +790,21 @@ class TestPersistMeaningfulEvent:
         assert len(rows) == 1
         assert rows[0]["device_ids"] == ["cam_entrance"]
         assert rows[0]["snapshot_count"] == 1
+
+    async def test_payload_excludes_timing(self, isolated_db, dao):
+        """timing 的正式消费方是 observability traces,落库这份 payload 不带它。"""
+        result = RealtimePerceptionResult(
+            matched_rules=[MatchedRule(rule_id="r1", reason="厨房在炒菜")],
+            timing={"厨房/gate_video_1184458598_ms": 7.46},
+        )
+
+        await _persist_meaningful_event(
+            result=result,
+            device_ids=["cam_kitchen_01"],
+            artifacts=_artifacts(),
+        )
+
+        payload_json = dao.query()[0]["payload_json"]
+        assert "gate_video_1184458598_ms" not in payload_json
+        assert '"timing"' not in payload_json
+        assert "厨房在炒菜" in payload_json


### PR DESCRIPTION
## 问题

`realtime_perceive` 的日志把整份 `RealtimePerceptionResult` dump 成 JSON，其中 `timing` 是 pipeline 逐设备写入的观测字段（`{room}/gate_video_{did}_ms`、`_gate_video_score_{did}`、`_device_trace_id_{did}` 等），key 数按相机数展开，真机上一条日志里 caption / matched_rules 这些正文被它挤掉。

timing 的消费方是 observability traces：不带 `_` 前缀的 key 进 `traces.timing_detail`，带 `_` 前缀的由 `processor._publish_trace` 逐 key 显式读进 `traces_device` 的专属列；同一轮的汇总另有 `[perf]` 一行。

落库路径（`_persist_meaningful_event`）本来就剔除了 timing，但和日志这处各写了一份判断依据。

顺带暴露出来的一处：`_gate_speech_prob_{did}` 带 `_` 前缀，但 `_publish_trace` 没有读它的那一行、`traces_device` 也没有对应列，两条出路都不在。它此前只在这条 dump 全量 timing 的日志里露出，日志一收走就没有出口了。

## 改动

- `perception/client.py`：新增模块级 `_EXCLUDE_TIMING`，日志与 `meaningful_events` payload 两处都用它；落库那处原来的 `payload_dict.pop("timing", None)` 换成 `model_dump(exclude=...)`
- `perception/engine/pipeline.py`：`_gate_speech_prob_{did}` 去掉 `_` 前缀，跟同为 0–1 浮点的 `gate_video_intra/cross_score` 走同一条 `timing_detail` 通道；注释改成写前缀规则本身——有专属列的才带 `_`
- `perception/engine/config.py`：`speech_vad_threshold` 的注释订正成 speech_prob 实际所在的位置
- 三条测试：日志与落库 payload 不含 timing 且实质内容照常输出；speech_prob 经 `_merge_results` 后带 `{room}/` 前缀

## 验证

- `uv run pytest -q`（backend 全量）全过
- `uv run ruff check . ../cli` 全过
- 变异测试：去掉两处的 `exclude=_EXCLUDE_TIMING`、把 speech_prob 的 `_` 前缀加回去，三次都恰好只有对应那一条测试变红，无收集错误